### PR TITLE
Drop PYTHON_VERSION and OS_NAME from the two test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -538,9 +538,6 @@ jobs:
         #   ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10",
         #    "pypy-3.11"]
         python-version: ["3.14"]
-    env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      OS_NAME: ${{ matrix.os }}
     needs: [build-windows, build-dynamic]
 
     steps:
@@ -611,9 +608,6 @@ jobs:
         #       python-version: "pypy-3.11"
         #     - os: windows-11-arm
         #       python-version: "3.10"
-    env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      OS_NAME: ${{ matrix.os }}
     needs: build-cibuildwheel
 
     steps:


### PR DESCRIPTION
Closes #38.

Nothing reads either one — not the tests, not the scripts, not `pyproject.toml` — and in a workflow where every choice carries its reasoning, dead configuration reads as load-bearing. Both values are already in the job name, which is where a reader of a failed run looks for them.

## Summary by Sourcery

CI:
- Remove unused PYTHON_VERSION and OS_NAME environment variables from Windows and cibuildwheel test jobs in the GitHub Actions workflow.