### PR TITLE
Run the entropy detectors over the tree, and only spare the vector data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -258,27 +258,44 @@ repos:
   # with --no-verify, an edit from the web interface, a fork.
   #
   # The test data of a signing library is private keys by the hundred,
-  # published upstream and vendored here to be compared against, so the
-  # two json vector files are 398 findings on their own. They are recorded
-  # in .secrets.baseline as already reviewed rather than excluded from the
-  # scan: an exclusion would have made those files blind for good, and the
-  # difference is not theoretical — an AWS key planted in one of them was
-  # not seen while they were excluded, and is seen now.
-  # The baseline was generated with the two entropy plugins off, and it is
-  # the baseline that governs which plugins run. That is a deliberate
-  # limit: with them on, the baseline grows from 398 entries in 2 files to
-  # 1829 in 5, and every new hex constant in any test fails the hook until
-  # someone regenerates it — in files made of nothing but 64-character hex
-  # strings, a new one is what a legitimate vector looks like, so the
-  # check would report the work rather than the risk.
-  # Adding a vector to those two files does require regenerating the
-  # baseline; see CONTRIBUTING.md
+  # published upstream and vendored here to be compared against. Nothing
+  # is excluded from the scan — an exclusion would make those files blind
+  # for good, and the difference is not theoretical: an AWS key planted in
+  # one of them was not seen while they were excluded, and is seen now.
+  #
+  # What differs between the two hooks below is the plugin set, and it is
+  # the baseline that governs it, one baseline each:
+  #
+  # - the tree runs every plugin, the two entropy detectors included. Those
+  #   are the ones worth having where the free plan gives no generic secret
+  #   scanning at all, and outside the vendored data they cost 38 findings,
+  #   reviewed once: 37 hex constants written inline in two test files, and
+  #   a CMake flag the base64 detector reads as a secret;
+  # - the vendored vector data runs the same plugins with the entropy pair
+  #   off. Those files are 64-character hex and nothing else, so with the
+  #   detectors on a new vector is indistinguishable from a new secret and
+  #   the check reports the work rather than the risk. The keyword, private
+  #   key and provider-token detectors — the ones that caught the planted
+  #   AWS key — keep running over them.
+  #
+  # The two hooks partition the tree: what the second matches, the first
+  # excludes, through the filter recorded in its own baseline rather than a
+  # second copy of the pattern here. That filter also names the second
+  # baseline file, which is 40-character hashes by the hundred:
+  # detect-secrets skips a baseline of its own accord, but only the one
+  # --baseline names. Adding a vector to a file the second hook matches
+  # requires regenerating that baseline; see CONTRIBUTING.md, which carries
+  # both commands
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
       - id: detect-secrets
         name: detect-secrets (credentials of other systems)
         args: [--baseline, .secrets.baseline]
