### PR TITLE
Take octets at the boundary, and put the README examples back inside their fences

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 408
+        "line_number": 420
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T07:02:48Z"
+  "generated_at": "2026-08-07T07:29:54Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 420
+        "line_number": 438
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T07:29:54Z"
+  "generated_at": "2026-08-07T07:31:29Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,18 @@ branch has to edit.
 
 ### The gate
 
+- **The README quickstart is executed again** (#74). Fencing the
+  indented blocks put the closing ``` flush against the last line of
+  each example, and doctest reads the line after an example as the
+  output it expects: three of the ten stopped passing, two of them
+  expecting `True` followed by a fence. A blank line before each closing
+  fence is what says an example's output ends there. The suite caught
+  it, which is what it is for -- `test_the_readme_examples_run` was added
+  in this same release because *"an example nobody runs is documentation
+  that stops being true silently"* -- and this is the first thing it
+  caught. `markdownlint-cli2` stays clean over the result: a blank line
+  inside a fenced block is not a blank line around one.
+
 - **The entropy detectors of `detect-secrets` run over the tree.**
   `.secrets.baseline` was generated with `HexHighEntropyString` and
   `Base64HighEntropyString` off, and it is the baseline that decides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ is the same 0.7.1 (1a53f49). What the public API gained is one function
 and two `compressed` flags; what it lost is `recovery.COMPRESSED` and
 `ellswift.COMPRESSED`, two copies of a flag macro that `keys.COMPRESSED`
 still declares — the one removal here, and the one entry a caller
-importing either has to act on. Three things changed behaviour: the text
-of one error message, the class `keys.serialize` raises for an argument
-no valid caller passes, and the exception a wrong *type* meets, which is
-now the boundary's and names the argument instead of cffi's a call
-later. Each has its entry below. Neither file counts its entries:
+importing either has to act on. What it also gained is a wider door:
+every argument that takes octets takes a `bytearray` and a `memoryview`
+as well as `bytes`, which is a widening and breaks nothing. Three things
+changed behaviour: the text of one error message, the class
+`keys.serialize` raises for an argument no valid caller passes, and the
+exception a wrong *type* meets, which is now the boundary's and names
+the argument instead of cffi's a call later. Each has its entry below.
+Neither file counts its entries:
 `grep -c '^- '` does that, whereas a stated number is a line every open
 branch has to edit.
 
@@ -96,22 +99,38 @@ branch has to edit.
   and `test_illegal_argument`'s *"which the bindings' own wrappers cannot
   do"* — and describe it instead.
 - **An argument is checked for its type where it is checked for its
-  length** (#73), those being one question about a bare pointer. `len`
-  answers for a `bytearray` and a `memoryview` as readily as for bytes,
-  so both passed every size check and reached cffi, which refused them a
-  call later in its own words and about a ctype — `initializer for ctype
-  'unsigned char *' must be a cdata pointer` — naming neither the
-  argument nor what was wrong with it; a `float` came back as `object of
-  type 'float' has no len()`; and `_scalar.scalar`, annotated `-> bytes`,
-  returned the bytearray it was handed. `_scalar.octets` is that one
-  check, and the eighteen size checks across eight modules are now that
-  call. Nothing that worked stops working — cffi already refused all of
-  it, further on. `bytes` and nothing else: a `bytearray` states the same
-  value and the same width, so converting one would guess at nothing, but
-  it would widen what every signature promises, and `bytes(x)` is the
-  conversion in the caller's own code. `keys.pubkey_sort(pubkey)` — one
-  key where a sequence of them goes, which bytes being a sequence made
-  silently wrong — now says `the public key must be bytes, not int`.
+  length** (#73, #74), those being one question about a bare pointer.
+  `len` answers for a `bytearray` and a `memoryview` as readily as for
+  bytes, so both passed every size check and reached cffi, which refused
+  them a call later in its own words and about a ctype — `initializer
+  for ctype 'unsigned char *' must be a cdata pointer` — naming neither
+  the argument nor what was wrong with it; a `float` came back as
+  `object of type 'float' has no len()`; and `_scalar.scalar`, annotated
+  `-> bytes`, returned the bytearray it was handed. `_scalar.octets` is
+  that one check, and every size check across the eight wrapper modules
+  is now that call. `keys.pubkey_sort(pubkey)` — one key where a
+  sequence of them goes, which bytes being a sequence made silently
+  wrong — now says `the public key must be bytes, not int`.
+- **And what crosses is octets, not `bytes` alone** (#74): a `bytearray`
+  and a `memoryview` are converted rather than refused, and `BytesLike`
+  is what the signatures say. #73 had refused them, on the argument that
+  converting would widen what every signature promises; the answer is
+  that the signatures widened. They are not the leniency a short value
+  is — each states a value *and* a width, so nothing has to be
+  disbelieved and nothing supplied, which makes them a narrower door
+  than the `int` this package has always taken, whose 32-octet width is
+  the curve's rather than the caller's. And a caller who holds a secret
+  in memory they can overwrite, which is the reason to want a mutable
+  buffer and is what SECURITY.md now describes this package doing with
+  its own, had been meeting a `TypeError` for it. The conversion is a
+  copy taken at the boundary, never a pass-through, so overwriting that
+  buffer cannot change what libsecp256k1 is about to read.
+  `tests/test_bytes_like.py` drives every entry point taking such an
+  argument with each of the three types and asserts one answer, which is
+  what makes a call site that checks without assigning fail there rather
+  than in a caller's code; a `test_the_sweep_is_whole` holds the list to
+  what the modules export, so a function added and not swept is an
+  absence that fails.
 - **A `bool` is refused where a scalar goes** (#73). `isinstance(True,
   int)` is true, so `True` was the scalar 1 and `False` the scalar 0:
   `keys.prvkey_verify(False)` answered False, the correct verdict on
@@ -387,12 +406,11 @@ branch has to edit.
   output it expects: three of the ten stopped passing, two of them
   expecting `True` followed by a fence. A blank line before each closing
   fence is what says an example's output ends there. The suite caught
-  it, which is what it is for -- `test_the_readme_examples_run` was added
+  it, which is what it is for — `test_the_readme_examples_run` was added
   in this same release because *"an example nobody runs is documentation
-  that stops being true silently"* -- and this is the first thing it
+  that stops being true silently"* — and this is the first thing it
   caught. `markdownlint-cli2` stays clean over the result: a blank line
   inside a fenced block is not a blank line around one.
-
 - **The entropy detectors of `detect-secrets` run over the tree.**
   `.secrets.baseline` was generated with `HexHighEntropyString` and
   `Base64HighEntropyString` off, and it is the baseline that decides

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ that stops working fails a build rather than sitting here:
 >>> prvkey = 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF
 >>> pubkey = keys.pubkey_from_prvkey(prvkey)
 >>> msg = hashlib.sha256(b"hello").digest()
+
 ```
 
 ECDSA, over the 32-byte hash, with the deterministic RFC6979 nonce:
@@ -53,6 +54,7 @@ ECDSA, over the 32-byte hash, with the deterministic RFC6979 nonce:
 >>> signature = dsa.sign(msg, prvkey)
 >>> dsa.verify(msg, pubkey, signature)
 True
+
 ```
 
 BIP340 Schnorr, over the same hash, against the x-only key:
@@ -62,6 +64,7 @@ BIP340 Schnorr, over the same hash, against the x-only key:
 >>> signature = ssa.sign(msg, prvkey)
 >>> ssa.verify(msg, xonly_pubkey, signature)
 True
+
 ```
 
 Both take the private key as `bytes` or as an `int`, and both return

--- a/README.md
+++ b/README.md
@@ -149,13 +149,17 @@ and decides nothing else.
   readily as for `bytes`, so a size check on its own let both through,
   and cffi refused them one call later in its own words and about a
   ctype — naming neither the argument nor what was wrong with it. What
-  crosses is `bytes`, and an `int` where a scalar is named; anything
-  else is refused here and called by the name the signature gives it.
-  A `bytearray` states the same value and the same width as `bytes`, so
-  converting one would guess at nothing — but it would widen what every
-  signature here promises, and `bytes(x)` is that conversion in the
-  caller's own code, where they can see it. This is the `TypeError`
-  these wrappers raise; every other refusal below is a `ValueError`
+  crosses is octets: `bytes`, `bytearray` or `memoryview`, plus an `int`
+  where a scalar is named. Anything else is refused here and called by
+  the name the signature gives it — the `TypeError` these wrappers
+  raise, every other refusal below being a `ValueError`.
+  The three are not a leniency of the kind refused above: each states a
+  value *and* a width, so nothing has to be disbelieved and nothing
+  supplied — the `int` is the wider door of the two, the 32-octet width
+  being the curve's. What they are not is passed through. The copy is
+  taken at the boundary, so a caller holding a secret in memory they can
+  overwrite — which is the reason to reach for a `bytearray` at all —
+  cannot change what libsecp256k1 is about to read
 - **validity is libsecp256k1's to decide, and it does.** Whether 32 bytes
   are a scalar in `[1, n-1]` is answered by
   `secp256k1_ec_seckey_verify`, and `keys.prvkey_verify` is that call, not

--- a/btclib_libsecp256k1/__init__.py
+++ b/btclib_libsecp256k1/__init__.py
@@ -20,6 +20,15 @@ __version__ = version("btclib_libsecp256k1")
 # alias still says what the value is
 CData = Any
 
+# what may be handed to an argument these bindings pass on as a bare
+# pointer. Three named types rather than the buffer protocol at large:
+# `bytes(x)` of anything else is a guess -- of an `int` it is that many
+# zero octets, which would turn `octets(32, "message hash", 32)` into a
+# valid argument -- while these three state a value and a width and are
+# copied, never passed through. `collections.abc.Buffer` is the same
+# idea and arrives with python 3.12, which is not yet the floor here
+BytesLike = bytes | bytearray | memoryview
+
 ffi = _btclib_libsecp256k1.ffi
 
 

--- a/btclib_libsecp256k1/_scalar.py
+++ b/btclib_libsecp256k1/_scalar.py
@@ -7,25 +7,31 @@
 
 from __future__ import annotations
 
+from . import BytesLike
 
-def octets(value: bytes, name: str, size: int | None = None) -> bytes:
-    """Hold an argument to the type and the length a bare pointer needs.
 
-    Both halves of that, and they are one question.
-    The length, because libsecp256k1 reads a fixed number of octets from
-    a pointer whose length never reached C to be checked. The type,
-    because `len` answers for anything with a length: a `bytearray` of
-    32 passed that check and left cffi to refuse it one call later, in
+def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
+    """Normalize an argument to the bytes a bare pointer needs, of a length.
+
+    Both halves of that, and they are one question. The length, because
+    libsecp256k1 reads a fixed number of octets from a pointer whose
+    length never reached C to be checked. The type, because `len`
+    answers for anything with a length: a `bytearray` of 32 passed the
+    size check on its own and left cffi to refuse it one call later, in
     its own words and about a ctype -- `initializer for ctype 'unsigned
     char *' must be a cdata pointer` -- which names neither the argument
     nor what was wrong with it. A `float` did not even get that far, and
     came back as `object of type 'float' has no len()`.
 
-    `bytes` and nothing else. A `bytearray` or a `memoryview` states the
-    same value and the same width, and converting one would be no guess
-    at all -- but it would widen what every signature here promises, and
-    that is the caller's to ask for, spelled `bytes(x)` where they can
-    see it.
+    A `bytearray` and a `memoryview` are converted rather than refused,
+    and that is not the leniency the short value is: they state a value
+    and a width, both of them, so nothing has to be disbelieved and
+    nothing supplied. The `int` this package already accepts for a
+    scalar is the wider door of the two, the 32-octet width being the
+    curve's rather than the caller's. What the conversion is not is a
+    pass-through: the copy is taken here, so a caller who overwrites
+    their own buffer -- which is the reason to hold a secret in a
+    mutable one -- cannot change what libsecp256k1 is about to read.
 
     Args:
         value: the argument, as the caller passed it.
@@ -34,29 +40,32 @@ def octets(value: bytes, name: str, size: int | None = None) -> bytes:
             the encoding carries its own length.
 
     Returns:
-        The same bytes, so that a call may wrap the argument it checks.
+        The value as bytes: itself, if that is what it already was.
 
     Raises:
-        TypeError: if the value is not bytes.
+        TypeError: if the value is not one of those three types.
         ValueError: if a size is given and the value is not that long.
     """
-    if not isinstance(value, bytes):
+    if not isinstance(value, (bytes, bytearray, memoryview)):
         raise TypeError(f"the {name} must be bytes, not {type(value).__name__}")
-    if size is not None and len(value) != size:
+    # bytes of bytes is bytes, so nothing is copied in the ordinary case
+    value_bytes = bytes(value)
+    if size is not None and len(value_bytes) != size:
         raise ValueError(f"the {name} must be {size} bytes")
-    return value
+    return value_bytes
 
 
-def scalar(num: bytes | int, name: str) -> bytes:
+def scalar(num: BytesLike | int, name: str) -> bytes:
     """Normalize a scalar argument to 32 bytes.
 
-    An int is serialized big endian, as libsecp256k1 expects; bytes are
-    passed through. The length is checked here because libsecp256k1
-    takes a bare pointer and would read past the end of a shorter one.
-    A short bytes is not padded to that length while an int is
-    serialized to it, and the asymmetry is not a leniency: bytes state a
-    value and a width, one of which would have to be disbelieved,
-    whereas an int states only a value and the width is the curve's.
+    An int is serialized big endian, as libsecp256k1 expects; anything
+    `octets` takes goes to it. The length is checked there because
+    libsecp256k1 takes a bare pointer and would read past the end of a
+    shorter one. A short value is not padded to that length while an int
+    is serialized to it, and the asymmetry is not a leniency: 20 octets
+    state a value and a width, one of which would have to be
+    disbelieved, whereas an int states only a value and the width is the
+    curve's.
 
     A secret is better passed as bytes, for a narrow reason. Not the
     serialization, which is a loop over nine CPython digits and measures
@@ -68,18 +77,19 @@ def scalar(num: bytes | int, name: str) -> bytes:
     must not leak belongs where that can be promised.
 
     Args:
-        num: the scalar, exactly 32 bytes or an int in [0, 2**256).
+        num: the scalar, exactly 32 octets or an int in [0, 2**256).
         name: what the scalar is, as the exception should call it.
 
     Returns:
         The scalar as 32 bytes, big endian.
 
     Raises:
-        TypeError: if the value is neither bytes nor an int, a bool
-            counting as neither although python makes it an int.
-        ValueError: if bytes are not exactly 32 long, or if an int does
-            not fit in 32 bytes. Whether the value is a valid scalar,
-            i.e. in [1, n-1], is for libsecp256k1 to say.
+        TypeError: if the value is neither an int nor one of the types
+            `octets` takes, a bool counting as neither although python
+            makes it an int.
+        ValueError: if it is not exactly 32 octets long, or if an int
+            does not fit in 32 bytes. Whether the value is a valid
+            scalar, i.e. in [1, n-1], is for libsecp256k1 to say.
     """
     # a bool is an int in python, and would be the scalar 1 or 0 without
     # the second test: `prvkey_verify(False)` then answers False, which
@@ -95,8 +105,8 @@ def scalar(num: bytes | int, name: str) -> bytes:
         if not 0 <= num < 2**256:
             raise ValueError(f"the {name} must fit in 32 bytes")
         return num.to_bytes(32, "big")
-    # the domain here is wider than octets', so the type is said here:
-    # what is left for it is the length
-    if not isinstance(num, bytes):
+    # the domain here is octets' plus the int above, so a value that is
+    # neither is named here: what is left for octets is the length
+    if not isinstance(num, (bytes, bytearray, memoryview)):
         raise TypeError(f"the {name} must be bytes or an int, not {type(num).__name__}")
     return octets(num, name, 32)

--- a/btclib_libsecp256k1/dsa.py
+++ b/btclib_libsecp256k1/dsa.py
@@ -7,12 +7,14 @@
 
 from __future__ import annotations
 
-from . import CData, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from .context import ctx
 
 
-def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> bytes:
+def sign(
+    msg_bytes: BytesLike, prvkey: BytesLike | int, ndata: BytesLike | None = None
+) -> bytes:
     """Create an ECDSA signature.
 
     The nonce is the deterministic RFC6979 one, so the signature is a
@@ -45,7 +47,7 @@ def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> b
         True
     """
     prvkey_bytes = scalar(prvkey, "private key")
-    octets(msg_bytes, "message hash", 32)
+    msg_bytes = octets(msg_bytes, "message hash", 32)
 
     sig = ffi.new("secp256k1_ecdsa_signature *")
 
@@ -68,7 +70,9 @@ def sign(msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None) -> b
     return _serialize_der(sig)
 
 
-def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> bool:
+def verify(
+    msg_bytes: BytesLike, pubkey_bytes: BytesLike, signature_bytes: BytesLike
+) -> bool:
     """Verify a ECDSA signature.
 
     A signature which is not in the normalized lower-s form is rejected;
@@ -95,11 +99,11 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
         >>> dsa.verify(msg, mult.mult_(1), dsa.sign(msg, 1))
         True
     """
-    octets(msg_bytes, "message hash", 32)
+    msg_bytes = octets(msg_bytes, "message hash", 32)
 
     signature = _parse_der(signature_bytes)
 
-    octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
@@ -107,7 +111,7 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
     return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
 
 
-def normalize(signature_bytes: bytes) -> bytes:
+def normalize(signature_bytes: BytesLike) -> bytes:
     """Convert a DER signature to its normalized lower-s form.
 
     Args:
@@ -129,7 +133,7 @@ def normalize(signature_bytes: bytes) -> bytes:
     return _serialize_der(normalized)
 
 
-def is_low_s(signature_bytes: bytes) -> bool:
+def is_low_s(signature_bytes: BytesLike) -> bool:
     """Return True if the DER signature is in the normalized lower-s form.
 
     ECDSA signatures are malleable: negating s modulo the group order
@@ -152,7 +156,7 @@ def is_low_s(signature_bytes: bytes) -> bool:
     return not lib.secp256k1_ecdsa_signature_normalize(ctx, ffi.NULL, signature)
 
 
-def to_compact(signature_bytes: bytes) -> bytes:
+def to_compact(signature_bytes: BytesLike) -> bytes:
     """Convert a DER signature into its 64-byte compact form.
 
     Args:
@@ -173,7 +177,7 @@ def to_compact(signature_bytes: bytes) -> bytes:
     return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes))
 
 
