### PR TITLE
Close the holes an audit of the boundary found

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "btclib_libsecp256k1/hashes.py",
         "hashed_secret": "a608d88cb7e04b46b5e44fa00bb7c01b7748e6f0",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       }
     ],
     "scripts/cffi_build.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T05:36:07Z"
+  "generated_at": "2026-08-07T06:49:37Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 408
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T06:49:37Z"
+  "generated_at": "2026-08-07T07:02:48Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,19 @@ release-notes length in the first place, and are still in
 ## v0.7.1.2 (work in progress, not released yet)
 
 Grouped, and the order runs from what a caller sees to what only
-maintainers do. Nothing here breaks a caller: the wrapped
+maintainers do. The wrapped
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.7.1)
-is the same 0.7.1 (1a53f49), nothing in the public API moved, and what it
-gained is one function. One wrapper changed behaviour, in the text of an
-error message, and the entry below says which and why. Neither file
-counts its entries: `grep -c '^- '` does that, whereas a stated number is
-a line every open branch has to edit.
+is the same 0.7.1 (1a53f49). What the public API gained is one function
+and two `compressed` flags; what it lost is `recovery.COMPRESSED` and
+`ellswift.COMPRESSED`, two copies of a flag macro that `keys.COMPRESSED`
+still declares — the one removal here, and the one entry a caller
+importing either has to act on. Three things changed behaviour: the text
+of one error message, the class `keys.serialize` raises for an argument
+no valid caller passes, and the exception a wrong *type* meets, which is
+now the boundary's and names the argument instead of cffi's a call
+later. Each has its entry below. Neither file counts its entries:
+`grep -c '^- '` does that, whereas a stated number is a line every open
+branch has to edit.
 
 ### What the boundary answers
 
@@ -70,9 +76,107 @@ a line every open branch has to edit.
   answers exactly the 65 bytes it did, opening with `0x04`, and
   `tests/test_core.py` asserts the new text so that the next change to it
   is deliberate.