+      - id: detect-secrets
+        name: detect-secrets (the vendored vector data)
+        args: [--baseline, .secrets.vectors.baseline]
+        files: ^tests/.*\.(csv|json)$
 
   # keep uv.lock in sync with pyproject.toml. The release workflow asserts
   # the same thing with uv lock --check, and every uv command in CI passes

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11,6 +11,10 @@
       "name": "AzureStorageKeyDetector"
     },
     {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
       "name": "BasicAuthDetector"
     },
     {
@@ -24,6 +28,10 @@
     },
     {
       "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -83,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -116,2799 +120,287 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^(\\.secrets\\.vectors\\.baseline|tests/.*\\.(csv|json))$"
+      ]
     }
   ],
   "results": {
-    "tests/ecdsa_custom_nonce_sig.json": [
+    "scripts/cffi_build.py": [
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/cffi_build.py",
+        "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 398
+      }
+    ],
+    "tests/test_properties.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_properties.py",
+        "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
+        "is_verified": false,
+        "line_number": 317
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_properties.py",
+        "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 340
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_properties.py",
+        "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 343
+      }
+    ],
+    "tests/test_vectors.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
+        "is_verified": false,
+        "line_number": 107
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 108
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
-        "is_verified": false,
-        "line_number": 31
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
-        "is_verified": false,
-        "line_number": 37
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
-        "is_verified": false,
-        "line_number": 43
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
-        "is_verified": false,
-        "line_number": 49
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
-        "is_verified": false,
-        "line_number": 55
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
-        "is_verified": false,
-        "line_number": 61
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
-        "is_verified": false,
-        "line_number": 67
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
-        "is_verified": false,
-        "line_number": 73
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
-        "is_verified": false,
-        "line_number": 79
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
-        "is_verified": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
-        "is_verified": false,
-        "line_number": 91
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
-        "is_verified": false,
-        "line_number": 97
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
-        "is_verified": false,
-        "line_number": 103
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
         "line_number": 109
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
         "line_number": 115
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
-        "is_verified": false,
-        "line_number": 121
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
-        "is_verified": false,
-        "line_number": 127
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
-        "is_verified": false,
-        "line_number": 133
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
-        "is_verified": false,
-        "line_number": 139
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
-        "is_verified": false,
-        "line_number": 145
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
-        "is_verified": false,
-        "line_number": 151
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
-        "is_verified": false,
-        "line_number": 157
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
-        "is_verified": false,
-        "line_number": 163
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
-        "is_verified": false,
-        "line_number": 169
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
-        "is_verified": false,
-        "line_number": 175
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
-        "is_verified": false,
-        "line_number": 187
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
-        "is_verified": false,
-        "line_number": 193
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
-        "is_verified": false,
-        "line_number": 199
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
-        "is_verified": false,
-        "line_number": 205
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
-        "is_verified": false,
-        "line_number": 211
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
-        "is_verified": false,
-        "line_number": 217
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
-        "is_verified": false,
-        "line_number": 223
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
-        "is_verified": false,
-        "line_number": 229
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
-        "is_verified": false,
-        "line_number": 235
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
-        "is_verified": false,
-        "line_number": 241
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
-        "is_verified": false,
-        "line_number": 247
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
-        "is_verified": false,
-        "line_number": 253
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
-        "is_verified": false,
-        "line_number": 259
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
-        "is_verified": false,
-        "line_number": 265
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
-        "is_verified": false,
-        "line_number": 271
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
-        "is_verified": false,
-        "line_number": 277
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
-        "is_verified": false,
-        "line_number": 283
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
-        "is_verified": false,
-        "line_number": 289
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
-        "is_verified": false,
-        "line_number": 295
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
-        "is_verified": false,
-        "line_number": 301
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
-        "is_verified": false,
-        "line_number": 307
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
-        "is_verified": false,
-        "line_number": 313
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
-        "is_verified": false,
-        "line_number": 325
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
-        "is_verified": false,
-        "line_number": 331
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
-        "is_verified": false,
-        "line_number": 337
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
-        "is_verified": false,
-        "line_number": 343
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
-        "is_verified": false,
-        "line_number": 349
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
-        "is_verified": false,
-        "line_number": 355
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
-        "is_verified": false,
-        "line_number": 361
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
-        "is_verified": false,
-        "line_number": 367
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
-        "is_verified": false,
-        "line_number": 373
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
-        "is_verified": false,
-        "line_number": 379
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
-        "is_verified": false,
-        "line_number": 385
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
-        "is_verified": false,
-        "line_number": 391
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
-        "is_verified": false,
-        "line_number": 397
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
-        "is_verified": false,
-        "line_number": 403
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
-        "is_verified": false,
-        "line_number": 409
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
-        "is_verified": false,
-        "line_number": 415
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
-        "is_verified": false,
-        "line_number": 421
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
-        "is_verified": false,
-        "line_number": 427
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
-        "is_verified": false,
-        "line_number": 433
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
-        "is_verified": false,
-        "line_number": 439
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
-        "is_verified": false,
-        "line_number": 445
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
-        "is_verified": false,
-        "line_number": 451
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
-        "is_verified": false,
-        "line_number": 457
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
-        "is_verified": false,
-        "line_number": 463
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
-        "is_verified": false,
-        "line_number": 475
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
-        "is_verified": false,
-        "line_number": 481
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
-        "is_verified": false,
-        "line_number": 493
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
-        "is_verified": false,
-        "line_number": 499
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
-        "is_verified": false,
-        "line_number": 505
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
-        "is_verified": false,
-        "line_number": 511
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
-        "is_verified": false,
-        "line_number": 517
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
-        "is_verified": false,
-        "line_number": 523
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
-        "is_verified": false,
-        "line_number": 529
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
-        "is_verified": false,
-        "line_number": 535
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
-        "is_verified": false,
-        "line_number": 541
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
-        "is_verified": false,
-        "line_number": 547
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
-        "is_verified": false,
-        "line_number": 553
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
-        "is_verified": false,
-        "line_number": 559
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
-        "is_verified": false,
-        "line_number": 565
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
-        "is_verified": false,
-        "line_number": 571
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
-        "is_verified": false,
-        "line_number": 577
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
-        "is_verified": false,
-        "line_number": 583
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
-        "is_verified": false,
-        "line_number": 589
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
-        "is_verified": false,
-        "line_number": 595
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
-        "is_verified": false,
-        "line_number": 601
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
-        "is_verified": false,
-        "line_number": 607
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
-        "is_verified": false,
-        "line_number": 613
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
-        "is_verified": false,
-        "line_number": 619
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
-        "is_verified": false,
-        "line_number": 625
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
-        "is_verified": false,
-        "line_number": 631
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
-        "is_verified": false,
-        "line_number": 637
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
-        "is_verified": false,
-        "line_number": 643
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
-        "is_verified": false,
-        "line_number": 649
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
-        "is_verified": false,
-        "line_number": 655
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
-        "is_verified": false,
-        "line_number": 661
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
-        "is_verified": false,
-        "line_number": 667
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
-        "is_verified": false,
-        "line_number": 673
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
-        "is_verified": false,
-        "line_number": 679
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
-        "is_verified": false,
-        "line_number": 685
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
-        "is_verified": false,
-        "line_number": 691
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
-        "is_verified": false,
-        "line_number": 697
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
-        "is_verified": false,
-        "line_number": 703
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
-        "is_verified": false,
-        "line_number": 709
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
-        "is_verified": false,
-        "line_number": 715
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
-        "is_verified": false,
-        "line_number": 721
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
-        "is_verified": false,
-        "line_number": 727
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
-        "is_verified": false,
-        "line_number": 733
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
-        "is_verified": false,
-        "line_number": 739
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
-        "is_verified": false,
-        "line_number": 745
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
-        "is_verified": false,
-        "line_number": 751
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
-        "is_verified": false,
-        "line_number": 757
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
-        "is_verified": false,
-        "line_number": 763
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
-        "is_verified": false,
-        "line_number": 769
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
-        "is_verified": false,
-        "line_number": 775
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
-        "is_verified": false,
-        "line_number": 781
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
-        "is_verified": false,
-        "line_number": 787
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
-        "is_verified": false,
-        "line_number": 793
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
-        "is_verified": false,
-        "line_number": 799
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
-        "is_verified": false,
-        "line_number": 805
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
-        "is_verified": false,
-        "line_number": 811
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
-        "is_verified": false,
-        "line_number": 817
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
-        "is_verified": false,
-        "line_number": 823
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
-        "is_verified": false,
-        "line_number": 829
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
-        "is_verified": false,
-        "line_number": 835
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
-        "is_verified": false,
-        "line_number": 841
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
-        "is_verified": false,
-        "line_number": 847
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
-        "is_verified": false,
-        "line_number": 853
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
-        "is_verified": false,
-        "line_number": 859
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
-        "is_verified": false,
-        "line_number": 865
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
-        "is_verified": false,
-        "line_number": 871
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
-        "is_verified": false,
-        "line_number": 877
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
-        "is_verified": false,
-        "line_number": 883
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
-        "is_verified": false,
-        "line_number": 889
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
-        "is_verified": false,
-        "line_number": 895
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
-        "is_verified": false,
-        "line_number": 901
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
-        "is_verified": false,
-        "line_number": 907
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
-        "is_verified": false,
-        "line_number": 913
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
-        "is_verified": false,
-        "line_number": 919
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
-        "is_verified": false,
-        "line_number": 925
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
-        "is_verified": false,
-        "line_number": 931
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
-        "is_verified": false,
-        "line_number": 937
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
-        "is_verified": false,
-        "line_number": 943
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
-        "is_verified": false,
-        "line_number": 949
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
-        "is_verified": false,
-        "line_number": 955
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
-        "is_verified": false,
-        "line_number": 961
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
-        "is_verified": false,
-        "line_number": 967
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
-        "is_verified": false,
-        "line_number": 973
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
-        "is_verified": false,
-        "line_number": 979
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
-        "is_verified": false,
-        "line_number": 985
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
-        "is_verified": false,
-        "line_number": 991
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
-        "is_verified": false,
-        "line_number": 997
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
-        "is_verified": false,
-        "line_number": 1003
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
-        "is_verified": false,
-        "line_number": 1009
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
-        "is_verified": false,
-        "line_number": 1015
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
-        "is_verified": false,
-        "line_number": 1021
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
-        "is_verified": false,
-        "line_number": 1027
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
-        "is_verified": false,
-        "line_number": 1033
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
-        "is_verified": false,
-        "line_number": 1039
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
-        "is_verified": false,
-        "line_number": 1045
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
-        "is_verified": false,
-        "line_number": 1051
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
-        "is_verified": false,
-        "line_number": 1057
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
-        "is_verified": false,
-        "line_number": 1063
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
-        "is_verified": false,
-        "line_number": 1069
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
-        "is_verified": false,
-        "line_number": 1075
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
-        "is_verified": false,
-        "line_number": 1081
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
-        "is_verified": false,
-        "line_number": 1087
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
-        "is_verified": false,
-        "line_number": 1093
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
-        "is_verified": false,
-        "line_number": 1099
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
-        "is_verified": false,
-        "line_number": 1105
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
-        "is_verified": false,
-        "line_number": 1111
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
-        "is_verified": false,
-        "line_number": 1117
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
-        "is_verified": false,
-        "line_number": 1123
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
-        "is_verified": false,
-        "line_number": 1129
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
-        "is_verified": false,
-        "line_number": 1135
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
-        "is_verified": false,
-        "line_number": 1141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
-        "is_verified": false,
-        "line_number": 1147
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
-        "is_verified": false,
-        "line_number": 1153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
-        "is_verified": false,
-        "line_number": 1159
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
-        "is_verified": false,
-        "line_number": 1165
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
-        "is_verified": false,
-        "line_number": 1171
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
-        "is_verified": false,
-        "line_number": 1177
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
-        "is_verified": false,
-        "line_number": 1183
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
-        "is_verified": false,
-        "line_number": 1189
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_custom_nonce_sig.json",
-        "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
-        "is_verified": false,
-        "line_number": 1195
-      }
-    ],
-    "tests/ecdsa_sig.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
-        "is_verified": false,
-        "line_number": 6
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
-        "is_verified": false,
-        "line_number": 11
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
-        "is_verified": false,
-        "line_number": 16
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
-        "is_verified": false,
-        "line_number": 31
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
-        "is_verified": false,
-        "line_number": 36
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
-        "is_verified": false,
-        "line_number": 41
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
-        "is_verified": false,
-        "line_number": 46
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
-        "is_verified": false,
-        "line_number": 61
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
-        "is_verified": false,
-        "line_number": 66
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
-        "is_verified": false,
-        "line_number": 71
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
-        "is_verified": false,
-        "line_number": 76
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
-        "is_verified": false,
-        "line_number": 81
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
-        "is_verified": false,
-        "line_number": 86
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
-        "is_verified": false,
-        "line_number": 91
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
-        "is_verified": false,
-        "line_number": 96
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
-        "is_verified": false,
-        "line_number": 101
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
-        "is_verified": false,
-        "line_number": 106
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
-        "is_verified": false,
-        "line_number": 111
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
         "line_number": 116
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
+        "is_verified": false,
+        "line_number": 119
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
         "line_number": 121
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 122
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 123
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 128
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 129
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 130
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 138
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 139
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 140
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 148
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 149
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 176
+        "line_number": 150
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 153
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 158
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 191
+        "line_number": 159
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 196
+        "line_number": 160
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 199
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 206
+        "line_number": 202
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
+        "is_verified": false,
+        "line_number": 203
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
+        "is_verified": false,
+        "line_number": 210
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
         "line_number": 211
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 244
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 221
+        "line_number": 245
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 226
+        "line_number": 269
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 231
+        "line_number": 270
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
-        "is_verified": false,
-        "line_number": 236
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
-        "is_verified": false,
-        "line_number": 241
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
-        "is_verified": false,
-        "line_number": 246
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
-        "is_verified": false,
-        "line_number": 251
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
-        "is_verified": false,
-        "line_number": 256
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
-        "is_verified": false,
-        "line_number": 261
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
-        "is_verified": false,
-        "line_number": 266
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
-        "is_verified": false,
-        "line_number": 271
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
-        "is_verified": false,
-        "line_number": 276
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
-        "is_verified": false,
-        "line_number": 281
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
         "line_number": 286
       },
       {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
-        "is_verified": false,
-        "line_number": 291
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
-        "is_verified": false,
-        "line_number": 301
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
-        "is_verified": false,
-        "line_number": 306
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
-        "is_verified": false,
-        "line_number": 311
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
-        "is_verified": false,
-        "line_number": 316
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
-        "is_verified": false,
-        "line_number": 321
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
-        "is_verified": false,
-        "line_number": 326
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
-        "is_verified": false,
-        "line_number": 331
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
-        "is_verified": false,
-        "line_number": 336
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
-        "is_verified": false,
-        "line_number": 341
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
-        "is_verified": false,
-        "line_number": 346
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
-        "is_verified": false,
-        "line_number": 351
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
-        "is_verified": false,
-        "line_number": 356
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
-        "is_verified": false,
-        "line_number": 361
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
-        "is_verified": false,
-        "line_number": 371
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
-        "is_verified": false,
-        "line_number": 376
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
-        "is_verified": false,
-        "line_number": 381
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
-        "is_verified": false,
-        "line_number": 386
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
-        "is_verified": false,
-        "line_number": 391
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
-        "is_verified": false,
-        "line_number": 396
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
-        "is_verified": false,
-        "line_number": 401
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
-        "is_verified": false,
-        "line_number": 406
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
-        "is_verified": false,
-        "line_number": 411
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
-        "is_verified": false,
-        "line_number": 416
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
-        "is_verified": false,
-        "line_number": 421
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
-        "is_verified": false,
-        "line_number": 426
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
-        "is_verified": false,
-        "line_number": 431
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
-        "is_verified": false,
-        "line_number": 436
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
-        "is_verified": false,
-        "line_number": 441
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
-        "is_verified": false,
-        "line_number": 446
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
-        "is_verified": false,
-        "line_number": 451
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
-        "is_verified": false,
-        "line_number": 456
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
-        "is_verified": false,
-        "line_number": 461
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
-        "is_verified": false,
-        "line_number": 466
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
-        "is_verified": false,
-        "line_number": 471
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
-        "is_verified": false,
-        "line_number": 476
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
-        "is_verified": false,
-        "line_number": 481
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
-        "is_verified": false,
-        "line_number": 486
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
-        "is_verified": false,
-        "line_number": 491
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
-        "is_verified": false,
-        "line_number": 496
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
-        "is_verified": false,
-        "line_number": 501
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
-        "is_verified": false,
-        "line_number": 506
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
-        "is_verified": false,
-        "line_number": 511
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
-        "is_verified": false,
-        "line_number": 516
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
-        "is_verified": false,
-        "line_number": 521
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
-        "is_verified": false,
-        "line_number": 526
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
-        "is_verified": false,
-        "line_number": 531
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
-        "is_verified": false,
-        "line_number": 536
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
-        "is_verified": false,
-        "line_number": 541
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
-        "is_verified": false,
-        "line_number": 546
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
-        "is_verified": false,
-        "line_number": 551
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
-        "is_verified": false,
-        "line_number": 556
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
-        "is_verified": false,
-        "line_number": 561
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
-        "is_verified": false,
-        "line_number": 566
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
-        "is_verified": false,
-        "line_number": 571
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
-        "is_verified": false,
-        "line_number": 576
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
-        "is_verified": false,
-        "line_number": 581
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
-        "is_verified": false,
-        "line_number": 586
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
-        "is_verified": false,
-        "line_number": 591
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
-        "is_verified": false,
-        "line_number": 596
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
-        "is_verified": false,
-        "line_number": 601
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
-        "is_verified": false,
-        "line_number": 606
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
-        "is_verified": false,
-        "line_number": 611
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
-        "is_verified": false,
-        "line_number": 616
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
-        "is_verified": false,
-        "line_number": 621
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
-        "is_verified": false,
-        "line_number": 626
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
-        "is_verified": false,
-        "line_number": 631
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
-        "is_verified": false,
-        "line_number": 636
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
-        "is_verified": false,
-        "line_number": 641
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
-        "is_verified": false,
-        "line_number": 646
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
-        "is_verified": false,
-        "line_number": 651
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
-        "is_verified": false,
-        "line_number": 656
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
-        "is_verified": false,
-        "line_number": 661
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
-        "is_verified": false,
-        "line_number": 666
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
-        "is_verified": false,
-        "line_number": 671
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
-        "is_verified": false,
-        "line_number": 676
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
-        "is_verified": false,
-        "line_number": 681
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
-        "is_verified": false,
-        "line_number": 686
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
-        "is_verified": false,
-        "line_number": 691
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
-        "is_verified": false,
-        "line_number": 696
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
-        "is_verified": false,
-        "line_number": 701
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
-        "is_verified": false,
-        "line_number": 706
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
-        "is_verified": false,
-        "line_number": 711
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
-        "is_verified": false,
-        "line_number": 716
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
-        "is_verified": false,
-        "line_number": 721
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
-        "is_verified": false,
-        "line_number": 731
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
-        "is_verified": false,
-        "line_number": 736
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
-        "is_verified": false,
-        "line_number": 741
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
-        "is_verified": false,
-        "line_number": 746
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
-        "is_verified": false,
-        "line_number": 751
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
-        "is_verified": false,
-        "line_number": 756
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
-        "is_verified": false,
-        "line_number": 761
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
-        "is_verified": false,
-        "line_number": 766
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
-        "is_verified": false,
-        "line_number": 771
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
-        "is_verified": false,
-        "line_number": 776
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
-        "is_verified": false,
-        "line_number": 781
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
-        "is_verified": false,
-        "line_number": 786
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
-        "is_verified": false,
-        "line_number": 791
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
-        "is_verified": false,
-        "line_number": 796
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
-        "is_verified": false,
-        "line_number": 801
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
-        "is_verified": false,
-        "line_number": 806
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
-        "is_verified": false,
-        "line_number": 811
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
-        "is_verified": false,
-        "line_number": 816
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
-        "is_verified": false,
-        "line_number": 821
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
-        "is_verified": false,
-        "line_number": 826
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
-        "is_verified": false,
-        "line_number": 831
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
-        "is_verified": false,
-        "line_number": 836
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
-        "is_verified": false,
-        "line_number": 841
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
-        "is_verified": false,
-        "line_number": 846
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
-        "is_verified": false,
-        "line_number": 851
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
-        "is_verified": false,
-        "line_number": 856
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
-        "is_verified": false,
-        "line_number": 861
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
-        "is_verified": false,
-        "line_number": 866
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
-        "is_verified": false,
-        "line_number": 871
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
-        "is_verified": false,
-        "line_number": 876
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
-        "is_verified": false,
-        "line_number": 881
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
-        "is_verified": false,
-        "line_number": 886
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
-        "is_verified": false,
-        "line_number": 891
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
-        "is_verified": false,
-        "line_number": 896
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
-        "is_verified": false,
-        "line_number": 901
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
-        "is_verified": false,
-        "line_number": 906
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
-        "is_verified": false,
-        "line_number": 911
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
-        "is_verified": false,
-        "line_number": 916
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
-        "is_verified": false,
-        "line_number": 921
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
-        "is_verified": false,
-        "line_number": 926
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
-        "is_verified": false,
-        "line_number": 931
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
-        "is_verified": false,
-        "line_number": 936
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
-        "is_verified": false,
-        "line_number": 941
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
-        "is_verified": false,
-        "line_number": 946
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
-        "is_verified": false,
-        "line_number": 951
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
-        "is_verified": false,
-        "line_number": 956
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
-        "is_verified": false,
-        "line_number": 961
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
-        "is_verified": false,
-        "line_number": 966
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
-        "is_verified": false,
-        "line_number": 971
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
-        "is_verified": false,
-        "line_number": 976
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
-        "is_verified": false,
-        "line_number": 981
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
-        "is_verified": false,
-        "line_number": 986
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
-        "is_verified": false,
-        "line_number": 991
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/ecdsa_sig.json",
-        "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
-        "is_verified": false,
-        "line_number": 996
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
+        "is_verified": false,
+        "line_number": 287
       }
     ]
   },
