### PR TITLE
Restore the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,4 @@
 ---
-# TEMPORARY: every matrix in this file is cut to ubuntu-latest and CPython
-# 3.14, and build-cibuildwheel to the cp314 identifiers, so that a series of
-# pull requests can be turned around while GitHub is degraded and the full
-# matrix is neither fast nor trustworthy. Each site says so and carries the
-# list it was cut from; the commit that did it is one `git revert` away, and
-# reverting it is what restores them all. Nothing here is a statement about
-# what the package supports: the eleven kinds of wheel are unchanged, and no
-# release may be cut while this note stands
 name: test
 
 on:
@@ -111,12 +103,6 @@ jobs:
     # off, an interpreter that is missing is a job that fails instead
     env:
       UV_PYTHON_DOWNLOADS: never
-      # TEMPORARY, see the note at the top of this file: the interpreters
-      # cibuildwheel builds for are not a matrix of this workflow but a
-      # `skip` in [tool.cibuildwheel], so cutting them to 3.14 is an
-      # override here rather than an edit to pyproject.toml, which a
-      # release reads. Unset, this job builds seven wheels per platform
-      CIBW_BUILD: "cp314-*"
     strategy:
       # as for the test matrices, and here it costs more: with the
       # default, one platform failing (or one flaky runner) cancels the
@@ -134,11 +120,16 @@ jobs:
         # everywhere, provisioned as a build requirement: no runner needs
         # a toolchain installed by hand.
         # Actions drops x86_64 macOS in August 2027, after which no runner
-        # can build a macosx x86_64 wheel at all.
-        # TEMPORARY, see the note at the top of this file. The full list is
-        #   [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest,
-        #    windows-latest, windows-11-arm]
-        os: [ubuntu-latest]
+        # can build a macosx x86_64 wheel at all
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-26-intel,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+          ]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -202,10 +193,8 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu-latest/macos-26-intel are x86_64,
-        # ubuntu-24.04-arm/macos-latest are arm64.
-        # TEMPORARY, see the note at the top of this file. The full list is
-        #   [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest]
-        os: [ubuntu-latest]
+        # ubuntu-24.04-arm/macos-latest are arm64
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -330,9 +319,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY, see the note at the top of this file. The full list is
-        #   [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # the wheel jobs all build with an interpreter of the runner's own
         # architecture, so nothing else exercises a build whose target is
         # not the host: an emulated x86-64 interpreter on Windows arm64,
@@ -340,15 +327,10 @@ jobs:
         # taking the host architecture left every libsecp256k1 symbol
         # unresolved at link time. This is the platform where an
         # architecture can be requested that is not the runner's, and the
-        # sdist is the path that compiles on the user's machine.
-        # TEMPORARY, see the note at the top of this file. The entry is
-        #   include:
-        #     - os: windows-11-arm
-        #       architecture: x64
-        # and the empty value below stands in for it: two expressions read
-        # matrix.architecture, and actionlint rejects a property no entry
-        # of the matrix defines
-        architecture: [""]
+        # sdist is the path that compiles on the user's machine
+        include:
+          - os: windows-11-arm
+            architecture: x64
     needs: build-sdist
 
     steps:
@@ -525,19 +507,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY, see the note at the top of this file. The full list is
-        #   [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest,
-        #    windows-latest]
-        os: [ubuntu-latest]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-26-intel,
+            macos-latest,
+            windows-latest,
+          ]
         # 3.14t, the free-threaded interpreter, matters here in particular:
         # the dynamic wheel is tagged py3-none, so it is what a
         # free-threaded interpreter installs, and unlike the static wheels
         # nothing else exercises it (cibuildwheel tests every wheel it
-        # builds, including cp314t; this job has no such counterpart).
-        # TEMPORARY, see the note at the top of this file. The full list is
-        #   ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10",
-        #    "pypy-3.11"]
-        python-version: ["3.14"]
+        # builds, including cp314t; this job has no such counterpart)
+        python-version:
+          [
+            "3.10",
+            "3.11",
+            "3.12",
+            "3.13",
+            "3.14",
+            "3.14t",
+            "pypy-3.10",
+            "pypy-3.11",
+          ]
     needs: [build-windows, build-dynamic]
 
     steps:
@@ -585,13 +578,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY, see the note at the top of this file. The full lists are
-        #   os: [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel,
-        #        macos-latest, windows-latest, windows-11-arm]
-        #   python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t",
-        #                    "pypy-3.11"]
-        os: [ubuntu-latest]
-        python-version: ["3.14"]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-26-intel,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+          ]
+        python-version:
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
         # cibuildwheel already runs the suite against every wheel it
         # builds, cp314t included: what this job adds is that pip, given a
         # directory holding all of them, selects the right one, which for
@@ -599,15 +596,14 @@ jobs:
         # PyPy wheels are not built on Windows, on either architecture.
         # CPython has no Windows arm64 build before 3.11, so there is no
         # interpreter to test a win_arm64 wheel against and cibuildwheel
-        # does not produce one.
-        # TEMPORARY, see the note at the top of this file. The entries are
-        #   exclude:
-        #     - os: windows-latest
-        #       python-version: "pypy-3.11"
-        #     - os: windows-11-arm
-        #       python-version: "pypy-3.11"
-        #     - os: windows-11-arm
-        #       python-version: "3.10"
+        # does not produce one
+        exclude:
+          - os: windows-latest
+            python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "pypy-3.11"
+          - os: windows-11-arm
+            python-version: "3.10"
     needs: build-cibuildwheel
 
     steps:


### PR DESCRIPTION
Revert of `e5e85db` (#50), which cut every matrix to `ubuntu-latest` and
CPython 3.14 while a run of pull requests was turned around against a
degraded GitHub. That run is over — seventeen of them were merged without
waiting for a matrix — and **this pull request is the first one that runs
it**, which is the point of merging it before anything else.

Two hunks conflicted, and were resolved by keeping what landed in between
rather than what the cut had displaced:

- the `concurrency-suffix` input of #52;
- the removal of the unread `PYTHON_VERSION` / `OS_NAME` of #56.

Against `e5e85db^` the file now differs by exactly those two changes, and no
`TEMPORARY` marker, `CIBW_BUILD` override or empty `architecture` entry
survives.

**Do not merge this on a red matrix without reading it**: a failure here is
the first news of whatever the seventeen merges did to the platforms this
machine cannot build for.

## Summary by Sourcery

Restore the full GitHub Actions test and build matrices that were temporarily reduced during degraded GitHub performance.

CI:
- Re-enable full OS matrices for wheel builds, test runs, and source distribution checks across Linux, macOS (Intel and Apple Silicon), and Windows (including arm64).
- Restore the complete Python version matrix for dynamic and cibuildwheel tests, including CPython 3.10–3.14, 3.14t, and relevant PyPy versions.
- Reinstate matrix include/exclude entries for Windows arm64 builds and tests, ensuring coverage of cross-architecture and PyPy scenarios.
- Remove temporary matrix-cut comments and the `CIBW_BUILD` override used to limit builds to CPython 3.14.