### PR TITLE
Document the deployment target the dynamic wheel command needs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,20 @@ the runner, and that is worth knowing before trying.
 
       BTCLIB_LIBSECP256K1_DYNAMIC=true uv build --wheel
 
+  on macOS the job exports a deployment target first, and reproducing it
+  means exporting the same one:
+
+      export MACOSX_DEPLOYMENT_TARGET=11.0    # 10.13 on x86_64
+
+  a dynamic wheel compiles no extension, so nothing derives its platform
+  tag from a toolchain: without that variable `hatch_build.py` falls back
+  to `platform.mac_ver()`, and the wheel comes out `macosx_26_0_arm64` on
+  a macOS 26 machine — a tag `pip` refuses on every older macOS the file
+  would in fact have loaded on. CMake reads the same variable, so the
+  vendored library is built for the floor the tag then claims; the two
+  values and the reasoning behind them are in `test.yml`, next to the
+  step that exports them
+
 - `Build sdist`, and `Test sdist install on <os>` after it
 
       uv build --sdist

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,7 +41,15 @@ What it does with the result:
 `dynamic_platform_tag()` is the one place that has to name the target
 platform itself, since a dynamic wheel gets no tag from the interpreter
 that built it. On Linux the tag it produces is a plain `linux_*`, which
-`auditwheel repair` later upgrades to a manylinux one.
+`auditwheel repair` later upgrades to a manylinux one. On macOS it reads
+`MACOSX_DEPLOYMENT_TARGET`, and falls back to `platform.mac_ver()` when
+nothing set one — which is honest, CMake having built the library for
+that same host default, and narrow: the wheel is then one only the build
+machine's macOS accepts. Every wheel that ships is built with the
+variable exported, by `test.yml` for the dynamic ones and by
+`cibuildwheel` for the static ones; a local build reproducing either has
+to export it too, and CONTRIBUTING.md says so where it gives the
+command.
 
 ## cffi_build.py
 


### PR DESCRIPTION
Closes #34.

Measured on macOS 26 arm64:

```
$ BTCLIB_LIBSECP256K1_DYNAMIC=true uv build --wheel
btclib_libsecp256k1-0.7.1.2-py3-none-macosx_26_0_arm64.whl
$ MACOSX_DEPLOYMENT_TARGET=11.0 BTCLIB_LIBSECP256K1_DYNAMIC=true uv build --wheel
btclib_libsecp256k1-0.7.1.2-py3-none-macosx_11_0_arm64.whl
```

**Documented rather than defaulted in `hatch_build.py`**, and the reason is
worth stating: the tag is not the only thing that variable decides. CMake
reads it too, so a default applied to the tag alone would claim a floor the
vendored library was not built for — a wheel that installs on macOS 12 and
fails to load, which is worse than the narrow one. Left unset the two agree:
the library is built for the host, and the tag says so.

One detail of the issue is stale: the command lives in CONTRIBUTING.md, under
the CI job it reproduces, not in README.md. The export goes next to it there,
and `scripts/README.md` says the same where `dynamic_platform_tag()` is
described.

## Summary by Sourcery

Document the required MACOSX_DEPLOYMENT_TARGET configuration for building dynamic wheels on macOS and explain how it affects the generated platform tag and library build.

Documentation:
- Update CONTRIBUTING.md to describe exporting MACOSX_DEPLOYMENT_TARGET when reproducing the macOS dynamic wheel CI job.
- Expand scripts/README.md to explain how dynamic_platform_tag() uses MACOSX_DEPLOYMENT_TARGET on macOS and why builds must export it.