-  "generated_at": "2026-07-30T09:23:15Z"
+  "generated_at": "2026-08-06T19:48:49Z"
 }

--- a/.secrets.vectors.baseline
+++ b/.secrets.vectors.baseline
@@ -1,0 +1,2910 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "tests/ecdsa_custom_nonce_sig.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
+        "is_verified": false,
+        "line_number": 145
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
+        "is_verified": false,
+        "line_number": 163
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
+        "is_verified": false,
+        "line_number": 211
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
+        "is_verified": false,
+        "line_number": 235
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
+        "is_verified": false,
+        "line_number": 241
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
+        "is_verified": false,
+        "line_number": 253
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
+        "is_verified": false,
+        "line_number": 259
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
+        "is_verified": false,
+        "line_number": 265
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
+        "is_verified": false,
+        "line_number": 277
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
+        "is_verified": false,
+        "line_number": 283
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
+        "is_verified": false,
+        "line_number": 289
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
+        "is_verified": false,
+        "line_number": 301
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
+        "is_verified": false,
+        "line_number": 307
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
+        "is_verified": false,
+        "line_number": 313
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
+        "is_verified": false,
+        "line_number": 319
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
+        "is_verified": false,
+        "line_number": 325
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
+        "is_verified": false,
+        "line_number": 331
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
+        "is_verified": false,
+        "line_number": 337
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
+        "is_verified": false,
+        "line_number": 349
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
+        "is_verified": false,
+        "line_number": 355
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
+        "is_verified": false,
+        "line_number": 361
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
+        "is_verified": false,
+        "line_number": 367
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
+        "is_verified": false,
+        "line_number": 373
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
+        "is_verified": false,
+        "line_number": 379
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
+        "is_verified": false,
+        "line_number": 385
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
+        "is_verified": false,
+        "line_number": 391
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
+        "is_verified": false,
+        "line_number": 397
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
+        "is_verified": false,
+        "line_number": 403
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
+        "is_verified": false,
+        "line_number": 409
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
+        "is_verified": false,
+        "line_number": 415
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
+        "is_verified": false,
+        "line_number": 427
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
+        "is_verified": false,
+        "line_number": 433
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
+        "is_verified": false,
+        "line_number": 445
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
+        "is_verified": false,
+        "line_number": 451
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
+        "is_verified": false,
+        "line_number": 457
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
+        "is_verified": false,
+        "line_number": 463
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
+        "is_verified": false,
+        "line_number": 475
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
+        "is_verified": false,
+        "line_number": 481
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
+        "is_verified": false,
+        "line_number": 487
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
+        "is_verified": false,
+        "line_number": 493
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
+        "is_verified": false,
+        "line_number": 499
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
+        "is_verified": false,
+        "line_number": 505
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
+        "is_verified": false,
+        "line_number": 511
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
+        "is_verified": false,
+        "line_number": 517
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
+        "is_verified": false,
+        "line_number": 523
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
+        "is_verified": false,
+        "line_number": 529
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
+        "is_verified": false,
+        "line_number": 535
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
+        "is_verified": false,
+        "line_number": 541
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
+        "is_verified": false,
+        "line_number": 547
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
+        "is_verified": false,
+        "line_number": 553
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
+        "is_verified": false,
+        "line_number": 559
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
+        "is_verified": false,
+        "line_number": 565
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
+        "is_verified": false,
+        "line_number": 571
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
+        "is_verified": false,
+        "line_number": 577
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
+        "is_verified": false,
+        "line_number": 583
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
+        "is_verified": false,
+        "line_number": 589
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
+        "is_verified": false,
+        "line_number": 595
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
+        "is_verified": false,
+        "line_number": 601
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
+        "is_verified": false,
+        "line_number": 607
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
+        "is_verified": false,
+        "line_number": 613
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
+        "is_verified": false,
+        "line_number": 619
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
+        "is_verified": false,
+        "line_number": 625
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
+        "is_verified": false,
+        "line_number": 631
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
+        "is_verified": false,
+        "line_number": 637
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
+        "is_verified": false,
+        "line_number": 643
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
+        "is_verified": false,
+        "line_number": 649
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
+        "is_verified": false,
+        "line_number": 655
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
+        "is_verified": false,
+        "line_number": 661
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
+        "is_verified": false,
+        "line_number": 667
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
+        "is_verified": false,
+        "line_number": 673
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
+        "is_verified": false,
+        "line_number": 679
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
+        "is_verified": false,
+        "line_number": 685
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
+        "is_verified": false,
+        "line_number": 691
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
+        "is_verified": false,
+        "line_number": 697
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
+        "is_verified": false,
+        "line_number": 703
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
+        "is_verified": false,
+        "line_number": 709
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
+        "is_verified": false,
+        "line_number": 715
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
+        "is_verified": false,
+        "line_number": 721
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
+        "is_verified": false,
+        "line_number": 727
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
+        "is_verified": false,
+        "line_number": 733
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
+        "is_verified": false,
+        "line_number": 739
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
+        "is_verified": false,
+        "line_number": 745
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
+        "is_verified": false,
+        "line_number": 751
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
+        "is_verified": false,
+        "line_number": 757
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
+        "is_verified": false,
+        "line_number": 763
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
+        "is_verified": false,
+        "line_number": 769
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
+        "is_verified": false,
+        "line_number": 775
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
+        "is_verified": false,
+        "line_number": 781
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
+        "is_verified": false,
+        "line_number": 787
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
+        "is_verified": false,
+        "line_number": 793
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
+        "is_verified": false,
+        "line_number": 799
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
+        "is_verified": false,
+        "line_number": 805
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
+        "is_verified": false,
+        "line_number": 811
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
+        "is_verified": false,
+        "line_number": 817
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
+        "is_verified": false,
+        "line_number": 823
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
+        "is_verified": false,
+        "line_number": 829
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
+        "is_verified": false,
+        "line_number": 835
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
+        "is_verified": false,
+        "line_number": 841
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
+        "is_verified": false,
+        "line_number": 847
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
+        "is_verified": false,
+        "line_number": 853
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
+        "is_verified": false,
+        "line_number": 859
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
+        "is_verified": false,
+        "line_number": 865
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
+        "is_verified": false,
+        "line_number": 871
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
+        "is_verified": false,
+        "line_number": 877
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
+        "is_verified": false,
+        "line_number": 883
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
+        "is_verified": false,
+        "line_number": 889
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
+        "is_verified": false,
+        "line_number": 895
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
+        "is_verified": false,
+        "line_number": 901
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
+        "is_verified": false,
+        "line_number": 907
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
+        "is_verified": false,
+        "line_number": 913
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
+        "is_verified": false,
+        "line_number": 919
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
+        "is_verified": false,
+        "line_number": 925
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
+        "is_verified": false,
+        "line_number": 931
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
+        "is_verified": false,
+        "line_number": 937
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
+        "is_verified": false,
+        "line_number": 943
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
+        "is_verified": false,
+        "line_number": 949
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
+        "is_verified": false,
+        "line_number": 955
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
+        "is_verified": false,
+        "line_number": 961
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
+        "is_verified": false,
+        "line_number": 967
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
+        "is_verified": false,
+        "line_number": 973
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
+        "is_verified": false,
+        "line_number": 979
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
+        "is_verified": false,
+        "line_number": 985
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
+        "is_verified": false,
+        "line_number": 991
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
+        "is_verified": false,
+        "line_number": 997
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
+        "is_verified": false,
+        "line_number": 1003
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
+        "is_verified": false,
+        "line_number": 1009
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
+        "is_verified": false,
+        "line_number": 1015
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
+        "is_verified": false,
+        "line_number": 1021
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
+        "is_verified": false,
+        "line_number": 1027
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
+        "is_verified": false,
+        "line_number": 1033
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
+        "is_verified": false,
+        "line_number": 1039
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
+        "is_verified": false,
+        "line_number": 1045
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
+        "is_verified": false,
+        "line_number": 1051
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
+        "is_verified": false,
+        "line_number": 1057
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
+        "is_verified": false,
+        "line_number": 1063
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
+        "is_verified": false,
+        "line_number": 1069
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
+        "is_verified": false,
+        "line_number": 1075
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
+        "is_verified": false,
+        "line_number": 1081
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
+        "is_verified": false,
+        "line_number": 1087
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
+        "is_verified": false,
+        "line_number": 1093
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
+        "is_verified": false,
+        "line_number": 1099
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
+        "is_verified": false,
+        "line_number": 1105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
+        "is_verified": false,
+        "line_number": 1111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
+        "is_verified": false,
+        "line_number": 1117
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
+        "is_verified": false,
+        "line_number": 1123
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
+        "is_verified": false,
+        "line_number": 1129
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
+        "is_verified": false,
+        "line_number": 1135
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
+        "is_verified": false,
+        "line_number": 1141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
+        "is_verified": false,
+        "line_number": 1147
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
+        "is_verified": false,
+        "line_number": 1153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
+        "is_verified": false,
+        "line_number": 1159
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
+        "is_verified": false,
+        "line_number": 1165
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
+        "is_verified": false,
+        "line_number": 1171
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
+        "is_verified": false,
+        "line_number": 1177
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
+        "is_verified": false,
+        "line_number": 1183
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
+        "is_verified": false,
+        "line_number": 1189
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_custom_nonce_sig.json",
+        "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
+        "is_verified": false,
+        "line_number": 1195
+      }
+    ],
+    "tests/ecdsa_sig.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
+        "is_verified": false,
+        "line_number": 101
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
+        "is_verified": false,
+        "line_number": 126
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
+        "is_verified": false,
+        "line_number": 146
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
+        "is_verified": false,
+        "line_number": 156
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
+        "is_verified": false,
+        "line_number": 161
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
+        "is_verified": false,
+        "line_number": 191
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
+        "is_verified": false,
+        "line_number": 196
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
+        "is_verified": false,
+        "line_number": 201
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
+        "is_verified": false,
+        "line_number": 206
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
+        "is_verified": false,
+        "line_number": 211
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
+        "is_verified": false,
+        "line_number": 221
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
+        "is_verified": false,
+        "line_number": 226
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
+        "is_verified": false,
+        "line_number": 231
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
+        "is_verified": false,
+        "line_number": 236
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
+        "is_verified": false,
+        "line_number": 241
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
+        "is_verified": false,
+        "line_number": 251
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
+        "is_verified": false,
+        "line_number": 261
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
+        "is_verified": false,
+        "line_number": 276
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
+        "is_verified": false,
+        "line_number": 281
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
+        "is_verified": false,
+        "line_number": 286
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
+        "is_verified": false,
+        "line_number": 301
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
+        "is_verified": false,
+        "line_number": 306
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
+        "is_verified": false,
+        "line_number": 311
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
+        "is_verified": false,
+        "line_number": 326
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
+        "is_verified": false,
+        "line_number": 331
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
+        "is_verified": false,
+        "line_number": 346
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
+        "is_verified": false,
+        "line_number": 351
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
+        "is_verified": false,
+        "line_number": 361
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
+        "is_verified": false,
+        "line_number": 366
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
+        "is_verified": false,
+        "line_number": 371
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
+        "is_verified": false,
+        "line_number": 376
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
+        "is_verified": false,
+        "line_number": 386
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
+        "is_verified": false,
+        "line_number": 391
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
+        "is_verified": false,
+        "line_number": 396
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
+        "is_verified": false,
+        "line_number": 401
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
+        "is_verified": false,
+        "line_number": 406
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
+        "is_verified": false,
+        "line_number": 411
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
+        "is_verified": false,
+        "line_number": 426
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
+        "is_verified": false,
+        "line_number": 431
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
+        "is_verified": false,
+        "line_number": 436
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
+        "is_verified": false,
+        "line_number": 441
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
+        "is_verified": false,
+        "line_number": 446
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
+        "is_verified": false,
+        "line_number": 451
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
+        "is_verified": false,
+        "line_number": 461
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
+        "is_verified": false,
+        "line_number": 466
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
+        "is_verified": false,
+        "line_number": 471
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
+        "is_verified": false,
+        "line_number": 476
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
+        "is_verified": false,
+        "line_number": 481
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
+        "is_verified": false,
+        "line_number": 491
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
+        "is_verified": false,
+        "line_number": 496
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
+        "is_verified": false,
+        "line_number": 501
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
+        "is_verified": false,
+        "line_number": 506
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
+        "is_verified": false,
+        "line_number": 511
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
+        "is_verified": false,
+        "line_number": 516
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
+        "is_verified": false,
+        "line_number": 521
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
+        "is_verified": false,
+        "line_number": 526
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
+        "is_verified": false,
+        "line_number": 531
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
+        "is_verified": false,
+        "line_number": 536
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
+        "is_verified": false,
+        "line_number": 541
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
+        "is_verified": false,
+        "line_number": 546
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
+        "is_verified": false,
+        "line_number": 551
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
+        "is_verified": false,
+        "line_number": 556
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
+        "is_verified": false,
+        "line_number": 561
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
+        "is_verified": false,
+        "line_number": 566
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
+        "is_verified": false,
+        "line_number": 571
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
+        "is_verified": false,
+        "line_number": 581
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
+        "is_verified": false,
+        "line_number": 586
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
+        "is_verified": false,
+        "line_number": 591
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
+        "is_verified": false,
+        "line_number": 596
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
+        "is_verified": false,
+        "line_number": 601
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
+        "is_verified": false,
+        "line_number": 611
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
+        "is_verified": false,
+        "line_number": 616
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
+        "is_verified": false,
+        "line_number": 621
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
+        "is_verified": false,
+        "line_number": 626
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
+        "is_verified": false,
+        "line_number": 631
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
+        "is_verified": false,
+        "line_number": 636
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
+        "is_verified": false,
+        "line_number": 641
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
+        "is_verified": false,
+        "line_number": 646
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
+        "is_verified": false,
+        "line_number": 651
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
+        "is_verified": false,
+        "line_number": 656
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
+        "is_verified": false,
+        "line_number": 661
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
+        "is_verified": false,
+        "line_number": 666
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
+        "is_verified": false,
+        "line_number": 671
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
+        "is_verified": false,
+        "line_number": 676
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
+        "is_verified": false,
+        "line_number": 681
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
+        "is_verified": false,
+        "line_number": 686
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
+        "is_verified": false,
+        "line_number": 691
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
+        "is_verified": false,
+        "line_number": 696
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
+        "is_verified": false,
+        "line_number": 701
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
+        "is_verified": false,
+        "line_number": 706
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
+        "is_verified": false,
+        "line_number": 711
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
+        "is_verified": false,
+        "line_number": 716
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
+        "is_verified": false,
+        "line_number": 721
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
+        "is_verified": false,
+        "line_number": 726
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
+        "is_verified": false,
+        "line_number": 731
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
+        "is_verified": false,
+        "line_number": 736
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
+        "is_verified": false,
+        "line_number": 741
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
+        "is_verified": false,
+        "line_number": 746
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
+        "is_verified": false,
+        "line_number": 751
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
+        "is_verified": false,
+        "line_number": 756
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
+        "is_verified": false,
+        "line_number": 761
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
+        "is_verified": false,
+        "line_number": 766
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
+        "is_verified": false,
+        "line_number": 771
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
+        "is_verified": false,
+        "line_number": 776
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
+        "is_verified": false,
+        "line_number": 781
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
+        "is_verified": false,
+        "line_number": 786
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
+        "is_verified": false,
+        "line_number": 791
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
+        "is_verified": false,
+        "line_number": 796
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
+        "is_verified": false,
+        "line_number": 801
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
+        "is_verified": false,
+        "line_number": 806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
+        "is_verified": false,
+        "line_number": 811
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
+        "is_verified": false,
+        "line_number": 816
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
+        "is_verified": false,
+        "line_number": 821
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
+        "is_verified": false,
+        "line_number": 826
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
+        "is_verified": false,
+        "line_number": 831
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
+        "is_verified": false,
+        "line_number": 836
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
+        "is_verified": false,
+        "line_number": 841
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
+        "is_verified": false,
+        "line_number": 846
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
+        "is_verified": false,
+        "line_number": 851
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
+        "is_verified": false,
+        "line_number": 856
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
+        "is_verified": false,
+        "line_number": 861
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
+        "is_verified": false,
+        "line_number": 866
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
+        "is_verified": false,
+        "line_number": 871
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
+        "is_verified": false,
+        "line_number": 876
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
+        "is_verified": false,
+        "line_number": 881
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
+        "is_verified": false,
+        "line_number": 886
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
+        "is_verified": false,
+        "line_number": 891
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
+        "is_verified": false,
+        "line_number": 896
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
+        "is_verified": false,
+        "line_number": 901
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
+        "is_verified": false,
+        "line_number": 906
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
+        "is_verified": false,
+        "line_number": 911
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
+        "is_verified": false,
+        "line_number": 916
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
+        "is_verified": false,
+        "line_number": 921
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
+        "is_verified": false,
+        "line_number": 926
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
+        "is_verified": false,
+        "line_number": 931
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
+        "is_verified": false,
+        "line_number": 936
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
+        "is_verified": false,
+        "line_number": 941
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
+        "is_verified": false,
+        "line_number": 946
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
+        "is_verified": false,
+        "line_number": 951
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
+        "is_verified": false,
+        "line_number": 956
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
+        "is_verified": false,
+        "line_number": 961
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
+        "is_verified": false,
+        "line_number": 966
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
+        "is_verified": false,
+        "line_number": 971
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
+        "is_verified": false,
+        "line_number": 976
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
+        "is_verified": false,
+        "line_number": 981
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
+        "is_verified": false,
+        "line_number": 986
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
+        "is_verified": false,
+        "line_number": 991
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/ecdsa_sig.json",
+        "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
+        "is_verified": false,
+        "line_number": 996
+      }
+    ]
+  },
+  "generated_at": "2026-08-06T19:46:40Z"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,9 @@ copy is for — `cp file file.bak`, then put it back.
     # after touching pyproject.toml; the uv-lock hook does it too
     uv lock
 
