### PR TITLE
Refuse a wheel whose extensions disagree on static or dynamic

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,12 @@ What it does with the result:
 - the wheel tag is set from the extension mode: `infer_tag` for a static
   extension, which is ABI-specific, and an explicit
   `py3-none-<platform>` for a dynamic one, which is not
-- a wheel mixing both modes is reported as a warning, not an error; it
-  cannot arise from the configurations CI builds
+- a wheel mixing both modes raises, and so does one with no extension at
+  all. Neither can arise from the configurations CI builds, which is the
+  argument for refusing them rather than for reporting them: nothing
+  downstream inspects a wheel's tag against its contents, so a `py3-none`
+  wheel carrying a `cpNN` extension would install on any interpreter of
+  the platform and fail to import on most of them
 
 `dynamic_platform_tag()` is the one place that has to name the target
 platform itself, since a dynamic wheel gets no tag from the interpreter

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -68,9 +68,15 @@ class CustomBuildHook(BuildHookInterface[Any]):
         An sdist returns at once, carrying sources and no build; a wheel
         gets `pure_python` cleared, every artifact force-included under its
         own name, and one of the two tags -- inferred for a static build,
-        `py3-none-<platform>` for a dynamic one. A wheel holding both kinds
-        is a build that went wrong in a way nothing downstream could
-        notice, so it is reported here rather than shipped quietly.
+        `py3-none-<platform>` for a dynamic one.
+
+        Raises RuntimeError unless the modules agree on which of the two it
+        is. The tag is a property of the whole wheel, so a wheel holding
+        both kinds has no tag that is true of it: `py3-none-<platform>`
+        over a `cpNN` extension is installable on any interpreter of that
+        platform and broken on most of them. Nothing downstream could
+        notice, and no configuration CI builds can produce it -- which is
+        why it is refused here rather than reported and shipped.
         """
         if self.target_name != "wheel":
             return
@@ -82,7 +88,12 @@ class CustomBuildHook(BuildHookInterface[Any]):
             shutil.rmtree(build_dir)
 
         build_data["pure_python"] = False
-        static = True
+        # one entry per module, True where libsecp256k1 is linked into the
+        # extension. A set rather than a running flag: the disagreement is
+        # what has to be caught, and a flag catches it in one order of the
+        # modules only -- a dynamic module after a static one used to leave
+        # the wheel tagged py3-none with no message at all
+        modes = set()
 
         for script, ext_name in cffi_config:
             ext = self.get_ext_object(script, ext_name)
@@ -93,18 +104,20 @@ class CustomBuildHook(BuildHookInterface[Any]):
             temp_dir.mkdir(parents=True)
 
             ffi, artifacts = ext.create_cffi(temp_dir)
-
-            if ffi._assigned_source[1]:  # static
-                if not static:
-                    msg = "Warning: this wheel contains both dynamic and static extensions"
-                    print(msg)
-            else:  # dynamic
-                static = False
+            modes.add(bool(ffi._assigned_source[1]))
 
             for artifact in artifacts:
                 build_data["force_include"][artifact] = artifact.name
 
-        if static:
+        # an empty set is the same failure seen from the other side: a
+        # wheel with pure_python cleared and no extension in it
+        if len(modes) != 1:
+            raise RuntimeError(
+                "the cffi modules disagree on static/dynamic, "
+                f"or there are none: {modes}"
+            )
+
+        if modes.pop():
             build_data["infer_tag"] = True
         else:
             build_data["tag"] = f"py3-none-{self.dynamic_platform_tag()}"


### PR DESCRIPTION
Closes #33.

The tag is a property of the whole wheel, so a wheel holding both kinds has
no tag that is true of it. Nothing downstream inspects a tag against the
contents it labels — which is the argument for refusing the wheel rather
than printing about it, on the one place in the build backend where a silent
fallback produces a wrong artifact instead of a failed build.

While there: the running flag only caught one of the two orders. It started
`True` and was cleared by a dynamic module, and the message was printed by a
*static* module finding it already cleared — so with the modules the other
way round the wheel came out `py3-none-<platform>` with a static extension in
it and nothing said so at all. A set of the modes has no order to get wrong,
and its empty case is the same failure from the other side: `pure_python`
cleared and no extension in the wheel.

## Verified by building

| build | result |
| --- | --- |
| `uv build --wheel` | `…-cp314-cp314-macosx_26_0_arm64.whl` |
| `BTCLIB_LIBSECP256K1_DYNAMIC=true uv build --wheel` | `…-py3-none-macosx_26_0_arm64.whl` |
| `modes = {True, False}` planted before the check | `RuntimeError: the cffi modules disagree on static/dynamic, or there are none: {False, True}` |
| file restored, rebuilt | green |

`PYTHONDONTWRITEBYTECODE=1` throughout, the mutation and its restore being
the same size.

## Summary by Sourcery

Reject wheels whose CFFI extensions do not consistently use static or dynamic linking, ensuring the wheel tag accurately reflects its contents.

New Features:
- Raise a RuntimeError when a wheel contains both static and dynamic CFFI extensions or no extensions at all.

Bug Fixes:
- Prevent wheels from being tagged as generic py3-none when they include a static cpNN extension, which previously produced silently broken artifacts.

Enhancements:
- Replace the single running static/dynamic flag with a per-module mode set to robustly detect disagreements in extension linkage.
- Clarify build script documentation to describe error behavior for mixed-mode or extension-less wheels.