+- **`keys.serialize` raises what libsecp256k1 reported, and takes it off
+  the thread** (#73). It is the one wrapper whose argument is a
+  libsecp256k1 object rather than bytes, so it is the one place where
+  nothing can be checked before the call and a precondition is
+  libsecp256k1's to violate: a NULL pointer, or a `secp256k1_pubkey`
+  nothing has written to, reached the illegal-argument callback. What
+  came back was `RuntimeError("point serialization failed")` — the class
+  reserved here for what no input can provoke — while the message
+  libsecp256k1 had just written stayed recorded on the thread. The next
+  `context.check()` found it and raised it, and that caller is the MuSig2
+  one going through `lib`: they were told `pubkey != NULL` about a call
+  they never made. That is what `test_check_clears_what_it_reported`
+  exists to prevent, and it was reachable from the public API.
+  `serialize` calls `check()` on the failing branch now, which raises the
+  message as the `ValueError` a caller's mistake is and, raising it,
+  clears it; the `RuntimeError` remains for a failure that reported
+  nothing. Two docstrings had claimed the case away — `check()`'s own,
+  and `test_illegal_argument`'s *"which the bindings' own wrappers cannot
+  do"* — and describe it instead.
+- **An argument is checked for its type where it is checked for its
+  length** (#73), those being one question about a bare pointer. `len`
+  answers for a `bytearray` and a `memoryview` as readily as for bytes,
+  so both passed every size check and reached cffi, which refused them a
+  call later in its own words and about a ctype — `initializer for ctype
+  'unsigned char *' must be a cdata pointer` — naming neither the
+  argument nor what was wrong with it; a `float` came back as `object of
+  type 'float' has no len()`; and `_scalar.scalar`, annotated `-> bytes`,
+  returned the bytearray it was handed. `_scalar.octets` is that one
+  check, and the eighteen size checks across eight modules are now that
+  call. Nothing that worked stops working — cffi already refused all of
+  it, further on. `bytes` and nothing else: a `bytearray` states the same
+  value and the same width, so converting one would guess at nothing, but
+  it would widen what every signature promises, and `bytes(x)` is the
+  conversion in the caller's own code. `keys.pubkey_sort(pubkey)` — one
+  key where a sequence of them goes, which bytes being a sequence made
+  silently wrong — now says `the public key must be bytes, not int`.
+- **A `bool` is refused where a scalar goes** (#73). `isinstance(True,
+  int)` is true, so `True` was the scalar 1 and `False` the scalar 0:
+  `keys.prvkey_verify(False)` answered False, the correct verdict on
+  zero and not distinguishable from the correct verdict on whatever was
+  meant, and `keys.pubkey_from_prvkey(True)` answered the generator.
+  That is what separates it from a `float` in the same place, which
+  raised then and raises now — the acceptance was invisible in the
+  answer, and invisible to mypy too, `bool` being a subtype of `int`.
+  For the scalars alone: `recid`, `party` and the y parity are flags
+  whose domain is `{0, 1}`, and a bool there is the 0 or 1 it is.
+- **The libsecp256k1 buffers a secret passes through are overwritten**
+  (#73). SECURITY.md records the python side as inherent, and it is: a
+  `bytes` is immutable, so what a caller hands in and what is handed back
+  stay until the collector gets to them. The copy in the middle is not
+  that — it is memory cffi allocated and this package owns, it is
+  writable, and nothing outside these wrappers sees it, so leaving a
+  private key in it was an omission rather than a limit. Read out and
+  zeroed now: the keys of `keys.prvkey_negate`, `prvkey_tweak_add` and
+  `prvkey_tweak_mul`, the taproot signing key of
+  `xonly.prvkey_tweak_add`, the shared secrets of `ecdh.shared_secret`
+  and `ellswift.xdh`, and the `secp256k1_keypair` of the two BIP340
+  signing calls and of the taproot tweak, wiped in a `finally` because
+  `_aux_rand32` can raise between its creation and the signature. The
+  length is asked of `ffi.buffer` rather than of `ffi.sizeof`: on a
+  `secp256k1_keypair *` the latter answers 8, the size of the pointer,
+  and wiping 8 octets would clear the first quarter of a private key and
+  report success — written that way the new test fails. One copy taken
+  back, not safety, and SECURITY.md says which.
+- **`recovery.recover` and `ellswift.decode` answer in either
+  serialization** (#73), through `keys.serialize` rather than through a
+  copy of it. Both wrote the same block — a `char[33]`, a length derived
+  from it, the `SECP256K1_EC_COMPRESSED` flag redeclared at the top of
+  the module, and a comment pointing at `keys.serialize` for the
+  reasoning, which was the argument for calling it. Each takes the
+  `compressed` flag every producer in `keys` has, defaulting to the 33
+  octets they always returned; reaching the uncompressed form meant
+  `keys.serialize(keys.parse(...))` in the caller before. The two
+  duplicated `COMPRESSED` constants go with the block, `keys.COMPRESSED`
+  being the one that carries the comment explaining why a flag macro is
+  written out at all.
+- **Three smaller things the same audit turned up** (#73). `noncefc` was
+  a typo of `noncefp`, which is what the header calls the nonce function
+  pointer, in both signing modules. `ndata`, annotated `bytes | None`,
+  was reassigned to `ffi.NULL` before being passed — mypy allowed it only
+  because `ffi` is `Any` — and has a name of its own now, with the
+  comment saying why a python nonce function is not offered: it would put
+  the secret through a python object on every call from inside the
+  signature. And `test_safe_abort` created a context on every run and
+  never destroyed it, with the flag `769`, which is `SIGN|VERIFY`,
+  deprecated since libsecp256k1 0.2 as `context.py`'s own comment says.
 
 ### The documented boundary
 
+- **`xonly.tweak_add_check` says what it does with a tweaked key that is
+  no point** (#73). Its contract promised `ValueError: if either key is
+  not 32 bytes or not a valid x coordinate`. Only the internal key is
+  parsed; the tweaked one is compared against the serialization of the
+  recomputed point, so 32 bytes which are the x coordinate of nothing
+  return False. That is the right behaviour — bytes that are no point are
+  the tweak of nothing, and comparing rather than parsing is the whole of
+  what this saves over recomputing the tweak — and Returns now says it,
+  with Raises naming the key that really is parsed. Nothing in the gate
+  could have caught it: `pydoclint` checks that a `Raises` section is
+  there, not that it is true, which is the concession recorded below, and
+  the suite had asserted the two keys only where both were points.
 - **Every function of the package documents its arguments, its return
   value and what it raises.** What lengths are accepted, what is refused
   rather than padded, which failure is a `ValueError` and which a

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ and decides nothing else.
   is the one part that cannot be left to the caller — a binding that
   reads adjacent heap into a signature when handed a short `bytes` would
   be safe only for the single caller who remembers to check first
+- **and the type is checked with the size, that check being one
+  question.** `len` answers for a `bytearray` and a `memoryview` as
+  readily as for `bytes`, so a size check on its own let both through,
+  and cffi refused them one call later in its own words and about a
+  ctype — naming neither the argument nor what was wrong with it. What
+  crosses is `bytes`, and an `int` where a scalar is named; anything
+  else is refused here and called by the name the signature gives it.
+  A `bytearray` states the same value and the same width as `bytes`, so
+  converting one would guess at nothing — but it would widen what every
+  signature here promises, and `bytes(x)` is that conversion in the
+  caller's own code, where they can see it. This is the `TypeError`
+  these wrappers raise; every other refusal below is a `ValueError`
 - **validity is libsecp256k1's to decide, and it does.** Whether 32 bytes
   are a scalar in `[1, n-1]` is answered by
   `secp256k1_ec_seckey_verify`, and `keys.prvkey_verify` is that call, not

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,14 @@ These are known and inherent, not vulnerabilities:
     which are immutable and not zeroized: it stays in the process memory
     until garbage collection, and may be copied by the interpreter. The
     constant-time properties of libsecp256k1 apply to the C side of the
-    boundary, not to what the caller does before and after it
+    boundary, not to what the caller does before and after it.
+    The copy in the middle is not a Python object and is overwritten: a
+    private key or a shared secret libsecp256k1 writes into a cffi buffer
+    — the output of a tweak or a negation, an ECDH secret, the
+    `secp256k1_keypair` a BIP340 signature is made with — is read out and
+    the buffer zeroed before it is dropped. That is one copy taken back,
+    not safety: the `bytes` handed to the caller holds the same secret
+    and cannot be overwritten
 - a scalar passed as an `int` leaks its magnitude. A Python integer is a
     variable-length object, so serializing one — and any arithmetic that
     produced it — takes a time that depends on the value; the argument

--- a/btclib_libsecp256k1/_scalar.py
+++ b/btclib_libsecp256k1/_scalar.py
@@ -3,9 +3,48 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Normalization of the scalar arguments of the bindings."""
+"""What the arguments of the bindings are held to before they cross."""
 
 from __future__ import annotations
+
+
+def octets(value: bytes, name: str, size: int | None = None) -> bytes:
+    """Hold an argument to the type and the length a bare pointer needs.
+
+    Both halves of that, and they are one question.
+    The length, because libsecp256k1 reads a fixed number of octets from
+    a pointer whose length never reached C to be checked. The type,
+    because `len` answers for anything with a length: a `bytearray` of
+    32 passed that check and left cffi to refuse it one call later, in
+    its own words and about a ctype -- `initializer for ctype 'unsigned
+    char *' must be a cdata pointer` -- which names neither the argument
+    nor what was wrong with it. A `float` did not even get that far, and
+    came back as `object of type 'float' has no len()`.
+
+    `bytes` and nothing else. A `bytearray` or a `memoryview` states the
+    same value and the same width, and converting one would be no guess
+    at all -- but it would widen what every signature here promises, and
+    that is the caller's to ask for, spelled `bytes(x)` where they can
+    see it.
+
+    Args:
+        value: the argument, as the caller passed it.
+        name: what the argument is, as the exception should call it.
+        size: the number of octets libsecp256k1 will read, or None where
+            the encoding carries its own length.
+
+    Returns:
+        The same bytes, so that a call may wrap the argument it checks.
+
+    Raises:
+        TypeError: if the value is not bytes.
+        ValueError: if a size is given and the value is not that long.
+    """
+    if not isinstance(value, bytes):
+        raise TypeError(f"the {name} must be bytes, not {type(value).__name__}")
+    if size is not None and len(value) != size:
+        raise ValueError(f"the {name} must be {size} bytes")
+    return value
 
 
 def scalar(num: bytes | int, name: str) -> bytes:
@@ -36,6 +75,7 @@ def scalar(num: bytes | int, name: str) -> bytes:
         The scalar as 32 bytes, big endian.
 
     Raises:
+        TypeError: if the value is neither bytes nor an int.
         ValueError: if bytes are not exactly 32 long, or if an int does
             not fit in 32 bytes. Whether the value is a valid scalar,
             i.e. in [1, n-1], is for libsecp256k1 to say.
@@ -47,9 +87,9 @@ def scalar(num: bytes | int, name: str) -> bytes:
         # is a valid scalar, i.e. in [1, n-1], is for libsecp256k1 to say
         if not 0 <= num < 2**256:
             raise ValueError(f"the {name} must fit in 32 bytes")
-        num_bytes = num.to_bytes(32, "big")
-    else:
-        num_bytes = num
-    if len(num_bytes) != 32:
-        raise ValueError(f"the {name} must be 32 bytes")
-    return num_bytes
+        return num.to_bytes(32, "big")
+    # the domain here is wider than octets', so the type is said here:
+    # what is left for it is the length
+    if not isinstance(num, bytes):
+        raise TypeError(f"the {name} must be bytes or an int, not {type(num).__name__}")
+    return octets(num, name, 32)

--- a/btclib_libsecp256k1/_scalar.py
+++ b/btclib_libsecp256k1/_scalar.py
@@ -75,12 +75,19 @@ def scalar(num: bytes | int, name: str) -> bytes:
         The scalar as 32 bytes, big endian.
 
     Raises:
-        TypeError: if the value is neither bytes nor an int.
+        TypeError: if the value is neither bytes nor an int, a bool
+            counting as neither although python makes it an int.
         ValueError: if bytes are not exactly 32 long, or if an int does
             not fit in 32 bytes. Whether the value is a valid scalar,
             i.e. in [1, n-1], is for libsecp256k1 to say.
     """
-    if isinstance(num, int):
+    # a bool is an int in python, and would be the scalar 1 or 0 without
+    # the second test: `prvkey_verify(False)` then answers False, which
+    # is the right verdict on a question nobody asked, and
+    # `pubkey_from_prvkey(True)` answers the generator. Neither can be
+    # told from the answer to the question that was meant, which is what
+    # makes this worth refusing where a `float` would only be a typo
+    if isinstance(num, int) and not isinstance(num, bool):
         # an int outside the 32-byte range is out of domain like any
         # other invalid argument, and must be reported the same way:
         # to_bytes would raise OverflowError instead. Whether the value

--- a/btclib_libsecp256k1/_secret.py
+++ b/btclib_libsecp256k1/_secret.py
@@ -1,0 +1,58 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Overwriting the libsecp256k1 buffers a secret passes through.
+
+What SECURITY.md records as inherent is the python side: a `bytes` is
+immutable, so the secret a caller hands in and the one handed back stay
+in the process until the garbage collector gets to them, and may have
+been copied on the way. The buffers here are not that. They are memory
+cffi allocated and this package owns, they are writable, and nothing
+outside these wrappers ever sees them -- so the copy they hold is the
+one copy that can be taken back, and leaving it was an omission rather
+than a limit.
+
+It buys one copy, not safety: the `bytes` returned to the caller holds
+the same secret and cannot be overwritten. Scalar work that must not
+leave a trace belongs where that can be promised.
+"""
+
+from __future__ import annotations
+
+from . import CData, ffi
+
+
+def wipe(buffer: CData) -> None:
+    """Overwrite a buffer that held a secret.
+
+    The length is the buffer's own, and is asked of it rather than
+    written here: `ffi.buffer` answers the size of what a cdata owns,
+    which for the `secp256k1_keypair *` below is the 96 octets of the
+    struct and not the 8 of the pointer -- `ffi.sizeof` would have said
+    8, and wiped the first quarter of the private key while reporting
+    success.
+
+    Args:
+        buffer: the cffi buffer to overwrite, as `ffi.new` returned it.
+    """
+    memory = ffi.buffer(buffer)
+    memory[:] = bytes(len(memory))
+
+
+def take(buffer: CData) -> bytes:
+    """Read a secret out of the buffer holding it, and overwrite that.
+
+    The pair of operations every wrapper producing a secret ends with,
+    so that neither is done without the other.
+
+    Args:
+        buffer: the cffi buffer holding the secret.
+
+    Returns:
+        Its contents, as bytes, the buffer itself left zeroed.
+    """
+    secret = bytes(ffi.buffer(buffer))
+    wipe(buffer)
+    return secret

--- a/btclib_libsecp256k1/context.py
+++ b/btclib_libsecp256k1/context.py
@@ -108,11 +108,16 @@ def check() -> None:
     same MuSig2 secret nonce, for one, is reported as the failed magic
     check of the nonce that the first signature zeroed.
 
-    The bindings validate their arguments before calling, so a violated
-    precondition is unreachable through them and none of them calls
-    this. It is meant for a call made through `lib` directly, as a
-    MuSig2 session is, and it reports what was last recorded: call it
-    right after the call whose return value you are explaining.
+    It is meant for a call made through `lib` directly, as a MuSig2
+    session is, and it reports what was last recorded: call it right
+    after the call whose return value you are explaining.
+
+    The bindings check their arguments before calling, so a violated
+    precondition is unreachable through all but one of them:
+    `keys.serialize` takes a libsecp256k1 object rather than bytes, and
+    there is nothing to check about one before handing it over. It calls
+    this itself, which is what keeps its own failure from being left on
+    the thread for the next caller to find.
 
     What was recorded is cleared, so a second call reports nothing and
     a later one cannot inherit this call's message.

--- a/btclib_libsecp256k1/dsa.py
+++ b/btclib_libsecp256k1/dsa.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from . import CData, ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 
@@ -45,8 +45,7 @@ def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> b
         True
     """
     prvkey_bytes = scalar(prvkey, "private key")
-    if len(msg_bytes) != 32:
-        raise ValueError("the message hash must be 32 bytes")
+    octets(msg_bytes, "message hash", 32)
 
     sig = ffi.new("secp256k1_ecdsa_signature *")
 
@@ -57,8 +56,8 @@ def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> b
     # nonce is the RFC6979 one alone
     if ndata is None:
         ndata = ffi.NULL
-    elif len(ndata) != 32:
-        raise ValueError("ndata must be 32 bytes")
+    else:
+        octets(ndata, "ndata", 32)
     if not lib.secp256k1_ecdsa_sign(ctx, sig, msg_bytes, prvkey_bytes, noncefc, ndata):
         raise ValueError("invalid private key")
     return _serialize_der(sig)
@@ -91,11 +90,11 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
         >>> dsa.verify(msg, mult.mult_(1), dsa.sign(msg, 1))
         True
     """
-    if len(msg_bytes) != 32:
-        raise ValueError("the message hash must be 32 bytes")
+    octets(msg_bytes, "message hash", 32)
 
     signature = _parse_der(signature_bytes)
 
+    octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -186,8 +185,7 @@ def to_der(signature_bytes: bytes) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize it, which no
             input can make it do.
     """
-    if len(signature_bytes) != 64:
-        raise ValueError("the compact signature must be 64 bytes")
+    octets(signature_bytes, "compact signature", 64)
 
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if not lib.secp256k1_ecdsa_signature_parse_compact(ctx, signature, signature_bytes):
@@ -207,6 +205,7 @@ def _parse_der(signature_bytes: bytes) -> CData:
     Raises:
         ValueError: if the DER signature is malformed.
     """
+    octets(signature_bytes, "DER signature")
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if not lib.secp256k1_ecdsa_signature_parse_der(
         ctx, signature, signature_bytes, len(signature_bytes)

--- a/btclib_libsecp256k1/dsa.py
+++ b/btclib_libsecp256k1/dsa.py
@@ -49,16 +49,21 @@ def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> b
 
     sig = ffi.new("secp256k1_ecdsa_signature *")
 
-    noncefc = ffi.NULL
-    # the nonce contribution is 32 bytes of entropy, not a serialization:
-    # a shorter value is a caller mistake rather than a small number, and
-    # padding it here would turn one into a valid argument. Omitted, the
-    # nonce is the RFC6979 one alone
-    if ndata is None:
-        ndata = ffi.NULL
-    else:
-        octets(ndata, "ndata", 32)
-    if not lib.secp256k1_ecdsa_sign(ctx, sig, msg_bytes, prvkey_bytes, noncefc, ndata):
+    # secp256k1_ecdsa_sign takes the nonce function and its data: NULL
+    # for the first selects the RFC6979 default, and it is the only one
+    # these bindings pass -- a python nonce function would be called from
+    # inside the signature, with the secret passing through a python
+    # object on every call.
+    #
+    # The contribution beside it is 32 bytes of entropy, not a
+    # serialization: a shorter value is a caller mistake rather than a
+    # small number, and padding it here would turn one into a valid
+    # argument. Omitted, the nonce is the RFC6979 one alone
+    noncefp = ffi.NULL
+    ndata_ptr = ffi.NULL if ndata is None else octets(ndata, "ndata", 32)
+    if not lib.secp256k1_ecdsa_sign(
+        ctx, sig, msg_bytes, prvkey_bytes, noncefp, ndata_ptr
+    ):
         raise ValueError("invalid private key")
     return _serialize_der(sig)
 

--- a/btclib_libsecp256k1/ecdh.py
+++ b/btclib_libsecp256k1/ecdh.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from . import ffi, lib
 from ._scalar import octets, scalar
+from ._secret import take
 from .context import ctx
 
 
@@ -51,4 +52,4 @@ def shared_secret(pubkey_bytes: bytes, prvkey: bytes | int) -> bytes:
     # which writes 32 bytes to output
     if not lib.secp256k1_ecdh(ctx, output, pubkey, prvkey_bytes, ffi.NULL, ffi.NULL):
         raise ValueError("invalid private key")
-    return ffi.unpack(output, ffi.sizeof(output))
+    return take(output)

--- a/btclib_libsecp256k1/ecdh.py
+++ b/btclib_libsecp256k1/ecdh.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from . import ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 
@@ -40,6 +40,7 @@ def shared_secret(pubkey_bytes: bytes, prvkey: bytes | int) -> bytes:
             it is not a valid scalar.
     """
     prvkey_bytes = scalar(prvkey, "private key")
+    octets(pubkey_bytes, "public key")
 
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):

--- a/btclib_libsecp256k1/ellswift.py
+++ b/btclib_libsecp256k1/ellswift.py
@@ -14,6 +14,7 @@ import secrets
 
 from . import ffi, lib
 from ._scalar import octets, scalar
+from ._secret import take
 from .context import ctx
 
 # SECP256K1_EC_COMPRESSED: the libsecp256k1 flag macros do not survive
@@ -169,4 +170,4 @@ def xdh(
         ffi.NULL,
     ):
         raise ValueError("invalid private key")
-    return ffi.unpack(output, ffi.sizeof(output))
+    return take(output)

--- a/btclib_libsecp256k1/ellswift.py
+++ b/btclib_libsecp256k1/ellswift.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import secrets
 
 from . import ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 # SECP256K1_EC_COMPRESSED: the libsecp256k1 flag macros do not survive
@@ -46,8 +46,8 @@ def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
     # rather than a small number, and is not padded into a valid argument
     if aux_rand32 is None:
         aux_rand32 = secrets.token_bytes(32)
-    elif len(aux_rand32) != 32:
-        raise ValueError("aux_rand32 must be 32 bytes")
+    else:
+        octets(aux_rand32, "aux_rand32", 32)
 
     ell_bytes = ffi.new("char[64]")
     if not lib.secp256k1_ellswift_create(ctx, ell_bytes, prvkey_bytes, aux_rand32):
@@ -76,6 +76,7 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
+    octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -83,8 +84,8 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
     # 32 bytes of entropy, or nothing: see the comment in create
     if rnd32 is None:
         rnd32 = secrets.token_bytes(32)
-    elif len(rnd32) != 32:
-        raise ValueError("rnd32 must be 32 bytes")
+    else:
+        octets(rnd32, "rnd32", 32)
 
     ell_bytes = ffi.new("char[64]")
     if not lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, rnd32):
