### PR TITLE
Skip the mutants no test can reach, and count the ones that ran

### DIFF
--- a/.github/mutation/bindings.toml
+++ b/.github/mutation/bindings.toml
@@ -13,15 +13,15 @@
 # had both: 383 survivors, `cr-rate --estimate` 49.68, on a tree at 100%
 # statement coverage -- two numbers answering different questions, which is
 # the whole reason this configuration exists. Of those 383, 341 were the
-# inert shape described under excluded-modules below and 42 were real.
+# inert shape the operator filter below now skips and 42 were real.
 #
 # The tests those 42 asked for are in tests/ now, and a second session
 # measured 359 survivors: every comparison mutant on a size check dead but
 # one, both loop mutants dead, and the four the second session still found
 # -- three recid bounds and one message-hash check -- killed by hand
 # afterwards, each mutation applied to the source and the suite watched to
-# fail. What is left is 14 real survivors, in two shapes that cannot be
-# killed by a test and are not holes:
+# fail. What is left, 13 on the session that measured the filter below, is
+# two shapes that cannot be killed by a test and are not holes:
 #
 #   ffi.new("size_t *", 73) -> 74 or 72, an output buffer for a
 #   serialization libsecp256k1 sizes itself, writing what it needs and
@@ -31,10 +31,15 @@
 #   secrets.token_bytes(32) -> 31 or 33, randomness this package generates
 #   rather than accepts -- a BIP340 aux, an ellswift encoding, the context
 #   seed. Its length is not observable in any answer: the aux is hashed, so
-#   a shorter one produces a different signature that verifies just as well
+#   a shorter one produces a different signature that verifies just as well.
+#   Where the value is copied into a fixed-size array the longer half of
+#   that pair does die -- `ffi.new("char[32]", ...)` in ssa.sign_ refuses 33
+#   octets and takes 31 -- which is cffi's boundary rather than a test, and
+#   is why one line of this shape has one survivor and the others two
 #
-# So read a survivor list expecting those two shapes and the annotations,
-# and read anything else as a test nobody has written. The settled rate is
+# So read a survivor list expecting those two shapes, and read anything else
+# as a test nobody has written. The list is that short because the filter
+# below skips the third shape before anything runs it. The settled rate is
 # whatever the next scheduled run reports; it is not restated here, a number
 # in a comment being a line every change to the suite would have to edit.
 #
@@ -84,18 +89,50 @@ timeout = 120
 # nothing: `_scalar` and `context` are as much the boundary as the wrappers
 # are, and `__init__` more than either -- `_load_lib` is the one branch
 # whose other half no build has, which is why it takes the module as an
-# argument. A mutant surviving in there is worth knowing about.
-#
-# What is worth knowing before reading a survivor list: one shape of
-# survivor is inert by construction. cosmic-ray mutates every expression it
-# finds, annotations included, and these modules open with
-# `from __future__ import annotations`, so `bytes | int` in a signature
-# becomes `bytes >> int` and nothing ever evaluates it. Those cannot be
-# killed and are not holes. `cr-filter-pragma` is the answer if they ever
-# outnumber the real ones -- it marks `# pragma: no mutate` lines as skipped
-# -- and it is deliberately not used yet: a pragma is a line of source added
-# for the benefit of a weekly report
+# argument. A mutant surviving in there is worth knowing about. What is
+# excluded here is an operator rather than a module, below
 excluded-modules = []
