### PR TITLE
Serialize the public key of a private key in either form, in one call

### DIFF
--- a/.github/mutation/bindings.toml
+++ b/.github/mutation/bindings.toml
@@ -52,7 +52,7 @@
 [cosmic-ray]
 # the package, not one module: it is small enough that scoping it further
 # would be excluding code from the question rather than dividing the work.
-# 771 mutants, which `cosmic-ray init` enumerates in under a second.
+# 777 mutants, which `cosmic-ray init` enumerates in under a second.
 # The vendored C is not in it and cannot be -- libsecp256k1 is upstream's,
 # and what this repository is answerable for is how the bindings drive it
 module-path = "btclib_libsecp256k1"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 304
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -160,27 +160,43 @@
         "line_number": 419
       }
     ],
+    "tests/test_keys.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "1ca7070af97c241308c852cf0d57aae03b700331",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_keys.py",
+        "hashed_secret": "558a75beb0a48857bb01a142c133f4bc1fc9755a",
+        "is_verified": false,
+        "line_number": 80
+      }
+    ],
     "tests/test_properties.py": [
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 324
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
         "is_verified": false,
-        "line_number": 340
+        "line_number": 347
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
-        "line_number": 343
+        "line_number": 350
       }
     ],
     "tests/test_vectors.py": [
@@ -189,240 +205,240 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 619
+        "line_number": 635
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 620
+        "line_number": 636
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 621
+        "line_number": 637
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 626
+        "line_number": 642
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 627
+        "line_number": 643
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 628
+        "line_number": 644
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 647
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 633
+        "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 634
+        "line_number": 650
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 635
+        "line_number": 651
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 640
+        "line_number": 656
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 641
+        "line_number": 657
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 642
+        "line_number": 658
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 650
+        "line_number": 666
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 651
+        "line_number": 667
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 652
+        "line_number": 668
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 660
+        "line_number": 676
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 661
+        "line_number": 677
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 662
+        "line_number": 678
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 681
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 670
+        "line_number": 686
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 671
+        "line_number": 687
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 672
+        "line_number": 688
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 711
+        "line_number": 727
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 714
+        "line_number": 730
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 731
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 738
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 723
+        "line_number": 739
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 756
+        "line_number": 772
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 757
+        "line_number": 773
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 781
+        "line_number": 797
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 782
+        "line_number": 798
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 798
+        "line_number": 814
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 799
+        "line_number": 815
       }
     ]
   },