-    # after adding to tests/ecdsa*_sig.json, whose known findings are
-    # recorded rather than excluded
+    # after adding a hex constant to a test module; the vendored vector
+    # data has a baseline of its own, whose command is in CONTRIBUTING.md.
+    # Neither file is excluded from the scan, only recorded as reviewed
     uvx --from detect-secrets detect-secrets scan --baseline .secrets.baseline
 
 ## The workflows that gate, and the four that do not
@@ -244,9 +245,11 @@ findings.
   `PYTHONDONTWRITEBYTECODE=1`, with a passing baseline run before and a
   passing control run after, is what makes a hand verification mean
   anything. cosmic-ray does not have the problem
-- **adding to the json vector files fails the `detect-secrets` hook**
-  until `.secrets.baseline` is regenerated; the command is in
-  CONTRIBUTING.md, and reading its diff is the point of the baseline
+- **`detect-secrets` runs twice, over two baselines**: the tree with the
+  entropy detectors on, and `tests/*.csv`/`tests/*.json` with them off,
+  those files being hex and nothing else. Adding to either side fails its
+  hook until that baseline is regenerated; both commands are in
+  CONTRIBUTING.md, and reading the diff is the point of a baseline
 - **the `published` workflow went green with 0.7.1**, on 4 August 2026,
   nineteen cells out of nineteen, having been nineteen out of nineteen red
   the day before: 0.4.0 had no arm64 wheel and its sdist no longer built,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,14 +244,27 @@ release.
   something, so new code arrives with the tests that cover its branches
 - **the secret-scanning baseline follows the vectors.** The test data is
   private keys, so `detect-secrets` would report all of it; the known