+
+# what a mutant of `bytes | int` is: nothing. Every module here opens with
+# `from __future__ import annotations`, so an annotation is an unevaluated
+# string, and cosmic-ray mutates the `|` inside it eleven ways --
+# `bytes >> int` and ten more -- none of which any test can reach, because
+# nothing ever evaluates the expression.
+#
+# Measured rather than argued, both sessions over this same scope: without
+# the filter, 365 survivors of 777 mutants in 5 minutes; with it, 352
+# skipped and 13 survivors of the 425 that ran, in 2. The two numbers say
+# the same thing twice -- 365 - 13 = 352 -- so the filter takes out exactly
+# the mutants that survived and not one that any test killed.
+#
+# The pattern is anchored on what is *replaced*, which is what leaves the
+# one BitOr mutant a test does kill: `2**256` in _scalar.py mutated to
+# `2 | 256` is `core/ReplaceBinaryOperator_Pow_BitOr`, so it does not match
+# and it still runs, dying on the int scalar test written for it.
+#
+# Excluded by operator rather than with `# pragma: no mutate`, and the
+# argument is where the decision lives. One line here, in the file that
+# already says what is mutated and what judges it, against a marker on each
+# of 26 library lines and again on every one a later signature adds. The
+# price is the same either way and is paid here instead of there: a real
+# `a | b` written into one of these modules would be skipped in silence, so
+# the claim behind this line is a grep, and it is the claim to re-check
+# rather than this comment:
+#
+#   grep -n ' | ' btclib_libsecp256k1/*.py
+#
+# Every hit today is an annotation, and there is no bitwise operator of any
+# kind in the package -- no `^`, no `&`, no shift outside a doctest prompt --
+# which is why the pattern excludes the BitOr family and nothing else. btclib
+# keeps the same exclusion that narrow for the opposite reason: `^` is what
+# one of its own checks is written with.
+#
+# What this does to the one number the workflow prints is why
+# .github/scripts/mutation_counts.py exists: `cr-rate` counts anything that
+# is not SURVIVED as a kill, a skip included, so on a filtered session it
+# divides by mutants nothing ran
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 
 # one mutant at a time, in this working tree. The local distributor writes
 # the mutation into the file itself and restores it afterwards, so a second

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -1,0 +1,173 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Count a Cosmic Ray session by outcome, the skipped mutants left out.
+
+`cr-rate` answers the wrong question for a filtered session, and not by a
+little: `WorkResult.is_killed` is `test_outcome != SURVIVED`, so every
+mutant the operator filter marked SKIPPED is counted as a kill, and the
+rate divides by all of them. The filter this repository's configuration
+applies skips the annotation mutants, which are most of the session: on
+the one measured while this script was written, 352 skipped of 777, so
+`cr-rate` reads 1.67% where the 425 mutants that ran survived at 3.06%.
+A session the runner cut short is diluted further still, every mutant
+that never ran counting as killed too. `cr-report`'s summary line uses
+the same two functions and is wrong the same way.
+
+So the numbers are counted here, and printed rather than reduced to one:
+killed, survived, skipped, and the rate over what actually ran. A rate
+alone cannot say whether a session was complete, and completeness is the
+first thing to know about one that had a timeout.
+
+**Every outcome is printed, and one that is not a verdict makes this exit
+non-zero.** A mutant can come back INCOMPETENT, or with a worker outcome
+of EXCEPTION, ABNORMAL or NO-TEST: the mutated tree would not run, or the
+runner would not run it, and `cosmic-ray exec` can finish with a zero exit
+having recorded them. None of those says anything about the suite, so
+counting them silently anywhere -- as killed, as executed, or by leaving
+them out of the line -- publishes a session that measured less than it
+appears to. This is the one thing the mutation workflow may be red about:
+a survivor is a test nobody has written yet, where these are the
+measurement itself not working.
+
+Read from the session file with `sqlite3`, which is a coupling worth
+stating. `cosmic-ray dump` is the documented interchange and would have
+been the honest input, but it cannot read a filtered session at all:
+`result_to_dict` does `d["test_outcome"].value`, a SKIPPED result has no
+test outcome, and the command dies with `AttributeError: 'NoneType'
+object has no attribute 'value'` at the first one -- after printing the
+records before it, so its output is both short and truncated mid-line.
+The three columns read below are the whole of what this needs.
+
+Ported from btclib's own mutation_counts.py, the two mutation workflows
+being the same workflow with a different scope.
+
+    python .github/scripts/mutation_counts.py session.sqlite
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from collections import Counter
+from contextlib import closing
+from pathlib import Path
+
+# `closing` and not `with sqlite3.connect(...)` alone: that context manager
+# commits a transaction and leaves the connection open, so a read-only query
+# through it is a `ResourceWarning: unclosed database` at whatever later
+# moment the collector notices -- which under this suite's
+# `filterwarnings = ["error"]` fails a test that has nothing to do with it
+
+# how Cosmic Ray spells the two verdicts and the one non-verdict a session
+# is meant to hold: a skipped mutant is one the operator filter excluded
+# before anything ran it, so it is deliberate rather than a failure.
+# Everything else that is neither verdict is a failure -- see the module
+# docstring.
+#
+# Compared after `_normalized`, because the enum members and what the
+# session stores agree on neither case nor the separator in `no-test`
+_KILLED = "killed"
+_SURVIVED = "survived"
+_SKIPPED = "skipped"
+_NORMAL = "normal"
+
+
+def _normalized(outcome: object) -> str:
+    """Return an outcome as one word, whichever spelling it was stored in."""
+    return str(outcome).strip().lower().replace("_", "-")
+
+
+def _outcome(test_outcome: object, worker_outcome: object) -> str:
+    """Return the one word for a result, the worker's failure winning.
+
+    Not `COALESCE(test_outcome, worker_outcome)`, which reads as if the two
+    columns were alternatives and is wrong on the row that matters most:
+    when `mutate_and_test` raises, Cosmic Ray stores
+    `worker_outcome=EXCEPTION` *and* `test_outcome=INCOMPETENT` in the same
+    row, so coalescing always answers INCOMPETENT and the exception is
+    never named. INCOMPETENT there is the consequence -- no suite judged
+    the mutant -- and the exception is what happened, so a worker outcome
+    that is not NORMAL is the answer.
+    """
+    worker = _normalized(worker_outcome)
+    return _normalized(test_outcome) if worker == _NORMAL else worker
+
+
+def _read_only(session: Path) -> str:
+    """Return the sqlite URI of that file, opened for reading and nothing else.
+
+    Built with `as_uri`, because a path is not a URI: `?` and `#` are
+    ordinary characters in a POSIX filename and delimiters here, so
+    `session?copy.sqlite` interpolated into `file:{path}?mode=ro` names the
+    database `session` with the rest read as query parameters -- which
+    opens the wrong file, reports `no such table`, and creates a `session`
+    on the way, the `mode=ro` that would have forbidden it having been
+    parsed as part of the name.
+    """
+    return f"{session.resolve().as_uri()}?mode=ro"
+
+
+def counts(session: Path) -> dict[str, int]:
+    """Return how many results the session holds, by what happened to them."""
+    query = "SELECT test_outcome, worker_outcome FROM work_results"
+    with closing(sqlite3.connect(_read_only(session), uri=True)) as db:
+        return Counter(_outcome(*row) for row in db.execute(query))
+
+
+def enumerated_mutants(session: Path) -> int:
+    """Return how many mutants the session enumerated, run or not."""
+    with closing(sqlite3.connect(_read_only(session), uri=True)) as db:
+        return int(db.execute("SELECT COUNT(*) FROM work_items").fetchone()[0])
+
+
+def report(by_outcome: dict[str, int], enumerated: int) -> tuple[str, bool]:
+    """Return the line worth reading, and whether the session measured soundly.
+
+    Unsound is an outcome that is neither verdict nor deliberate skip, and
+    the line names each of them with its count: a number nobody can
+    interpret is worse than a red step, so the step is red for it.
+    """
+    killed = by_outcome.get(_KILLED, 0)
+    survived = by_outcome.get(_SURVIVED, 0)
+    skipped = by_outcome.get(_SKIPPED, 0)
+    executed = killed + survived
+    pending = enumerated - sum(by_outcome.values())
+    failed = {
+        outcome: count
+        for outcome, count in sorted(by_outcome.items())
+        if outcome not in (_KILLED, _SURVIVED, _SKIPPED)
+    }
+
+    line = f"killed {killed}, survived {survived}, skipped {skipped}"
+    if pending:
+        line += f", never run {pending}"
+    rate = f"{survived / executed * 100:.2f}%" if executed else "no mutant ran"
+    line += f"; survival rate over the {executed} executed: {rate}"
+    if failed:
+        named = ", ".join(f"{outcome} {count}" for outcome, count in failed.items())
+        line += f". No verdict on the suite: {named}"
+    return line, not failed
+
+
+def main() -> None:
+    """Print the counts of the session named on the command line.
+
+    A second argument is a label to print the line under, which is what the
+    workflow passes instead of piping this through `sed`: a pipeline's
+    status is its last command's, and GitHub runs a `run` step as `bash -e`
+    without `pipefail`, so the exit code below would have been thrown away
+    by the very step that reads it.
+    """
+    session = Path(sys.argv[1])
+    label = f"{sys.argv[2]}: " if len(sys.argv) > 2 else ""
+    line, sound = report(counts(session), enumerated_mutants(session))
+    print(f"{label}{line}")
+    if not sound:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -46,8 +46,8 @@ on:
   workflow_dispatch:
   # no pull_request trigger, unlike links.yml, which does run itself when
   # its own configuration changes. The difference is what the two cost: a
