### PR TITLE
Give every function of the boundary its contract, and a gate to hold it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,6 +178,23 @@ repos:
         args: [--fix]
       - id: ruff-format
         name: ruff (format, in place fixes)
+  # what ruff's D rules do not reach: they ask that a docstring exists,
+  # and this asks that it documents the arguments and the return value.
+  # The configuration is in pyproject.toml, next to the ruff one.
+  #
+  # Scoped to the package, which is where the contract of a compiled
+  # wheel has to live: a caller reading help() or an IDE tooltip has no
+  # source to fall back on. A test function documents what it claims, not
+  # its fixtures, and the build scripts are read from the source tree by
+  # whoever changes them
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.9.1
+    hooks:
+      - id: pydoclint
+        name: pydoclint (arguments and return values)
+        args: [--config=pyproject.toml]
+        files: ^btclib_libsecp256k1/.*\.py$
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,6 +133,15 @@
     }
   ],
   "results": {
+    "btclib_libsecp256k1/hashes.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "btclib_libsecp256k1/hashes.py",
+        "hashed_secret": "a608d88cb7e04b46b5e44fa00bb7c01b7748e6f0",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
     "scripts/cffi_build.py": [
       {
         "type": "Base64 High Entropy String",
@@ -406,5 +415,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-06T20:45:03Z"
+  "generated_at": "2026-08-06T21:02:27Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,11 +316,27 @@ Explanatory detail is wanted; decoration is not.
 
 **A docstring states the contract.** What the function takes, what it
 returns or raises, and the rule the behaviour comes from — not a
-restatement of the name. A test's docstring states what it verifies: the
-property, the published vector, the failure mode, and which side of the
-assertion is the independent one. That last part is why a docstring is
-required of a test at all — the name says which call is under test, which
-is not the same as what is being claimed about it.
+restatement of the name. In the package the first two are enforced:
+`pydoclint` requires an `Args` entry per parameter and a `Returns`
+section, in the Google style napoleon renders, so a new argument that
+nobody documented fails the gate. `Raises` is not enforced and is still
+required — these wrappers raise mostly through what they call, so the
+check that compares a `Raises` section with the body's own `raise`
+statements would ask the docstrings to be wrong; `pyproject.toml` says
+so where it turns that check off.
+
+A test's docstring states what it verifies: the property, the published
+vector, the failure mode, and which side of the assertion is the
+independent one. That last part is why a docstring is required of a test
+at all — the name says which call is under test, which is not the same as
+what is being claimed about it.
+
+**An example is executed.** Anything written as a doctest, in a docstring
+or in README.md, is run by `tests/test_examples.py` on every interpreter
+and every kind of wheel. That constrains an example to be deterministic —
+fixed keys, and a verification rather than a signature wherever the value
+depends on randomness that is not pinned — which is the price of the one
+form of documentation this repository can gate like a test.
 
 **A comment carries the reasoning, including the negative result.** Say
 why the code is as it is and why *not* the obvious alternative. The second

--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ To install (and/or upgrade):
 
     python -m pip install --upgrade btclib_libsecp256k1
 
+## Quickstart
+
+Sign and verify, ECDSA and BIP340. Every line below is executed by the
+test suite, on every interpreter and every kind of wheel, so an example
+that stops working fails a build rather than sitting here:
+
+    >>> import hashlib
+    >>> from btclib_libsecp256k1 import dsa, keys, mult, ssa, xonly
+
+    >>> # BIP340 test vector 1; yours comes from os.urandom or a wallet
+    >>> prvkey = 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF
+    >>> pubkey = keys.serialize(keys.parse(mult.mult_(prvkey)))
+    >>> msg = hashlib.sha256(b"hello").digest()
+
+ECDSA, over the 32-byte hash, with the deterministic RFC6979 nonce:
+
+    >>> signature = dsa.sign(msg, prvkey)
+    >>> dsa.verify(msg, pubkey, signature)
+    True
+
+BIP340 Schnorr, over the same hash, against the x-only key:
+
+    >>> xonly_pubkey, parity = xonly.from_pubkey(pubkey)
+    >>> signature = ssa.sign(msg, prvkey)
+    >>> ssa.verify(msg, xonly_pubkey, signature)
+    True
+
+Both take the private key as `bytes` or as an `int`, and both return
+`bytes`. What each argument may be, and what is refused rather than
+coerced, is *What the boundary checks* below; every function states its
+own contract in its docstring.
+
 ## Versioning
 
 btclib_libsecp256k1 version numbers track the wrapped libsecp256k1

--- a/btclib_libsecp256k1/__init__.py
+++ b/btclib_libsecp256k1/__init__.py
@@ -30,6 +30,18 @@ def _load_lib(module: Any) -> Any:
     enclosing scope, because only one of the two branches below exists
     in any given build: the other one is only reachable, and therefore
     only testable, with a stand-in.
+
+    Args:
+        module: the compiled extension module, or a stand-in for it.
+
+    Returns:
+        The object every wrapper calls libsecp256k1 through: the `lib`
+        of a static extension, or what `ffi.dlopen` returns for the
+        shared object shipped beside a dynamic one.
+
+    Raises:
+        ImportError: if the extension carries no linked-in library and
+            no shared object beside it can be loaded.
     """
     # a static extension has the library linked in
     if hasattr(module, "lib"):

--- a/btclib_libsecp256k1/_scalar.py
+++ b/btclib_libsecp256k1/_scalar.py
@@ -27,6 +27,18 @@ def scalar(num: bytes | int, name: str) -> bytes:
     call. bytes are not zeroized either, so what they buy is only that
     no arithmetic on the secret happened here; scalar arithmetic that
     must not leak belongs where that can be promised.
+
+    Args:
+        num: the scalar, exactly 32 bytes or an int in [0, 2**256).
+        name: what the scalar is, as the exception should call it.
+
+    Returns:
+        The scalar as 32 bytes, big endian.
+
+    Raises:
+        ValueError: if bytes are not exactly 32 long, or if an int does
+            not fit in 32 bytes. Whether the value is a valid scalar,
+            i.e. in [1, n-1], is for libsecp256k1 to say.
     """
     if isinstance(num, int):
         # an int outside the 32-byte range is out of domain like any

--- a/btclib_libsecp256k1/context.py
+++ b/btclib_libsecp256k1/context.py
@@ -23,6 +23,10 @@ class _Reported(threading.local):
 
     A callback runs on the thread of the call that triggered it, so a
     thread local is what attributes a message to the right call.
+
+    Attributes:
+        illegal: the last violated precondition, or None.
+        error: the last internal error, or None.
     """
 
     illegal: str | None = None
@@ -33,12 +37,22 @@ _reported = _Reported()
 
 
 def _record_illegal(message: CData, data: CData) -> None:
-    """Record a violated precondition. Called by libsecp256k1."""
+    """Record a violated precondition. Called by libsecp256k1.
+
+    Args:
+        message: the failed condition, as a C string.
+        data: the pointer the callback was registered with, NULL here.
+    """
     _reported.illegal = ffi.string(message).decode()
 
 
 def _record_error(message: CData, data: CData) -> None:
-    """Record an internal error. Called by libsecp256k1."""
+    """Record an internal error. Called by libsecp256k1.
+
+    Args:
+        message: the failed condition, as a C string.
+        data: the pointer the callback was registered with, NULL here.
+    """
     _reported.error = ffi.string(message).decode()
 
 
@@ -76,6 +90,14 @@ def check() -> None:
     this. It is meant for a call made through `lib` directly, as a
     MuSig2 session is, and it reports what was last recorded: call it
     right after the call whose return value you are explaining.
+
+    What was recorded is cleared, so a second call reports nothing and
+    a later one cannot inherit this call's message.
+
+    Raises:
+        ValueError: if libsecp256k1 reported a violated precondition.
+        RuntimeError: if it reported an internal error, which takes
+            precedence, being the graver of the two.
     """
     illegal, error = _reported.illegal, _reported.error
     _reported.illegal = _reported.error = None

--- a/btclib_libsecp256k1/dsa.py
+++ b/btclib_libsecp256k1/dsa.py
@@ -13,7 +13,37 @@ from .context import ctx
 
 
 def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> bytes:
-    """Create an ECDSA signature."""
+    """Create an ECDSA signature.
+
+    The nonce is the deterministic RFC6979 one, so the signature is a
+    function of the message and the key alone unless ndata is given.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        ndata: 32 bytes of extra entropy mixed into the nonce, or None
+            for the RFC6979 nonce alone. Never a shorter value: entropy
+            is not a serialization, and padding one would make a caller
+            mistake a valid argument.
+
+    Returns:
+        The signature in DER encoding, in the lower-s form libsecp256k1
+        always produces.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if ndata is
+            given and is not 32 bytes, or if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to serialize the signature,
+            which no input can make it do.
+
+    Example:
+        >>> import hashlib
+        >>> from btclib_libsecp256k1 import dsa
+        >>> msg = hashlib.sha256(b"hello").digest()
+        >>> dsa.is_low_s(dsa.sign(msg, 1))
+        True
+    """
     prvkey_bytes = scalar(prvkey, "private key")
     if len(msg_bytes) != 32:
         raise ValueError("the message hash must be 32 bytes")
@@ -39,6 +69,27 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
 
     A signature which is not in the normalized lower-s form is rejected;
     normalize it first if it comes from a system not enforcing it.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        signature_bytes: the signature in DER encoding.
+
+    Returns:
+        True if the signature is valid for that key and message.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if the DER
+            signature is malformed, or if the public key is not a valid
+            point. A well-formed signature that simply does not verify
+            is False, not an exception.
+
+    Example:
+        >>> import hashlib
+        >>> from btclib_libsecp256k1 import dsa, mult
+        >>> msg = hashlib.sha256(b"hello").digest()
+        >>> dsa.verify(msg, mult.mult_(1), dsa.sign(msg, 1))
+        True
     """
     if len(msg_bytes) != 32:
         raise ValueError("the message hash must be 32 bytes")
@@ -53,7 +104,21 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
 
 
 def normalize(signature_bytes: bytes) -> bytes:
-    """Convert a DER signature to its normalized lower-s form."""
+    """Convert a DER signature to its normalized lower-s form.
+
+    Args:
+        signature_bytes: the signature in DER encoding.
+
+    Returns:
+        The same signature with s replaced by n - s where s was the
+        higher of the two, in DER encoding. A signature already
+        normalized is returned unchanged.
+
+    Raises:
+        ValueError: if the DER signature is malformed.
+        RuntimeError: if libsecp256k1 fails to serialize the result,
+            which no input can make it do.
+    """
     signature = _parse_der(signature_bytes)
     normalized = ffi.new("secp256k1_ecdsa_signature *")
     lib.secp256k1_ecdsa_signature_normalize(ctx, normalized, signature)
@@ -66,6 +131,16 @@ def is_low_s(signature_bytes: bytes) -> bool:
     ECDSA signatures are malleable: negating s modulo the group order
     yields a second valid signature of the same message, which the
     lower-s requirement rules out.
+
+    Args:
+        signature_bytes: the signature in DER encoding.
+
+    Returns:
+        True if s is the lower of the two, which is what `verify`
+        requires and what `sign` always produces.
+
+    Raises:
+        ValueError: if the DER signature is malformed.
     """
     signature = _parse_der(signature_bytes)
     # a NULL output only checks the input, which is reported as
@@ -74,7 +149,19 @@ def is_low_s(signature_bytes: bytes) -> bool:
 
 
 def to_compact(signature_bytes: bytes) -> bytes:
-    """Convert a DER signature into its 64-byte compact form."""
+    """Convert a DER signature into its 64-byte compact form.
+
+    Args:
+        signature_bytes: the signature in DER encoding.
+
+    Returns:
+        The 64 bytes of r and s, each big endian and zero padded.
+
+    Raises:
+        ValueError: if the DER signature is malformed.
+        RuntimeError: if libsecp256k1 fails to serialize it, which no
+            input can make it do.
+    """
     signature = _parse_der(signature_bytes)
     sig_bytes = ffi.new("char[64]")
     if not lib.secp256k1_ecdsa_signature_serialize_compact(ctx, sig_bytes, signature):
@@ -83,7 +170,22 @@ def to_compact(signature_bytes: bytes) -> bytes:
 
 
 def to_der(signature_bytes: bytes) -> bytes:
-    """Convert a 64-byte compact signature into its DER form."""
+    """Convert a 64-byte compact signature into its DER form.
+
+    Args:
+        signature_bytes: the 64 bytes of r and s.
+
+    Returns:
+        The same signature in DER encoding. s is not normalized: a
+        high-s input gives a DER signature `verify` refuses, which
+        `normalize` is for.
+
+    Raises:
+        ValueError: if the input is not 64 bytes, or if r or s is not
+            below the group order.
+        RuntimeError: if libsecp256k1 fails to serialize it, which no
+            input can make it do.
+    """
     if len(signature_bytes) != 64:
         raise ValueError("the compact signature must be 64 bytes")
 
@@ -94,7 +196,17 @@ def to_der(signature_bytes: bytes) -> bytes:
 
 
 def _parse_der(signature_bytes: bytes) -> CData:
-    """Parse a DER signature into its internal representation."""
+    """Parse a DER signature into its internal representation.
+
+    Args:
+        signature_bytes: the signature in DER encoding.
+
+    Returns:
+        The libsecp256k1 signature object.
+
+    Raises:
+        ValueError: if the DER signature is malformed.
+    """
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if not lib.secp256k1_ecdsa_signature_parse_der(
         ctx, signature, signature_bytes, len(signature_bytes)
@@ -104,7 +216,18 @@ def _parse_der(signature_bytes: bytes) -> CData:
 
 
 def _serialize_der(sig: CData) -> bytes:
-    """Serialize an internal signature in DER form."""
+    """Serialize an internal signature in DER form.
+
+    Args:
+        sig: the libsecp256k1 signature object.
+
+    Returns:
+        Its DER encoding, at most 72 bytes.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails, which the 73-byte buffer
+            makes unreachable.
+    """
     sig_bytes = ffi.new("char[73]")
     length = ffi.new("size_t *", 73)
     if not lib.secp256k1_ecdsa_signature_serialize_der(ctx, sig_bytes, length, sig):

--- a/btclib_libsecp256k1/ecdh.py
+++ b/btclib_libsecp256k1/ecdh.py
@@ -25,6 +25,19 @@ def shared_secret(pubkey_bytes: bytes, prvkey: bytes | int) -> bytes:
     being available as keys.pubkey_tweak_mul(pubkey_bytes, prvkey),
     itself constant time. A protocol needing another derivation applies
     it to that: SHA256 of it is what this function returns.
+
+    Args:
+        pubkey_bytes: the other party's public key, 33 or 65 bytes.
+        prvkey: this party's private key, 32 bytes or an int below
+            2**256.
+
+    Returns:
+        The 32-byte shared secret.
+
+    Raises:
+        ValueError: if the public key is not a valid point, if the
+            private key is not 32 bytes or does not fit in them, or if
+            it is not a valid scalar.
     """
     prvkey_bytes = scalar(prvkey, "private key")
 

--- a/btclib_libsecp256k1/ellswift.py
+++ b/btclib_libsecp256k1/ellswift.py
@@ -26,6 +26,19 @@ def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
 
     This is safer than encode(mult_(prvkey)), as the private key itself
     is used as entropy for the encoding.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: 32 bytes of auxiliary randomness, or None for fresh
+            randomness.
+
+    Returns:
+        The 64-byte ElligatorSwift encoding of the public key.
+
+    Raises:
+        ValueError: if aux_rand32 is given and is not 32 bytes, or if
+            the private key is not 32 bytes, does not fit in them, or is
+            not in [1, n-1].
     """
     prvkey_bytes = scalar(prvkey, "private key")
 
@@ -47,6 +60,21 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
 
     The randomness must not be a deterministic function of the public
     key; when it is not provided, it is freshly generated.
+
+    Args:
+        pubkey_bytes: the public key to encode, 33 or 65 bytes.
+        rnd32: the 32 bytes deciding which of the encodings of that key
+            is produced, or None for fresh randomness.
+
+    Returns:
+        The 64-byte ElligatorSwift encoding, indistinguishable from
+        uniform bytes.
+
+    Raises:
+        ValueError: if the public key is not a valid point, or if rnd32
+            is given and is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to encode, which no valid
+            input can make it do.
     """
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
@@ -65,7 +93,21 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
 
 
 def decode(ell_bytes: bytes) -> bytes:
-    """Decode a 64-byte ElligatorSwift public key into its compressed form."""
+    """Decode a 64-byte ElligatorSwift public key into its compressed form.
+
+    Args:
+        ell_bytes: the 64-byte encoding.
+
+    Returns:
+        The 33-byte compressed public key. Every 64 bytes decode to a
+        point, which is what makes the encoding indistinguishable from
+        random: there is nothing to reject.
+
+    Raises:
+        ValueError: if the input is not 64 bytes.
+        RuntimeError: if libsecp256k1 fails to decode or serialize,
+            which no 64 bytes can make it do.
+    """
     if len(ell_bytes) != 64:
         raise ValueError("the ElligatorSwift public key must be 64 bytes")
 
@@ -88,6 +130,23 @@ def xdh(
     The private key must be the one of the given party: 0 for party A,
     1 for party B; the correspondence is not checked. The 32-byte secret
     is derived with the BIP324 hash function.
+
+    Args:
+        ell_a_bytes: the 64-byte encoding of party A's key.
+        ell_b_bytes: the 64-byte encoding of party B's key.
+        prvkey: the private key of the party below, 32 bytes or an int
+            below 2**256.
+        party: 0 if the private key is A's, 1 if it is B's.
+
+    Returns:
+        The 32-byte shared secret, which both parties compute alike. The
+        two encodings enter the hash in the order they are given here,
+        so BIP324's initiator goes first.
+
+    Raises:
+        ValueError: if either encoding is not 64 bytes, if party is not
+            0 or 1, or if the private key is not 32 bytes, does not fit
+            in them, or is not a valid scalar.
     """
     if len(ell_a_bytes) != 64 or len(ell_b_bytes) != 64:
         raise ValueError("the ElligatorSwift public keys must be 64 bytes")

--- a/btclib_libsecp256k1/hashes.py
+++ b/btclib_libsecp256k1/hashes.py
@@ -21,6 +21,22 @@ def tagged_sha256(tag: bytes, msg: bytes) -> bytes:
     the domains of the protocols using it, so that what one of them signs
     cannot be read as a message of another. The BIP340 challenge and the
     BIP341 taproot tags (TapLeaf, TapBranch, TapTweak) are built with it.
+
+    Args:
+        tag: the domain separation tag, of any length.
+        msg: the message to hash, of any length.
+
+    Returns:
+        The 32-byte tagged hash.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails, which no input can make it
+            do.
+
+    Example:
+        >>> from btclib_libsecp256k1 import hashes
+        >>> hashes.tagged_sha256(b"TapLeaf", b"").hex()
+        '5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb'
     """
     output = ffi.new("char[32]")
     if not lib.secp256k1_tagged_sha256(ctx, output, tag, len(tag), msg, len(msg)):

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -29,13 +29,36 @@ UNCOMPRESSED = 2
 
 
 def prvkey_verify(prvkey: bytes | int) -> bool:
-    """Return True if the private key is a valid scalar, i.e. in [1, n-1]."""
+    """Return True if the private key is a valid scalar, i.e. in [1, n-1].
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        True if it is in [1, n-1]; False for zero and for anything at or
+        above the group order, which is a verdict and not an error.
+
+    Raises:
+        ValueError: if it is not 32 bytes, or does not fit in them: that
+            is a malformed argument rather than an invalid key.
+    """
     prvkey_bytes = scalar(prvkey, "private key")
     return bool(lib.secp256k1_ec_seckey_verify(ctx, prvkey_bytes))
 
 
 def prvkey_negate(prvkey: bytes | int) -> bytes:
-    """Negate a private key."""
+    """Negate a private key.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32 bytes of n - k, the key of the negated public key.
+
+    Raises:
+        ValueError: if it is not 32 bytes, does not fit in them, or is
+            not in [1, n-1].
+    """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     if not lib.secp256k1_ec_seckey_negate(ctx, prvkey_buffer):
         raise ValueError("invalid private key")
@@ -43,7 +66,23 @@ def prvkey_negate(prvkey: bytes | int) -> bytes:
 
 
 def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
-    """Add a tweak to a private key."""
+    """Add a tweak to a private key.
+
+    This is the private-key side of BIP32 derivation, and of any other
+    scheme adding a scalar to a key.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32 bytes of (k + t) mod n.
+
+    Raises:
+        ValueError: if either value is not 32 bytes or does not fit in
+            them, if the private key is not in [1, n-1], or if the sum
+            is zero, which is the one tweak with no valid result.
+    """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_add(ctx, prvkey_buffer, tweak_bytes):
@@ -52,7 +91,20 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
 
 
 def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
-    """Multiply a private key by a tweak."""
+    """Multiply a private key by a tweak.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32 bytes of (k * t) mod n.
+
+    Raises:
+        ValueError: if either value is not 32 bytes or does not fit in
+            them, if the private key is not in [1, n-1], or if the tweak
+            is zero or at or above the group order.
+    """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_mul(ctx, prvkey_buffer, tweak_bytes):
@@ -61,7 +113,20 @@ def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
 
 
 def pubkey_negate(pubkey_bytes: bytes, compressed: bool = True) -> bytes:
-    """Negate a public key."""
+    """Negate a public key.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The point with the same x and the other y, serialized.
+
+    Raises:
+        ValueError: if the public key is not a valid point.
+        RuntimeError: if libsecp256k1 fails to negate or serialize it,
+            which no valid key can make it do.
+    """
     pubkey = parse(pubkey_bytes)
     if not lib.secp256k1_ec_pubkey_negate(ctx, pubkey):
         raise RuntimeError("public key negation failed")
@@ -71,7 +136,26 @@ def pubkey_negate(pubkey_bytes: bytes, compressed: bool = True) -> bytes:
 def pubkey_tweak_add(
     pubkey_bytes: bytes, tweak: bytes | int, compressed: bool = True
 ) -> bytes:
-    """Add the generator multiplied by the tweak to a public key."""
+    """Add the generator multiplied by the tweak to a public key.
+
+    This is the public-key side of BIP32 derivation: the key of
+    `prvkey_tweak_add(k, t)` is `pubkey_tweak_add(pubkey(k), t)`.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The serialized point P + tG.
+
+    Raises:
+        ValueError: if the public key is not a valid point, if the tweak
+            is not 32 bytes or does not fit in them, or if the tweak or
+            the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to serialize the result,
+            which no valid input can make it do.
+    """
     pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, tweak_bytes):
@@ -85,7 +169,25 @@ def pubkey_tweak_mul(
     """Multiply a public key by a tweak.
 
     This is the multiplication of an arbitrary point, as opposed to the
-    multiplication of the generator provided by the mult module.
+    multiplication of the generator provided by the mult module. It is
+    constant time, and is the shared point of an ECDH exchange: see
+    `ecdh.shared_secret`, which hashes it.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        tweak: the scalar to multiply by, 32 bytes or an int below
+            2**256.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The serialized point tP.
+
+    Raises:
+        ValueError: if the public key is not a valid point, if the tweak
+            is not 32 bytes or does not fit in them, or if it is zero or
+            at or above the group order.
+        RuntimeError: if libsecp256k1 fails to serialize the result,
+            which no valid input can make it do.
     """
     pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
@@ -95,7 +197,23 @@ def pubkey_tweak_mul(
 
 
 def pubkey_combine(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> bytes:
-    """Add public keys together."""
+    """Add public keys together.
+
+    Args:
+        pubkeys_bytes: the public keys, each 33 or 65 bytes. At least
+            one is required.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The serialized sum of the points.
+
+    Raises:
+        ValueError: if the sequence is empty, if any key is not a valid
+            point, or if the sum is the point at infinity, which has no
+            serialization.
+        RuntimeError: if libsecp256k1 fails to serialize the result,
+            which no valid input can make it do.
+    """
     if not pubkeys_bytes:
         raise ValueError("at least one public key is required")
 
@@ -111,10 +229,20 @@ def pubkey_combine(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> b
 def pubkey_cmp(pubkey1_bytes: bytes, pubkey2_bytes: bytes) -> int:
     """Compare two public keys, in lexicographic order of compressed form.
 
-    Return a negative number, zero, or a positive number, according to
-    whether the first key sorts before, equal to, or after the second.
     The order is the one of the compressed serialization, whichever form
     the arguments are given in.
+
+    Args:
+        pubkey1_bytes: the first public key, 33 or 65 bytes.
+        pubkey2_bytes: the second public key, 33 or 65 bytes.
+
+    Returns:
+        A negative number, zero, or a positive number, according to
+        whether the first key sorts before, equal to, or after the
+        second.
+
+    Raises:
+        ValueError: if either key is not a valid point.
     """
     return int(
         lib.secp256k1_ec_pubkey_cmp(ctx, parse(pubkey1_bytes), parse(pubkey2_bytes))
@@ -127,6 +255,19 @@ def pubkey_sort(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> list
     This is the ordering of a BIP67 multisig script, and the one MuSig2
     key aggregation applies when the participants have not agreed on a
     different one.
+
+    Args:
+        pubkeys_bytes: the public keys, each 33 or 65 bytes. An empty
+            sequence sorts to an empty list.
+        compressed: whether to return 33 bytes each rather than 65.
+
+    Returns:
+        The same keys, serialized, in ascending order.
+
+    Raises:
+        ValueError: if any key is not a valid point.
+        RuntimeError: if libsecp256k1 fails to sort or serialize, which
+            no valid input can make it do.
     """
     pubkeys = [parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]
     # the array holds borrowed pointers, and is what gets reordered: the
@@ -138,7 +279,22 @@ def pubkey_sort(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> list
 
 
 def parse(pubkey_bytes: bytes) -> CData:
-    """Parse a public key into its internal libsecp256k1 representation."""
+    """Parse a public key into its internal libsecp256k1 representation.
+
+    The internal form is what the raw `lib` calls take, and what
+    `serialize` turns back into bytes: `serialize(parse(key))` is the
+    compressed form of a key given in either form.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+
+    Returns:
+        The libsecp256k1 public key object.
+
+    Raises:
+        ValueError: if the bytes are not a valid point in either
+            serialization.
+    """
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -146,7 +302,25 @@ def parse(pubkey_bytes: bytes) -> CData:
 
 
 def serialize(pubkey: CData, compressed: bool = True) -> bytes:
-    """Serialize an internal public key, in compressed form by default."""
+    """Serialize an internal public key, in compressed form by default.
+
+    Args:
+        pubkey: the libsecp256k1 public key object, as `parse` returns.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The 33-byte compressed serialization, or the 65-byte
+        uncompressed one.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails, which a key it produced
+            cannot make it do.
+
+    Example:
+        >>> from btclib_libsecp256k1 import keys, mult
+        >>> keys.serialize(keys.parse(mult.mult_(1))).hex()[:10]
+        '0279be667e'
+    """
     size = 33 if compressed else 65
     output = ffi.new(f"char[{size}]")
     length = ffi.new("size_t *", size)

--- a/btclib_libsecp256k1/mult.py
+++ b/btclib_libsecp256k1/mult.py
@@ -13,7 +13,27 @@ from .context import ctx
 
 
 def mult_(num: bytes | int) -> bytes:
-    """Multiply the generator point."""
+    """Multiply the generator point, in serialized form.
+
+    Args:
+        num: the scalar to multiply the generator by, 32 bytes or an int
+            below 2**256.
+
+    Returns:
+        The resulting point, uncompressed: 65 bytes opening with 0x04.
+        `keys.serialize(keys.parse(...))` is the compressed form of it.
+
+    Raises:
+        ValueError: if the scalar is not 32 bytes or does not fit in
+            them, or if it is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to serialize the point,
+            which no input can make it do.
+
+    Example:
+        >>> from btclib_libsecp256k1 import mult
+        >>> mult.mult_(1).hex()[:10]
+        '0479be667e'
+    """
     num_bytes = scalar(num, "scalar")
     point = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_create(ctx, point, num_bytes):
@@ -28,6 +48,22 @@ def mult_(num: bytes | int) -> bytes:
 
 
 def mult(num: bytes | int) -> tuple[int, int]:
-    """Multiply the generator point."""
+    """Multiply the generator point, as a pair of coordinates.
+
+    Args:
+        num: the scalar to multiply the generator by, 32 bytes or an int
+            below 2**256.
+
+    Returns:
+        The affine coordinates (x, y) of the resulting point, as ints.
+        This is `mult_` with the two halves of its output read as big
+        endian integers; a caller that wants bytes wants `mult_`.
+
+    Raises:
+        ValueError: if the scalar is not 32 bytes or does not fit in
+            them, or if it is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to serialize the point,
+            which no input can make it do.
+    """
     result = mult_(num)
     return int.from_bytes(result[1:33], "big"), int.from_bytes(result[33:], "big")

--- a/btclib_libsecp256k1/recovery.py
+++ b/btclib_libsecp256k1/recovery.py
@@ -21,7 +21,24 @@ def sign(
 ) -> tuple[bytes, int]:
     """Create a recoverable ECDSA signature.
 
-    Return the 64-byte compact signature and its recovery id.
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        ndata: 32 bytes of extra entropy mixed into the nonce, or None
+            for the RFC6979 nonce alone.
+
+    Returns:
+        The 64-byte compact signature and its recovery id. The id is 0
+        or 1 for any signature this function produces; 2 and 3 exist for
+        a nonce point whose x exceeded the group order, which no key
+        reaches in practice.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if ndata is
+            given and is not 32 bytes, or if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to serialize the signature,
+            which no input can make it do.
     """
     prvkey_bytes = scalar(prvkey, "private key")
     if len(msg_bytes) != 32:
@@ -50,7 +67,26 @@ def sign(
 
 
 def recover(msg_bytes: bytes, signature_bytes: bytes, recid: int) -> bytes:
-    """Recover the compressed public key from a recoverable ECDSA signature."""
+    """Recover the compressed public key from a recoverable ECDSA signature.
+
+    Args:
+        msg_bytes: the 32-byte hash the signature was made over.
+        signature_bytes: the 64-byte compact signature.
+        recid: the recovery id, 0 to 3. A wrong one recovers a different
+            key rather than failing, so it is part of the signature and
+            not a guess.
+
+    Returns:
+        The 33-byte compressed public key.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if the
+            signature is not 64 bytes or has r or s at or above the
+            group order, if recid is outside 0 to 3, or if no key can be
+            recovered.
+        RuntimeError: if libsecp256k1 fails to serialize the key, which
+            no input can make it do.
+    """
     if len(msg_bytes) != 32:
         raise ValueError("the message hash must be 32 bytes")
     if len(signature_bytes) != 64:
@@ -78,6 +114,21 @@ def to_der(signature_bytes: bytes, recid: int) -> bytes:
     Beware: the conversion does not normalize the signature, so a
     high-s input is rejected by dsa.verify; signatures produced by
     sign are always low-s.
+
+    Args:
+        signature_bytes: the 64-byte compact signature.
+        recid: the recovery id, 0 to 3. It is required because
+            libsecp256k1 parses the pair before dropping the id, and
+            refuses one out of range.
+
+    Returns:
+        The same signature in DER encoding, s unchanged.
+
+    Raises:
+        ValueError: if the signature is not 64 bytes or has r or s at or
+            above the group order, or if recid is outside 0 to 3.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            signature, which no input can make it do.
     """
     if len(signature_bytes) != 64:
         raise ValueError("the signature must be 64 bytes")
@@ -98,7 +149,18 @@ def to_der(signature_bytes: bytes, recid: int) -> bytes:
 
 
 def _parse(signature_bytes: bytes, recid: int) -> CData:
-    """Parse a compact signature and its recovery id."""
+    """Parse a compact signature and its recovery id.
+
+    Args:
+        signature_bytes: the 64-byte compact signature.
+        recid: the recovery id, 0 to 3.
+
+    Returns:
+        The libsecp256k1 recoverable signature object.
+
+    Raises:
+        ValueError: if r or s is at or above the group order.
+    """
     signature = ffi.new("secp256k1_ecdsa_recoverable_signature *")
     if not lib.secp256k1_ecdsa_recoverable_signature_parse_compact(
         ctx, signature, signature_bytes, recid

--- a/btclib_libsecp256k1/ssa.py
+++ b/btclib_libsecp256k1/ssa.py
@@ -25,7 +25,35 @@ EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"
 def sign(
     msg_bytes: bytes, prvkey: bytes | int, aux_rand32: bytes | None = None
 ) -> bytes:
-    """Create a Schnorr signature of a 32-byte message hash."""
+    """Create a Schnorr signature of a 32-byte message hash.
+
+    Args:
+        msg_bytes: the 32-byte message hash.
+        prvkey: the private key, 32 bytes or an int below 2**256. The
+            signature is of its x-only public key, so the key is negated
+            first where its y is odd, as BIP340 prescribes.
+        aux_rand32: the 32 bytes of auxiliary randomness BIP340 defines,
+            or None for fresh randomness. Never a shorter value: BIP340
+            defines a 32-byte a, and padding a short one would make a
+            caller mistake a valid argument.
+
+    Returns:
+        The 64-byte signature.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if aux_rand32
+            is given and is not 32 bytes, or if the private key is not
+            32 bytes, does not fit in them, or is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to sign, which no input can
+            make it do.
+
+    Example:
+        >>> from btclib_libsecp256k1 import ssa, xonly, mult
+        >>> msg, prvkey = bytes(32), 1
+        >>> pubkey, _ = xonly.from_pubkey(mult.mult_(prvkey))
+        >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
+        True
+    """
     if len(msg_bytes) != 32:
         raise ValueError("the message hash must be 32 bytes")
     keypair = _keypair(prvkey)
@@ -49,6 +77,22 @@ def sign_custom(
     (hashes.tagged_sha256) and sign that instead, so that a signature
     cannot be read as one of a different protocol. For a 32-byte message
     the signature is the one sign returns.
+
+    Args:
+        msg_bytes: the message, of any length.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: the 32 bytes of auxiliary randomness, or None for
+            fresh randomness.
+
+    Returns:
+        The 64-byte signature.
+
+    Raises:
+        ValueError: if aux_rand32 is given and is not 32 bytes, or if
+            the private key is not 32 bytes, does not fit in them, or is
+            not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to sign, which no input can
+            make it do.
     """
     keypair = _keypair(prvkey)
 
@@ -75,6 +119,21 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
     that: dropping the y coordinate of a full public key is a decision
     of the caller, `xonly.from_pubkey` being the conversion, because a
     key with odd y verifies as the point that is not the one passed.
+
+    Args:
+        msg_bytes: the message, of any length. It is the 32-byte hash
+            for a signature made by `sign`.
+        pubkey_bytes: the 32-byte x-only public key, and only that.
+        signature_bytes: the 64-byte signature.
+
+    Returns:
+        True if the signature is valid for that key and message.
+
+    Raises:
+        ValueError: if the signature is not 64 bytes, if the public key
+            is not 32 bytes, or if it is not a valid x coordinate. A
+            well-formed signature that simply does not verify is False,
+            not an exception.
     """
     if len(signature_bytes) != 64:
         raise ValueError("the signature must be 64 bytes")
@@ -94,7 +153,18 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
 
 
 def _keypair(prvkey: bytes | int) -> CData:
-    """Create a keypair from a private key."""
+    """Create a keypair from a private key.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The libsecp256k1 keypair object.
+
+    Raises:
+        ValueError: if the key is not 32 bytes, does not fit in them, or
+            is not in [1, n-1].
+    """
     keypair = ffi.new("secp256k1_keypair *")
     if not lib.secp256k1_keypair_create(ctx, keypair, scalar(prvkey, "private key")):
         raise ValueError("invalid private key")
@@ -109,6 +179,15 @@ def _aux_rand32(aux_rand32: bytes | None) -> bytes:
     the entropy of a nonce and not a serialization: a shorter value is a
     caller mistake rather than a small number, and padding it here would
     turn one into a valid argument.
+
+    Args:
+        aux_rand32: the 32 bytes given by the caller, or None.
+
+    Returns:
+        Those 32 bytes, or 32 freshly generated ones.
+
+    Raises:
+        ValueError: if a value is given and is not 32 bytes.
     """
     if aux_rand32 is None:
         return secrets.token_bytes(32)

--- a/btclib_libsecp256k1/xonly.py
+++ b/btclib_libsecp256k1/xonly.py
@@ -26,7 +26,22 @@ from .context import ctx
 
 
 def from_pubkey(pubkey_bytes: bytes) -> tuple[bytes, int]:
-    """Convert a public key into its x-only form and y parity."""
+    """Convert a public key into its x-only form and y parity.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+
+    Returns:
+        The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
+        odd. The parity is returned rather than dropped because the
+        x-only key of an odd-y point is the key of its negation, which
+        the caller may need to know.
+
+    Raises:
+        ValueError: if the public key is not a valid point.
+        RuntimeError: if libsecp256k1 fails to convert or serialize it,
+            which no valid key can make it do.
+    """
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -36,7 +51,24 @@ def from_pubkey(pubkey_bytes: bytes) -> tuple[bytes, int]:
 def tweak_add(pubkey_bytes: bytes, tweak: bytes | int) -> tuple[bytes, int]:
     """Add the generator multiplied by the tweak to an x-only public key.
 
-    Return the tweaked x-only public key and its y parity.
+    This is the BIP341 taproot output key, given the internal key and
+    the TapTweak hash.
+
+    Args:
+        pubkey_bytes: the 32-byte x-only internal key.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked x-only key, and the parity of its y: that
+        parity is what a taproot output commits to, and what
+        `tweak_add_check` is given back.
+
+    Raises:
+        ValueError: if the key is not 32 bytes or not a valid x
+            coordinate, if the tweak is not 32 bytes or does not fit in
+            them, or if the tweak or the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            result, which no valid input can make it do.
     """
     internal_pubkey = _parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
@@ -59,6 +91,22 @@ def tweak_add_check(
 
     This is the verification of a taproot commitment: it is cheaper than
     recomputing the tweak, as it compares the serialized keys.
+
+    Args:
+        tweaked_pubkey_bytes: the 32-byte x-only key to check.
+        tweaked_parity: the parity of its y, 0 or 1, as `tweak_add`
+            returned it.
+        pubkey_bytes: the 32-byte x-only internal key.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        True if tweaking the internal key by that tweak gives that key
+        and that parity.
+
+    Raises:
+        ValueError: if either key is not 32 bytes or not a valid x
+            coordinate, if the parity is not 0 or 1, or if the tweak is
+            not 32 bytes or does not fit in them.
     """
     if len(tweaked_pubkey_bytes) != 32:
         raise ValueError("the tweaked x-only public key must be 32 bytes")
@@ -82,6 +130,21 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     even y point, so that the x-only public key of the result is the
     tweak_add of the x-only public key of the input: this is the private
     key to sign a taproot key path spending with.
+
+    Args:
+        prvkey: the internal private key, 32 bytes or an int below
+            2**256.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked private key.
+
+    Raises:
+        ValueError: if either value is not 32 bytes or does not fit in
+            them, if the private key is not in [1, n-1], or if the tweak
+            or the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to extract the key, which no
+            valid input can make it do.
     """
     keypair = _keypair(prvkey)
     tweak_bytes = scalar(tweak, "tweak")
@@ -95,7 +158,17 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
 
 
 def _parse(pubkey_bytes: bytes) -> CData:
-    """Parse a 32-byte x-only public key."""
+    """Parse a 32-byte x-only public key.
+
+    Args:
+        pubkey_bytes: the 32-byte x coordinate.
+
+    Returns:
+        The libsecp256k1 x-only public key object.
+
+    Raises:
+        ValueError: if it is not 32 bytes, or not a valid x coordinate.
+    """
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
     if len(pubkey_bytes) != 32:
         raise ValueError("the x-only public key must be 32 bytes")
@@ -107,7 +180,18 @@ def _parse(pubkey_bytes: bytes) -> CData:
 
 
 def _to_xonly(pubkey: CData) -> tuple[bytes, int]:
-    """Serialize a public key as its x-only form and y parity."""
+    """Serialize a public key as its x-only form and y parity.
+
+    Args:
+        pubkey: the libsecp256k1 public key object.
+
+    Returns:
+        Its 32-byte x coordinate, and the parity of y.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to convert or serialize it,
+            which no valid key can make it do.
+    """
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     parity = ffi.new("int *")
     if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
@@ -120,7 +204,18 @@ def _to_xonly(pubkey: CData) -> tuple[bytes, int]:
 
 
 def _keypair(prvkey: bytes | int) -> CData:
-    """Create a keypair from a private key."""
+    """Create a keypair from a private key.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The libsecp256k1 keypair object.
+
+    Raises:
+        ValueError: if the key is not 32 bytes, does not fit in them, or
+            is not in [1, n-1].
+    """
     keypair = ffi.new("secp256k1_keypair *")
     if not lib.secp256k1_keypair_create(ctx, keypair, scalar(prvkey, "private key")):
         raise ValueError("invalid private key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,6 +390,31 @@ ignore = [
 # wraps the decorator over three lines to say the same thing
 parametrize-names-type = "csv"
 
+# what keeps the docstrings of the boundary complete, ruff having no
+# rule for a missing argument: pydocstyle below asks that a docstring
+# exists, and this asks that it says what the function takes and gives
+# back. Run as a hook, over btclib_libsecp256k1 only; see the comment
+# there for the scope
+[tool.pydoclint]
+# napoleon renders it, which is what docs/source/conf.py enables, so the
+# sections here are the ones sphinx already understands
+style = "google"
+# the types are in the signature, and mypy is strict: repeating them in
+# the docstring is a second place to be wrong
+arg-type-hints-in-docstring = false
+check-return-types = false
+# the default skips a docstring that is only a summary line, which is
+# exactly the state this check exists to end: without it every function
+# documented in one line passes, and the gate holds nothing
+skip-checking-short-docstrings = false
+# and this one is off, deliberately. It compares the Raises section with
+# the `raise` statements of the body, and these wrappers raise mostly
+# through what they call -- _scalar.scalar, keys.parse, keys.serialize --
+# so what a caller catches is not what the body raises. Kept on, it would
+# force each docstring to document its own body instead of its contract,
+# which is the opposite of what these sections are for
+skip-checking-raises = true
+
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,89 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every example in the documentation is executed.
+
+An example nobody runs is documentation that stops being true silently,
+and the README's own example was one: it sat there through five
+releases with nothing to notice if the call it shows had changed shape.
+
+`doctest` is used through the standard library rather than through
+pytest's `--doctest-modules`, and the reason is what this package is.
+`testpaths` is `tests`, and widening it to the package would collect the
+*source* tree -- which is the right thing locally, where the extension
+is an editable build of it, and the wrong thing in the wheel jobs, where
+what has to be exercised is the module inside the installed wheel.
+Importing the package by name gets whichever of the two is installed, on
+every one of the eleven kinds of wheel, which is the point.
+
+The examples are therefore constrained to be deterministic: fixed keys,
+and a verification rather than a signature wherever the value depends on
+randomness that is not pinned.
+"""
+
+from __future__ import annotations
+
+import doctest
+import importlib
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+import btclib_libsecp256k1
+
+_ROOT = Path(__file__).parents[1]
+
+
+def _modules() -> list[str]:
+    """Every module of the installed package, the package itself included.
+
+    Returns:
+        The dotted names, sorted, read off the imported package rather
+        than off the source tree: what is documented has to be what a
+        user imports.
+    """
+    prefix = f"{btclib_libsecp256k1.__name__}."
+    found = pkgutil.iter_modules(btclib_libsecp256k1.__path__, prefix)
+    return sorted([btclib_libsecp256k1.__name__, *(info.name for info in found)])
+
+
+@pytest.mark.parametrize("name", _modules())
+def test_the_examples_of_a_module_run(name: str) -> None:
+    """Run the doctests of one module, and require that none failed.
+
+    Args:
+        name: the dotted name of the module.
+    """
+    results = doctest.testmod(importlib.import_module(name))
+    assert results.failed == 0, (
+        f"{results.failed} of {results.attempted} examples failed in {name};"
+        " the captured output above is what doctest reported"
+    )
+
+
+def test_the_package_carries_examples_at_all() -> None:
+    """Guard the test above against passing on a package with no examples."""
+    attempted = sum(
+        doctest.testmod(importlib.import_module(name)).attempted for name in _modules()
+    )
+    assert attempted > 0, "no module of the package carries a doctest any more"
+
+
+def test_the_readme_examples_run() -> None:
+    """Run the quickstart, which is the README's own examples.
+
+    The README is the documentation of this package, and the quickstart
+    is the page a reader arriving from `pip install` lands on: it is
+    executed here for the same reason the docstrings are.
+    """
+    results = doctest.testfile(
+        str(_ROOT / "README.md"), module_relative=False, verbose=False
+    )
+    assert results.attempted > 0, "the README carries no doctest any more"
+    assert results.failed == 0, (
+        f"{results.failed} of {results.attempted} README examples failed;"
+        " the captured output above is what doctest reported"
+    )


### PR DESCRIPTION
Steps 0 to 2 of #40. **Step 3 is deliberately not here**, and the reason is
that the tree answered that question the other way after the issue was
written: `1066ab0 Give the bindings a Sphinx build, matching btclib's own
docs/` created `docs/`, `.readthedocs.yaml` and the
`documentation = "https://btclib-libsecp256k1.readthedocs.io"` url, which is
the sphinx-on-Read-the-Docs option the issue considered and rejected in
favour of pdoc on Pages. Reversing a decision the tree now carries is not
something a docstring pull request should do — see the issue comment.

## 0 — the contracts, and the gate

Every function documents its arguments, its return value and what it raises,
in the Google style napoleon already renders. The `Raises` lines are the
README's *What the boundary checks*, said where a reader of `help()` or of an
IDE tooltip will find them — which for a package shipped as a compiled wheel
is the only place they can be. `mult.mult_` and `mult.mult`, which shared a
docstring verbatim, now each say what they return.

The gate is a **pydoclint** hook over the package, configured in
`pyproject.toml`:

- `skip-checking-short-docstrings = false`, because the default lets a
  one-line docstring — the state this ends — pass, and the gate would hold
  nothing;
- `skip-checking-raises = true`, deliberately: these wrappers raise through
  `_scalar.scalar`, `keys.parse` and `keys.serialize`, so comparing a
  `Raises` section with the body's own `raise` statements would ask the
  docstrings to be wrong. The reasoning is recorded where it is turned off.

## 1 — the examples run

`tests/test_examples.py` runs `doctest` over every module of the **installed**
package and over `README.md`, on every interpreter and every kind of wheel.
Through the standard library rather than `--doctest-modules`, because
widening `testpaths` to the package would collect the *source* tree where the
wheel jobs have to exercise the module inside the wheel.

## 2 — a quickstart, tested

`README.md` opens with one: sign and verify, ECDSA and BIP340, for someone
who has just typed `pip install`. It is those doctests.

## Handed something bad, and watched to fail

| planted | caught by |
| --- | --- |
| an argument added to `tagged_sha256`, undocumented | `DOC101`, `DOC103` |
| a wrong expected value in the README example | `test_the_readme_examples_run` |
| a wrong expected value in a docstring example | `test_the_examples_of_a_module_run[…hashes]` |

All three restored: 230 passed at 100.00% coverage, gate green.

## Summary by Sourcery

Document public API contracts and enforce them via docstring linting and executable examples.

Enhancements:
- Expand docstrings across the public boundary (keys, dsa, ssa, xonly, recovery, ellswift, mult, hashes, ecdh, context, scalar, library loader) to fully describe arguments, return values, raised exceptions, and include illustrative doctest examples where helpful.

Build:
- Configure pydoclint in pyproject.toml and wire it into pre-commit to ensure boundary functions document their parameters and return values, with explicit rationale for disabled raise-checking.

Documentation:
- Add a README quickstart section showing end-to-end ECDSA and BIP340 signing/verifying and clarify CONTRIBUTING guidelines around docstring contracts and executable documentation.

Tests:
- Introduce tests/test_examples.py to run doctests for every installed package module and README.md, and add guards that fail if examples are removed or start failing.