### PR TITLE
Fix RELEASING.md against what the sibling repositories already got right

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -388,9 +388,13 @@ next fork.
   round, the log itself warning that the claims are for debugging and
   not for configuring from
 - on GitHub, repository Settings, Environments: create the `pypi` and
-  `testpypi` environments, each with the required reviewers who approve.
-  Leaving `testpypi` without reviewers would be the one part of a
-  release that the rehearsal stops exercising
+  `testpypi` environments, each with the required reviewers who approve
+  -- `fametrano` on both. Self-review stays allowed on purpose: the
+  maintainer who pushes the tag is the reviewer, and forbidding it would
+  deadlock a one-maintainer release. The approval is a confirmation
+  step, not a second pair of eyes; it becomes one as soon as there is a
+  second reviewer to add. Leaving `testpypi` without reviewers would be
+  the one part of a release that the rehearsal stops exercising
 - `pypi` carries a deployment branch policy besides, a custom rule
   admitting the tag pattern `v*`, that environment being reachable only
   from a tag; `testpypi` has none, being reached from a branch by

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,19 +61,20 @@ the release it rehearses.
 
 ## Cutting a release
 
-Two of the sentinels are worth dispatching before the tag rather than
-waiting for their cron, because what they answer is cheaper to know before a
-version is consumed than after. Neither gates anything, so neither will stop
-you: reading them is the point.
+`latest` is worth dispatching before the tag rather than waiting for its
+cron, because what it answers is cheaper to know before a version is
+consumed than after. It gates nothing, so it will not stop you: reading
+it is the point. It resolves every dependency at its newest and then runs
+the suite, the lint gate and the packaging checks; a release ships what
+`uv.lock` pins, so a red run here does not make the release wrong — it
+says the next dependency bump is going to be work, and that is worth
+knowing before rather than during.
 
-- **`latest`**, which resolves every dependency at its newest and then runs
-  the suite, the lint gate and the packaging checks. A release ships what
-  `uv.lock` pins, so a red run here does not make the release wrong — it
-  says the next dependency bump is going to be work, and that is worth
-  knowing before rather than during
-- **`mutation`**, if the release added or changed a wrapper. A surviving
-  mutant is a test nobody has written, and the release is the last moment
-  at which adding it costs nothing
+`mutation` is not: it asks whether the suite would notice a wrong line,
+which a release does not change the answer to, and a session is measured
+in minutes to hours against a schedule already built for the weekend it
+runs on regardless. Dispatching it as part of cutting a release conflates
+two independent activities for no question a release-timing answers.
 
 Then:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -138,16 +138,25 @@ Then:
    0.7.1 rehearsal did on TestPyPI, and a version survives a failed
    exchange: delete the tag, fix the registration, tag again
 6. check that what was published installs, in an environment of its own
-   rather than one that may already hold it:
+   rather than one that may already hold it, and run something with it —
+   installing being weaker than working where a compiled extension is
+   what was installed:
 
-       python -m pip install --upgrade btclib_libsecp256k1
+       uv run --isolated --no-project --with btclib_libsecp256k1==0.7.1 \
+         python -c "
+       from btclib_libsecp256k1 import ssa
+       msg = bytes(32)
+       pub = bytes.fromhex('F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9')
+       sig = bytes.fromhex('E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0')
+       assert ssa.verify(msg, pub, sig)
+       "
 
-   then run something with it, and check the attestations, the two checks
-   the rehearsal makes and for the same reasons: a compiled extension can
-   install and not work, and the attestations are under
-   `/integrity/<project>/<version>/<filename>/provenance` rather than in
-   the JSON API, which answers `null` for `provenance` even where they
-   are
+   BIP340 vector 0, the same check `published` makes below. Then check
+   the attestations, the two checks the rehearsal makes and for the same
+   reasons: a compiled extension can install and not work, and the
+   attestations are under `/integrity/<project>/<version>/<filename>/provenance`
+   rather than in the JSON API, which answers `null` for `provenance`
+   even where they are
 7. run the `published` workflow from the Actions tab, and expect it green:
    it installs from PyPI what was just uploaded, on every platform and at
    both ends of the supported interpreter range, and verifies BIP340
@@ -298,19 +307,21 @@ without rebuilding anything.
    there, and `0.7.1rc1` is a version PyPI would then hand to `--pre`
    installs. The `version-check` job refuses a tag whose version is not
    digits and dots, so the mistake stops before anything is built
-2. approve it, then check that what was published installs. A re-run has
-   to be approved again, the protection applying to each deployment
-   attempt rather than once per run:
+2. approve it, then check that what was published installs, in an
+   environment of its own rather than one that may already hold it. A
+   re-run has to be approved again, the protection applying to each
+   deployment attempt rather than once per run:
 