-  # link sweep is a few hundred requests, and a session is 771 runs of the
-  # suite. check-toml parses this configuration on every commit, and
+  # link sweep is a few hundred requests, and a session is one run of the
+  # suite per mutant. check-toml parses this configuration on every commit, and
   # `cosmic-ray baseline` below fails the run before any mutant if the test
   # command has gone stale, which is what that trigger would have caught
 
@@ -67,8 +67,11 @@ jobs:
   mutation:
     name: Mutate the bindings
     runs-on: ubuntu-latest
-    # 771 mutants at a suite that runs in well under a second, so what this
-    # bounds is a session gone wrong rather than a session gone long
+    # a few hundred mutants at a suite that runs in about a second, the
+    # operator filter having taken out the family that could only survive,
+    # so what this bounds is a session gone wrong rather than one gone long.
+    # Not tight: the ceiling cancels the job, and a cancelled job takes the
+    # reports and the artifact with it
     timeout-minutes: 90
 
     steps:
@@ -97,6 +100,18 @@ jobs:
           uv run --locked --no-default-groups --group test --group mutation
           cosmic-ray init .github/mutation/bindings.toml bindings.sqlite
 
+      # marks as skipped whatever the configuration excludes by operator,
+      # which here is the annotation family and most of the session: a mutant
+      # of an unevaluated `bytes | int` cannot be killed by any test, and one
+      # that cannot be killed costs the whole test command to survive. The
+      # decision stays in the toml -- this is a no-op for a configuration
+      # that excludes nothing -- and the comment there carries the grep that
+      # keeps it true
+      - name: Skip the mutants no test can reach
+        run: >
+          uv run --locked --no-default-groups --group test --group mutation
+          cr-filter-operators bindings.sqlite .github/mutation/bindings.toml
+
       # resumable: it runs whatever the session still has pending, so a
       # cancelled run costs only the mutant it was on, and the artifact
       # below can be finished locally
