### PR TITLE
Write the release pull request first, and rebase it rather than squash it

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -180,7 +180,47 @@ Then:
    start with `v`, `release.yml` triggering on `tags: ["v*"]`. Nothing in
    the working tree changes, the two trees being identical, and
    `git diff origin/master origin/dev` is how to say so rather than
-   assume it. Every branch still open against `dev` has had its base
+   assume it.
+
+   That last push can fail on its own, distinctly from everything above
+   it: `dev`'s branch protection blocking force pushes is not one of the
+   rules `enforce_admins` being off exempts an administrator from. That
+   toggle covers required reviews, required status checks, required
+   signatures and required linear history -- what a *pull request*
+   enforces -- and force-push protection is a rule of its own that GitHub
+   applies to every push over the git protocol regardless of who is
+   pushing, admin included. 0.7.1.1 is where this was learned: the
+   maintainer's own push, run by hand, came back
+   `remote: - Cannot force-push to this branch`, and no `--admin`-like
+   flag on `git push` exists to ask around it. What worked instead was
+   flipping the one setting that governs it, immediately before the push
+   and immediately after:
+
+       gh api repos/<owner>/<repo>/branches/dev/protection --jq \
+         '{required_status_checks, enforce_admins: .enforce_admins.enabled,
+           required_pull_request_reviews, restrictions,
+           required_linear_history: .required_linear_history.enabled,
+           allow_force_pushes: true, allow_deletions: .allow_deletions.enabled,
+           block_creations: .block_creations.enabled,
+           required_conversation_resolution: .required_conversation_resolution.enabled,
+           lock_branch: .lock_branch.enabled,
+           allow_fork_syncing: .allow_fork_syncing.enabled}' \
+         | gh api -X PUT repos/<owner>/<repo>/branches/dev/protection --input -
+
+   read the four nullable fields back first (`required_status_checks`,
+   `required_pull_request_reviews`, `restrictions`, and `required_signatures`,
+   which is its own endpoint and this PUT does not touch) and carry
+   whatever they hold into the payload unchanged -- a PUT that drops one
+   silently disables it, the same warning the master section above makes
+   about reviews and signatures. On `dev` today all three are unset, which
+   is what makes the jq filter above safe to run as shown; a `dev` with
+   any of them configured needs its current values read and kept, not
+   assumed absent. Push, then set `allow_force_pushes` back to `false`
+   through the same PUT at once: the setting, not only this one push, is
+   what stands open in between, and every other push to `dev` shares that
+   window while it is.
+
+   Every branch still open against `dev` has had its base
    moved out from under it, and reports the whole release as its own diff
    until it is rebased:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,7 +86,18 @@ Then:
    submodule has moved since
 2. add the release notes to `HISTORY.md`; if the vendored libsecp256k1
    moved, update the version named at the top of `README.md` too
-3. merge `dev` into `master` with a green CI, using **Rebase and merge**.
+3. give the pull request its title and its body before merging it, not
+   after. The title is the version; the body says what the release is —
+   what moved, what did not, and which of the two a user would notice.
+   A rebase leaves no merge commit, so none of that reaches `master`'s
+   history: the pull request is where it stays, and where a reader of
+   any commit in it arrives. A template left unfilled, or a bot's
+   summary of the diff, is not a substitute — the summary can stay, but
+   what the diff cannot say has to be written, and what a reader should
+   not have to discover at the button belongs there too.
+
+   Then merge `dev` into `master` with a green CI, using **Rebase and
+   merge** and never *Squash and merge*.
    Which button that is has to be read before it is pressed: all three
    methods are enabled on this repository, and GitHub preselects the one
    used last. *Squash and merge* is what 0.7.1 got, and it left a single

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -242,6 +242,16 @@ Then:
     A fourth number below the published one would be worse than no bump
     at all: `0.7.0.1` sorts *under* `0.7.1`, so nothing would ever
     resolve it, and `version-check` accepts it, being digits and dots
+11. open a draft pull request from `dev` to `master` for the version step
+    10 just opened, title included, and leave its body for what step 3
+    already asked for: written before the release is cut, not
+    reconstructed from the diff at the last minute. A draft one is
+    exactly what step 3 could not be until now — everything that lands on
+    `dev` between one release and the next has a place to be described as
+    it lands, rather than a promise kept only if someone remembers to keep
+    it. Marking it ready and pressing **Rebase and merge** is what step 3
+    still is; this step is what makes reaching it with a body already
+    written the ordinary case rather than the exception
 
 ## Rehearsing on TestPyPI
 


### PR DESCRIPTION
## What this changes, and why

RELEASING.md, in all three repositories, now states two things about the
pull request that merges `dev` into `master`, both of them before the
button rather than after it:

1. **the title and the body are written first.** A rebase leaves no merge
   commit, so nothing said at merge time reaches `master`'s history: the
   pull request is the only place a release is described as a whole, and
   the place a reader of any of its commits lands. A template with its
   headings unfilled, or a bot's summary of the diff under them, is not
   that
2. **"Rebase and merge", never "Squash and merge".** All three methods are
   enabled and GitHub preselects whichever was used last, so the button
   that must not be pressed sits one click from the one that must

Both were paid for rather than reasoned out: btclib_libsecp256k1 squashed
its 0.7.1 release by exactly that route and could not undo it, the tag and
the PEP 740 attestations being bound to the squashed commit; and its
0.7.1.1 release pull request reached the merge button with the template
unfilled.

Documentation only. No code, no workflow, no packaging metadata.

## Summary by Sourcery

Clarify the release process documentation for merging dev into master, emphasizing proper pull request preparation and merge strategy.

Documentation:
- Update RELEASING.md to require writing a complete release PR title and body before merging.
- Explicitly document that release PRs must use "Rebase and merge" and must not use "Squash and merge".

## Aggiornato dopo il rilascio di 0.7.1.1

Due cose imparate portando davvero questo rilascio in fondo, non solo
scrivendole in anticipo:

- **il force-push del passo 9 (`git push --force-with-lease origin
  dev`) può fallire di suo**, e con questo rilascio è successo: il
  push del maintainer, fatto a mano da amministratore, è tornato
  `remote: - Cannot force-push to this branch`. `enforce_admins` spento
  esenta un amministratore dalle review, dai check, dalle firme e dalla
  storia lineare richiesti — non dal blocco dei force-push, che GitHub
  applica a chiunque a livello di protocollo git, senza eccezioni. La
  via che ha funzionato: attivare `allow_force_pushes` per la durata del
  singolo push, e disattivarlo subito dopo — ora documentata a passo 9
  con il comando esatto
- **nuovo passo 11**: aprire la pull request `dev` → `master` della
  prossima versione appena il passo 10 apre il segnaposto, in draft, e
  scriverne il corpo mentre il lavoro atterra — non tutto insieme
  all'ultimo momento, che è esattamente il rischio che il passo 3 (title
  e body prima del bottone) voleva evitare
