### PR TITLE
Make the callback stubs append idempotent, fixing sdist rebuilds

### DIFF
--- a/scripts/cffi_build.py
+++ b/scripts/cffi_build.py
@@ -182,15 +182,22 @@ class Secp256k1CFFIExtension(FFIExtension):
         subprocess.call(command, cwd=self.wd)  # nosec B603
 
         # add source for safe callback
-        with open(self.wd / "src" / "secp256k1.c", "a") as f:
-            f.write(
-                """
+        # idempotent guard: in an sdist there is no .git, so the git reset
+        # below cannot undo the append, and the second build pass of a
+        # PEP 517 frontend would duplicate the definitions, failing the
+        # compilation with "error: redefinition of ..."
+        callbacks = """
             void secp256k1_default_illegal_callback_fn(const char* str, void* data) {
             }
             void secp256k1_default_error_callback_fn(const char* str, void* data) {
             }
             """
-            )
+        src_file = self.wd / "src" / "secp256k1.c"
+        with open(src_file) as f:
+            already_appended = callbacks in f.read()
+        if not already_appended:
+            with open(src_file, "a") as f:
+                f.write(callbacks)
 
         subprocess.call(["make"], cwd=self.wd)  # nosec B603 B607
         subprocess.call(["git", "reset", "--hard"], cwd=self.wd)  # nosec B603 B607


### PR DESCRIPTION
## The bug

`scripts/cffi_build.py` appends the external default callback stubs to
the vendored `secp256k1.c` (needed since configure runs with
`--enable-external-default-callbacks`) and cleans up with
`git reset --hard`:

- that cleanup works in the development checkout, where secp256k1 is a
  git submodule, but is a **silent no-op inside an sdist**, which ships
  no `.git` (and `subprocess.call` ignores the exit code);
- the append is therefore non-idempotent across builds on the same
  source tree: a second build pass duplicates the stubs and the
  compilation fails with

      error: redefinition of 'secp256k1_default_illegal_callback_fn'

## Who hits it

PEP 517 frontends that build the sdist twice on a cached work dir. uv
does — one pass for metadata, one for the wheel — so
`uv pip install btclib-libsecp256k1` **fails on the very first
install, on any python version and platform**; each retry appends one
more copy to uv's cached source dir. pip builds single-pass on a fresh
extract, which is why the bug went unnoticed.

Reproduce with: `uv pip install --no-cache btclib-libsecp256k1==0.4.0`

## The fix

Guard the append with the presence of the exact stub block. Matching
the whole block, not the function name, matters: the pristine upstream
`secp256k1.c` already defines these functions under
`#ifndef USE_EXTERNAL_DEFAULT_CALLBACKS`.

Verified building cp311 and cp314 wheels from a patched sdist on macOS
arm64 (clang 2026), where the unpatched one fails under uv.

Possible follow-ups, not done here to keep the diff minimal: write the
stubs to a separate compilation unit instead of mutating the vendored
source, and check the `subprocess.call` return codes (the silently
failing `git reset` is what enabled this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix non-idempotent callback stub appending in sdists that caused redefinition build failures with multi-pass PEP 517 frontends.