@@ -105,21 +120,52 @@ jobs:
           uv run --locked --no-default-groups --group test --group mutation
           cosmic-ray exec .github/mutation/bindings.toml bindings.sqlite
 
-      # --surviving-only, which is the whole of what anybody acts on: a
-      # killed mutant is the suite doing its job, and printing all 771 of
-      # them buries the few that are not
+      # always(), because the reports are the whole product: a session whose
+      # exec died still holds every verdict reached before that, and those
+      # are what somebody reads on Monday.
+      #
+      # --surviving-only with the diff, which is the whole of what anybody
+      # acts on: a killed mutant is the suite doing its job, and printing
+      # every one of them buries the few that are not. Not --show-output,
+      # which is the pytest run of each mutant, megabytes of it; the html
+      # beside it has the full picture.
+      #
+      # The counter and not `cr-rate`: that tool's `is_killed` is
+      # `test_outcome != SURVIVED`, so a mutant the filter skipped counts as
+      # a kill and the rate divides by every result -- on this profile most
+      # of the session, and on one nothing has run yet a perfect 0.00%,
+      # which is the failure mode a mutation run has that looks like good
+      # news. mutation_counts.py prints the counts as well as the rate, a
+      # rate alone being unable to say whether the session finished, and its
+      # docstring says why it reads the session file rather than
+      # `cosmic-ray dump`.
+      #
+      # No threshold on that rate: a survivor is a test nobody has written
+      # yet, and this workflow is not allowed to be red about one. An outcome
+      # that is no verdict -- INCOMPETENT, or a worker that raised -- is the
+      # other thing, and the counter exits non-zero for it
       - name: Report the survivors