-def to_der(signature_bytes: bytes) -> bytes:
+def to_der(signature_bytes: BytesLike) -> bytes:
     """Convert a 64-byte compact signature into its DER form.
 
     Args:
@@ -190,7 +194,7 @@ def to_der(signature_bytes: bytes) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize it, which no
             input can make it do.
     """
-    octets(signature_bytes, "compact signature", 64)
+    signature_bytes = octets(signature_bytes, "compact signature", 64)
 
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if not lib.secp256k1_ecdsa_signature_parse_compact(ctx, signature, signature_bytes):
@@ -198,7 +202,7 @@ def to_der(signature_bytes: bytes) -> bytes:
     return _serialize_der(signature)
 
 
-def _parse_der(signature_bytes: bytes) -> CData:
+def _parse_der(signature_bytes: BytesLike) -> CData:
     """Parse a DER signature into its internal representation.
 
     Args:
@@ -210,7 +214,7 @@ def _parse_der(signature_bytes: bytes) -> CData:
     Raises:
         ValueError: if the DER signature is malformed.
     """
-    octets(signature_bytes, "DER signature")
+    signature_bytes = octets(signature_bytes, "DER signature")
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if not lib.secp256k1_ecdsa_signature_parse_der(
         ctx, signature, signature_bytes, len(signature_bytes)

--- a/btclib_libsecp256k1/ecdh.py
+++ b/btclib_libsecp256k1/ecdh.py
@@ -7,13 +7,13 @@
 
 from __future__ import annotations
 
-from . import ffi, lib
+from . import BytesLike, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take
 from .context import ctx
 
 
-def shared_secret(pubkey_bytes: bytes, prvkey: bytes | int) -> bytes:
+def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
     """Compute the ECDH shared secret.
 
     The result is the SHA256 of the compressed shared point, i.e. the
@@ -41,7 +41,7 @@ def shared_secret(pubkey_bytes: bytes, prvkey: bytes | int) -> bytes:
             it is not a valid scalar.
     """
     prvkey_bytes = scalar(prvkey, "private key")
-    octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, "public key")
 
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):

