### PR TITLE
Name the encoding, name the rule, hug the bracket

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,21 +182,21 @@
         "filename": "tests/test_properties.py",
         "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 325
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
         "is_verified": false,
-        "line_number": 347
+        "line_number": 348
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
-        "line_number": 350
+        "line_number": 351
       }
     ],
     "tests/test_vectors.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-06T21:26:24Z"
+  "generated_at": "2026-08-07T05:36:07Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,16 @@ extend-ignore-re = ['"[0-9a-fA-F]+"']
 extend-exclude = ["secp256k1"]
 
 [tool.ruff.lint]
+# these two go together, and neither means what it says alone. Naming a
+# rule instead of coding it -- see the comment above `ignore` -- is itself
+# a preview feature, so the first line is the price of the second, and on
+# its own it would also turn on every rule ruff is still designing. The
+# second takes those back off: with it a preview rule runs only where it
+# is named exactly, and every entry of `select` below is a family, which
+# no preview rule can be reached through. So the gate stays the stable
+# rule set it was, and what preview buys here is a config that reads
+preview = true
+explicit-preview-rules = true
 select = [
     "F",     # pyflakes
     "E",     # pycodestyle errors
@@ -378,14 +388,21 @@ select = [
     # exempted below rather than fixed: see per-file-ignores
     "PYI",   # flake8-pyi
 ]
+# here and in per-file-ignores below, a rule is named rather than coded.
+# `select` above has no choice, a family having no name form, but an entry
+# that suppresses one rule can say which one: the reason then sits in the
+# comment and the rule in the entry, rather than the reason in the comment
+# and a lookup in the entry. RUF201 asks for exactly this and is preview,
+# so nothing here enforces it -- what does is that the next reader of this
+# file should not have to look each code up to find out what was allowed
 ignore = [
     # comparing against a key, signature or hash length (32, 33, 64, 65)
     # is not a magic value: it is the domain
-    "PLR2004",
+    "magic-value-comparison",
     # the message of an exception belongs where it is raised, not in a
     # class defined to carry it: these wrappers raise ValueError and
     # RuntimeError, which is what a caller catches
-    "TRY003",
+    "raise-vanilla-args",
 ]
 
 [tool.ruff.lint.flake8-pytest-style]
@@ -441,38 +458,49 @@ max-doc-length = 80
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-# asserts are the point of a test suite. D103 is deliberately *not* here:
-# a test function states what it verifies -- the property, the published
-# vector, the failure mode -- which its name cannot, and which is what a
-# reader deciding whether a red test matters needs. The name says which
-# call is under test; the docstring says what about it is being claimed
-"tests/*" = ["S101"]
+# asserts are the point of a test suite. undocumented-public-function is
+# deliberately *not* here: a test function states what it verifies -- the
+# property, the published vector, the failure mode -- which its name
+# cannot, and which is what a reader deciding whether a red test matters
+# needs. The name says which call is under test; the docstring says what
+# about it is being claimed
+"tests/*" = ["assert"]
 # the benchmark script asserts its own results before timing them, and
 # prints them: T20 is selected for the library, which writes to no stream
 # of its own, and a script whose caller is a terminal is the case it is
 # not about
-"scripts/benchmark.py" = ["S101", "T201"]
+"scripts/benchmark.py" = ["assert", "print"]
 # the build scripts drive CMake and load the cffi build description by
 # exec(): both are inherent to compiling a C dependency from a build
-# backend, and neither ever sees untrusted input
-"scripts/cffi_build.py" = ["S404", "S603", "S607"]
-# same T201 exemption as the benchmark script above: the warning printed
-# here is what a wheel builder reads in its own log, not the library
-# talking to a stream it does not own
-"scripts/hatch_build.py" = ["S102", "T201"]
-# PYI021 wants no docstring in a stub, on the assumption that one
-# lives in the .py file the stub mirrors -- true everywhere else, and
+# backend, and neither ever sees untrusted input.
+# suspicious-subprocess-import stood in this list and suppressed nothing:
+# it is a preview rule, and a preview rule is not reached through the "S"
+# family that selects the rest of them -- it has to be named, and no line
+# names it. An exemption for a check nobody runs claims a decision that
+# was never taken, so it goes. Naming the rule in `select` is what would
+# bring it back, and this line with it -- wider than it was, the import
+# being in the mutation counter and the vendored-vector check too
+"scripts/cffi_build.py" = [
+    "subprocess-without-shell-equals-true",
+    "start-process-with-partial-path",
+]
+# same `print` exemption as the benchmark script above: the warning
+# printed here is what a wheel builder reads in its own log, not the
+# library talking to a stream it does not own
+"scripts/hatch_build.py" = ["exec-builtin", "print"]
+# docstring-in-stub asks that a stub carry none, on the assumption that
+# one lives in the .py file the stub mirrors -- true everywhere else, and
 # not here: the extension this stub describes is compiled, not
 # written, so this module docstring is the only place its own
 # reasoning (why ffi and lib need one, why lib stays Any) can live
-"stubs/_btclib_libsecp256k1.pyi" = ["PYI021"]
+"stubs/_btclib_libsecp256k1.pyi" = ["docstring-in-stub"]
 # BEHIND, SKIPPED and the all-clear line are what a monthly run's log
 # says happened, the issue it opens or closes being the same report a
 # second way; matching btclib's own T201 exemption for the same script
-".github/scripts/check_vendored_vectors.py" = ["T201"]
+".github/scripts/check_vendored_vectors.py" = ["print"]
 # and the mutation counter, whose one line of output is what the workflow
 # step exists to put in the log: same exemption, same reason
-".github/scripts/mutation_counts.py" = ["T201"]
+".github/scripts/mutation_counts.py" = ["print"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,18 @@ extend-ignore-re = ['"[0-9a-fA-F]+"']
 # the vendored upstream sources are not ours to lint or reformat
 extend-exclude = ["secp256k1"]
 
+[tool.ruff.format]
+# one preview style is worth the instability: a call whose sole argument
+# is a collection keeps that collection's bracket on the call's own line,
+# rather than indenting it a level further in and closing it twice. It
+# reads as the single expression it is. Measured before being taken --
+# `ruff format --preview --diff .` reformats one hunk, in
+# tests/test_properties.py -- and that is the whole of the cost today.
+# The cost later is the point to remember: an unstable style is one the
+# next rev of the hook can change underneath the tree, so bumping
+# ruff-pre-commit is a `--diff` before it is a version number
+preview = true
+
 [tool.ruff.lint]
 # these two go together, and neither means what it says alone. Naming a
 # rule instead of coding it -- see the comment above `ignore` -- is itself

--- a/scripts/cffi_build.py
+++ b/scripts/cffi_build.py
@@ -389,9 +389,9 @@ class Secp256k1CFFIExtension(FFIExtension):
         """Build the vendored library with CMake, on every platform."""
         self.cmake_dir.mkdir(parents=True, exist_ok=True)
         callbacks = self.cmake_dir / "btclib_default_callbacks.c"
-        callbacks.write_text(CALLBACK_STUBS)
+        callbacks.write_text(CALLBACK_STUBS, encoding="utf-8")
         project_include = self.cmake_dir / "btclib_callbacks.cmake"
-        project_include.write_text(PROJECT_INCLUDE)
+        project_include.write_text(PROJECT_INCLUDE, encoding="utf-8")
 
         configure = [
             "cmake",
@@ -460,7 +460,7 @@ class Secp256k1CFFIExtension(FFIExtension):
         ffi_header = ""
         for h in self.headers:
             location = self.include_dir / h
-            with location.open() as f:
+            with location.open(encoding="utf-8") as f:
                 ffi_header += f.read() + "\n"
 
         ffi_header = re.sub(r"#include .*", "", ffi_header)

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -54,7 +54,7 @@ class CustomBuildHook(BuildHookInterface[Any]):
         # the cffi build description is a module of this very repository,
         # named in pyproject.toml: exec() runs it without importing it,
         # so that the build backend needs no import path setup
-        src = Path(script).read_text()
+        src = Path(script).read_text(encoding="utf-8")
         code = compile(src, script, "exec")
         build_vars = {"__name__": "__cffi__", "__file__": script}
         exec(code, build_vars, build_vars)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -133,9 +133,10 @@ def test_scalar_algebra_matches_point_algebra() -> None:
         ) == keys.pubkey_tweak_mul(pubkey, tweak)
 
         # combining points is adding scalars
-        assert keys.pubkey_combine(
-            [pubkey, compress(mult.mult_(tweak))]
-        ) == keys.pubkey_tweak_add(pubkey, tweak)
+        assert keys.pubkey_combine([
+            pubkey,
+            compress(mult.mult_(tweak)),
+        ]) == keys.pubkey_tweak_add(pubkey, tweak)
 
 
 def test_ecdsa_signature_forms() -> None:

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -129,7 +129,7 @@ def compressed(point: Point) -> bytes:
 def bip340_vectors() -> list[dict[str, str]]:
     """Read the BIP340 vector csv, vendored from bitcoin/bips."""
     path = pathlib.Path(__file__).parent / "bip340_test_vectors.csv"
-    with path.open(newline="") as csv_file:
+    with path.open(newline="", encoding="utf-8") as csv_file:
         return list(csv.DictReader(csv_file))
 
 
@@ -180,7 +180,7 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
 def bip324_vectors(name: str) -> list[dict[str, str]]:
     """Read one of the BIP324 vector csv files, vendored from bitcoin/bips."""
     path = pathlib.Path(__file__).parent / f"bip324_{name}_test_vectors.csv"
-    with path.open(newline="") as csv_file:
+    with path.open(newline="", encoding="utf-8") as csv_file:
         return list(csv.DictReader(csv_file))
 
 


### PR DESCRIPTION
`uvx ruff@0.16.1 check --preview` reports forty findings on this tree,
none of which the stable gate sees. This takes the three that are worth
taking and leaves the rest, which is most of them — rules that would
contradict the architecture (`__init__.py` holds `_load_lib` by design;
`tests/test_extension.py` imports `_load_lib` and `_cffi_backend` on
purpose), and ruff's new `# ruff: ignore` suppression syntax, which is an
unstable feature rather than a finding.

### Name the encoding of every text file the build and the suite open

Six calls read or wrote text without one — the locale's encoding on
Windows and utf-8 nowhere in particular. The two files the CMake glue
writes, the public headers concatenated into the cdef, the cffi build
description the hatch hook `exec()`s, and the two csv readers of the BIP
vectors. Every one of those files is ASCII today, so nothing was broken;
that is what made it cheap to take now rather than on the morning a
non-ASCII byte lands in an upstream header and fails on one runner of the
matrix and no other.

PLW1514 pointed at it and pointing is all it can do: the rule sees
`Path(...).read_text()` spelled out and not a Path held in a variable, so
it finds one of the six. The fix is the six sites; the rule stays
unselected.

### Say which rule is allowed, not which code

`ignore` and `per-file-ignores` named nine codes between them, each with a
comment saying why — the reason written down, the thing it excused left to
be looked up. Ruff takes the name: `"assert"` for the tests, `"print"` for
the scripts whose caller is a terminal, `"docstring-in-stub"` for the
`.pyi` of an extension that is compiled rather than written. `select`
keeps its codes, a family having no name form.

Names in selectors are themselves a preview feature, so `preview` goes on
— and `explicit-preview-rules` immediately takes back what it would
otherwise bring in: a preview rule now runs only where it is named
exactly, and every entry of `select` is a family, which reaches none of
them. The gate is the stable rule set it was, measured rather than argued:
`ruff check` finds nothing before and nothing after.

One line leaves instead of being translated. `suspicious-subprocess-import`
was exempted for `scripts/cffi_build.py` and suppressed nothing — the rule
went preview, and nothing named it. An exemption for a check nobody runs
records a decision that was never taken.

### Hug the bracket of a call whose only argument is a collection

Enabled for the formatter alone, and measured before being enabled:
`ruff format --preview --diff .` reformats a single hunk, the
`pubkey_combine` assertion of `tests/test_properties.py`. The cost is
stated next to the setting — an unstable style is one the next rev of
ruff-pre-commit can change underneath the tree, so that bump is a
`--diff` before it is a version number. `.secrets.baseline` moves with it,
three hex vectors one line further down.

### Verified

- `uvx pre-commit run --all-files` green on the committed tree
- `uv run --locked --no-default-groups --group test pytest --cov` — 237
  passed, 100.00% coverage
- `uv sync --locked --reinstall-package btclib_libsecp256k1 --no-cache` —
  a build from scratch, which is the only thing that runs the header
  concatenation and the `exec()` of the build description that the
  encoding change touches
- macOS/arm64 and CPython 3.14 only; the matrix has seen none of it

## Summary by Sourcery

Adopt named Ruff rule ignores and preview formatting while standardizing text encoding usage in build and test utilities.

Bug Fixes:
- Specify UTF-8 encoding for build-time header generation and CSV test vector loading to avoid locale-dependent behavior.

Enhancements:
- Enable Ruff formatter preview style for calls whose sole argument is a collection and reformat the affected assertion.
- Refine Ruff lint configuration to use named rule suppressions, enable preview rules only when explicitly named, and remove an unused subprocess exemption.

CI:
- Align linting configuration with Ruff’s preview features to keep the enforced rule set stable while improving configuration clarity.

Chores:
- Refresh the secrets baseline to reflect the formatting change impact on tracked files.