-  "generated_at": "2026-08-06T21:22:01Z"
+  "generated_at": "2026-08-06T21:26:24Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,62 @@ release-notes length in the first place, and are still in
 Grouped, and the order runs from what a caller sees to what only
 maintainers do. Nothing here breaks a caller: the wrapped
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.7.1)
-is the same 0.7.1 (1a53f49), no wrapper changed behaviour, and nothing in
-the public API moved. Neither file counts its entries: `grep -c '^- '`
-does that, whereas a stated number is a line every open branch has to
-edit.
+is the same 0.7.1 (1a53f49), nothing in the public API moved, and what it
+gained is one function. One wrapper changed behaviour, in the text of an
+error message, and the entry below says which and why. Neither file
+counts its entries: `grep -c '^- '` does that, whereas a stated number is
+a line every open branch has to edit.
+
+### What the boundary answers
+
+- **`keys.pubkey_from_prvkey` is the public key of a private key, in
+  either serialization** (#41, #68). One `secp256k1_ec_pubkey_create`
+  plus one `keys.serialize`, which is the shape `pubkey_negate`,
+  `pubkey_tweak_add`, `pubkey_tweak_mul`, `pubkey_combine` and
+  `pubkey_sort` already had — a C operation on a `secp256k1_pubkey`, then
+  the serialization with its flag as an argument. Generator
+  multiplication was the exception: `mult.mult_` wrote that serialize
+  inline with the flag as the literal `2`, so the one producer whose
+  input is a private key rather than a point was also the one that could
+  not answer the compressed form `keys`' own docstring promises. Put
+  structurally, the package could create a `secp256k1_pubkey` from a
+  private key, and could serialize one compressed, and never let the same
+  caller do both: `serialize` takes a pointer only `parse` hands out,
+  that is, bytes already serialized. `mult_` is the `compressed=False`
+  case of the new function now and has lost the inline serialize, the one
+  duplication of `serialize` the package had, so the API gains a name
+  while the code at the cffi boundary shrinks. What it saves a caller who
+  had been composing it, measured per call over 2000 random keys, best of
+  nine: 7.67 µs, against 7.75 for the byte slice btclib ships, 8.13 for
+  `keys.serialize(keys.parse(mult_(q)))` — which pays a
+  `secp256k1_ec_pubkey_parse` to undo a serialization the same library
+  has just done — and 8.90 for the composition through the coordinates,
+  which turns 64 bytes into two ints and re-proves on curve a point
+  libsecp256k1 had just produced. Against the slice that is 0.8%, and it
+  was not treated as the argument: the argument, with its alternatives,
+  is in #41 — the compressed encoding stops being written outside the
+  wrapper. btclib reads `sec[64]` rather than `sec[-1]` so that a 33-byte
+  answer raises instead of passing off a byte of x as a parity, and keeps
+  a test pinning this package's 65-byte serialization from outside it;
+  making `mult_` the uncompressed case of one function is what keeps that
+  contract true by construction rather than by a downstream test.
+  Validated against what is published rather than against the bindings:
+  the BIP340 vectors' *public key* column is the x of this call for every
+  vector carrying a secret key, 1G is pinned in both forms against the
+  generator of SEC 2 v.2 section 2.4.1 and 6G for the odd y no smaller
+  key exhibits, and the 128-key sweep compares what libsecp256k1
+  serializes with the compression `tests/test_properties.py` composes
+  itself, both parities occurring across it. The README quickstart, which
+  had been composing `keys.serialize(keys.parse(mult.mult_(prvkey)))` on
+  the package's own front page, is the one call now.
+- **The `ValueError` of a generator multiplication names a private key**
+  where it said scalar, which is the one behaviour a caller can see
+  change. `secp256k1_ec_pubkey_create` calls its argument a seckey and is
+  what refuses anything outside `[1, n-1]`, so the message names what the
+  library refused rather than what the mult module calls it; `mult_`
+  answers exactly the 65 bytes it did, opening with `0x04`, and
+  `tests/test_core.py` asserts the new text so that the next change to it
+  is deliberate.
 
 ### The documented boundary
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,12 +9,24 @@ a tag is generated from.
 
 The same
 [libsecp256k1 0.7.1](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.7.1)
-(1a53f49) as v0.7.1, and the same bindings: **no breaking changes** — no
-wrapper changed behaviour, and nothing in the public API moved. What a
-fourth number carries here is the contract of each function where a
-caller reads it, a static extension compiled the way the interpreter
-compiles its own, and metadata that says what the wheels are.
+(1a53f49) as v0.7.1: **no breaking changes** — nothing in the public API
+moved, and the one wrapper whose behaviour changed changed the text of an
+error message. What a fourth number carries here is one new function, the
+contract of every function where a caller reads it, a static extension
+compiled the way the interpreter compiles its own, and metadata that says
+what the wheels are.
 
+- **`keys.pubkey_from_prvkey` is the public key of a private key**,
+  compressed by default, and the 65 bytes of `mult.mult_` with
+  `compressed=False` — which is what `mult_` now is. Generator
+  multiplication was the one producer here that could not answer the
+  compressed form, so a caller who wanted the 33 bytes had to parse and
+  re-serialize what libsecp256k1 had just serialized, or slice the parity
+  out of the 65 bytes themselves. `mult_` answers exactly what it did;
+  the one thing to know is that the `ValueError` of a scalar outside
+  `[1, n-1]` now names a private key, which is what
+  `secp256k1_ec_pubkey_create` calls its argument, so code matching on
+  that message matches on the new text.
 - **Every function documents its arguments, its return value and what it
   raises.** That contract used to be prose in the README, several hundred
   lines from the functions it applies to, which for a package shipped as

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ test suite, on every interpreter and every kind of wheel, so an example
 that stops working fails a build rather than sitting here:
 
     >>> import hashlib
-    >>> from btclib_libsecp256k1 import dsa, keys, mult, ssa, xonly
+    >>> from btclib_libsecp256k1 import dsa, keys, ssa, xonly
 
     >>> # BIP340 test vector 1; yours comes from os.urandom or a wallet
     >>> prvkey = 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF
-    >>> pubkey = keys.serialize(keys.parse(mult.mult_(prvkey)))
+    >>> pubkey = keys.pubkey_from_prvkey(prvkey)
     >>> msg = hashlib.sha256(b"hello").digest()
 
 ECDSA, over the 32-byte hash, with the deterministic RFC6979 nonce:
@@ -197,7 +197,9 @@ declarations are available through the `lib` and `ffi` cffi objects:
 | `musig`             | raw `lib` bindings, by decision           |
 | `ellswift`          | `ellswift` (BIP324)                       |
 
-`keys` provides the scalar and point algebra (tweaking, negation,
+`keys` provides the public key of a private key (`pubkey_from_prvkey`,
+compressed by default, of which `mult.mult_` is the uncompressed
+spelling) and the scalar and point algebra (tweaking, negation,
 combination, arbitrary point multiplication) underlying BIP32 key
 derivation, plus the lexicographic ordering of public keys (`pubkey_cmp`,
 `pubkey_sort`) that BIP67 and MuSig2 key aggregation call for; `xonly`

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -112,6 +112,40 @@ def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     return ffi.unpack(prvkey_buffer, 32)
 
 
+def pubkey_from_prvkey(prvkey: bytes | int, compressed: bool = True) -> bytes:
+    """Return the public key of a private key, i.e. the point kG.
+
+    This is the generator multiplication of `mult.mult_`, with the
+    serialization flag this module's other producers all take: `mult_`
+    is its `compressed=False` case, and every private-to-public
+    conversion that wants the compressed form -- BIP32 neutering, a
+    fingerprint, an address -- is this call and nothing after it.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The serialized point kG: 33 bytes whose first octet carries the
+        parity of y, or the 65 bytes of 0x04 || x || y.
+
+    Raises:
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to serialize the point,
+            which no valid key can make it do.
+
+    Example:
+        >>> from btclib_libsecp256k1 import keys
+        >>> keys.pubkey_from_prvkey(1).hex()[:10]
+        '0279be667e'
+    """
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_create(ctx, pubkey, scalar(prvkey, "private key")):
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return serialize(pubkey, compressed)
+
+
 def pubkey_negate(pubkey_bytes: bytes, compressed: bool = True) -> bytes:
     """Negate a public key.
 

--- a/btclib_libsecp256k1/mult.py
+++ b/btclib_libsecp256k1/mult.py
@@ -3,13 +3,18 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Secp256k1 point multiplication."""
+"""Secp256k1 point multiplication.
+
+The two spellings of generator multiplication for a caller who thinks of
+it as an operation on a scalar rather than as the public key of a private
+key: serialized uncompressed, and as a pair of coordinates. The C call is
+`keys.pubkey_from_prvkey`, which is the same multiplication answering in
+either serialization.
+"""
 
 from __future__ import annotations
 
-from . import ffi, lib
-from ._scalar import scalar
-from .context import ctx
+from .keys import pubkey_from_prvkey
 
 
 def mult_(num: bytes | int) -> bytes:
@@ -21,11 +26,14 @@ def mult_(num: bytes | int) -> bytes:
 
     Returns:
         The resulting point, uncompressed: 65 bytes opening with 0x04.
-        `keys.serialize(keys.parse(...))` is the compressed form of it.
+        This is `keys.pubkey_from_prvkey(num, compressed=False)`, whose
+        default is the compressed form of the same point.
 
     Raises:
         ValueError: if the scalar is not 32 bytes or does not fit in
-            them, or if it is not in [1, n-1].
+            them, or if it is not in [1, n-1]. The message names a
+            private key, that being what the scalar of a generator
+            multiplication is to libsecp256k1.
         RuntimeError: if libsecp256k1 fails to serialize the point,
             which no input can make it do.
 
@@ -34,17 +42,7 @@ def mult_(num: bytes | int) -> bytes:
         >>> mult.mult_(1).hex()[:10]
         '0479be667e'
     """
-    num_bytes = scalar(num, "scalar")
-    point = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_create(ctx, point, num_bytes):
-        raise ValueError("invalid scalar: not in [1, n-1]")
-
-    output = ffi.new("char[65]")
-    length = ffi.new("size_t *", 65)
-
-    if lib.secp256k1_ec_pubkey_serialize(ctx, output, length, point, 2):
-        return ffi.unpack(output, 65)
-    raise RuntimeError("point serialization failed")
+    return pubkey_from_prvkey(num, compressed=False)
 
 
 def mult(num: bytes | int) -> tuple[int, int]:
@@ -57,7 +55,8 @@ def mult(num: bytes | int) -> tuple[int, int]:
     Returns:
         The affine coordinates (x, y) of the resulting point, as ints.
         This is `mult_` with the two halves of its output read as big
-        endian integers; a caller that wants bytes wants `mult_`.
+        endian integers; a caller that wants bytes wants `mult_`, or
+        `keys.pubkey_from_prvkey` for the compressed form.
 
     Raises:
         ValueError: if the scalar is not 32 bytes or does not fit in

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,7 +176,9 @@ def test_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="fit in 32 bytes"):
         mult.mult(-1)
 
-    with pytest.raises(ValueError, match="scalar"):
+    # generator multiplication is keys.pubkey_from_prvkey, so what its
+    # message names is the private key the scalar of it is
+    with pytest.raises(ValueError, match="private key"):
         mult.mult(0)
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -64,6 +64,46 @@ def test_prvkey_algebra() -> None:
         keys.prvkey_tweak_add(a, N - a)
 
 
+def test_pubkey_from_prvkey() -> None:
+    """The public key of 1 is the generator, in both serializations.
+
+    The generator is the one published in SEC 2 v.2 section 2.4.1, so
+    neither form is compared with a second computation of this package's.
+    Both parities are exercised, the y of 1G being even and that of 6G
+    odd: the first octet of the compressed form is what carries it, and
+    the uncompressed form drops the 32 bytes it is read from. `mult_` is
+    checked to be the uncompressed case of this function, which is what
+    keeps its 65-byte answer true.
+    """
+    generator = bytes.fromhex(
+        "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    )
+    assert keys.pubkey_from_prvkey(1, False) == generator
+    assert keys.pubkey_from_prvkey(1) == b"\x02" + generator[1:33]
+    # the same key given as bytes and as an int
+    assert keys.pubkey_from_prvkey((1).to_bytes(32, "big")) == b"\x02" + generator[1:33]
+
+    # the odd y, which 1G cannot exhibit
+    assert mult.mult(6)[1] & 1
+    assert keys.pubkey_from_prvkey(6) == b"\x03" + mult.mult_(6)[1:33]
+
+    # mult_ is this function with the compressed flag off
+    for prvkey in (1, 6, N - 1):
+        assert mult.mult_(prvkey) == keys.pubkey_from_prvkey(prvkey, False)
+        assert keys.pubkey_from_prvkey(prvkey) == compress(mult.mult_(prvkey))
+
+    # zero is no private key, and neither is the group order
+    with pytest.raises(ValueError, match="private key"):
+        keys.pubkey_from_prvkey(0)
+    with pytest.raises(ValueError, match="private key"):
+        keys.pubkey_from_prvkey(N)
+    with pytest.raises(ValueError, match="fit in 32 bytes"):
+        keys.pubkey_from_prvkey(2**256)
+    with pytest.raises(ValueError, match="private key must be 32 bytes"):
+        keys.pubkey_from_prvkey(b"\x01" * 31)
+
+
 def test_pubkey_algebra() -> None:
     """Tweaking a public key matches tweaking the private key under it.
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -79,7 +79,10 @@ def test_serialization_round_trips() -> None:
     `mult` is checked to agree with the serialization it is derived from,
     and negating the private key is checked to flip the y while leaving
     the x alone -- which is the point-level meaning of the scalar
-    operation, asserted rather than assumed.
+    operation, asserted rather than assumed. What
+    `keys.pubkey_from_prvkey` serializes in C is checked against the
+    compression composed here, over a sweep in which both parities occur:
+    a fixed key exercises one of them.
     """
     for prvkey in derived(b"serialization"):
         uncompressed = mult.mult_(prvkey)
@@ -88,6 +91,10 @@ def test_serialization_round_trips() -> None:
         # either form parses, and serializes back to either form
         assert keys.serialize(keys.parse(uncompressed)) == compressed
         assert keys.serialize(keys.parse(compressed), False) == uncompressed
+        # and both are what pubkey_from_prvkey answers, whose compressed
+        # form libsecp256k1 writes where this file composes it
+        assert keys.pubkey_from_prvkey(prvkey) == compressed
+        assert keys.pubkey_from_prvkey(prvkey, False) == uncompressed
         # mult agrees with the serialization it is derived from
         assert mult.mult(prvkey) == (
             int.from_bytes(uncompressed[1:33], "big"),

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -45,7 +45,17 @@ from typing import Any
 
 import pytest
 
-from btclib_libsecp256k1 import CData, dsa, ellswift, ffi, lib, mult, recovery, ssa
+from btclib_libsecp256k1 import (
+    CData,
+    dsa,
+    ellswift,
+    ffi,
+    keys,
+    lib,
+    mult,
+    recovery,
+    ssa,
+)
 from btclib_libsecp256k1.context import ctx
 
 # secp256k1 group order
@@ -131,7 +141,10 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
 
     The verification verdict is the vector's own. A vector carrying a
     secret key is also signed and the signature compared byte for byte,
-    which the fixed aux_rand makes possible. Which function signs it is
+    which the fixed aux_rand makes possible, and the public key of that
+    secret key is checked against the vector's -- the published anchor
+    for `keys.pubkey_from_prvkey`, whose compressed answer carries that
+    x and a parity octet BIP340 drops. Which function signs it is
     the length of the message: `ssa.sign` is BIP340's 32-byte signing, and
     `ssa.sign_custom` is the arbitrary-length one, so the four vectors
     added in 2022 -- messages of 0, 1, 17 and 100 octets -- are the only
@@ -147,6 +160,9 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
     if vector["secret key"]:
         seckey = bytes.fromhex(vector["secret key"])
         aux_rand = bytes.fromhex(vector["aux_rand"])
+        # the vector's public key is x(dG), which is the compressed
+        # serialization of the same point without its first octet
+        assert keys.pubkey_from_prvkey(seckey)[1:] == pubkey
         assert ssa.sign_custom(msg, seckey, aux_rand) == sig
         # sign_custom answers a 32-byte message with the signature sign
         # returns, which is what makes the two comparable at all


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## What this changes, and why

Option B of #41, in `keys`, on the argument in that issue's last comment:
the function adds no logic, it removes a hardcoded flag.

`keys.pubkey_from_prvkey(prvkey, compressed=True)` is one
`secp256k1_ec_pubkey_create` plus one `keys.serialize` — the shape
`pubkey_negate`, `pubkey_tweak_add`, `pubkey_tweak_mul`, `pubkey_combine`
and `pubkey_sort` already have, a C operation on a `secp256k1_pubkey`
followed by the serialization with its flag as an argument. `mult.mult_`
becomes its `compressed=False` case and loses the inline serialize whose
flag was the literal `2`, the one duplication of `serialize` the package
had: the published API grows by a name while the code at the cffi
boundary shrinks.

The case is not the microseconds — against the byte slice btclib ships
the function is worth 0.8%. It is that this package could create a
`secp256k1_pubkey` from a private key, and could serialize one
compressed, and never let the same caller do both: `serialize` wants a
pointer only `parse` hands out, that is, bytes already serialized. Every
route across that gap either pays C work the library has just done or
writes the compressed encoding at the call site — which is where btclib's
`sec[64]` and its `test_the_bindings_answer_65_bytes` came from, a
downstream test pinning this package's serialization from outside it.
Making `mult_` the uncompressed case is what keeps that 65-byte contract
true by construction.

**The one observable change** is that the `ValueError` of a generator
multiplication names a private key where it said scalar:
`secp256k1_ec_pubkey_create` calls its argument a seckey, and what
refuses anything outside `[1, n-1]` is that call. Nothing else moves — no
signature changes, and `mult_` still answers 65 bytes opening with
`0x04`.

## How it was verified

Validated against what is published rather than against these bindings:

- the BIP340 vectors' *public key* column is the x of this call, checked
  for every vector carrying a secret key;
- 1G is pinned in both serializations against the generator published in
  SEC 2 v.2 section 2.4.1, and 6G for the odd y no smaller key exhibits;
- the 128-key sweep in `tests/test_properties.py` compares what
  libsecp256k1 serializes with the compression that file composes itself,
  both parities occurring across the sweep;
- `mult_` is asserted to be this function with the flag off, and
  `tests/test_core.py` asserts the new message text.

Commands, and what they answered:

- `uv run --locked --no-default-groups --group test pytest --cov` — 231
  passed, 100.00%, ratchet included;
- `uvx pre-commit run --all-files` — exit 0, read as an exit code and not
  as filtered output;
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — clean, the two
  markdown files edited here being on the documentation site;
- `cosmic-ray init .github/mutation/bindings.toml` on this branch and on
  `dev`, in a second worktree: 777 against 771, which is the count the
  comment in that file states.

CI is not what says so here: **merged without waiting for it**, GitHub
being degraded, and #67 is the pull request that restores the matrix and
reads it.

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest --cov` passes, the coverage ratchet included
- [x] new wrapped functionality is validated against vectors published
      elsewhere, not against these bindings' own output
- [x] comments that this change makes untrue have been updated: the
      mutant count in `.github/mutation/bindings.toml`, `mult_`'s and
      `mult`'s docstrings, and the openings of both `CHANGELOG.md` and
      `HISTORY.md`, which said no wrapper had changed behaviour
- [x] `CHANGELOG.md` has an entry for it, under a group of its own, and
      `HISTORY.md` names the function and the message that changed
- [x] the `secp256k1` submodule is untouched

## Anything the reviewer should know

Two things.

**The error message was a decision.** Sharing one implementation means
one label for the argument, and `keys`' own convention is "private key"
while `mult`'s was "scalar". Keeping both would have meant passing the
label down for the sake of a message, or leaving `mult_` its own copy of
the C call — which is the duplication this removes. What settled it is
that the C function calls the argument a seckey and refuses anything a
private key may not be.

**The README quickstart was composing the issue's second row** —
`keys.serialize(keys.parse(mult.mult_(prvkey)))`, a
`secp256k1_ec_pubkey_parse` undoing a serialization the same library had
just done — on the package's own front page. It is the one call now.