+        if: always()
         run: |
           uv run --locked --no-default-groups --group test --group mutation \
-            cr-rate --estimate bindings.sqlite
+            cr-report --surviving-only --show-diff bindings.sqlite \
+            > bindings-survivors.txt
           uv run --locked --no-default-groups --group test --group mutation \
-            cr-report --surviving-only --show-diff bindings.sqlite
+            cr-html bindings.sqlite > bindings-report.html
+          uv run --locked --no-default-groups \
+            python .github/scripts/mutation_counts.py bindings.sqlite bindings
 
-      # the session is the artifact: cr-report, cr-html and cr-rate all read
-      # one, so a downloaded session answers a question the log did not
+      # the session as well as the reports: a .sqlite is what cr-report and
+      # cr-html are re-run against, and what a later `cosmic-ray exec`
+      # resumes, so a downloaded one answers a question the log did not
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: mutation-session
-          path: bindings.sqlite
+          path: |
+            bindings.sqlite
+            bindings-survivors.txt
+            bindings-report.html
+          # an empty upload is another way for a broken run to look green
+          if-no-files-found: error
           retention-days: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,9 +220,13 @@ them run locally.
       uv run --locked --no-default-groups --group test --group mutation \
           cosmic-ray init .github/mutation/bindings.toml bindings.sqlite
       uv run --locked --no-default-groups --group test --group mutation \
+          cr-filter-operators bindings.sqlite .github/mutation/bindings.toml
+      uv run --locked --no-default-groups --group test --group mutation \
           cosmic-ray exec .github/mutation/bindings.toml bindings.sqlite
       uv run --locked --no-default-groups --group test --group mutation \
           cr-report --surviving-only --show-diff bindings.sqlite
+      uv run --locked --no-default-groups \
+          python .github/scripts/mutation_counts.py bindings.sqlite
 
   `baseline` first, always: it runs the configured test command against the
   unmutated tree, and without it a stale command fails every mutant
@@ -232,16 +236,29 @@ them run locally.
   it runs: no second session, no `pytest` in another shell, and a
   `git status` in the middle is a working tree with a mutant in it. `exec`
   is resumable, so interrupting one costs only the mutant it was on, and the
-  `.sqlite` is the artifact the workflow uploads — `cr-report`, `cr-html`
-  and `cr-rate` all read one.
+  `.sqlite` is what the workflow uploads beside the reports — `cr-report`,
+  `cr-html` and the counter all read one.
+
+  `cr-filter-operators` marks as skipped what the configuration excludes by
+  operator, which here is every mutant of a `|` in an annotation: none of
+  them is reachable by any test, and an unreachable mutant costs a whole run
+  of the suite to survive. Skipping them is what leaves a survivor list
+  somebody reads to the end — the comment in `bindings.toml` carries the
+  grep that keeps the exclusion honest.
 
   `--surviving-only` is the whole of what anybody acts on, a killed mutant
-  being the suite doing its job. Read the list expecting two shapes that are
-  not holes: `core/ReplaceBinaryOperator` on a signature line is an
-  annotation, which `from __future__ import annotations` leaves unevaluated,
-  and an output buffer or a piece of internally generated randomness has a
-  size nothing observable depends on. Anything else is a test nobody has
-  written yet.
+  being the suite doing its job. Read the list expecting one shape that is
+  not a hole: an output buffer, or a piece of internally generated
+  randomness, whose size nothing observable depends on. Anything else is a
+  test nobody has written yet.
+
+  The counter last, and not `cr-rate`: that tool reads anything that is not
+  SURVIVED as a kill, so it counts the skipped mutants among them and
+  divides by the whole session. `mutation_counts.py` prints killed, survived
+  and skipped with the rate over what actually ran, and exits non-zero on an
+  outcome that is no verdict at all — an INCOMPETENT mutant, or a worker
+  that raised, which is Cosmic Ray not having measured rather than a test
+  that is missing.
 
 ## What a change has to satisfy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,6 +470,9 @@ max-complexity = 10
 # says happened, the issue it opens or closes being the same report a
 # second way; matching btclib's own T201 exemption for the same script
 ".github/scripts/check_vendored_vectors.py" = ["T201"]
