### PR TITLE
Follow the repository's rename to btclib-libsecp256k1

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/btclib-org/btclib_libsecp256k1/security/advisories/new
+    url: https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new
     about: >
       Never a public issue. Report it privately here, or by email as the
       security policy describes; a flaw in libsecp256k1 itself goes to

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: >
         Discussions are not enabled here, so a question is an issue. Check
-        the [README](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/README.md)
+        the [README](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/README.md)
         first: it is the documentation of this package, and its Design and
         Wrapped modules sections answer most of what gets asked.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
     # workflow, gets the build and stops there
     if: >-
       github.event_name == 'workflow_dispatch'
-      && github.repository == 'btclib-org/btclib_libsecp256k1'
+      && github.repository == 'btclib-org/btclib-libsecp256k1'
     needs: [lint, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -171,7 +171,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
-    if: github.event_name == 'push' && github.repository == 'btclib-org/btclib_libsecp256k1'
+    if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-libsecp256k1'
     needs: [lint, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@
 
 To see the list of btclib_libsecp256k1 authors for copyright purposes,
 see the revision history in source control:
-<https://github.com/btclib-org/btclib_libsecp256k1/graphs/contributors>
+<https://github.com/btclib-org/btclib-libsecp256k1/graphs/contributors>
 
 The vendored [libsecp256k1](https://github.com/bitcoin-core/secp256k1) is
 not this project's work: it is distributed under its own licence, by its

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ A vulnerability is never an issue: see the
 
 ## Opening an issue
 
-Search the [issues](https://github.com/btclib-org/btclib_libsecp256k1/issues)
-and [pull requests](https://github.com/btclib-org/btclib_libsecp256k1/pulls)
+Search the [issues](https://github.com/btclib-org/btclib-libsecp256k1/issues)
+and [pull requests](https://github.com/btclib-org/btclib-libsecp256k1/pulls)
 first, then use one of the
-[forms](https://github.com/btclib-org/btclib_libsecp256k1/issues/new/choose).
+[forms](https://github.com/btclib-org/btclib-libsecp256k1/issues/new/choose).
 The bug form asks which of the three artifacts is installed — a static
 wheel, a dynamic one, or a build from the sdist — because they differ in
 how libsecp256k1 is linked and a bug is rarely in all three.
@@ -362,4 +362,4 @@ Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.
 
 Once merged, your contribution is visible on the
-[contributors page](https://github.com/btclib-org/btclib_libsecp256k1/graphs/contributors).
+[contributors page](https://github.com/btclib-org/btclib-libsecp256k1/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 [![pypi](https://img.shields.io/pypi/v/btclib_libsecp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib_libsecp256k1)](https://pepy.tech/project/btclib_libsecp256k1)
 [![status](https://img.shields.io/pypi/status/btclib_libsecp256k1.svg)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
-[![license](https://img.shields.io/github/license/btclib-org/btclib_libsecp256k1.svg)](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/LICENSE)
 [![lint and format: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![type-check: mypy](https://img.shields.io/badge/type--check-mypy-yellowgreen.svg?logo=mypy)](http://mypy-lang.org/)
-[![lint](https://github.com/btclib-org/btclib_libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib_libsecp256k1/actions/workflows/lint.yml)
-[![test](https://github.com/btclib-org/btclib_libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib_libsecp256k1/actions/workflows/test.yml)
+[![lint](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
+[![test](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
 [![docs](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
 
 [![Follow on Twitter](https://img.shields.io/twitter/follow/btclib?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=btclib)
 
 ---
 
-[Browse GitHub Code Repository](https://github.com/btclib-org/btclib_libsecp256k1/)
+[Browse GitHub Code Repository](https://github.com/btclib-org/btclib-libsecp256k1/)
 
 ---
 
@@ -142,7 +142,7 @@ type, a length, or a magnitude, all of which the caller knows already —
 so the constant-time guarantee is the C call's, and it is intact. What
 python cannot give back is what happens on either side of that call:
 `bytes` is not zeroized either, and
-[SECURITY.md](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/SECURITY.md)
+[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/SECURITY.md)
 records both limits as inherent.
 
 And there is a way past all of it: `lib` and `ffi` are exported, and a
@@ -237,7 +237,7 @@ attributes a message to the right caller.
 
 What is not protected is the secret material itself, which lives in
 Python objects for as long as the interpreter keeps them: see
-[SECURITY.md](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/SECURITY.md).
+[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/SECURITY.md).
 
 ## The vendored library is not optional
 
@@ -315,7 +315,7 @@ x86_64 only.
 How to get the submodule, set up the development environment, run the
 suite and the benchmarks, reproduce each CI job locally, and what a
 change is expected to satisfy are in
-[CONTRIBUTING.md](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/CONTRIBUTING.md).
 
 ## Release process
 
@@ -328,4 +328,4 @@ their provenance can be verified on PyPI.
 
 The steps to cut a release, to rehearse one on TestPyPI, and the
 one-time setup each index needs are in
-[RELEASING.md](https://github.com/btclib-org/btclib_libsecp256k1/blob/master/RELEASING.md).
+[RELEASING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -352,7 +352,7 @@ The PyPI side is already done; this is here for the next index, or the
 next fork.
 
 - on PyPI, and on TestPyPI, project Publishing settings: add a GitHub
-  trusted publisher for `btclib-org/btclib_libsecp256k1`, workflow
+  trusted publisher for `btclib-org/btclib-libsecp256k1`, workflow
   `release.yml`, environment `pypi` and `testpypi` respectively. The two
   indexes are separate accounts and separate registrations, and separate
   credentials with them, TestPyPI being its own deployment of Warehouse

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -25,7 +25,7 @@ nothing.
 `checks` with an `app_id` rather than the bare `contexts` list, so nothing
 else can satisfy one:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/branches/master/protection \
+    gh api repos/btclib-org/btclib-libsecp256k1/branches/master/protection \
       --jq '.required_status_checks'
 
 | Check | Produced by |
@@ -34,14 +34,14 @@ else can satisfy one:
 | `Lint and type-check` | `lint.yml`, its only job |
 | `CodeQL` | code scanning's default setup |
 
-    gh api repos/btclib-org/btclib_libsecp256k1/commits/<sha>/check-runs \
+    gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
       --jq '[.check_runs[] | {name, app: .app.slug}] | unique_by(.app)'
 
 **CodeQL is code scanning's default setup, not a workflow of this
 repository** — `state: configured`, python and actions, the default query
 suite, weekly — so there is no file here to read its triggers off:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/code-scanning/default-setup
+    gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
 
 That absence of a file is also why the check was first left out of the
 rule, on a measurement that was the wrong one: every ordinary pull
@@ -53,7 +53,7 @@ matters there is the other kind, `dev` into `master`; #21, the 0.7.1
 release merge, has CodeQL analyses under `refs/pull/21/head`. That is
 the pull request this rule actually gates, and CodeQL runs on it:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/code-scanning/analyses \
+    gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/analyses \
       --jq '.[] | {ref, category, created_at}'
 
 `Dependency Graph` is not a candidate either: its runs are `dynamic`,
@@ -84,7 +84,7 @@ self-approval, so the review is a stop rather than a speed bump, and the
 admin bypass is the only way past it without a second maintainer to add.
 
     gh api -X DELETE \
-      repos/btclib-org/btclib_libsecp256k1/branches/master/protection/enforce_admins
+      repos/btclib-org/btclib-libsecp256k1/branches/master/protection/enforce_admins
 
 Turned off after being on through the 0.7.1 release, whose squash merge
 (see RELEASING.md) is what the previous setting actually cost: with
@@ -98,7 +98,7 @@ next incident has the same escape hatch btclib already keeps.
 
 `dev` is protected too, minimally and identically to btclib's own:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/branches/dev/protection \
+    gh api repos/btclib-org/btclib-libsecp256k1/branches/dev/protection \
       --jq '{required_linear_history, allow_force_pushes, allow_deletions,
         enforce_admins, required_conversation_resolution}'
 
@@ -125,7 +125,7 @@ instead of closing.
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
 needing more declares it:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/actions/permissions/workflow \
+    gh api repos/btclib-org/btclib-libsecp256k1/actions/permissions/workflow \
       --jq '.default_workflow_permissions'   # "read"
 
 Only `release.yml` asks for more: `contents: write` on `github-release`,
@@ -138,7 +138,7 @@ readable where the job is.
 
 Both environments require a review, so an upload waits for a person:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/environments \
+    gh api repos/btclib-org/btclib-libsecp256k1/environments \
       --jq '.environments[] | {name, protection_rules}'
 
 `pypi` and `testpypi` each have `fametrano` as the required reviewer.
@@ -182,7 +182,7 @@ saying nothing. Dependabot security updates are on.
 
 Some settings cannot be enabled and fail silently:
 
-    gh api repos/btclib-org/btclib_libsecp256k1 --jq '.security_and_analysis'
+    gh api repos/btclib-org/btclib-libsecp256k1 --jq '.security_and_analysis'
 
 Secret scanning and push protection are enabled;
 `secret_scanning_non_provider_patterns` and
@@ -197,7 +197,7 @@ carries what maintaining its baseline costs.
 Unlike btclib, this repository serves no GitHub Pages site, so no file in
 its root is a URL anywhere:
 
-    gh api repos/btclib-org/btclib_libsecp256k1/pages   # 404
+    gh api repos/btclib-org/btclib-libsecp256k1/pages   # 404
 
 btclib.org is built from the btclib repository's `master` root, which is
 why that project's README is also a web page and this one's is not.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,11 @@ homepage = "https://btclib.org"
 # of docs/source, the README included in its toctree rather than left as
 # the whole of the documentation
 documentation = "https://btclib-libsecp256k1.readthedocs.io"
-repository = "https://github.com/btclib-org/btclib_libsecp256k1"
-download = "https://github.com/btclib-org/btclib_libsecp256k1/releases"
-changelog = "https://github.com/btclib-org/btclib_libsecp256k1/blob/master/HISTORY.md"
-issues = "https://github.com/btclib-org/btclib_libsecp256k1/issues"
-pull_requests = "https://github.com/btclib-org/btclib_libsecp256k1/pulls"
+repository = "https://github.com/btclib-org/btclib-libsecp256k1"
+download = "https://github.com/btclib-org/btclib-libsecp256k1/releases"
+changelog = "https://github.com/btclib-org/btclib-libsecp256k1/blob/master/HISTORY.md"
+issues = "https://github.com/btclib-org/btclib-libsecp256k1/issues"
+pull_requests = "https://github.com/btclib-org/btclib-libsecp256k1/pulls"
 
 [build-system]
 # cmake builds the vendored library: it is a build requirement, not a


### PR DESCRIPTION
## What this changes, and why

The GitHub repository is now `btclib-org/btclib-libsecp256k1`, renamed
outside this pull request. This is what following that rename through
the tree looks like: every literal `btclib-org/btclib_libsecp256k1` in
nine files, updated to the hyphenated slug.

Not renamed: the Python package (`btclib_libsecp256k1`, PyPI
distribution name, import name, extension module, every path under it).
A repository rename does not touch any of those, and this org already
has the precedent for the two differing — `btclib-bitcoin-core-rpc` on
GitHub, `bitcoin-core-rpc` on PyPI, `bitcoin_core_rpc` to import.

Two of these lines are not cosmetic: `release.yml`'s `publish-pypi` and
`publish-testpypi` jobs each gate on
`github.repository == 'btclib-org/btclib_libsecp256k1'`, and
`github.repository` reports the repository's *current* name. Left
alone, both jobs would have stopped running on every future release —
the `if:` simply never matching again, nothing failing loudly enough to
notice before an upload never happened.

## Outside this tree

Two things this pull request cannot reach, and that block the next
release if left alone:

- **the PyPI and TestPyPI trusted publisher registrations** for this
  project still name the old repository. The next release's OIDC token
  presents the new one, and a mismatched registration fails the
  exchange with `invalid-publisher` — the same failure the 0.7.1
  TestPyPI rehearsal hit for an unrelated reason. Each index's project
  → Publishing settings needs the registration's repository field
  updated to `btclib-libsecp256k1`
- **Read the Docs** is worth a look, though less urgent: its GitHub
  integration is more likely to track the account than the name and to
  have already followed on its own

Branch protection, the `pypi`/`testpypi` environments, CodeQL's default
setup and Dependabot are unaffected — all four are keyed to the
repository's id, which a rename does not change.

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest --cov` passes, the coverage ratchet included
- [ ] new wrapped functionality is validated against vectors published
      elsewhere, not against these bindings' own output — no
      functionality is wrapped here
- [x] comments that this change makes untrue have been updated, in the
      workflows and build scripts too
- [x] `HISTORY.md` mentions it, if a user of the package would notice —
      not applicable: a GitHub URL, not something the installed package
      exposes
- [x] the `secp256k1` submodule is untouched, or moving it is what this
      pull request is about and the version named in `README.md` moved
      with it

## Summary by Sourcery

Update repository references to match the GitHub rename to btclib-libsecp256k1 and keep release workflows functioning.

Enhancements:
- Refresh documentation and metadata links to point to the renamed GitHub repository.

CI:
- Update release workflow conditions so publish jobs continue to run under the new repository name.