### PR TITLE
Make the copyright hook read files: --enforce-all, and the .pyi with it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,10 +153,19 @@ repos:
     rev: 0.1.1
     hooks:
       - id: copyright-notice
-        args: [--notice=COPYRIGHT]
-        # "python" as a filename pattern never matched anything: the
-        # notice was checked on no file at all
-        files: \.py$
+        # --enforce-all, because without it the hook intersects the files
+        # pre-commit hands it with `git diff --staged --diff-filter=A` and
+        # checks the notice on newly *added* staged files alone. On a clean
+        # checkout that set is empty, so the run in the lint workflow --
+        # `pre-commit run --all-files`, the one that gates a pull request --
+        # was checking no file at all, whatever the pattern below matched
+        args: [--notice=COPYRIGHT, --enforce-all]
+        # "python" as a filename pattern never matched anything either. The
+        # optional i is the same miss one extension over:
+        # stubs/_btclib_libsecp256k1.pyi is a source file of this project,
+        # named in mypy_path and force-included in the sdist, and its header
+        # was the pre-MIT one for as long as nothing read it
+        files: \.pyi?$
   # ruff replaces black, isort, flake8, autoflake, pyupgrade, bandit,
   # pydocstringformatter and yesqa: one tool, one config section in
   # pyproject.toml, and a fraction of the runtime. The rule selection

--- a/stubs/_btclib_libsecp256k1.pyi
+++ b/stubs/_btclib_libsecp256k1.pyi
@@ -1,10 +1,7 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 """Type stub for the cffi generated extension module.
 


### PR DESCRIPTION
Closes #37 — and the issue understated it. Three misses, of the same shape as
the one the comment on that hook already records.

1. **`files: \.py$`** never matched `stubs/_btclib_libsecp256k1.pyi`, a source
   file of this project (named in `mypy_path`, force-included in the sdist).
   That is the `\.pyi?$` the issue asked for.
2. **`--enforce-all` was missing**, and this is the larger one. Without it the
   tool intersects the filenames pre-commit hands it with
   `git diff --staged --name-only --diff-filter=A` — newly *added* staged
   files, nothing else. On a clean checkout that set is empty, so
   `pre-commit run --all-files`, the run the `lint` workflow makes and the one
   that gates a pull request, **was checking no file at all**, whatever the
   pattern matched. The hook has been green since it was added because it
   never read a file.
3. With both fixed, exactly one file failed: the stub, whose header was still
   the pre-MIT btclib one — five lines about copying and propagating where
   `COPYRIGHT` has two about the MIT license. `03ccccc` (lowercase `(c)`) and
   `cc6cd89` (shorten the header) moved every `.py` and could not have moved
   this one, which is the whole argument for the hook.

## Handed something bad, and watched to fail

```
$ # notice stripped from the stub
WARNING:root:File stubs/_btclib_libsecp256k1.pyi does not contain a valid copyright notice.
$ # and from btclib_libsecp256k1/mult.py as well
WARNING:root:File btclib_libsecp256k1/mult.py does not contain a valid copyright notice.
WARNING:root:File stubs/_btclib_libsecp256k1.pyi does not contain a valid copyright notice.
$ # both restored
copyright-notice.........................................................Passed
```

## Summary by Sourcery

Ensure the copyright-notice pre-commit hook actually validates all relevant Python sources, including stub files, and align a stub’s header with the project’s MIT license notice.

Bug Fixes:
- Fix the copyright-notice hook so it runs on all files during pre-commit checks instead of only newly added staged files.
- Expand the hook’s file pattern so that Python stub (.pyi) files are also validated.

Build:
- Update pre-commit configuration to pass --enforce-all and match both .py and .pyi files for the copyright-notice hook.

Chores:
- Update the copyright header in the _btclib_libsecp256k1 type stub to use the current MIT license text.