### PR TITLE
Sign the four long BIP340 vectors, which is sign_custom's only external test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -171,240 +171,240 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 112
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 113
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 114
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 119
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 120
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 121
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 124
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 126
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 127
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 128
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 133
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 134
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 135
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 143
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 144
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 145
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 153
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 154
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 155
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 158
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 158
+        "line_number": 163
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 164
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 165
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 204
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 202
+        "line_number": 207
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 208
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 210
+        "line_number": 215
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 211
+        "line_number": 216
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 249
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 245
+        "line_number": 250
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 269
+        "line_number": 274
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 270
+        "line_number": 275
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 286
+        "line_number": 291
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 287
+        "line_number": 292
       }
     ]
   },
-  "generated_at": "2026-08-06T20:01:30Z"
+  "generated_at": "2026-08-06T20:23:01Z"
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,11 +59,16 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **identical**, CRLF included. All 19 vectors, all eight
-columns. Four of the 19 are messages of 0, 1, 17 and 100 bytes: BIP340
-accepts a message of any size, and `ssa.sign`/`ssa.verify` insist on a
-32-byte hash (issue 169), so `test_vectors.py` skips these four rather
-than failing them -- the same four btclib's own copy of this file takes
-the pure-Python path for, having the fallback this package does not.
+columns. Four of the 19 are messages of 0, 1, 17 and 100 bytes, which
+BIP340 accepts and `ssa.sign` does not: those four are what
+`ssa.sign_custom` is signed against, the only published values it can be
+held to, while `ssa.sign` takes the 32-byte rows. Every row carrying a
+secret key is therefore signed and compared byte for byte, and the
+32-byte ones twice, once through each function -- `sign_custom`
+answering a 32-byte message with the signature `sign` returns is itself
+part of what is checked. btclib's own copy of this file takes the
+pure-Python path for the same four, having the fallback this package
+does not.
 
 ## rustyrussell/secp256k1-py
 

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -74,22 +74,27 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
 
     The verification verdict is the vector's own. A vector carrying a
     secret key is also signed and the signature compared byte for byte,
-    which the fixed aux_rand makes possible -- but only for a 32-octet
-    message, `ssa.sign` exposing BIP340's 32-byte signing alone and the
-    longer messages being `ssa.sign_custom`'s. A structurally invalid input
-    raises where the vector says false, so the exception is read as that
-    verdict rather than as an error.
+    which the fixed aux_rand makes possible. Which function signs it is
+    the length of the message: `ssa.sign` is BIP340's 32-byte signing, and
+    `ssa.sign_custom` is the arbitrary-length one, so the four vectors
+    added in 2022 -- messages of 0, 1, 17 and 100 octets -- are the only
+    published values `sign_custom` can be held against. A structurally
+    invalid input raises where the vector says false, so the exception is
+    read as that verdict rather than as an error.
     """
     msg = bytes.fromhex(vector["message"])
     pubkey = bytes.fromhex(vector["public key"])
     sig = bytes.fromhex(vector["signature"])
     expected = vector["verification result"] == "TRUE"
 
-    # the bindings expose the 32-byte message BIP340 signing only
-    if vector["secret key"] and len(msg) == 32:
+    if vector["secret key"]:
         seckey = bytes.fromhex(vector["secret key"])
         aux_rand = bytes.fromhex(vector["aux_rand"])
-        assert ssa.sign(msg, seckey, aux_rand) == sig
+        assert ssa.sign_custom(msg, seckey, aux_rand) == sig
+        # sign_custom answers a 32-byte message with the signature sign
+        # returns, which is what makes the two comparable at all
+        if len(msg) == 32:
+            assert ssa.sign(msg, seckey, aux_rand) == sig
 
     try:
         result = bool(ssa.verify(msg, pubkey, sig))


### PR DESCRIPTION
Closes #25.

Rows 15–18 of the vendored csv — messages of 0, 1, 17 and 100 octets, each
with a secret key and an aux_rand — were verified and never signed, the gate
being `if vector["secret key"] and len(msg) == 32:`. They are exactly the
domain of `ssa.sign_custom`, and the only published values it can be held
against: without them the function was tested only against this package's own
output.

Every row carrying a secret key now goes through `sign_custom`, and the
32-byte ones through `sign` as well — that `sign_custom` answers a 32-byte
message with the signature `sign` returns is itself part of what the vectors
then check.

## Verified live, not assumed green

```
$ # first nibble of row 18's signature flipped
FAILED tests/test_vectors.py::test_bip340_vector[bip340-18] - AssertionError
tests/test_vectors.py:93   # the sign_custom assertion
$ # file restored
19 passed, 12 deselected
```

Suite 104 passed at 100.00% coverage. The `.secrets.baseline` lines are the
recorded findings in `test_vectors.py` following their line numbers, and
`tests/README.md` no longer says those four rows are skipped.

## Summary by Sourcery

Expand BIP340 test coverage so all secret-key vectors exercise both standard and custom signing where applicable.

Documentation:
- Clarify BIP340 test README to describe how non-32-byte message vectors are used to validate sign_custom and how 32-byte rows are checked with both signing functions.

Tests:
- Update BIP340 vector test to sign all secret-key rows with sign_custom and also verify 32-byte messages with sign for byte-for-byte equality.

Chores:
- Refresh the secrets baseline metadata to reflect the updated test file line numbers.