@@ -108,8 +109,7 @@ def decode(ell_bytes: bytes) -> bytes:
         RuntimeError: if libsecp256k1 fails to decode or serialize,
             which no 64 bytes can make it do.
     """
-    if len(ell_bytes) != 64:
-        raise ValueError("the ElligatorSwift public key must be 64 bytes")
+    octets(ell_bytes, "ElligatorSwift public key", 64)
 
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
@@ -150,8 +150,8 @@ def xdh(
             0 or 1, or if the private key is not 32 bytes, does not fit
             in them, or is not a valid scalar.
     """
-    if len(ell_a_bytes) != 64 or len(ell_b_bytes) != 64:
-        raise ValueError("the ElligatorSwift public keys must be 64 bytes")
+    octets(ell_a_bytes, "ElligatorSwift public key of A", 64)
+    octets(ell_b_bytes, "ElligatorSwift public key of B", 64)
     if party not in (0, 1):
         raise ValueError("the party must be 0 (A) or 1 (B)")
 

--- a/btclib_libsecp256k1/ellswift.py
+++ b/btclib_libsecp256k1/ellswift.py
@@ -16,10 +16,7 @@ from . import ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take
 from .context import ctx
-
-# SECP256K1_EC_COMPRESSED: the libsecp256k1 flag macros do not survive
-# the preprocessing of the headers into cffi definitions
-COMPRESSED = 258
+from .keys import serialize
 
 
 def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