+# and the mutation counter, whose one line of output is what the workflow
+# step exists to put in the log: same exemption, same reason
+".github/scripts/mutation_counts.py" = ["T201"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_mutation_counts.py
+++ b/tests/test_mutation_counts.py
@@ -1,0 +1,228 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the mutation session counter of `.github/scripts`.
+
+The script is what the `mutation` workflow prints, and what it prints is
+the only thing anybody reads on a Sunday: a wrong denominator, or an
+outcome left out of the line, is a session that measured less than it
+appears to. Neither is visible in a green run, so it is tested here
+instead.
+
+Sessions are built with the schema Cosmic Ray creates, recorded below
+from a real one -- `cosmic-ray init .github/mutation/bindings.toml` is
+what re-derives it. A synthetic session is what lets a test hold the rows
+a real run only produces when something goes wrong: an INCOMPETENT
+mutant, a worker that raised, a session with nothing in it at all.
+
+The script is loaded by path, `.github/scripts` being no package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "mutation_counts.py"
+
+# the three tables `cosmic-ray init` creates, as it creates them. Only two
+# are read here; `mutation_specs` is recorded so that a session built by
+# this file is one the real tools could also open, rather than the subset
+# one script happens to need
+_SCHEMA = """
+CREATE TABLE work_items (job_id VARCHAR NOT NULL, PRIMARY KEY (job_id));
+CREATE TABLE mutation_specs (
+    module_path VARCHAR, operator_name VARCHAR, operator_args JSON,
+    occurrence INTEGER, start_pos_row INTEGER, start_pos_col INTEGER,
+    end_pos_row INTEGER, end_pos_col INTEGER, definition_name VARCHAR,
+    job_id VARCHAR NOT NULL, PRIMARY KEY (job_id),
+    FOREIGN KEY(job_id) REFERENCES work_items (job_id)
+);
+CREATE TABLE work_results (
+    worker_outcome VARCHAR(9), output TEXT, test_outcome VARCHAR(11),
+    diff TEXT, job_id VARCHAR NOT NULL, PRIMARY KEY (job_id),
+    FOREIGN KEY(job_id) REFERENCES work_items (job_id)
+);
+"""
+
+
+@pytest.fixture(scope="module")
+def counter() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("mutation_counts", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def session(
+    path: Path, results: list[tuple[str | None, str]], pending: int = 0
+) -> Path:
+    """Write a session holding these results, and `pending` mutants with none.
+
+    Each result is the pair the script reads: the test outcome, which is
+    None for a mutant no suite judged, and the worker outcome beside it.
+    """
+    db = sqlite3.connect(path)
+    with db:
+        db.executescript(_SCHEMA)
+        for index, (test_outcome, worker_outcome) in enumerate(results):
+            job_id = f"job-{index}"
+            db.execute("INSERT INTO work_items VALUES (?)", (job_id,))
+            db.execute(
+                "INSERT INTO work_results"
+                " (worker_outcome, output, test_outcome, diff, job_id)"
+                " VALUES (?, NULL, ?, NULL, ?)",
+                (worker_outcome, test_outcome, job_id),
+            )
+        for index in range(pending):
+            db.execute("INSERT INTO work_items VALUES (?)", (f"pending-{index}",))
+    db.close()
+    return path
+
+
+def test_the_rate_is_over_the_mutants_that_ran(
+    counter: ModuleType, tmp_path: Path
+) -> None:
+    """Skipped mutants are not kills, and are not in the denominator.
+
+    The counts of a real session of this repository's own profile, where
+    the operator filter excludes the annotation mutants before anything
+    runs them and they are the majority: three kinds of row, and only two
+    of them verdicts. `cr-rate` counts the skipped as killed and divides by
+    all of them, which is the whole reason this script exists -- on these
+    very numbers it reads 1.67% where the mutants that ran survived at
+    3.06%.
+    """
+    results: list[tuple[str | None, str]] = [("KILLED", "NORMAL")] * 412
+    results += [("SURVIVED", "NORMAL")] * 13
+    results += [(None, "SKIPPED")] * 352
+    line, sound = counter.report(
+        counter.counts(session(tmp_path / "s.sqlite", results)), 777
+    )
+    assert sound
+    assert "killed 412, survived 13, skipped 352" in line
+    assert "over the 425 executed: 3.06%" in line
+
+
+def test_an_outcome_that_is_no_verdict_is_named_and_is_not_sound(
+    counter: ModuleType, tmp_path: Path
+) -> None:
+    """INCOMPETENT, EXCEPTION, ABNORMAL and NO_TEST are the measurement failing.
+
+    `cosmic-ray exec` can finish with a zero exit having recorded them, so
+    nothing else says they happened. Counting them as killed would flatter
+    the rate, counting them as executed would deflate it, and leaving them
+    out of the line publishes a session that measured less than it appears
+    to: the only honest answer is to name them and be red.
+    """
+    results: list[tuple[str | None, str]] = [
+        ("KILLED", "NORMAL"),
+        ("SURVIVED", "NORMAL"),
+        (None, "SKIPPED"),
+        # the pair Cosmic Ray actually writes when `mutate_and_test`
+        # raises: one row carrying both, where a `COALESCE(test_outcome,
+        # worker_outcome)` answers INCOMPETENT and never names the
+        # exception
+        ("INCOMPETENT", "EXCEPTION"),
+        ("INCOMPETENT", "NORMAL"),
+        (None, "ABNORMAL"),
+        (None, "NO_TEST"),
+    ]
+    line, sound = counter.report(
+        counter.counts(session(tmp_path / "s.sqlite", results, pending=1)), 8
+    )
+    assert not sound
+    assert "killed 1, survived 1, skipped 1, never run 1" in line
+    # named one by one, and `no-test` in the spelling of the enum rather
+    # than of the column. The exception is there rather than hidden behind
+    # the INCOMPETENT its own row also carries
+    assert "No verdict on the suite: abnormal 1, exception 1, incompetent 1" in line
+    assert "no-test 1" in line
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param(
+            "session?copy.sqlite",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="NTFS refuses `?` in a filename, so there is none to write",
+            ),
+        ),
+        "session#copy.sqlite",
+    ],
+)
+def test_a_session_whose_name_is_not_a_uri(
+    counter: ModuleType, tmp_path: Path, name: str
+) -> None:
+    """A path is not a URI, and `?` and `#` are ordinary in a filename.
+
+    Interpolated into `file:{path}?mode=ro`, the first of those names the
+    database `session` and reads the rest as query parameters: the wrong
+    file, `no such table`, and a `session` created beside it -- the
+    `mode=ro` that would have forbidden the creation having been parsed as
+    part of the name. A downloaded session artifact is exactly where a `?`
+    in a name comes from.
+
+    Skipped for `?` on Windows: NTFS refuses that character in a filename,
+    so the fixture has no file to write there, and `#` alone still
+    exercises the same escaping on that platform.
+    """
+    line, sound = counter.report(
+        counter.counts(session(tmp_path / name, [("KILLED", "NORMAL")] * 2)), 2
+    )
+    assert sound
+    assert "killed 2" in line
+    # nothing was created beside it, which is the half `mode=ro` promises
+    assert sorted(path.name for path in tmp_path.iterdir()) == [name]
+
+
+def test_a_session_nothing_has_run_says_so(counter: ModuleType, tmp_path: Path) -> None:
+    """No executed mutant is no rate, and dividing by it would be worse."""
+    line, sound = counter.report(
+        counter.counts(session(tmp_path / "s.sqlite", [], pending=12)), 12
+    )
+    assert sound
+    assert "never run 12" in line
+    assert "no mutant ran" in line
+
+
+def test_the_script_reads_a_session_and_exits_on_an_unsound_one(
+    tmp_path: Path,
+) -> None:
+    """End to end, as the workflow runs it: a path in, a line out, a status.
+
+    The exit status is the half the workflow acts on, and the only case it
+    is allowed to be red for -- a survival rate is a test nobody has
+    written yet, where this is Cosmic Ray not having measured.
+    """
+    sound = session(tmp_path / "sound.sqlite", [("KILLED", "NORMAL")] * 3)
+    done = subprocess.run(  # noqa: S603
+        [sys.executable, str(_SCRIPT), str(sound)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "killed 3, survived 0, skipped 0" in done.stdout
+
+    broken = session(tmp_path / "broken.sqlite", [(None, "EXCEPTION")])
+    failed = subprocess.run(  # noqa: S603
+        [sys.executable, str(_SCRIPT), str(broken)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert failed.returncode == 1
+    assert "exception 1" in failed.stdout


### PR DESCRIPTION
The `mutation` workflow has never run on a runner — it reached `master` on
5 August and its cron is Sunday, so the first scheduled run is 9 August.
What it would print today is a survivor list of 365 entries, 352 of which
no test could ever kill: `from __future__ import annotations` leaves
`bytes | int` in a signature unevaluated, and cosmic-ray mutates it anyway.

This is the three things btclib's own mutation setup grew after this
repository took its first copy, and nothing else. No library code changes,
and no test of the bindings: the holes the August sessions found are
already closed.

**The operator filter.** Three lines in `bindings.toml` and a
`cr-filter-operators` step, which marks the BitOr family as skipped before
`exec` runs anything.

**The counter.** `cr-rate` reads anything that is not SURVIVED as a kill,
so on a filtered session it counts the skipped among them and divides by
the whole session. `.github/scripts/mutation_counts.py` — ported from
btclib, with its test — prints killed, survived and skipped with the rate
over what actually ran, and is red only for an outcome that is no verdict
at all.

**The reports.** `cr-report --surviving-only` and `cr-html` join the
session in the artifact, written under `always()`, with
`if-no-files-found: error`.

## Measured, both sessions over this scope

|                 | mutants | killed | survived | skipped | wall clock |
| --------------- | ------: | -----: | -------: | ------: | ---------: |
| unfiltered      |     777 |    412 |      365 |       0 |      5 min |
| filtered        |     777 |    412 |       13 |     352 |      2 min |

`365 - 13 = 352`: the filter takes out exactly the mutants that survived,
and not one the suite killed. The pattern is anchored on what is *replaced*,
so `2**256` → `2 | 256` in `_scalar.py` — the one BitOr mutant a test does
kill — still runs and still dies.

The 13 are the two shapes `bindings.toml` already describes, and no third
one: an output buffer libsecp256k1 sizes itself, and randomness this
package generates rather than accepts. One nuance the session added, now
recorded there: where that randomness is copied into a fixed-size array the
longer mutant does die, `ffi.new("char[32]", ...)` in `ssa.sign_` refusing
33 octets and taking 31 — cffi's boundary rather than a test.

## What keeps the exclusion honest

A real `a | b` written into one of these modules would be skipped in
silence. The comment carries the check rather than the claim:

    grep -n ' | ' btclib_libsecp256k1/*.py

26 hits today, every one an annotation, and the package has no bitwise
operator of any kind — no `^`, no `&`, no shift outside a doctest prompt.

Gate green, 237 tests, coverage 100%.

## Summary by Sourcery

Introduce operator-based filtering and robust counting for Cosmic Ray mutation sessions to focus on actionable mutants and accurate metrics.

New Features:
- Add a mutation_counts.py helper script that reads Cosmic Ray session databases to report per-outcome counts and survival rate over executed mutants, treating non-verdict outcomes as failures.

Enhancements:
- Configure an operator filter in the mutation bindings to skip BitOr mutations in type annotations that tests can never execute, and document the rationale and safeguards.
- Refine the mutation GitHub workflow to apply operator filtering, always generate text and HTML survivor reports, and upload the session plus reports as required artifacts.
- Document local usage of operator filtering and the new counter script in CONTRIBUTING, clarifying how to interpret survivor shapes and session results.

Documentation:
- Update CONTRIBUTING to describe the operator filter, expected survivor shapes, and how to run and interpret the mutation counter locally.

Tests:
- Add comprehensive tests for the mutation_counts.py script to validate counting, rate calculation, outcome handling, URI safety, and CLI behavior across realistic and edge-case Cosmic Ray sessions.

Chores:
- Add a T201 flake8-typing-imports exemption for the mutation_counts.py helper script used by the mutation workflow.