--- a/btclib_libsecp256k1/ellswift.py
+++ b/btclib_libsecp256k1/ellswift.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 
 import secrets
 
-from . import ffi, lib
+from . import BytesLike, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take
 from .context import ctx
 from .keys import serialize
 
 
-def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
+def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> bytes:
     """Create the 64-byte ElligatorSwift encoding of a private key's public key.
 
     This is safer than encode(mult_(prvkey)), as the private key itself
@@ -42,10 +42,11 @@ def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
 
     # entropy is not a serialization: a shorter value is a caller mistake
     # rather than a small number, and is not padded into a valid argument
-    if aux_rand32 is None:
-        aux_rand32 = secrets.token_bytes(32)
-    else:
-        octets(aux_rand32, "aux_rand32", 32)
+    aux_rand32 = (
+        secrets.token_bytes(32)
+        if aux_rand32 is None
+        else octets(aux_rand32, "aux_rand32", 32)
+    )
 
     ell_bytes = ffi.new("char[64]")
     if not lib.secp256k1_ellswift_create(ctx, ell_bytes, prvkey_bytes, aux_rand32):
@@ -53,7 +54,7 @@ def create(prvkey: bytes | int, aux_rand32: bytes | None = None) -> bytes:
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
-def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
+def encode(pubkey_bytes: BytesLike, rnd32: BytesLike | None = None) -> bytes:
     """Encode a public key as 64 ElligatorSwift bytes.
 
     The randomness must not be a deterministic function of the public