@@ -94,16 +91,17 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
-def decode(ell_bytes: bytes) -> bytes:
-    """Decode a 64-byte ElligatorSwift public key into its compressed form.
+def decode(ell_bytes: bytes, compressed: bool = True) -> bytes:
+    """Decode a 64-byte ElligatorSwift public key into a public key.
 
     Args:
         ell_bytes: the 64-byte encoding.
+        compressed: whether to return 33 bytes rather than 65.
 
     Returns:
-        The 33-byte compressed public key. Every 64 bytes decode to a
-        point, which is what makes the encoding indistinguishable from
-        random: there is nothing to reject.
+        The serialized public key. Every 64 bytes decode to a point,
+        which is what makes the encoding indistinguishable from random:
+        there is nothing to reject.
 
     Raises:
         ValueError: if the input is not 64 bytes.
@@ -115,14 +113,7 @@ def decode(ell_bytes: bytes) -> bytes:
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
         raise RuntimeError("ElligatorSwift decoding failed")
-
-    # one length per flag, so the buffer is what is unpacked: see the
-    # comment in keys.serialize
-    output = ffi.new("char[33]")
-    length = ffi.new("size_t *", ffi.sizeof(output))
-    if not lib.secp256k1_ec_pubkey_serialize(ctx, output, length, pubkey, COMPRESSED):
-        raise RuntimeError("point serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
+    return serialize(pubkey, compressed)
 
 
 def xdh(

--- a/btclib_libsecp256k1/hashes.py
+++ b/btclib_libsecp256k1/hashes.py
@@ -11,6 +11,7 @@ https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 from __future__ import annotations
 
 from . import ffi, lib
+from ._scalar import octets
 from .context import ctx
 
 
@@ -38,6 +39,8 @@ def tagged_sha256(tag: bytes, msg: bytes) -> bytes:
         >>> hashes.tagged_sha256(b"TapLeaf", b"").hex()
         '5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb'
     """
+    octets(tag, "tag")
+    octets(msg, "message")
     output = ffi.new("char[32]")
     if not lib.secp256k1_tagged_sha256(ctx, output, tag, len(tag), msg, len(msg)):
         raise RuntimeError("tagged hashing failed")

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from . import CData, ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import check, ctx
 
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
@@ -329,6 +329,7 @@ def parse(pubkey_bytes: bytes) -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
+    octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 
 from . import CData, ffi, lib
 from ._scalar import scalar
-from .context import ctx
+from .context import check, ctx
 
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
 # libsecp256k1 flag macros do not survive the preprocessing of the
@@ -347,8 +347,13 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
         uncompressed one.
 
     Raises:
-        RuntimeError: if libsecp256k1 fails, which a key it produced
-            cannot make it do.
+        ValueError: if the object is not a public key libsecp256k1 will
+            read -- a NULL pointer, or a `secp256k1_pubkey` nothing has
+            written to. This is the one argument of these bindings that
+            is a libsecp256k1 object rather than bytes, and so the one
+            that cannot be checked before the call.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a key it produced cannot make it do.
 
     Example:
         >>> from btclib_libsecp256k1 import keys, mult
@@ -368,5 +373,14 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     length = ffi.new("size_t *", ffi.sizeof(output))
     flags = COMPRESSED if compressed else UNCOMPRESSED
     if not lib.secp256k1_ec_pubkey_serialize(ctx, output, length, pubkey, flags):
+        # every other argument of these bindings is bytes, checked before
+        # the call; this one is a libsecp256k1 object the caller holds, so
+        # a violated precondition is reachable here and nowhere else.
+        # check() is what turns it back into the message libsecp256k1
+        # wrote -- and, raising it, takes it off the thread. Left there it
+        # would be found by the next check(), which is the one a MuSig2
+        # caller makes through `lib`, and blamed on a call that did not
+        # produce it
+        check()
         raise RuntimeError("point serialization failed")
     return ffi.unpack(output, ffi.sizeof(output))

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 
 from . import CData, ffi, lib
 from ._scalar import octets, scalar
+from ._secret import take
 from .context import check, ctx
 
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
@@ -62,7 +63,7 @@ def prvkey_negate(prvkey: bytes | int) -> bytes:
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     if not lib.secp256k1_ec_seckey_negate(ctx, prvkey_buffer):
         raise ValueError("invalid private key")
-    return ffi.unpack(prvkey_buffer, ffi.sizeof(prvkey_buffer))
+    return take(prvkey_buffer)
 
 
 def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
@@ -87,7 +88,7 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_add(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")
-    return ffi.unpack(prvkey_buffer, ffi.sizeof(prvkey_buffer))
+    return take(prvkey_buffer)
 
 
 def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
@@ -109,7 +110,7 @@ def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_mul(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")
-    return ffi.unpack(prvkey_buffer, ffi.sizeof(prvkey_buffer))
+    return take(prvkey_buffer)
 
 
 def pubkey_from_prvkey(prvkey: bytes | int, compressed: bool = True) -> bytes:

--- a/btclib_libsecp256k1/recovery.py
+++ b/btclib_libsecp256k1/recovery.py
@@ -10,10 +10,7 @@ from __future__ import annotations
 from . import CData, ffi, lib
 from ._scalar import octets, scalar
 from .context import ctx
-
-# SECP256K1_EC_COMPRESSED: the libsecp256k1 flag macros do not survive
-# the preprocessing of the headers into cffi definitions
-COMPRESSED = 258
+from .keys import serialize
 
 
 def sign(
@@ -65,8 +62,10 @@ def sign(
     return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes)), recid[0]
 
 
-def recover(msg_bytes: bytes, signature_bytes: bytes, recid: int) -> bytes:
-    """Recover the compressed public key from a recoverable ECDSA signature.
+def recover(
+    msg_bytes: bytes, signature_bytes: bytes, recid: int, compressed: bool = True
+) -> bytes:
+    """Recover the public key from a recoverable ECDSA signature.
 
     Args:
         msg_bytes: the 32-byte hash the signature was made over.
@@ -74,9 +73,10 @@ def recover(msg_bytes: bytes, signature_bytes: bytes, recid: int) -> bytes:
         recid: the recovery id, 0 to 3. A wrong one recovers a different
             key rather than failing, so it is part of the signature and
             not a guess.
+        compressed: whether to return 33 bytes rather than 65.
 
     Returns:
-        The 33-byte compressed public key.
+        The serialized recovered public key.
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if the
@@ -96,14 +96,7 @@ def recover(msg_bytes: bytes, signature_bytes: bytes, recid: int) -> bytes:
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ecdsa_recover(ctx, pubkey, signature, msg_bytes):
         raise ValueError("public key recovery failed")
-
-    # one length per flag, so the buffer is what is unpacked: see the
-    # comment in keys.serialize
-    output = ffi.new("char[33]")
-    length = ffi.new("size_t *", ffi.sizeof(output))
-    if not lib.secp256k1_ec_pubkey_serialize(ctx, output, length, pubkey, COMPRESSED):
-        raise RuntimeError("point serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
+    return serialize(pubkey, compressed)
 
 
 def to_der(signature_bytes: bytes, recid: int) -> bytes:

--- a/btclib_libsecp256k1/recovery.py
+++ b/btclib_libsecp256k1/recovery.py
@@ -42,14 +42,12 @@ def sign(
 
     sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
-    noncefc = ffi.NULL
-    # 32 bytes of entropy, or nothing: see the comment in dsa.sign
-    if ndata is None:
-        ndata = ffi.NULL
-    else:
-        octets(ndata, "ndata", 32)
+    # the default nonce function, and 32 bytes of entropy or nothing:
+    # see the comment in dsa.sign
+    noncefp = ffi.NULL
+    ndata_ptr = ffi.NULL if ndata is None else octets(ndata, "ndata", 32)
     if not lib.secp256k1_ecdsa_sign_recoverable(
-        ctx, sig, msg_bytes, prvkey_bytes, noncefc, ndata
+        ctx, sig, msg_bytes, prvkey_bytes, noncefp, ndata_ptr
     ):
         raise ValueError("invalid private key")
 

--- a/btclib_libsecp256k1/recovery.py
+++ b/btclib_libsecp256k1/recovery.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from . import CData, ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 # SECP256K1_EC_COMPRESSED: the libsecp256k1 flag macros do not survive
@@ -41,8 +41,7 @@ def sign(
             which no input can make it do.
     """
     prvkey_bytes = scalar(prvkey, "private key")
-    if len(msg_bytes) != 32:
-        raise ValueError("the message hash must be 32 bytes")
+    octets(msg_bytes, "message hash", 32)
 
     sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
@@ -50,8 +49,8 @@ def sign(
     # 32 bytes of entropy, or nothing: see the comment in dsa.sign
     if ndata is None:
         ndata = ffi.NULL
-    elif len(ndata) != 32:
-        raise ValueError("ndata must be 32 bytes")
+    else:
+        octets(ndata, "ndata", 32)
     if not lib.secp256k1_ecdsa_sign_recoverable(
         ctx, sig, msg_bytes, prvkey_bytes, noncefc, ndata
     ):
@@ -87,10 +86,8 @@ def recover(msg_bytes: bytes, signature_bytes: bytes, recid: int) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize the key, which
             no input can make it do.
     """
-    if len(msg_bytes) != 32:
-        raise ValueError("the message hash must be 32 bytes")
-    if len(signature_bytes) != 64:
-        raise ValueError("the signature must be 64 bytes")
+    octets(msg_bytes, "message hash", 32)
+    octets(signature_bytes, "signature", 64)
     if recid not in (0, 1, 2, 3):
         raise ValueError("the recovery id must be 0, 1, 2, or 3")
 
@@ -132,8 +129,7 @@ def to_der(signature_bytes: bytes, recid: int) -> bytes:
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             signature, which no input can make it do.
     """
-    if len(signature_bytes) != 64:
-        raise ValueError("the signature must be 64 bytes")
+    octets(signature_bytes, "signature", 64)
     if recid not in (0, 1, 2, 3):
         raise ValueError("the recovery id must be 0, 1, 2, or 3")
 

--- a/btclib_libsecp256k1/ssa.py
+++ b/btclib_libsecp256k1/ssa.py
@@ -15,6 +15,7 @@ import secrets
 
 from . import CData, ffi, lib
 from ._scalar import octets, scalar
+from ._secret import wipe
 from .context import ctx
 
 # SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC: the libsecp256k1 macros do not
@@ -58,9 +59,16 @@ def sign(
     keypair = _keypair(prvkey)
 
     sig = ffi.new("char[64]")
-    if lib.secp256k1_schnorrsig_sign32(
-        ctx, sig, msg_bytes, keypair, _aux_rand32(aux_rand32)
-    ):
+    try:
+        signed = lib.secp256k1_schnorrsig_sign32(
+            ctx, sig, msg_bytes, keypair, _aux_rand32(aux_rand32)
+        )
+    finally:
+        # a keypair carries the private key: overwrite it whether the
+        # signature was made, refused, or never attempted, _aux_rand32
+        # being able to raise between the two
+        wipe(keypair)
+    if signed:
         return ffi.unpack(sig, ffi.sizeof(sig))
     raise RuntimeError("schnorr signing failed")
 
@@ -96,18 +104,23 @@ def sign_custom(
     octets(msg_bytes, "message")
     keypair = _keypair(prvkey)
 
-    ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
-    extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
-    extraparams.magic = EXTRAPARAMS_MAGIC
-    extraparams.noncefp = ffi.NULL
-    # ndata has to stay referenced until the call is over: cffi keeps
-    # alive what a variable points to, not what a struct field does
-    extraparams.ndata = ndata
-
     sig = ffi.new("char[64]")
-    if lib.secp256k1_schnorrsig_sign_custom(
-        ctx, sig, msg_bytes, len(msg_bytes), keypair, extraparams
-    ):
+    try:
+        ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
+        extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
+        extraparams.magic = EXTRAPARAMS_MAGIC
+        extraparams.noncefp = ffi.NULL
+        # ndata has to stay referenced until the call is over: cffi keeps
+        # alive what a variable points to, not what a struct field does
+        extraparams.ndata = ndata
+
+        signed = lib.secp256k1_schnorrsig_sign_custom(
+            ctx, sig, msg_bytes, len(msg_bytes), keypair, extraparams
+        )
+    finally:
+        # the keypair carries the private key: see sign
+        wipe(keypair)
+    if signed:
         return ffi.unpack(sig, ffi.sizeof(sig))
     raise RuntimeError("schnorr signing failed")
 

--- a/btclib_libsecp256k1/ssa.py
+++ b/btclib_libsecp256k1/ssa.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import secrets
 
 from . import CData, ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 # SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC: the libsecp256k1 macros do not
@@ -54,8 +54,7 @@ def sign(
         >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
         True
     """
-    if len(msg_bytes) != 32:
-        raise ValueError("the message hash must be 32 bytes")
+    octets(msg_bytes, "message hash", 32)
     keypair = _keypair(prvkey)
 
     sig = ffi.new("char[64]")
@@ -94,6 +93,7 @@ def sign_custom(
         RuntimeError: if libsecp256k1 fails to sign, which no input can
             make it do.
     """
+    octets(msg_bytes, "message")
     keypair = _keypair(prvkey)
 
     ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
@@ -135,11 +135,10 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
             well-formed signature that simply does not verify is False,
             not an exception.
     """
-    if len(signature_bytes) != 64:
-        raise ValueError("the signature must be 64 bytes")
+    octets(msg_bytes, "message")
+    octets(signature_bytes, "signature", 64)
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    if len(pubkey_bytes) != 32:
-        raise ValueError("the x-only public key must be 32 bytes")
+    octets(pubkey_bytes, "x-only public key", 32)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
@@ -191,6 +190,4 @@ def _aux_rand32(aux_rand32: bytes | None) -> bytes:
     """
     if aux_rand32 is None:
         return secrets.token_bytes(32)
-    if len(aux_rand32) != 32:
-        raise ValueError("aux_rand32 must be 32 bytes")
-    return aux_rand32
+    return octets(aux_rand32, "aux_rand32", 32)

--- a/btclib_libsecp256k1/xonly.py
+++ b/btclib_libsecp256k1/xonly.py
@@ -21,7 +21,7 @@ not inside an argument check.
 from __future__ import annotations
 
 from . import CData, ffi, lib
-from ._scalar import scalar
+from ._scalar import octets, scalar
 from .context import ctx
 
 
@@ -42,6 +42,7 @@ def from_pubkey(pubkey_bytes: bytes) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
+    octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -108,8 +109,7 @@ def tweak_add_check(
             coordinate, if the parity is not 0 or 1, or if the tweak is
             not 32 bytes or does not fit in them.
     """
-    if len(tweaked_pubkey_bytes) != 32:
-        raise ValueError("the tweaked x-only public key must be 32 bytes")
+    octets(tweaked_pubkey_bytes, "tweaked x-only public key", 32)
     if tweaked_parity not in (0, 1):
         raise ValueError("the parity must be 0 or 1")
 
@@ -170,8 +170,7 @@ def _parse(pubkey_bytes: bytes) -> CData:
         ValueError: if it is not 32 bytes, or not a valid x coordinate.
     """
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    if len(pubkey_bytes) != 32:
-        raise ValueError("the x-only public key must be 32 bytes")
+    octets(pubkey_bytes, "x-only public key", 32)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):

--- a/btclib_libsecp256k1/xonly.py
+++ b/btclib_libsecp256k1/xonly.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from . import CData, ffi, lib
 from ._scalar import octets, scalar
+from ._secret import take, wipe
 from .context import ctx
 
 
@@ -152,14 +153,20 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
             valid input can make it do.
     """
     keypair = _keypair(prvkey)
-    tweak_bytes = scalar(tweak, "tweak")
-    if not lib.secp256k1_keypair_xonly_tweak_add(ctx, keypair, tweak_bytes):
-        raise ValueError("invalid tweak or resulting private key")
-
     prvkey_buffer = ffi.new("char[32]")
-    if not lib.secp256k1_keypair_sec(ctx, prvkey_buffer, keypair):
-        raise RuntimeError("private key extraction failed")
-    return ffi.unpack(prvkey_buffer, ffi.sizeof(prvkey_buffer))
+    try:
+        tweak_bytes = scalar(tweak, "tweak")
+        if not lib.secp256k1_keypair_xonly_tweak_add(ctx, keypair, tweak_bytes):
+            raise ValueError("invalid tweak or resulting private key")
+
+        if not lib.secp256k1_keypair_sec(ctx, prvkey_buffer, keypair):
+            raise RuntimeError("private key extraction failed")
+        return take(prvkey_buffer)
+    finally:
+        # a keypair carries the private key -- the tweaked one here,
+        # which is the one that signs -- so it is overwritten on the way
+        # out whether that was reached or refused
+        wipe(keypair)
 
 
 def _parse(pubkey_bytes: bytes) -> CData:

--- a/btclib_libsecp256k1/xonly.py
+++ b/btclib_libsecp256k1/xonly.py
@@ -102,12 +102,17 @@ def tweak_add_check(
 
     Returns:
         True if tweaking the internal key by that tweak gives that key
-        and that parity.
+        and that parity. 32 bytes which are the x coordinate of no point
+        at all are one of the ways of being False: this compares the
+        serialization rather than parsing it, which is where the saving
+        over recomputing the tweak comes from.
 
     Raises:
-        ValueError: if either key is not 32 bytes or not a valid x
-            coordinate, if the parity is not 0 or 1, or if the tweak is
-            not 32 bytes or does not fit in them.
+        ValueError: if either key is not 32 bytes, if the internal key
+            is not a valid x coordinate, if the parity is not 0 or 1, or
+            if the tweak is not 32 bytes or does not fit in them. The
+            tweaked key is not parsed, and so is never invalid: see
+            Returns.
     """
     octets(tweaked_pubkey_bytes, "tweaked x-only public key", 32)
     if tweaked_parity not in (0, 1):

--- a/stubs/_btclib_libsecp256k1.pyi
+++ b/stubs/_btclib_libsecp256k1.pyi
@@ -18,6 +18,11 @@ be a second source of truth that nothing keeps honest.
 `unpack` is narrowed to bytes. In general it returns bytes, str or a
 list, depending on the cdata type; the package only ever unpacks
 `char[]`, which is the bytes case.
+
+`buffer` answers a writable view of what a cdata owns, and its length is
+that of the memory rather than of a pointer to it: `_secret` reads both
+from it. `memoryview` is what it is used as -- sliced, assigned to, and
+measured -- so that is what it is declared to return.
 """
 
 from typing import Any
@@ -26,6 +31,7 @@ class _FFI:
     NULL: Any
     def new(self, cdecl: str, init: Any = ...) -> Any: ...
     def sizeof(self, cdecl_or_cdata: Any) -> int: ...
+    def buffer(self, cdata: Any, size: int = ...) -> memoryview: ...
     def unpack(self, cdata: Any, length: int) -> bytes: ...
     def string(self, cdata: Any) -> bytes: ...
     def callback(self, cdecl: str, python_callable: Any) -> Any: ...

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,11 +5,12 @@
 
 """Tests of what libsecp256k1 reports through the callbacks of the context.
 
-An illegal argument is reachable through `lib` and driven that way here.
-An internal error is not: libsecp256k1 reports through that callback what
-it holds to be unreachable, so the recording function is called directly,
-the way test_extension.py drives the branch of the loader that the build
-it runs on does not have.
+An illegal argument is reachable through `lib`, and through the one
+wrapper that takes a libsecp256k1 object rather than bytes; both are
+driven here. An internal error is not: libsecp256k1 reports through that
+callback what it holds to be unreachable, so the recording function is
+called directly, the way test_extension.py drives the branch of the
+loader that the build it runs on does not have.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ import threading
 
 import pytest
 
-from btclib_libsecp256k1 import context, ffi, lib
+from btclib_libsecp256k1 import context, ffi, keys, lib
 from btclib_libsecp256k1.context import ctx
 
 # a public key libsecp256k1 is asked to parse into nowhere: the bindings
@@ -35,8 +36,9 @@ def test_check_with_nothing_reported() -> None:
 def test_illegal_argument() -> None:
     """An illegal argument reaches the caller as ValueError, with its text.
 
-    Driven through `lib`, which the bindings' own wrappers cannot do:
-    they always give libsecp256k1 the buffer it asks for.
+    Driven through `lib`, which all but one of the bindings' wrappers
+    cannot do: they give libsecp256k1 bytes they have already checked.
+    `keys.serialize` is the exception, and has a test of its own below.
     """
     assert not lib.secp256k1_ec_pubkey_parse(ctx, *NOWHERE_ARGS)
     with pytest.raises(ValueError, match="illegal argument: pubkey != NULL"):
@@ -55,6 +57,33 @@ def test_check_clears_what_it_reported() -> None:
         context.check()
     # the message is not reported twice, and cannot be attributed to a
     # later call which did not produce one
+    context.check()
+
+
+def test_serialize_raises_what_was_reported() -> None:
+    """`keys.serialize` raises the message, rather than a bare failure.
+
+    It takes the libsecp256k1 object the caller holds, so there is
+    nothing to check about it before the call and the precondition is
+    libsecp256k1's to violate. A NULL pointer is the shortest way there;
+    what comes back names it.
+    """
+    with pytest.raises(ValueError, match="illegal argument: pubkey != NULL"):
+        keys.serialize(ffi.NULL)
+
+
+def test_serialize_leaves_nothing_on_the_thread() -> None:
+    """And what it raised is not left for the next caller to be blamed for.
+
+    A `secp256k1_pubkey` nothing has written to is the reachable form of
+    the mistake: the message is about the zero field it finds, not about
+    a pointer. Left on the thread, it would come back out of the next
+    `check` -- which is the one a MuSig2 caller makes through `lib`,
+    about a call of their own.
+    """
+    with pytest.raises(ValueError, match="illegal argument"):
+        keys.serialize(ffi.new("secp256k1_pubkey *"))
+    # raising it took it off the thread: this reports nothing
     context.check()
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,15 +116,23 @@ def test_safe_abort() -> None:
     them with do-nothing stubs, compiled as a unit of their own rather
     than by editing the submodule. That the test returns at all is the
     assertion.
+
+    A context of its own, because the shared one has the recording
+    callbacks of `context` set on it and this is about the defaults --
+    and destroyed after, a context being an allocation that nothing else
+    frees. `1` is SECP256K1_CONTEXT_NONE, the flags naming SIGN and
+    VERIFY having been deprecated since libsecp256k1 0.2.
     """
+    default_callbacks_ctx = lib.secp256k1_context_create(1)
     lib.secp256k1_ecdsa_sign(
-        lib.secp256k1_context_create(769),
+        default_callbacks_ctx,
         ffi.new("secp256k1_ecdsa_signature *"),
         b"0" * 32,
         ffi.NULL,
         ffi.NULL,
         b"0" * 32,
     )
+    lib.secp256k1_context_destroy(default_callbacks_ctx)
 
 
 def test_mult() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,8 @@ from btclib_libsecp256k1 import (
     dsa,
     ellswift,
     ffi,
+    hashes,
+    keys,
     lib,
     mult,
     recovery,
@@ -191,6 +193,55 @@ def test_invalid_inputs() -> None:
     # message names is the private key the scalar of it is
     with pytest.raises(ValueError, match="private key"):
         mult.mult(0)
+
+
+def test_type_checks_refuse_what_merely_has_a_length() -> None:
+    """A size check alone is not a check: `len` answers for more than bytes.
+
+    A `bytearray` of 32 passed every one of them and reached cffi, which
+    refused it a call later in its own words and about a ctype --
+    `initializer for ctype 'unsigned char *' must be a cdata pointer` --
+    naming neither the argument nor what was wrong with it. A `float`
+    did not get that far, and came back as `object of type 'float' has
+    no len()`. Both are the binding's to refuse, and it names them.
+
+    That a `bytearray` is refused rather than converted is the decision
+    and not the oversight: it states the same value and the same width
+    as bytes, and `bytes(x)` is the conversion -- in the caller's code,
+    where they can see it, rather than in a signature that promises
+    bytes and quietly means more.
+
+    Every call below is annotated for what it is: an argument of a type
+    the signature refuses, which is why each carries the `type: ignore`
+    that says mypy already knew.
+    """
+    msg = b"\x01" * 32
+    prvkey = 7
+    pubkey_bytes = mult.mult_(prvkey)
+    der_bytes = dsa.sign(msg, prvkey)
+
+    with pytest.raises(TypeError, match="message hash must be bytes, not bytearray"):
+        dsa.sign(bytearray(msg), prvkey)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="public key must be bytes, not memoryview"):
+        dsa.verify(msg, memoryview(pubkey_bytes), der_bytes)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="tag must be bytes, not str"):
+        hashes.tagged_sha256("TapLeaf", b"")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="ElligatorSwift public key must be bytes"):
+        ellswift.decode(bytearray(64))  # type: ignore[arg-type]
+
+    # the scalars take an int too, so their message says so
+    with pytest.raises(TypeError, match="private key must be bytes or an int"):
+        dsa.sign(msg, bytearray(32))  # type: ignore[arg-type]
+    with pytest.raises(
+        TypeError, match="private key must be bytes or an int, not float"
+    ):
+        mult.mult(1.0)  # type: ignore[arg-type]
+
+    # a sequence of public keys handed one public key: bytes is itself a
+    # sequence, so what reaches parse is an int, and saying so is the
+    # whole of the diagnosis
+    with pytest.raises(TypeError, match="public key must be bytes, not int"):
+        keys.pubkey_sort(pubkey_bytes)  # type: ignore[arg-type]
 
 
 def test_size_checks_refuse_both_sides() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,6 +244,39 @@ def test_type_checks_refuse_what_merely_has_a_length() -> None:
         keys.pubkey_sort(pubkey_bytes)  # type: ignore[arg-type]
 
 
+def test_a_bool_is_not_a_scalar() -> None:
+    """A bool is refused where a scalar goes, python making it an int.
+
+    This is the one type whose acceptance could not be seen in the
+    answer. `keys.prvkey_verify(False)` returned False, which is the
+    correct verdict on the scalar zero and indistinguishable from the
+    correct verdict on whatever the caller meant; `mult.mult_(True)`
+    returned the generator. A `float` or a `str` in the same place is a
+    typo that raises, and always did.
+
+    Nor could the type checker say so: `bool` is a subtype of `int`, so
+    these two calls are the only ones in this module that need no
+    `type: ignore` -- mypy holds them to be correct. That is the whole
+    argument for the check being made at run time.
+
+    Refused for the scalars alone. `recid`, `party` and the y parity
+    take a bool as the 0 or 1 it is, those being flags rather than
+    values, and reading one as `True` guesses at nothing.
+    """
+    for value in (True, False):
+        with pytest.raises(TypeError, match="private key must be bytes or an int"):
+            keys.prvkey_verify(value)
+        with pytest.raises(TypeError, match="tweak must be bytes or an int, not bool"):
+            keys.prvkey_tweak_add(7, value)
+
+    # the flags are unaffected: a bool there is the 0 or 1 it is, and
+    # the recovery id of any signature is one of the two
+    msg = b"\x01" * 32
+    sig_bytes, recid = recovery.sign(msg, 7)
+    assert recid in (0, 1)
+    assert recovery.recover(msg, sig_bytes, bool(recid)) == keys.pubkey_from_prvkey(7)
+
+
 def test_size_checks_refuse_both_sides() -> None:
     """Every size check refuses a value too long as well as one too short.
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -275,6 +275,14 @@ def test_xonly_tweak_add() -> None:
     )
     assert not xonly.tweak_add_check(tweaked_bytes, 1 - parity, xonly_bytes, tweak)
 
+    # and 32 bytes which are the x coordinate of no point at all are
+    # False rather than an error: this compares the serialization
+    # instead of parsing it, which is the whole of what it saves over
+    # recomputing the tweak. The internal key is parsed, and does raise
+    assert not xonly.tweak_add_check(b"\xff" * 32, parity, xonly_bytes, tweak)
+    with pytest.raises(ValueError, match="invalid x-only public key"):
+        xonly.tweak_add_check(tweaked_bytes, parity, b"\xff" * 32, tweak)
+
 
 def test_taproot_key_path() -> None:
     """Sign a taproot key path spending with a tweaked private key."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -111,6 +111,12 @@ def test_recovery() -> None:
     assert custom[0] != signature_bytes
     assert recovery.recover(msg, *custom) == pubkey_bytes
 
+    # the recovered key comes back in either form, this being
+    # keys.serialize and the same point either way
+    uncompressed = recovery.recover(msg, signature_bytes, recid, compressed=False)
+    assert uncompressed == mult.mult_(prvkey)
+    assert compress(uncompressed) == pubkey_bytes
+
 
 def test_recovery_invalid_inputs() -> None:
     """Every argument the recovery module bounds is refused out of range.
@@ -170,6 +176,9 @@ def test_ellswift() -> None:
     assert ellswift.decode(fixed) == pubkey_a
     # the encoding is randomized: a fresh one differs
     assert ellswift.create(prvkey_a) != ell_a
+    # and the decoding comes back in either form, this being
+    # keys.serialize and the same point either way
+    assert ellswift.decode(ell_a, compressed=False) == mult.mult_(prvkey_a)
 
     # x-only ECDH: both parties agree on the BIP324 shared secret
     ell_b = ellswift.create(prvkey_b)

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,0 +1,50 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The buffers a secret passes through are overwritten before being dropped.
+
+What the wrappers do with these is invisible from their answers -- the
+buffer is a local, and it is gone by the time a caller could look -- so
+the two functions are driven here directly, on the two shapes they are
+given: the `char[32]` a tweaked private key comes back in, and the
+`secp256k1_keypair` a BIP340 signature is made with.
+"""
+
+from __future__ import annotations
+
+from btclib_libsecp256k1 import _secret, ffi, lib
+from btclib_libsecp256k1.context import ctx
+
+SECRET = b"\x07" * 32
+
+
+def test_take_reads_the_secret_out_and_zeroes_the_buffer() -> None:
+    """What the caller gets is the secret; what is left is zeros."""
+    buffer = ffi.new("char[32]", SECRET)
+
+    assert _secret.take(buffer) == SECRET
+    assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+
+
+def test_wipe_asks_the_buffer_for_its_own_size() -> None:
+    """A keypair is wiped whole, and it is larger than the pointer to it.
+
+    This is the reason the length is taken from `ffi.buffer` rather than
+    from `ffi.sizeof`: on a `secp256k1_keypair *` the latter answers 8,
+    the size of the pointer, and wiping 8 octets would clear the first
+    quarter of the private key and leave the rest -- while every
+    assertion about the call still passed.
+    """
+    keypair = ffi.new("secp256k1_keypair *")
+    assert lib.secp256k1_keypair_create(ctx, keypair, SECRET)
+
+    memory = ffi.buffer(keypair)
+    # the private key is in there, and there is more of the struct than
+    # there is of a pointer to it
+    assert SECRET in bytes(memory)
+    assert len(memory) > ffi.sizeof(keypair)
+
+    _secret.wipe(keypair)
+    assert bytes(memory) == bytes(len(memory))


### PR DESCRIPTION
An audit of the package, reading every wrapper and driving the boundary
against the built library. Seven findings, one commit each, none of which
the gate could have caught: `pre-commit` was green, mypy strict was clean,
and the suite was 239 passing at 100% before any of them.

## What was wrong

**`keys.serialize` tripped a precondition and left the message behind.**
It is the one wrapper whose argument is a libsecp256k1 object rather than
bytes, so nothing can be checked before the call. Handed `ffi.NULL`, or a
`secp256k1_pubkey` nothing has written to, it raised
`RuntimeError("point serialization failed")` -- the class reserved here
for what no input can provoke -- and left `pubkey != NULL` recorded on the
thread. The next `context.check()` raised it, and that caller is the
MuSig2 one going through `lib`: they were told about a call they never
made. `test_check_clears_what_it_reported` exists to prevent exactly this,
and it was reachable from the public API. Two docstrings claimed the case
away and now describe it.

**A size check is not a check.** `len` answers for a `bytearray` and a
`memoryview`, so both passed every one of the eighteen and reached cffi,
which refused them a call later in its own words and about a ctype;
a `float` came back as `object of type 'float' has no len()`; and
`_scalar.scalar`, annotated `-> bytes`, returned the bytearray it was
handed. `_scalar.octets` now asks type and length together.

**A `bool` was a scalar.** `keys.prvkey_verify(False)` answered False --
the correct verdict on zero, indistinguishable from the correct verdict on
whatever was meant -- and `keys.pubkey_from_prvkey(True)` answered the
generator. mypy could not say so either: `bool` is a subtype of `int`.

**`xonly.tweak_add_check` promised a `ValueError` it does not raise.**
Only the internal key is parsed; a tweaked key that is the x coordinate of
no point returns False. The behaviour is right, the contract was not.

**The cffi buffers holding a secret were never overwritten.** SECURITY.md
records the python side as inherent, and it is -- but the copy in the
middle is writable memory this package owns, and leaving a private key in
it was an omission rather than a limit.

**`recovery.recover` and `ellswift.decode` each copied `keys.serialize`,**
comment included, and so were the two producers without the `compressed`
flag every producer in `keys` has.

**And three small things:** `noncefc` for `noncefp`, `ndata` reassigned to
`ffi.NULL` past its own annotation, and a context `test_safe_abort`
created on every run and never freed.

## What a caller sees

Nothing that worked stops working. Three visible changes, each in the
CHANGELOG:

- `keys.serialize` raises `ValueError` with libsecp256k1's own message,
  where it raised a bare `RuntimeError`
- a wrong *type* raises `TypeError` from the binding, naming the argument,
  where cffi raised one a call later about a ctype
- `recovery.COMPRESSED` and `ellswift.COMPRESSED` are gone: two copies of
  a flag macro `keys.COMPRESSED` still declares. The one removal here

## The decision worth a second opinion

`octets` accepts `bytes` and nothing else. A `bytearray` states the same
value and the same width, so converting one would guess at nothing -- but
it would widen what every signature here promises, and `bytes(x)` is that
conversion in the caller's own code. That is one line of `octets` if the
wider door is wanted.

The type rule is stated once, in the README section that already carries
the reasoning for the size check, rather than in thirty-three `Raises`
sections that would each say the same sentence.

## Verified

`uvx pre-commit run --all-files` exits 0, 34 hooks. Suite at 246, coverage
100%. The `ffi.buffer` choice in `_secret` was verified by making it fail:
written with `ffi.sizeof`, which answers 8 for a `secp256k1_keypair *`, the
new test fails; restored, it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten the secp256k1 Python binding boundary by hardening argument validation, correcting error propagation, and ensuring intermediate secret buffers are wiped while extending a few APIs to support both compressed and uncompressed public key serialization.

New Features:
- Allow recovery.recover and ellswift.decode to return either compressed or uncompressed serialized public keys via a new compressed flag parameter.

Bug Fixes:
- Make keys.serialize surface libsecp256k1 illegal-argument messages as ValueError and clear the context so subsequent callers are not affected by stale errors.
- Validate both type and length of byte arguments at the binding boundary so non-bytes inputs and mistakenly passed sequences fail early with clear TypeError messages.
- Reject bool values as scalars in key and tweak APIs so they cannot be silently treated as 0 or 1 while preserving bool usage for explicit flag parameters.
- Align xonly.tweak_add_check documentation with its actual behaviour for tweaked keys that are not valid points.
- Fix misuse of nonce function/data arguments and a context leak in tests, and correct minor naming issues in nonce-related parameters.

Enhancements:
- Introduce a shared octets helper to centralize byte-argument validation and reuse it across signing, hashing, ECDH, x-only, recovery, ElligatorSwift, and key APIs.
- Add a small _secret module and use it to overwrite cffi buffers that briefly hold private keys, keypairs, and shared secrets before returning values to callers, documenting this behaviour in SECURITY.md.
- Improve error messaging throughout the boundary so callers see argument-specific TypeError and ValueError messages instead of low-level cffi or generic RuntimeError text.
- Clarify context.check semantics and keys.serialize docs around when libsecp256k1 precondition violations can surface through the bindings.

Documentation:
- Update README and CHANGELOG to describe the stricter type checking at the boundary and the small public API changes around serialization flags and exceptions.
- Clarify SECURITY.md to note that intermediate C-side secret buffers are now overwritten even though Python-side objects remain inherently non-zeroizable.

Tests:
- Extend and add tests to cover new type-checking behaviour, bool-as-scalar rejection, xonly.tweak_add_check edge cases, secret buffer wiping, new serialization options, and the corrected callback and context handling behaviours.