### PR TITLE
Fail a release tag that is not on master, before anything is built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # the whole history, and every branch with it: the ancestry
+          # check below has nothing to read in the single commit the
+          # default shallow clone fetches
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
@@ -87,6 +91,26 @@ jobs:
             echo "::error::$version is not a final version; $hint"
             exit 1
           fi
+
+      # CONTRIBUTING.md and RELEASING.md both say a release is a tag on
+      # the merge commit on master; nothing enforced it. The deployment
+      # tag policy of the pypi environment constrains the *name* of the
+      # ref and nothing else, so a v* tag on a branch head, on an old dev
+      # state or on a fork-synced commit reaches the environment exactly
+      # as the release tag does -- and the reviewer approving sees the
+      # tag name, not its ancestry. This is the ancestry, before the
+      # matrix builds anything.
+      # origin/master rather than a fetch of its own: the checkout above
+      # takes the whole history, remote-tracking branches included, and a
+      # missing origin/master fails the step, which is the safe way round
+      - name: Check that the tag is on master
+        if: github.event_name == 'push'
+        run: |
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::$GITHUB_REF_NAME is on $GITHUB_SHA, which is not on master"
+            exit 1
+          fi
+          echo "$GITHUB_SHA is on master"
 
       # the fourth invariant, and the last one that was checked only
       # after the point of no return: github-release reads the tag's

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,8 +14,9 @@ them, and runs before anything is built: a `v0.7.1` tag on a tree still
 reading `0.7.1rc1` fails there, rather than burning `0.7.1rc1` on PyPI.
 The same job checks that `uv.lock` carries the version the tree declares,
 that the libsecp256k1 release named in `README.md` is the commit the
-submodule is pinned to, and that `HISTORY.md` has a section for the tag —
-four invariants, all of them before the point of no return.
+submodule is pinned to, that `HISTORY.md` has a section for the tag, and
+that the tagged commit is on `master`. Every invariant a release rests on
+is checked there, before the point of no return.
 
 ## Which version string is which
 
@@ -360,8 +361,9 @@ metadata, which is more than `twine check --strict` can say. What it
 cannot cover is the trusted publisher on PyPI itself, a separate
 registration that can be wrong on its own, nor the deployment branch
 policy of the `pypi` environment, which the environment a rehearsal does
-reach has none of, nor the two checks of `version-check` that need a tag:
-the version comparison and the `HISTORY.md` section.
+reach has none of, nor the checks of `version-check` that need a tag: the
+version comparison, the `HISTORY.md` section, and the ancestry on
+`master`.
 
 ## When a release turns out to be broken
 
@@ -411,3 +413,10 @@ next fork.
   the whole matrix had been built:
 
       gh api repos/{owner}/{repo}/environments/pypi/deployment-branch-policies
+
+  What that rule constrains is the *name* of the ref, and nothing else: a
+  `v*` tag pushed on a branch head, on an old `dev` state or on a
+  fork-synced commit satisfies it exactly as the release tag does, and
+  the reviewer approving sees the tag name rather than its ancestry.
+  The ancestry is checked in `version-check` instead, which fails a tag
+  that is not on `master` before the matrix builds anything

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -153,9 +153,16 @@ dispatch:
 The asymmetry is worth reading rather than assuming: a policy admitting
 branches alone would refuse the deployment *after* the whole matrix had
 been built, and no rehearsal would reveal it, reaching the other
-environment. [RELEASING.md](RELEASING.md) has the rest, including what a
-mismatched trusted publisher looks like and why self-review stays
-allowed.
+environment.
+
+What that rule constrains is the *name* of the ref and nothing else. A
+`v*` tag pushed on a branch head, on an old `dev` state or on a
+fork-synced commit satisfies it exactly as the release tag does, so it is
+not the check that a release is a release: the `version-check` job of
+`release.yml` fails a tag that is not an ancestor of `master`, before the
+matrix builds anything. [RELEASING.md](RELEASING.md) has the rest,
+including what a mismatched trusted publisher looks like and why
+self-review stays allowed.
 
 **On TestPyPI the project is not ours.** The name carries an unrelated
 `0.0.1` from 2021, and a trusted publisher can only be registered by an


### PR DESCRIPTION
Closes #39 — with a correction to the first of its two proposed fixes.

**The deployment tag policy already exists**, and it is not the check this
issue wants:

```
$ gh api repos/btclib-org/btclib-libsecp256k1/environments/pypi/deployment-branch-policies
{"name":"v*","type":"tag"}
```

What it constrains is the *name* of the ref and nothing else, so a `v*` tag
pushed on a branch head, on an old `dev` state or on a fork-synced commit
reaches the `pypi` environment exactly as the release tag does. The
structural barrier the issue hoped for is not available: GitHub's policy
matches ref patterns, not ancestry.

So the fix is the second half, the one the issue called optional.
`version-check` refuses a tagged commit that is not an ancestor of
`origin/master`, on the push path, before the matrix builds anything. The
job's checkout takes the whole history for it, and the step reads
`origin/master` rather than fetching one of its own — a missing
`origin/master` fails the step, which is the safe way round.

Checked against this repository: the head of `master` and its parent are
ancestors; the head of `dev` is not.

REPOSITORY.md and RELEASING.md both stated the tag policy without saying what
it does not cover, which is how it comes to read as this check. Both now say
which one holds which half.

## Summary by Sourcery

Enforce that release tags are only created on commits that are ancestors of master and document the separation between tag-naming policy and ancestry checks in the release process.

New Features:
- Add a CI check in the release workflow that fails pushes where the tagged commit is not an ancestor of origin/master before any build jobs run.

Enhancements:
- Update the release workflow checkout to fetch full repository history so ancestry checks have complete information.
- Clarify in RELEASING.md and REPOSITORY.md that the deployment tag policy only constrains tag names and that version-check enforces that release tags sit on master.