-   <!-- markdownlint-disable MD013 -->
+       uv run --isolated --no-project \
+         --index-url https://test.pypi.org/simple/ \
+         --extra-index-url https://pypi.org/simple/ \
+         --index-strategy unsafe-best-match --prerelease allow \
+         --with btclib_libsecp256k1==0.7.1.dev1 \
+         python -c "import btclib_libsecp256k1 as m; print(m.__version__)"
 
-       pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ --pre btclib_libsecp256k1
-
-   <!-- markdownlint-enable MD013 -->
-
-   the extra index being needed for `cffi`, which TestPyPI does not have.
-   The version installed carries the `.dev<run number>` suffix, and
-   `--pre` is what makes it resolvable
+   the extra index being needed for `cffi`, which TestPyPI does not have,
+   and `--prerelease allow` for the `.dev<run number>` suffix the version
+   installed carries
 3. run something with it, installing being weaker than working where a
    compiled extension is what was installed. The check the `published`
    workflow makes — BIP340 vector 0, and the round trip of a signature

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -175,10 +175,16 @@ Then:
    Rebase and merge replays `dev`'s commits with new SHAs, so the moment
    a release is merged the two branches hold the same tree through
    different histories, and the merge base between them stops advancing.
-   Left alone, the next release's pull request presents the whole of this
-   one as new, and asks the rebase to replay commits `master` already
-   carries. Archive what is about to become unreachable, then move the
-   branch:
+   Left alone this is not the cosmetic issue it looks like: it is what the
+   pull request that added this very step hit, during 0.7.1.1's own
+   release -- its branch built against `dev` before this step's own reset
+   ran, so once that reset moved `dev`, GitHub reported the pull request
+   `CONFLICTING` and `gh pr merge --rebase` on it refused with `the merge
+   commit cannot be cleanly created`. Reapplying "add this line" where a
+   rebase-and-merge already added it under a different SHA is a conflict,
+   not a no-op, and GitHub does not drop the commit the way a local
+   `git rebase` would. Archive what is about to become unreachable, then
+   move the branch:
 
        git fetch origin
        git tag -a history/dev-0.7.1 dev -m "dev's own commits for 0.7.1"


### PR DESCRIPTION
## What this changes, and why

Four fixes to RELEASING.md found by comparing it against the same file
in btclib and btclib-bitcoin-core-rpc, which follow the same conventions
by design (see the "matching btclib's own" pattern throughout this
tree's history).

- **`mutation` dropped from the pre-tag sentinel advice.** `latest` and
  `mutation` were listed together as worth dispatching before a tag, but
  they answer different questions: `latest` asks whether the tree about
  to be released still resolves and builds against the newest
  dependencies, which a release is a natural moment to check; `mutation`
  asks whether the suite would notice a wrong line, which nothing about
  cutting a release changes the answer to, and which already runs on its
  own weekly schedule regardless. Recommending it here conflated the two.
- **The two install-and-check commands now actually isolate.** Step 6
  said "in an environment of its own rather than one that may already
  hold it" and then ran `python -m pip install --upgrade
  btclib_libsecp256k1`, which upgrades whatever environment is running
  it — the opposite. Same defect in the TestPyPI rehearsal's check. Both
  now use `uv run --isolated --no-project --with <pkg>==<version>`,
  matching the pattern already used for this exact check in both sibling
  repositories. Step 6 also now runs something (BIP340 vector 0) rather
  than only importing, which "then run something with it" already asked
  for and the old command never did.
- **Step 9 now says what skipping it actually breaks**, not just what it
  changes. The pull request that added this step is the case: opened
  against `dev` before this step's own reset ran, then reported
  `CONFLICTING` by GitHub once that reset moved `dev` during the same
  release, and refused by `gh pr merge --rebase` with "the merge commit
  cannot be cleanly created". Both sibling repositories already cite
  this evidence; this file, which is where it happened, did not.
- **The self-review note is here now.** `fametrano` is the required
  reviewer on `pypi` in all three repositories (checked against the
  API), and both siblings explain that self-approval is intentional
  rather than a gap. This file didn't.

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest --cov` passes, the coverage ratchet included
- [ ] new wrapped functionality is validated against vectors published
      elsewhere — not applicable, documentation only
- [x] comments that this change makes untrue have been updated
- [ ] `HISTORY.md` mentions it — not applicable, nothing a user of the
      package would notice
- [x] the `secp256k1` submodule is untouched

## Summary by Sourcery

Update release process documentation to better align with practices used in sibling repositories and clarify expected behaviors around pre-tag checks, installation verification, branch reset, and reviewer configuration.

Documentation:
- Clarify that only the `latest` sentinel should be run before tagging while `mutation` remains an independent activity.
- Strengthen post-publish installation checks to use isolated environments, execute a concrete verification (BIP340 vector 0), and explicitly verify attestations.
- Update TestPyPI rehearsal instructions to install and verify the package in an isolated environment using the current tooling and flags.
- Document the concrete failure mode that occurs if the `dev` branch reset step is skipped during a release.
- Explain the intentional self-review setup for the `pypi` and `testpypi` environments and its rationale for a single-maintainer workflow.