### PR TITLE
Exercise recovery ids 2 and 3, and high s through recovery

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -171,240 +171,240 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 249
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 250
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 251
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 256
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 257
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 258
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 261
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 263
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 264
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 265
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 270
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 271
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 272
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 280
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 281
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 282
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 290
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 291
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 155
+        "line_number": 292
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 158
+        "line_number": 295
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 300
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 301
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 165
+        "line_number": 302
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 341
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 344
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 208
+        "line_number": 345
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 352
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 353
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 249
+        "line_number": 386
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 387
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 412
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 428
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 429
       }
     ]
   },
-  "generated_at": "2026-08-06T20:23:01Z"
+  "generated_at": "2026-08-06T20:28:17Z"
 }

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -21,6 +21,9 @@
   note: the rfc6979.json vectors used by btclib are NOT imported,
   as they only cover NIST curves (per RFC 6979 appendix A.2),
   not secp256k1
+- the recovery id 2 and 3 fixture, which is published nowhere and is
+  constructed here instead, against arithmetic this file does itself.
+  Its derivation is documented where it is built
 """
 
 from __future__ import annotations
@@ -32,10 +35,19 @@ import pathlib
 
 import pytest
 
-from btclib_libsecp256k1 import dsa, mult, ssa
+from btclib_libsecp256k1 import dsa, mult, recovery, ssa
 
 # secp256k1 group order
 N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+# and its field prime and generator: the recovery below is computed here
+# as well as by the bindings, which is what holds one to the other
+P = 2**256 - 2**32 - 977
+G = (
+    0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+    0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8,
+)
+
+Point = tuple[int, int] | None
 
 
 def der_decode(sig: bytes) -> tuple[int, int]:
@@ -57,6 +69,40 @@ def der_decode(sig: bytes) -> tuple[int, int]:
         cursor += 2 + length
     assert cursor == len(sig), "trailing garbage in DER"
     return ints[0], ints[1]
+
+
+def point_add(point_1: Point, point_2: Point) -> Point:
+    """Add two points of secp256k1, None being the point at infinity."""
+    if point_1 is None:
+        return point_2
+    if point_2 is None:
+        return point_1
+    if point_1[0] == point_2[0] and (point_1[1] + point_2[1]) % P == 0:
+        return None
+    if point_1 == point_2:
+        slope = 3 * point_1[0] * point_1[0] * pow(2 * point_1[1], -1, P) % P
+    else:
+        slope = (point_2[1] - point_1[1]) * pow(point_2[0] - point_1[0], -1, P) % P
+    x = (slope * slope - point_1[0] - point_2[0]) % P
+    return x, (slope * (point_1[0] - x) - point_1[1]) % P
+
+
+def point_mul(scalar: int, point: Point) -> Point:
+    """Multiply a point of secp256k1 by a scalar, double and add."""
+    result: Point = None
+    addend = point
+    while scalar:
+        if scalar & 1:
+            result = point_add(result, addend)
+        addend = point_add(addend, addend)
+        scalar >>= 1
+    return result
+
+
+def compressed(point: Point) -> bytes:
+    """Serialize a point of secp256k1 in its 33-byte compressed form."""
+    assert point is not None, "the point at infinity has no serialization"
+    return bytes([2 + (point[1] & 1)]) + point[0].to_bytes(32, "big")
 
 
 def bip340_vectors() -> list[dict[str, str]]:
@@ -102,6 +148,97 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
         # structurally invalid inputs raise instead of returning false
         result = False
     assert result == expected, vector["comment"]
+
+
+# A signature whose nonce point has an x coordinate above the group
+# order, which is what a recovery id of 2 or 3 says. No search produces
+# one: x(kG) lands in [n, p) with probability about 2**-128, and finding
+# a k that puts it there is the discrete logarithm problem. So the point
+# comes first and the signature is built around it, which needs no k at
+# all -- recovery is r**-1 (sR - eG), an equation in R rather than in its
+# logarithm, and the key it answers with is defined by that equation
+# rather than by a signer. Nobody holds the private key of this
+# signature, and nothing here needs to.
+#
+# x is the smallest one above the order that is on the curve, and s is an
+# arbitrary low-s scalar, low so that the DER conversion of the same
+# signature is one dsa.verify accepts
+HIGH_X_NONCE = N + 2
+HIGH_X_S = 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
+HIGH_X_MSG = hashlib.sha256(b"btclib_libsecp256k1 recid 2 and 3").digest()
+
+
+@pytest.mark.parametrize("recid", [2, 3])
+def test_recovery_of_a_high_x_nonce(recid: int) -> None:
+    """Recover a key from a signature whose nonce point x exceeds the order.
+
+    recovery.py accepts `recid in range(4)` and the suite only ever fed
+    it 0 and 1, so half of the accepted domain reached libsecp256k1 from
+    no test. What the high bit of the recovery id says is that the x
+    coordinate of the nonce point was reduced modulo the order on the way
+    into r, so recovery has to add the order back before decompressing
+    it; getting that wrong recovers a different key, or none.
+
+    The recovered key is compared against the recovery equation computed
+    here in python, not against something these bindings produced.
+    """
+    # n itself is on the curve, and would make r zero; n + 1 is not
+    assert pow((pow(N + 1, 3, P) + 7) % P, (P - 1) // 2, P) == P - 1
+    y_squared = (pow(HIGH_X_NONCE, 3, P) + 7) % P
+    y = pow(y_squared, (P + 1) // 4, P)
+    assert pow(y, 2, P) == y_squared, "n + 2 is not on the curve"
+
+    # the low bit of the recovery id is the parity of that y
+    if (y % 2 == 0) != (recid == 2):
+        y = P - y
+    r = HIGH_X_NONCE - N
+    e = int.from_bytes(HIGH_X_MSG, "big") % N
+    expected = compressed(
+        point_mul(
+            pow(r, -1, N),
+            point_add(point_mul(HIGH_X_S, (HIGH_X_NONCE, y)), point_mul(N - e, G)),
+        )
+    )
+
+    signature = r.to_bytes(32, "big") + HIGH_X_S.to_bytes(32, "big")
+    pubkey = recovery.recover(HIGH_X_MSG, signature, recid)
+    assert pubkey == expected
+
+    # and it is a key this signature verifies under, which is the whole
+    # point of recovering one
+    assert dsa.verify(HIGH_X_MSG, pubkey, recovery.to_der(signature, recid))
+    # the same signature read as a low recovery id answers another key,
+    # so the high bit is doing something rather than being ignored
+    assert recovery.recover(HIGH_X_MSG, signature, recid - 2) != pubkey
+
+
+def test_high_s_is_carried_through_recovery_unchanged() -> None:
+    """recovery.recover and recovery.to_der leave a high-s signature alone.
+
+    `to_der` documents that it does not normalize s, and nothing held it
+    to that. Negating s modulo the order is the malleability ECDSA has:
+    the result is a second valid signature of the same message under the
+    same key, and it flips the parity of the nonce point, so it is the
+    other recovery id that recovers the key from it.
+    """
+    msg = hashlib.sha256(b"btclib_libsecp256k1 high s").digest()
+    prvkey = 7
+    signature, recid = recovery.sign(msg, prvkey)
+    pubkey = recovery.recover(msg, signature, recid)
+    s = int.from_bytes(signature[32:], "big")
+    assert s <= N // 2, "libsecp256k1 signs low-s"
+
+    high_s = signature[:32] + (N - s).to_bytes(32, "big")
+    assert recovery.recover(msg, high_s, recid ^ 1) == pubkey
+    assert recovery.recover(msg, high_s, recid) != pubkey
+
+    der = recovery.to_der(high_s, recid ^ 1)
+    assert not dsa.is_low_s(der)
+    # which is why dsa.verify refuses it, and normalizing recovers the
+    # signature dsa.sign would have produced
+    assert not dsa.verify(msg, pubkey, der)
+    assert dsa.verify(msg, pubkey, dsa.normalize(der))
+    assert dsa.normalize(der) == dsa.sign(msg, prvkey)
 
 
 # (secret key, message, k, r, s)


### PR DESCRIPTION
Closes #28.

## recid 2 and 3

Half the accepted domain reached libsecp256k1 from no test. The issue asked
for "a crafted key/nonce pair whose r exceeds the curve order" — and that
pair cannot be crafted: `x(kG)` lands in `[n, p)` with probability about
`2**-128`, and aiming a `k` there is the discrete logarithm problem.

So the point comes first and the signature is built around it, which needs no
`k` at all. Recovery is `r**-1 (sR - eG)`, an equation in `R` rather than in
its logarithm, and the key it answers with is defined by that equation rather
than by a signer. **Nobody holds the private key of this signature**, and
nothing here needs to.

`x` is the smallest value above the order that is on the curve, `n + 2`, and
the test proves that too: `n` itself is on the curve and would give `r = 0`,
`n + 1` is a quadratic non-residue.

Since no published vector exists, the recovered key is compared against the
same equation computed **in python** — point arithmetic this file now does —
rather than against anything these bindings produced. That is the standard
`der_decode` already sets in this file.

## High s

`to_der` documents that it does not normalize s, and nothing held it to that.
Negating s is the malleability ECDSA has: a second valid signature of the
same message under the same key, with the parity of the nonce point flipped,
so it is the *other* recovery id that answers it. `to_der` keeps the high s,
`dsa.verify` refuses what it produced, and `dsa.normalize` gives back exactly
what `dsa.sign` returns.

## Checked by breaking it

With the order dropped from the expected point (`HIGH_X_NONCE - N` in the
hand computation), both recid cases fail; restored, 107 passed at 100.00%
coverage.

## Summary by Sourcery

Add secp256k1 arithmetic helpers in tests and expand recovery tests to cover high-x nonces and high-s signatures, validating behavior of recovery APIs against independent Python calculations.

New Features:
- Introduce test-only secp256k1 point arithmetic utilities to compute expected recovery results independently of the bindings.

Tests:
- Add recovery tests for signatures with nonce x coordinates above the group order, exercising recovery ids 2 and 3.
- Add tests ensuring high-s ECDSA signatures are passed through recovery unchanged and behave correctly with DER encoding, verification, and normalization.