@@ -74,16 +75,13 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
-    octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
 
     # 32 bytes of entropy, or nothing: see the comment in create
-    if rnd32 is None:
-        rnd32 = secrets.token_bytes(32)
-    else:
-        octets(rnd32, "rnd32", 32)
+    rnd32 = secrets.token_bytes(32) if rnd32 is None else octets(rnd32, "rnd32", 32)
 
     ell_bytes = ffi.new("char[64]")
     if not lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, rnd32):
@@ -91,7 +89,7 @@ def encode(pubkey_bytes: bytes, rnd32: bytes | None = None) -> bytes:
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
-def decode(ell_bytes: bytes, compressed: bool = True) -> bytes:
+def decode(ell_bytes: BytesLike, compressed: bool = True) -> bytes:
     """Decode a 64-byte ElligatorSwift public key into a public key.
 
     Args:
@@ -108,7 +106,7 @@ def decode(ell_bytes: bytes, compressed: bool = True) -> bytes:
         RuntimeError: if libsecp256k1 fails to decode or serialize,
             which no 64 bytes can make it do.
     """
-    octets(ell_bytes, "ElligatorSwift public key", 64)
+    ell_bytes = octets(ell_bytes, "ElligatorSwift public key", 64)
 
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
@@ -117,7 +115,7 @@ def decode(ell_bytes: bytes, compressed: bool = True) -> bytes:
 
 
 def xdh(
-    ell_a_bytes: bytes, ell_b_bytes: bytes, prvkey: bytes | int, party: int
+    ell_a_bytes: BytesLike, ell_b_bytes: BytesLike, prvkey: BytesLike | int, party: int
 ) -> bytes:
     """Compute the x-only ECDH shared secret of two ElligatorSwift keys.
 
@@ -142,8 +140,8 @@ def xdh(
             0 or 1, or if the private key is not 32 bytes, does not fit
             in them, or is not a valid scalar.
     """
-    octets(ell_a_bytes, "ElligatorSwift public key of A", 64)
-    octets(ell_b_bytes, "ElligatorSwift public key of B", 64)
+    ell_a_bytes = octets(ell_a_bytes, "ElligatorSwift public key of A", 64)
+    ell_b_bytes = octets(ell_b_bytes, "ElligatorSwift public key of B", 64)
     if party not in (0, 1):
         raise ValueError("the party must be 0 (A) or 1 (B)")
 

--- a/btclib_libsecp256k1/hashes.py
+++ b/btclib_libsecp256k1/hashes.py
@@ -10,12 +10,12 @@ https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 
 from __future__ import annotations
 
-from . import ffi, lib
+from . import BytesLike, ffi, lib
 from ._scalar import octets
 from .context import ctx
 
 
-def tagged_sha256(tag: bytes, msg: bytes) -> bytes:
+def tagged_sha256(tag: BytesLike, msg: BytesLike) -> bytes:
     """Return the BIP340 tagged hash of a message.
 
     That is SHA256(SHA256(tag) || SHA256(tag) || msg): the tag separates
@@ -39,8 +39,8 @@ def tagged_sha256(tag: bytes, msg: bytes) -> bytes:
         >>> hashes.tagged_sha256(b"TapLeaf", b"").hex()
         '5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb'
     """
-    octets(tag, "tag")
-    octets(msg, "message")
+    tag = octets(tag, "tag")
+    msg = octets(msg, "message")
     output = ffi.new("char[32]")
     if not lib.secp256k1_tagged_sha256(ctx, output, tag, len(tag), msg, len(msg)):
         raise RuntimeError("tagged hashing failed")

--- a/btclib_libsecp256k1/keys.py
+++ b/btclib_libsecp256k1/keys.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from . import CData, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take
 from .context import check, ctx
@@ -29,7 +29,7 @@ COMPRESSED = 258
 UNCOMPRESSED = 2
 
 
-def prvkey_verify(prvkey: bytes | int) -> bool:
+def prvkey_verify(prvkey: BytesLike | int) -> bool:
     """Return True if the private key is a valid scalar, i.e. in [1, n-1].
 
     Args:
@@ -47,7 +47,7 @@ def prvkey_verify(prvkey: bytes | int) -> bool:
     return bool(lib.secp256k1_ec_seckey_verify(ctx, prvkey_bytes))
 
 
-def prvkey_negate(prvkey: bytes | int) -> bytes:
+def prvkey_negate(prvkey: BytesLike | int) -> bytes:
     """Negate a private key.
 
     Args:
@@ -66,7 +66,7 @@ def prvkey_negate(prvkey: bytes | int) -> bytes:
     return take(prvkey_buffer)
 
 
-def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
+def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     """Add a tweak to a private key.
 
     This is the private-key side of BIP32 derivation, and of any other
@@ -91,7 +91,7 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     return take(prvkey_buffer)
 
 
-def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
+def prvkey_tweak_mul(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     """Multiply a private key by a tweak.
 
     Args:
@@ -113,7 +113,7 @@ def prvkey_tweak_mul(prvkey: bytes | int, tweak: bytes | int) -> bytes:
     return take(prvkey_buffer)
 
 
-def pubkey_from_prvkey(prvkey: bytes | int, compressed: bool = True) -> bytes:
+def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> bytes:
     """Return the public key of a private key, i.e. the point kG.
 
     This is the generator multiplication of `mult.mult_`, with the
@@ -147,7 +147,7 @@ def pubkey_from_prvkey(prvkey: bytes | int, compressed: bool = True) -> bytes:
     return serialize(pubkey, compressed)
 
 
-def pubkey_negate(pubkey_bytes: bytes, compressed: bool = True) -> bytes:
+def pubkey_negate(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
     """Negate a public key.
 
     Args:
@@ -169,7 +169,7 @@ def pubkey_negate(pubkey_bytes: bytes, compressed: bool = True) -> bytes:
 
 
 def pubkey_tweak_add(
-    pubkey_bytes: bytes, tweak: bytes | int, compressed: bool = True
+    pubkey_bytes: BytesLike, tweak: BytesLike | int, compressed: bool = True
 ) -> bytes:
     """Add the generator multiplied by the tweak to a public key.
 
@@ -199,7 +199,7 @@ def pubkey_tweak_add(
 
 
 def pubkey_tweak_mul(
-    pubkey_bytes: bytes, tweak: bytes | int, compressed: bool = True
+    pubkey_bytes: BytesLike, tweak: BytesLike | int, compressed: bool = True
 ) -> bytes:
     """Multiply a public key by a tweak.
 
@@ -231,7 +231,9 @@ def pubkey_tweak_mul(
     return serialize(pubkey, compressed)
 
 
-def pubkey_combine(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> bytes:
+def pubkey_combine(
+    pubkeys_bytes: Sequence[BytesLike], compressed: bool = True
+) -> bytes:
     """Add public keys together.
 
     Args:
@@ -261,7 +263,7 @@ def pubkey_combine(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> b
     return serialize(combined, compressed)
 
 
-def pubkey_cmp(pubkey1_bytes: bytes, pubkey2_bytes: bytes) -> int:
+def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
     """Compare two public keys, in lexicographic order of compressed form.
 
     The order is the one of the compressed serialization, whichever form
@@ -284,7 +286,9 @@ def pubkey_cmp(pubkey1_bytes: bytes, pubkey2_bytes: bytes) -> int:
     )
 
 
-def pubkey_sort(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> list[bytes]:
+def pubkey_sort(
+    pubkeys_bytes: Sequence[BytesLike], compressed: bool = True
+) -> list[bytes]:
     """Sort public keys, in lexicographic order of compressed form.
 
     This is the ordering of a BIP67 multisig script, and the one MuSig2
@@ -313,7 +317,7 @@ def pubkey_sort(pubkeys_bytes: Sequence[bytes], compressed: bool = True) -> list
     return [serialize(pubkey, compressed) for pubkey in array]
 
 
-def parse(pubkey_bytes: bytes) -> CData:
+def parse(pubkey_bytes: BytesLike) -> CData:
     """Parse a public key into its internal libsecp256k1 representation.
 
     The internal form is what the raw `lib` calls take, and what
@@ -330,7 +334,7 @@ def parse(pubkey_bytes: bytes) -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
-    octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")

--- a/btclib_libsecp256k1/mult.py
+++ b/btclib_libsecp256k1/mult.py
@@ -14,10 +14,11 @@ either serialization.
 
 from __future__ import annotations
 
+from . import BytesLike
 from .keys import pubkey_from_prvkey
 
 
-def mult_(num: bytes | int) -> bytes:
+def mult_(num: BytesLike | int) -> bytes:
     """Multiply the generator point, in serialized form.
 
     Args:
@@ -45,7 +46,7 @@ def mult_(num: bytes | int) -> bytes:
     return pubkey_from_prvkey(num, compressed=False)
 
 
-def mult(num: bytes | int) -> tuple[int, int]:
+def mult(num: BytesLike | int) -> tuple[int, int]:
     """Multiply the generator point, as a pair of coordinates.
 
     Args:

--- a/btclib_libsecp256k1/recovery.py
+++ b/btclib_libsecp256k1/recovery.py
@@ -7,14 +7,14 @@
 
 from __future__ import annotations
 
-from . import CData, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from .context import ctx
 from .keys import serialize
 
 
 def sign(
-    msg_bytes: bytes, prvkey: bytes | int, ndata: bytes | None = None
+    msg_bytes: BytesLike, prvkey: BytesLike | int, ndata: BytesLike | None = None
 ) -> tuple[bytes, int]:
     """Create a recoverable ECDSA signature.
 
@@ -38,7 +38,7 @@ def sign(
             which no input can make it do.
     """
     prvkey_bytes = scalar(prvkey, "private key")
-    octets(msg_bytes, "message hash", 32)
+    msg_bytes = octets(msg_bytes, "message hash", 32)
 
     sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
@@ -61,7 +61,10 @@ def sign(
 
 
 def recover(
-    msg_bytes: bytes, signature_bytes: bytes, recid: int, compressed: bool = True
+    msg_bytes: BytesLike,
+    signature_bytes: BytesLike,
+    recid: int,
+    compressed: bool = True,
 ) -> bytes:
     """Recover the public key from a recoverable ECDSA signature.
 
@@ -84,8 +87,8 @@ def recover(
         RuntimeError: if libsecp256k1 fails to serialize the key, which
             no input can make it do.
     """
-    octets(msg_bytes, "message hash", 32)
-    octets(signature_bytes, "signature", 64)
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    signature_bytes = octets(signature_bytes, "signature", 64)
     if recid not in (0, 1, 2, 3):
         raise ValueError("the recovery id must be 0, 1, 2, or 3")
 
@@ -97,7 +100,7 @@ def recover(
     return serialize(pubkey, compressed)
 
 
-def to_der(signature_bytes: bytes, recid: int) -> bytes:
+def to_der(signature_bytes: BytesLike, recid: int) -> bytes:
     """Convert a recoverable signature into a plain DER signature.
 
     The recovery id is dropped, as it is not part of the DER encoding.
@@ -120,7 +123,7 @@ def to_der(signature_bytes: bytes, recid: int) -> bytes:
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             signature, which no input can make it do.
     """
-    octets(signature_bytes, "signature", 64)
+    signature_bytes = octets(signature_bytes, "signature", 64)
     if recid not in (0, 1, 2, 3):
         raise ValueError("the recovery id must be 0, 1, 2, or 3")
 
@@ -139,7 +142,7 @@ def to_der(signature_bytes: bytes, recid: int) -> bytes:
     return ffi.unpack(sig_bytes, length[0])
 
 
-def _parse(signature_bytes: bytes, recid: int) -> CData:
+def _parse(signature_bytes: BytesLike, recid: int) -> CData:
     """Parse a compact signature and its recovery id.
 
     Args:

--- a/btclib_libsecp256k1/ssa.py
+++ b/btclib_libsecp256k1/ssa.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import secrets
 
-from . import CData, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import wipe
 from .context import ctx
@@ -24,7 +24,7 @@ EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"
 
 
 def sign(
-    msg_bytes: bytes, prvkey: bytes | int, aux_rand32: bytes | None = None
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
 ) -> bytes:
     """Create a Schnorr signature of a 32-byte message hash.
 
@@ -55,7 +55,7 @@ def sign(
         >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
         True
     """
-    octets(msg_bytes, "message hash", 32)
+    msg_bytes = octets(msg_bytes, "message hash", 32)
     keypair = _keypair(prvkey)
 
     sig = ffi.new("char[64]")
@@ -74,7 +74,7 @@ def sign(
 
 
 def sign_custom(
-    msg_bytes: bytes, prvkey: bytes | int, aux_rand32: bytes | None = None
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
 ) -> bytes:
     """Create a Schnorr signature of a message of any length.
 
@@ -101,7 +101,7 @@ def sign_custom(
         RuntimeError: if libsecp256k1 fails to sign, which no input can
             make it do.
     """
-    octets(msg_bytes, "message")
+    msg_bytes = octets(msg_bytes, "message")
     keypair = _keypair(prvkey)
 
     sig = ffi.new("char[64]")
@@ -125,7 +125,9 @@ def sign_custom(
     raise RuntimeError("schnorr signing failed")
 
 
-def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> bool:
+def verify(
+    msg_bytes: BytesLike, pubkey_bytes: BytesLike, signature_bytes: BytesLike
+) -> bool:
     """Verify a Schnorr signature against a 32-byte x-only public key.
 
     The public key is the x-only one BIP340 verifies against, and only
@@ -148,10 +150,10 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
             well-formed signature that simply does not verify is False,
             not an exception.
     """
-    octets(msg_bytes, "message")
-    octets(signature_bytes, "signature", 64)
+    msg_bytes = octets(msg_bytes, "message")
+    signature_bytes = octets(signature_bytes, "signature", 64)
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    octets(pubkey_bytes, "x-only public key", 32)
+    pubkey_bytes = octets(pubkey_bytes, "x-only public key", 32)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
@@ -164,7 +166,7 @@ def verify(msg_bytes: bytes, pubkey_bytes: bytes, signature_bytes: bytes) -> boo
     )
 
 
-def _keypair(prvkey: bytes | int) -> CData:
+def _keypair(prvkey: BytesLike | int) -> CData:
     """Create a keypair from a private key.
 
     Args:
@@ -183,7 +185,7 @@ def _keypair(prvkey: bytes | int) -> CData:
     return keypair
 
 
-def _aux_rand32(aux_rand32: bytes | None) -> bytes:
+def _aux_rand32(aux_rand32: BytesLike | None) -> bytes:
     """Check the auxiliary randomness of BIP340 signing.
 
     It is freshly generated when not provided, BIP340 recommending fresh

--- a/btclib_libsecp256k1/xonly.py
+++ b/btclib_libsecp256k1/xonly.py
@@ -20,13 +20,13 @@ not inside an argument check.
 
 from __future__ import annotations
 
-from . import CData, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take, wipe
 from .context import ctx
 
 
-def from_pubkey(pubkey_bytes: bytes) -> tuple[bytes, int]:
+def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
     """Convert a public key into its x-only form and y parity.
 
     Args:
@@ -43,14 +43,14 @@ def from_pubkey(pubkey_bytes: bytes) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
-    octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, "public key")
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError("invalid public key")
     return _to_xonly(pubkey)
 
 
-def tweak_add(pubkey_bytes: bytes, tweak: bytes | int) -> tuple[bytes, int]:
+def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, int]:
     """Add the generator multiplied by the tweak to an x-only public key.
 
     This is the BIP341 taproot output key, given the internal key and
@@ -84,10 +84,10 @@ def tweak_add(pubkey_bytes: bytes, tweak: bytes | int) -> tuple[bytes, int]:
 
 
 def tweak_add_check(
-    tweaked_pubkey_bytes: bytes,
+    tweaked_pubkey_bytes: BytesLike,
     tweaked_parity: int,
-    pubkey_bytes: bytes,
-    tweak: bytes | int,
+    pubkey_bytes: BytesLike,
+    tweak: BytesLike | int,
 ) -> bool:
     """Check that a tweaked x-only public key is the tweak of another one.
 
@@ -115,7 +115,7 @@ def tweak_add_check(
             tweaked key is not parsed, and so is never invalid: see
             Returns.
     """
-    octets(tweaked_pubkey_bytes, "tweaked x-only public key", 32)
+    tweaked_pubkey_bytes = octets(tweaked_pubkey_bytes, "tweaked x-only public key", 32)
     if tweaked_parity not in (0, 1):
         raise ValueError("the parity must be 0 or 1")
 
@@ -129,7 +129,7 @@ def tweak_add_check(
     )
 
 
-def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
+def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     """Add a tweak to the private key of an x-only public key.
 
     The private key is first negated, if needed, to be the one of the
@@ -169,7 +169,7 @@ def prvkey_tweak_add(prvkey: bytes | int, tweak: bytes | int) -> bytes:
         wipe(keypair)
 
 
-def _parse(pubkey_bytes: bytes) -> CData:
+def _parse(pubkey_bytes: BytesLike) -> CData:
     """Parse a 32-byte x-only public key.
 
     Args:
@@ -182,7 +182,7 @@ def _parse(pubkey_bytes: bytes) -> CData:
         ValueError: if it is not 32 bytes, or not a valid x coordinate.
     """
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    octets(pubkey_bytes, "x-only public key", 32)
+    pubkey_bytes = octets(pubkey_bytes, "x-only public key", 32)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
@@ -214,7 +214,7 @@ def _to_xonly(pubkey: CData) -> tuple[bytes, int]:
     return ffi.unpack(output, ffi.sizeof(output)), parity[0]
 
 
-def _keypair(prvkey: bytes | int) -> CData:
+def _keypair(prvkey: BytesLike | int) -> CData:
     """Create a keypair from a private key.
 
     Args:

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -1,0 +1,177 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every argument that takes bytes takes a bytearray and a memoryview.
+
+The check is a normalization, so it has to be the normalized value that
+reaches libsecp256k1: a call site that checks its argument and then
+passes the one it was given would still hand cffi a bytearray, and cffi
+would refuse it. Nothing in the answers distinguishes the two, so this
+drives every entry point taking such an argument with each of the three
+types and asserts one answer -- which is what makes a call site that
+checks without assigning fail here rather than in a caller's code.
+
+The sweep is written as data so that a function added to the boundary
+and not added here is visible as an absence: `test_the_sweep_is_whole`
+holds it to the modules' own contents.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from btclib_libsecp256k1 import (
+    dsa,
+    ecdh,
+    ellswift,
+    hashes,
+    keys,
+    mult,
+    recovery,
+    ssa,
+    xonly,
+)
+
+PRVKEY = (7).to_bytes(32, "big")
+TWEAK = (11).to_bytes(32, "big")
+MSG = b"\x01" * 32
+PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
+PUBKEY_LONG = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+XONLY, PARITY = xonly.from_pubkey(PUBKEY)
+DER = dsa.sign(MSG, PRVKEY)
+COMPACT = dsa.to_compact(DER)
+SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
+RECOVERABLE, RECID = recovery.sign(MSG, PRVKEY)
+ELL_A = ellswift.create(PRVKEY, bytes(32))
+ELL_B = ellswift.create(TWEAK, bytes(32))
+TWEAKED, TWEAKED_PARITY = xonly.tweak_add(XONLY, TWEAK)
+
+# every entry point taking an argument that crosses as a bare pointer,
+# with the arguments it takes: the bytes ones are retyped below
+CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
+    ("keys.prvkey_verify", keys.prvkey_verify, (PRVKEY,), {}),
+    ("keys.prvkey_negate", keys.prvkey_negate, (PRVKEY,), {}),
+    ("keys.prvkey_tweak_add", keys.prvkey_tweak_add, (PRVKEY, TWEAK), {}),
+    ("keys.prvkey_tweak_mul", keys.prvkey_tweak_mul, (PRVKEY, TWEAK), {}),
+    ("keys.pubkey_from_prvkey", keys.pubkey_from_prvkey, (PRVKEY,), {}),
+    ("keys.pubkey_negate", keys.pubkey_negate, (PUBKEY,), {}),
+    ("keys.pubkey_tweak_add", keys.pubkey_tweak_add, (PUBKEY, TWEAK), {}),
+    ("keys.pubkey_tweak_mul", keys.pubkey_tweak_mul, (PUBKEY, TWEAK), {}),
+    ("keys.pubkey_combine", keys.pubkey_combine, ([PUBKEY, PUBKEY_LONG],), {}),
+    ("keys.pubkey_cmp", keys.pubkey_cmp, (PUBKEY, PUBKEY_LONG), {}),
+    ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
+    ("mult.mult_", mult.mult_, (PRVKEY,), {}),
+    ("mult.mult", mult.mult, (PRVKEY,), {}),
+    ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),
+    ("dsa.sign", dsa.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("dsa.verify", dsa.verify, (MSG, PUBKEY, DER), {}),
+    ("dsa.normalize", dsa.normalize, (DER,), {}),
+    ("dsa.is_low_s", dsa.is_low_s, (DER,), {}),
+    ("dsa.to_compact", dsa.to_compact, (DER,), {}),
+    ("dsa.to_der", dsa.to_der, (COMPACT,), {}),
+    ("ssa.sign", ssa.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("ssa.sign_custom", ssa.sign_custom, (b"a message", PRVKEY, bytes(32)), {}),
+    ("ssa.verify", ssa.verify, (MSG, XONLY, SSA_SIG), {}),
+    ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
+    ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
+    (
+        "xonly.tweak_add_check",
+        xonly.tweak_add_check,
+        (TWEAKED, TWEAKED_PARITY, XONLY, TWEAK),
+        {},
+    ),
+    ("xonly.prvkey_tweak_add", xonly.prvkey_tweak_add, (PRVKEY, TWEAK), {}),
+    ("recovery.sign", recovery.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("recovery.recover", recovery.recover, (MSG, RECOVERABLE, RECID), {}),
+    ("recovery.to_der", recovery.to_der, (RECOVERABLE, RECID), {}),
+    ("ecdh.shared_secret", ecdh.shared_secret, (PUBKEY, PRVKEY), {}),
+    ("ellswift.create", ellswift.create, (PRVKEY, bytes(32)), {}),
+    ("ellswift.encode", ellswift.encode, (PUBKEY, bytes(32)), {}),
+    ("ellswift.decode", ellswift.decode, (ELL_A,), {}),
+    ("ellswift.xdh", ellswift.xdh, (ELL_A, ELL_B, PRVKEY, 0), {}),
+]
+
+MODULES = {
+    "dsa": dsa,
+    "ecdh": ecdh,
+    "ellswift": ellswift,
+    "hashes": hashes,
+    "keys": keys,
+    "mult": mult,
+    "recovery": recovery,
+    "ssa": ssa,
+    "xonly": xonly,
+}
+
+# the two that take no argument crossing as a bare pointer: `parse` takes
+# one and is covered through every wrapper above, `serialize` takes the
+# libsecp256k1 object `parse` hands back and no bytes at all
+NOT_SWEPT = {"keys.serialize", "keys.parse"}
+
+
+def retyped(value: Any, kind: type) -> Any:
+    """Return the argument as a bytearray or a memoryview, if it is bytes.
+
+    A list of them is retyped element by element, which is what the two
+    functions taking a sequence of public keys are given.
+
+    Args:
+        value: one argument of a call below.
+        kind: `bytearray` or `memoryview`.
+
+    Returns:
+        The same value in that type, or unchanged if it is not bytes.
+    """
+    if isinstance(value, bytes):
+        return kind(value)
+    if isinstance(value, list):
+        return [retyped(item, kind) for item in value]
+    return value
+
+
+@pytest.mark.parametrize("kind", [bytearray, memoryview])
+@pytest.mark.parametrize("name,call,args,kwargs", CALLS, ids=[c[0] for c in CALLS])
+def test_answers_the_same_for_every_bytes_like(
+    name: str,
+    call: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    kind: type,
+) -> None:
+    """The answer does not depend on which of the three types was passed.
+
+    Args:
+        name: the entry point, for the test id.
+        call: the entry point itself.
+        args: its arguments, as bytes.
+        kwargs: its keyword arguments.
+        kind: the type to retype the bytes arguments to.
+    """
+    assert call(*args, **kwargs) == call(*(retyped(a, kind) for a in args), **kwargs)
+
+
+def test_the_sweep_is_whole() -> None:
+    """Every public function of every wrapped module is swept, or excused.
+
+    A function added to the boundary and not added to `CALLS` is a hole
+    this sweep would not cover and nothing else would report, so the
+    list is checked against what the modules actually export rather than
+    trusted to have been kept up to date.
+    """
+    swept = {name for name, *_ in CALLS} | NOT_SWEPT
+    exported = {
+        f"{module_name}.{name}"
+        for module_name, module in MODULES.items()
+        for name in dir(module)
+        if not name.startswith("_")
+        and callable(getattr(module, name))
+        and getattr(getattr(module, name), "__module__", "")
+        == f"btclib_libsecp256k1.{module_name}"
+    }
+
+    assert exported - swept == set()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,44 +206,34 @@ def test_invalid_inputs() -> None:
 def test_type_checks_refuse_what_merely_has_a_length() -> None:
     """A size check alone is not a check: `len` answers for more than bytes.
 
-    A `bytearray` of 32 passed every one of them and reached cffi, which
-    refused it a call later in its own words and about a ctype --
-    `initializer for ctype 'unsigned char *' must be a cdata pointer` --
-    naming neither the argument nor what was wrong with it. A `float`
-    did not get that far, and came back as `object of type 'float' has
-    no len()`. Both are the binding's to refuse, and it names them.
-
-    That a `bytearray` is refused rather than converted is the decision
-    and not the oversight: it states the same value and the same width
-    as bytes, and `bytes(x)` is the conversion -- in the caller's code,
-    where they can see it, rather than in a signature that promises
-    bytes and quietly means more.
+    What the boundary takes is bytes, a bytearray and a memoryview --
+    `tests/test_bytes_like.py` drives every entry point with each of the
+    three. What it refuses is everything else, and it refuses it by
+    name: a `str` has a length and is not octets, a `float` has none and
+    came back as `object of type 'float' has no len()` before there was
+    a type check to meet.
 
     Every call below is annotated for what it is: an argument of a type
     the signature refuses, which is why each carries the `type: ignore`
     that says mypy already knew.
     """
-    msg = b"\x01" * 32
     prvkey = 7
     pubkey_bytes = mult.mult_(prvkey)
-    der_bytes = dsa.sign(msg, prvkey)
 
-    with pytest.raises(TypeError, match="message hash must be bytes, not bytearray"):
-        dsa.sign(bytearray(msg), prvkey)  # type: ignore[arg-type]
-    with pytest.raises(TypeError, match="public key must be bytes, not memoryview"):
-        dsa.verify(msg, memoryview(pubkey_bytes), der_bytes)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="tag must be bytes, not str"):
         hashes.tagged_sha256("TapLeaf", b"")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="message hash must be bytes, not str"):
+        dsa.sign("x" * 32, prvkey)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="ElligatorSwift public key must be bytes"):
-        ellswift.decode(bytearray(64))  # type: ignore[arg-type]
+        ellswift.decode(None)  # type: ignore[arg-type]
 
     # the scalars take an int too, so their message says so
-    with pytest.raises(TypeError, match="private key must be bytes or an int"):
-        dsa.sign(msg, bytearray(32))  # type: ignore[arg-type]
     with pytest.raises(
         TypeError, match="private key must be bytes or an int, not float"
     ):
         mult.mult(1.0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="tweak must be bytes or an int, not str"):
+        keys.prvkey_tweak_add(prvkey, "x" * 32)  # type: ignore[arg-type]
 
     # a sequence of public keys handed one public key: bytes is itself a
     # sequence, so what reaches parse is an int, and saying so is the


### PR DESCRIPTION
Two commits. The first fixes a regression on `dev` that I did not
introduce; the second is the decision #73 left open, reversed.

## `dev` is red, and the suite said so before the matrix did

`dd29da0` fenced the indented code blocks and left the closing ``` flush
against the last line of each example. doctest reads the line after an
example as the output it expects, so three of the README's ten stopped
passing — one expecting a bare fence, two expecting `True` followed by
one. Bisected rather than guessed:

| commit | README doctests |
| --- | --- |
| `705a59a` | 10 attempted, 0 failed |
| `d461d4c` | 10 attempted, 0 failed |
| `dd29da0` | 10 attempted, **3 failed** |

A blank line before each closing fence is what says an example's output
ends there. `markdownlint-cli2` stays clean: a blank line *inside* a
fenced block is not a blank line *around* one.

Worth noting where this was caught. `test_the_readme_examples_run` was
added earlier in this same release, on the argument that *"an example
nobody runs is documentation that stops being true silently"*. This is
the first thing it caught — and the `test` run for `dd29da0` was still
queued when it did.

## The wide door

#73 refused a `bytearray` and a `memoryview`, on the argument that
converting them would widen what every signature promises. The answer is
that the signatures widened: `BytesLike` is what they say, and `octets`
converts.

They are not the leniency a short value is. Each states a value **and** a
width, so nothing has to be disbelieved and nothing supplied — which
makes them a *narrower* door than the `int` this package has always
taken, whose 32-octet width is the curve's rather than the caller's. And
a caller holding a secret in memory they can overwrite — the reason to
want a mutable buffer at all, and what SECURITY.md now describes this
package doing with its own — had been meeting a `TypeError` for it.

Three named types, not the buffer protocol at large: `bytes(x)` of
anything else is a guess, and of an `int` it is that many zero octets,
which would have turned `octets(32, "message hash", 32)` into a valid
argument.

The conversion is a copy taken at the boundary, never a pass-through, so
overwriting that buffer cannot change what libsecp256k1 is about to read.

### What made this more than a one-line change

The check is now a *normalization*, so it is the returned value that has
to reach C. Twenty-seven call sites assign it back, and a site that
checked without assigning would still hand cffi what cffi refuses —
invisibly, because nothing in the answers distinguishes the two.

`tests/test_bytes_like.py` is the net: it drives every entry point taking
such an argument with each of the three types and asserts one answer.
Verified by making it fail — reverting the assignment in `dsa.verify`
fails exactly the two `dsa.verify` cases and nothing else. Its
`test_the_sweep_is_whole` holds the list against what the modules
export, so a function added to the boundary and not swept fails as an
absence rather than passing as a gap.

## The count #73 stated, and got wrong

#73's message and changelog entry said *"the eighteen size checks across
eight modules"*. Eight modules is right; the checks are twenty. The count
is gone rather than corrected — this repository does not state one that
nothing checks — and the commit message cannot be fixed without
rewriting `dev`, so it stands with this note against it.

## Prior art, since the question came up

`coincurve`, the other cffi binding to this library, accepts a
`bytearray` and a `memoryview` at every entry point I tried, and
normalizes both to `bytes`. It does not say so anywhere: every
annotation reads `bytes` (`PrivateKey.__init__(secret: bytes | None)`,
`validate_secret(secret: bytes) -> bytes`), the docstrings say
`data (bytes)`, and `memoryview` appears nowhere in the repository. The
acceptance is a by-product of `pad_scalar`, which is
`(ZERO * (KEY_SIZE - len(scalar))) + scalar` — and `bytes + bytearray`
is `bytes`.

That same line is the leniency this package refuses:
`coincurve.PrivateKey(b"\x07")` is accepted, left-padded, and gives the
public key of `PrivateKey(bytes(31) + b"\x07")`. One octet where 32 go.

So both packages take the three types; this one now takes them by
contract, with the width still checked.

## Verified

`uvx pre-commit run --all-files` exits 0, 34 hooks. Suite 246 → **317**,
coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Broaden bytes-based arguments to accept a defined bytes-like union, ensure normalization is used at all C boundary call sites, and restore README doctest examples by fixing fenced code blocks.

New Features:
- Introduce a BytesLike type alias covering bytes, bytearray, and memoryview for arguments passed as bare pointers.
- Allow all public API entry points that previously accepted bytes to also accept bytearray and memoryview while preserving width checks.

Bug Fixes:
- Fix failing README doctests caused by incorrectly fenced code blocks that truncated expected output.

Enhancements:
- Refine octets and scalar helpers to normalize bytes-like inputs and consistently pass normalized values into libsecp256k1.
- Update function annotations and error messaging across cryptographic modules to reflect the widened bytes-like contract.
- Add a comprehensive bytes-like sweep test that exercises every entry point with bytes, bytearray, and memoryview and verifies consistent behavior, including a completeness check against exported functions.

Documentation:
- Document the widened octet/BytesLike contract and mutation-safety guarantees in README and CHANGELOG, and explain the new behavior and prior decision reversal.
- Fix README fenced code examples by inserting blank lines before closing fences so doctests run and pass again.

Tests:
- Add tests verifying consistent behavior across bytes-like inputs for all relevant entry points and that the sweep covers all exported functions.
- Adjust core type-checking tests to target non-bytes-like inputs now that bytearray and memoryview are accepted.