### PR TITLE
Keep the release path out of the branch concurrency groups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,13 @@ on:
   pull_request:
   # allows the release workflow to reuse this gate
   workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
   # the escape hatch: a run on demand for a branch whose pull request is
   # not open yet
   workflow_dispatch:
@@ -41,9 +48,21 @@ permissions:
 # compute the same group when the release workflow calls both, and
 # cancel-in-progress would have the second cancel the first: a release
 # losing either its lint gate or its whole build matrix, on a path that
-# runs once per release and where nobody is watching for a cancellation
+# runs once per release and where nobody is watching for a cancellation.
+#
+# github.ref has the same shape of problem one level down, and it is why
+# the suffix is there. Inside a called workflow that context is the
+# caller's ref, so a rehearsal -- a workflow_dispatch of release.yml on a
+# branch, which is what RELEASING.md prescribes -- computes
+# lint-refs/heads/<branch>, the very group a push to that branch or a
+# direct dispatch of this workflow computes. One then kills the other:
+# either the rehearsal dies mid-build, or it cancels the run of the push.
+# A tag run is unaffected, refs/tags/v* being a ref nothing else uses.
+# release.yml passes a suffix of its own, which keeps the release path
+# out of the branch groups while still letting a second rehearsal of the
+# same branch supersede the first
 concurrency:
-  group: lint-${{ github.ref }}
+  group: lint-${{ github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
   # that the tagged commit does not lint
   lint:
     uses: ./.github/workflows/lint.yml
+    with:
+      # what keeps this run out of the branch concurrency groups: inside a
+      # called workflow github.ref is the ref of this workflow's own run,
+      # so without it a rehearsal dispatched on a branch and a push to that
+      # branch share a group and cancel each other. The reasoning is in
+      # lint.yml, next to the group; the value only has to be a string no
+      # branch group can contain
+      concurrency-suffix: "-release"
 
   # what a version cannot survive being wrong about, checked before
   # anything is built and long before anything is uploaded: a version is
@@ -116,6 +124,8 @@ jobs:
       version-suffix: >-
         ${{ github.event_name == 'workflow_dispatch'
         && format('.dev{0}', github.run_number) || '' }}
+      # see the lint job above
+      concurrency-suffix: "-release"
 
   # the two publish jobs differ only in where they upload to, and are two
   # jobs rather than one parameterized by an expression on purpose. The

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ on:
           index has not already consumed.
         type: string
         default: ""
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
   # the escape hatch: the matrix on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:
@@ -45,9 +51,10 @@ permissions:
   contents: read
 
 # cancel superseded runs on the same branch/PR; named literally rather
-# than through github.workflow, for the reason given in lint.yml
+# than through github.workflow, and discriminated by an input rather than
+# left to github.ref alone, for the two reasons given in lint.yml
 concurrency:
-  group: test-${{ github.ref }}
+  group: test-${{ github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,11 @@ findings.
 - `concurrency` groups are named literally (`test-${{ github.ref }}`),
   never through `github.workflow`: in a called workflow what that resolves
   to is undocumented, and if it is the caller's name the two workflows a
-  release calls would cancel each other
+  release calls would cancel each other. `github.ref` in a called workflow
+  is the *caller's* ref, so a reusable workflow also takes a
+  `concurrency-suffix` input, and `release.yml` passes one: without it a
+  rehearsal dispatched on a branch shares a group with a push to that
+  branch, and one cancels the other
 - `actions/checkout` passes `persist-credentials: false`, so the token
   does not stay in `.git/config` where an artifact upload could carry it
 - uv commands pass `--locked`, never `--frozen`: the second takes


### PR DESCRIPTION
Closes #30.

`github.ref` inside a called workflow is the **caller's** ref, so
`lint-${{ github.ref }}` and `test-${{ github.ref }}` put a rehearsal — a
`workflow_dispatch` of `release.yml` on a branch, which is what RELEASING.md
prescribes — into `lint-refs/heads/<branch>` and `test-refs/heads/<branch>`:
the very groups a push to that branch, or a direct dispatch of `test.yml`,
computes. With `cancel-in-progress: true` one kills the other, either way
round.

Both reusable workflows now take a `concurrency-suffix` input and append it
to their group; `release.yml` passes `-release` to both. A tag run was
already unique and stays so; a second rehearsal of the same branch still
supersedes the first, which is what cancellation is for.

The group comment in `lint.yml` reasoned about the *name* and not about the
shared ref — it now carries both, and CLAUDE.md's workflow conventions say so
too.

## Summary by Sourcery

Adjust workflow concurrency grouping so release rehearsals no longer conflict with branch runs while preserving cancellation of superseded runs.

Enhancements:
- Add an optional concurrency-suffix input to reusable lint and test workflows and incorporate it into their concurrency group names.
- Update release workflow to pass a -release concurrency suffix when invoking lint and test workflows, isolating release runs from branch concurrency groups.
- Clarify workflow concurrency conventions in CLAUDE.md to document github.ref behavior in called workflows and the use of concurrency-suffix.