-  findings live in `.secrets.baseline`, reviewed once. Adding to
-  `tests/ecdsa_sig.json` or `tests/ecdsa_custom_nonce_sig.json` therefore
-  fails that hook until the baseline is regenerated:
+  findings are recorded as reviewed rather than excluded, in two baselines
+  that differ only in whether the entropy detectors run. Adding a hex
+  constant to a test module, or a vector to a file under `tests/` matching
+  `*.csv` or `*.json`, fails the corresponding hook until its baseline is
+  regenerated:
 
+      # the tree, entropy detectors on; the vendored vector data is
+      # excluded by a filter the baseline itself records
       uvx --from detect-secrets detect-secrets scan \
           --baseline .secrets.baseline
 
-  read the diff before committing it, which is the whole point of the
+      # the vendored vector data, entropy detectors off: these files are
+      # 64-character hex and nothing else, so a new vector would read as a
+      # new secret. The paths are the hook's `files` pattern spelled out
+      uvx --from detect-secrets detect-secrets scan \
+          --disable-plugin HexHighEntropyString \
+          --disable-plugin Base64HighEntropyString \
+          tests/*.csv tests/*.json \
+          > .secrets.vectors.baseline
+
+  read the diff before committing it, which is the whole point of a
   baseline: what appears there is what nobody has looked at yet
 - **new wrapped functionality is validated against external vectors.**
   A test that compares these bindings against themselves proves nothing.


### PR DESCRIPTION
Closes #29.

`.secrets.baseline` was generated with `HexHighEntropyString` and
`Base64HighEntropyString` off, and it is the baseline that decides which
plugins run — so the two detectors were off **everywhere**, not just over the
two json files that motivated turning them off.

The reason not to exclude those files stands (an AWS key planted in one of
them went unseen while they were excluded), so the split is by plugin set
rather than by scan, one baseline each, and `detect-secrets` runs twice:

| hook | baseline | plugins | subject | findings |
| --- | --- | --- | --- | --- |
| credentials of other systems | `.secrets.baseline` | all | everything else | 38 |
| the vendored vector data | `.secrets.vectors.baseline` | entropy pair off | `tests/*.csv`, `tests/*.json` | 398 |

The 38 newly recorded findings were reviewed: 37 are hex constants written
inline in `tests/test_vectors.py` and `tests/test_properties.py`, and the
last is `"-DSECP256K1_BUILD_BENCHMARK=OFF"` in `scripts/cffi_build.py`, which
the base64 detector reads as a secret.

The first hook's exclusion is the filter its own baseline records, so the
pattern is stated once, in the second hook's `files`. It names the second
baseline too: `detect-secrets` skips the baseline `--baseline` points at, and
that one is 40-character hashes by the hundred.

## Handed something bad, and watched to fail

```
$ # a 64-character hex constant appended to tests/test_hashes.py,
$ # an AWS access key inserted into tests/ecdsa_sig.json
$ uvx pre-commit run detect-secrets --all-files
detect-secrets (credentials of other systems)............................Failed
Secret Type: Hex High Entropy String
Location:    tests/test_hashes.py:49
detect-secrets (the vendored vector data)................................Failed
Secret Type: AWS Access Key
Location:    tests/ecdsa_sig.json:3
$ # both files restored
$ uvx pre-commit run detect-secrets --all-files   # exit 0
```

`uvx pre-commit run --all-files` is green, and the suite is 104 passed at
100.00% coverage.

## Summary by Sourcery

Partition secret scanning into two detect-secrets hooks so entropy-based detectors run across the tree but are disabled for vendored test vector data, and document the new workflow and baselines.

Bug Fixes:
- Ensure entropy-based secret detectors run on all non-vector files so injected secrets in previously excluded test data are now detected.

Enhancements:
- Introduce a second detect-secrets hook and dedicated baseline for vector CSV/JSON files with entropy plugins disabled while keeping all other detectors active.
- Clarify contributor documentation on when and how to regenerate detect-secrets baselines for code, tests, and vector files, including separate commands for each baseline.
- Update internal AI usage guide to describe the dual detect-secrets baseline setup and its impact on contribution workflow.

Chores:
- Add and populate a new .secrets.vectors.baseline file alongside the existing .secrets.baseline.