### PR TITLE
Check the HISTORY.md section before the release builds anything

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,29 @@ jobs:
             exit 1
           fi
 
+      # the fourth invariant, and the last one that was checked only
+      # after the point of no return: github-release reads the tag's
+      # section out of HISTORY.md for the release notes, and a section
+      # that is not there is a ::warning:: with generated notes as the
+      # fallback -- correct there, PyPI having accepted the upload
+      # already, and no use at all as the place the omission is found.
+      # The same awk, on the same push path as the tag comparison, so
+      # release day starts with all four green. The fallback downstream
+      # stays: it covers the release deleted by hand and recreated
+      - name: Check that HISTORY.md has a section for the tag
+        if: github.event_name == 'push'
+        run: |
+          notes=$(awk -v tag="$GITHUB_REF_NAME" '
+            $0 ~ "^## " tag "( |$)" {found=1; next}
+            /^## / && found {exit}
+            found {print}
+          ' HISTORY.md)
+          if [ -z "$notes" ]; then
+            echo "::error::HISTORY.md has no $GITHUB_REF_NAME section to release with"
+            exit 1
+          fi
+          echo "HISTORY.md documents $GITHUB_REF_NAME"
+
       # the version of the wrapped library is a second thing this package
       # declares twice: the tag named in README.md, and the commit the
       # submodule is pinned to. The tag is resolved at the source rather

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,9 @@ decides which index is reached. The `version-check` job cross-checks
 them, and runs before anything is built: a `v0.7.1` tag on a tree still
 reading `0.7.1rc1` fails there, rather than burning `0.7.1rc1` on PyPI.
 The same job checks that `uv.lock` carries the version the tree declares,
-and that the libsecp256k1 release named in `README.md` is the commit the
-submodule is pinned to.
+that the libsecp256k1 release named in `README.md` is the commit the
+submodule is pinned to, and that `HISTORY.md` has a section for the tag —
+four invariants, all of them before the point of no return.
 
 ## Which version string is which
 
@@ -359,8 +360,8 @@ metadata, which is more than `twine check --strict` can say. What it
 cannot cover is the trusted publisher on PyPI itself, a separate
 registration that can be wrong on its own, nor the deployment branch
 policy of the `pypi` environment, which the environment a rehearsal does
-reach has none of, nor the tag comparison of `version-check`, there
-being no tag.
+reach has none of, nor the two checks of `version-check` that need a tag:
+the version comparison and the `HISTORY.md` section.
 
 ## When a release turns out to be broken
 


### PR DESCRIPTION
Closes #31.

The same `awk`, on the same push path as the tag comparison, so release day
starts with all four invariants green. The `::warning::` fallback in
`github-release` stays: it still covers a release deleted by hand and
recreated.

Run against `HISTORY.md` as it stands:

| tag | result |
| --- | --- |
| `v0.7.1.1` | found, 44 lines |
| `v0.7.1` | found, 161 lines |
| `v0.7.1.2` | `::error::HISTORY.md has no v0.7.1.2 section to release with` |
| `v9.9.9` | same error |

`v0.7.1.2` failing is the point: it is the version open in `pyproject.toml`
whose notes are not written yet, and it is exactly the case that used to be
found after PyPI had accepted the upload.

RELEASING.md's opening paragraph now says four invariants, and the rehearsal
section says the rehearsal covers neither of the two that need a tag.

## Summary by Sourcery

Enforce that releases only proceed when the tagged version has a documented section in HISTORY.md and document this additional invariant in the release process guide.

Enhancements:
- Add a release workflow check that verifies HISTORY.md contains a section matching the pushed tag before any build or publish steps run.

Documentation:
- Update RELEASING.md to describe the four pre-release invariants and clarify which checks are covered during a release rehearsal.