### PR TITLE
Report a vanished vendored path, name a build failure, and benchmark python

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -21,6 +21,10 @@ documented as behind would be a decision already made, and
 re-reporting the same gap every month would be noise rather than news;
 btclib's own README has that shape today, this one does not yet.
 
+A path upstream has renamed or deleted is reported rather than raising:
+it has no commit to name as a tip, and a pin standing on a file that is
+not there any more is the one drift nobody would otherwise notice.
+
 Two more shapes this script does not attempt, for the same reason
 btclib's does not, present or not in this project's own README today: a
 path carrying a `<name>` placeholder, where one pin serves several
@@ -79,6 +83,16 @@ class Drift:
     latest_commit: str
     latest_date: str
 
+    @property
+    def path_is_gone(self) -> bool:
+        """True where upstream has no commit touching the pinned path.
+
+        The empty `latest_commit` is what says so: there is no tip to
+        name, `_latest_commit` having answered None. Reading it through
+        a name keeps that encoding in one place.
+        """
+        return not self.latest_commit
+
 
 def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     """Return the checkable entries, and the headings this skips.
@@ -115,8 +129,17 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     return entries, skipped
 
 
-def _latest_commit(repo: str, path: str) -> tuple[str, str]:
-    """Return the sha and date of the most recent commit touching path."""
+def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
+    """Return the sha and date of the most recent commit touching path.
+
+    None where upstream has no commit touching it at all, which means the
+    path has been renamed or deleted: the sharpest drift there is, a pin
+    naming a file that is not there any more. This used to unpack one
+    commit out of an empty list and raise `ValueError` instead, so the
+    monthly run went red and `report` was never reached -- no issue
+    opened, on the one kind of drift nobody would otherwise notice, which
+    is what this workflow exists for.
+    """
     result = subprocess.run(  # noqa: S603
         [
             _GH,
@@ -133,7 +156,10 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str]:
         check=True,
         text=True,
     )
-    (commit,) = json.loads(result.stdout)
+    commits = json.loads(result.stdout)
+    if not commits:
+        return None
+    commit = commits[0]
     date: str = commit["commit"]["committer"]["date"][:10]
     sha: str = commit["sha"]
     return sha, date
@@ -144,9 +170,12 @@ def find_drift(readme_path: Path) -> tuple[list[Drift], list[str]]:
     entries, skipped = _entries_at_tip(readme_path.read_text(encoding="utf-8"))
     drifted = []
     for entry in entries:
-        latest_sha, latest_date = _latest_commit(entry.repo, entry.path)
-        if latest_sha != entry.commit:
-            drifted.append(Drift(entry, latest_sha, latest_date))
+        latest = _latest_commit(entry.repo, entry.path)
+        if latest is None:
+            # a path upstream no longer has: drift with no tip to name
+            drifted.append(Drift(entry, "", ""))
+        elif latest[0] != entry.commit:
+            drifted.append(Drift(entry, *latest))
     return drifted, skipped
 
 
@@ -157,6 +186,14 @@ def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> 
         "",
     ]
     for drift in drifted:
+        if drift.path_is_gone:
+            lines.append(
+                f"- **{drift.entry.heading}**: pinned to"
+                f" `{drift.entry.commit[:12]}`, and `{drift.entry.repo}` has no"
+                f" commit touching `{drift.entry.path}` any more -- renamed,"
+                " moved or deleted upstream"
+            )
+            continue
         lines.append(
             f"- **{drift.entry.heading}**: pinned to `{drift.entry.commit[:12]}`,"
             f" upstream's tip of `{drift.entry.path}` is now"
@@ -230,9 +267,25 @@ def main() -> int:
     """
     args = [a for a in sys.argv[1:] if a != "--dry-run"]
     dry_run = len(args) != len(sys.argv) - 1
+    if len(args) != 1:
+        # a human running this by hand is the only way here, the workflow
+        # passing the path every time: an IndexError naming a list is
+        # what they used to get
+        print(
+            f"usage: {Path(sys.argv[0]).name} <README path> [--dry-run]",
+            file=sys.stderr,
+        )
+        return 2
     readme_path = Path(args[0])
     drifted, skipped = find_drift(readme_path)
     for drift in drifted:
+        if drift.path_is_gone:
+            print(
+                f"GONE: {drift.entry.heading} pinned to"
+                f" {drift.entry.commit[:12]}, and {drift.entry.repo} has no"
+                f" commit touching {drift.entry.path} any more"
+            )
+            continue
         print(
             f"BEHIND: {drift.entry.heading} pinned to {drift.entry.commit[:12]},"
             f" tip is {drift.latest_commit[:12]} ({drift.latest_date})"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 438
+        "line_number": 488
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T07:31:29Z"
+  "generated_at": "2026-08-07T08:33:55Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,18 @@ branch has to edit.
 
 ### What the wheels are built with
 
+- **Two failures of the build hook say what went wrong** (#75).
+  `get_ext_object` raised a bare `RuntimeError` -- no message at all --
+  for a `cffi_modules` entry naming an object its script does not define;
+  it now names both halves of the entry, which is the only thing that can
+  be wrong there, and matters the more because the line is excluded from
+  the coverage measure. And `dynamic_platform_tag` subscripted a dict
+  literal of three Windows architectures, so a fourth answered `KeyError`
+  -- `win-arm32`, which `scripts/cffi_build.py` does aim CMake at, being
+  the one the two files disagreed about. It is in the map now, and
+  anything else raises a `RuntimeError` naming the architecture, which is
+  the policy `shared_library_extension` beside it already had.
+
 - **The static Unix extension is compiled with the interpreter's own
   `CFLAGS`.** `CC`, `CFLAGS`, `CCSHARED` in that order is what
   `customize_compiler` composes for the extensions the interpreter
@@ -319,6 +331,25 @@ branch has to edit.
   so the ratchet is unmoved.
 
 ### External vectors
+
+- **The vendored-vector re-checker reports a path upstream has deleted,
+  rather than raising on it** (#75). `repos/{repo}/commits?path=` answers
+  `[]` with a 200 when no commit touches that path any more -- renamed,
+  moved or deleted -- and `(commit,) = json.loads(...)` unpacked one
+  commit out of that. The `ValueError` took `find_drift` down with it and
+  `report` was never reached: the monthly run turned red and no issue was
+  opened, which is the one outcome the workflow exists to prevent, on the
+  one drift a vendored file nobody re-reads would otherwise hide.
+  `_latest_commit` answers None there now, `Drift` carries a
+  `path_is_gone` reading that encoding in one place, and the issue body
+  and stdout say GONE with the reason instead of naming a tip that does
+  not exist. Called with no README, or two, it prints its usage on stderr
+  and exits 2, where `Path(args[0])` had answered `IndexError: list index
+  out of range` about a list the caller never saw. btclib's copy of this
+  script is the same code and has the same fix, with the tests: this
+  repository has no test module for it, `.github/scripts` being outside
+  the coverage source here, so what holds it is btclib's suite and the
+  hand check in the session log.
 
 - **ellswift is held to BIP324's published vectors.** The tests encoded,
   decoded and agreed with themselves, which says nothing about the map
@@ -411,6 +442,25 @@ branch has to edit.
   that stops being true silently"* — and this is the first thing it
   caught. `markdownlint-cli2` stays clean over the result: a blank line
   inside a fenced block is not a blank line around one.
+- **The benchmark measures btclib's python arithmetic, which it had
+  stopped doing** (#75). Two of its eight rows are labelled *"through
+  btclib's pure python arithmetic"*, and `dsa.verify_` and `ssa.verify_`
+  delegate to these very bindings for secp256k1 with sha256 -- which is
+  exactly the fixture the script sets up. Traced, the two rows called
+  `btclib_libsecp256k1.dsa.verify` and `.ssa.verify`: the same C as the
+  package's own rows with a python wrapper in front, 22.5 and 24.9 us
+  against 13.9 and 13.8, where the python path is 1214 and 1270.
+  `python_arithmetic_only` turns the dispatch off before the rows run,
+  and it does so in three namespaces because `_libsecp256k1_applicable`
+  is imported *by name* into `ecc.dsa`, `ecc.ssa` and `curves.curve`:
+  patching one leaves the other two delegating, which is a partial patch
+  that still measures C and still looks like python -- the first
+  measurement taken for this entry was wrong that way. The two rows drop
+  to `mult=1`, a thousand calls of a millisecond being a second of clock
+  where they had been sized for twenty microseconds, and the loop reads
+  `perf_counter` rather than `time`, a wall clock being the one thing a
+  benchmark should not use.
+
 - **The entropy detectors of `detect-secrets` run over the tree.**
   `.secrets.baseline` was generated with `HexHighEntropyString` and
   `Base64HighEntropyString` off, and it is the baseline that decides

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -15,8 +15,13 @@ The point is not a ranking: the three binding packages call the same
 libsecp256k1, so what separates them is the boundary crossing, and what
 separates them from btclib is the C. Read the output as an order of
 magnitude and never as a number to quote -- the loop count differs per
-function, the timings are wall clock, and nothing here repeats a
-measurement or discards an outlier.
+function, and nothing here repeats a measurement or discards an outlier.
+
+btclib's own rows need its dispatch turned off, which
+`python_arithmetic_only` below does and says why: `dsa.verify_` and
+`ssa.verify_` delegate to these very bindings for secp256k1 with sha256,
+so without it the two rows measured C with a python wrapper in front and
+called it python.
 
 Not part of the test suite and not run by CI: it needs three third-party
 packages this project does not depend on.
@@ -28,6 +33,7 @@ import time
 from collections.abc import Callable
 
 import coincurve
+from btclib.curves import curve
 from btclib.ecc import dsa, ssa
 from btclib.hashes import reduce_to_hlen
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
@@ -42,6 +48,31 @@ xonly_pubkey = pubkey[1:]
 msg = reduce_to_hlen(b"Satoshi Nakamoto")
 dsa_sig = btclib_libsecp256k1.dsa.sign(msg, prvkey)
 ssa_sig = btclib_libsecp256k1.ssa.sign(msg, prvkey)
+
+
+def python_arithmetic_only() -> None:
+    """Turn btclib's libsecp256k1 dispatch off, in every namespace.
+
+    Without this the two btclib rows below measured *these bindings* with
+    a btclib wrapper in front, and reported it as python: `dsa.verify_`
+    and `ssa.verify_` delegate for secp256k1 with sha256, which is
+    exactly what is set up above. The two rows came out a little slower
+    than this package's own and nothing said why.
+
+    Every namespace, because `_libsecp256k1_applicable` is imported *by
+    name* into `ecc.dsa`, `ecc.ssa` and `curves.curve`: patching one
+    leaves the other two delegating, so a partial patch still measures C
+    and still looks like python. The multiplication under the
+    verification equation lives in the third of them.
+
+    Called once, after the fixtures above are built -- they go through
+    btclib too, and there is no reason to slow those down.
+    """
+    for module in (dsa, ssa, curve):
+        module._libsecp256k1_applicable = lambda *_: False
+
+
+python_arithmetic_only()
 
 
 def dsa_btclib() -> None:
@@ -103,19 +134,25 @@ def benchmark(func: Callable[[], None], mult: int = 1) -> None:
     all of them would either take minutes on btclib or measure the C
     calls against the resolution of the clock.
     """
-    start = time.time()
+    # perf_counter and not time(): the wall clock can step backwards
+    # under an NTP correction, and a benchmark is the one place that
+    # shows up as a negative duration
+    start = time.perf_counter()
     for _ in range(1000 * mult):
         func()
-    end = time.time()
+    end = time.perf_counter()
     print(f"{func.__name__:<17}: {((end - start) / mult):.6f}")
 
 
-benchmark(dsa_btclib, 10)
+# one thousand calls of the python path is already a second of wall
+# clock, where the C rows need a hundred thousand to leave the clock's
+# own resolution behind
+benchmark(dsa_btclib, 1)
 benchmark(dsa_coincurve, 100)
 benchmark(dsa_secp256k1, 100)
 benchmark(dsa_libsecp256k1, 100)
 
-benchmark(ssa_btclib, 10)
+benchmark(ssa_btclib, 1)
 benchmark(ssa_coincurve, 100)
 benchmark(ssa_secp256k1, 100)
 benchmark(ssa_libsecp256k1, 100)

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -59,7 +59,13 @@ class CustomBuildHook(BuildHookInterface[Any]):
         build_vars = {"__name__": "__cffi__", "__file__": script}
         exec(code, build_vars, build_vars)
         if ext_name not in build_vars:
-            raise RuntimeError
+            # the message names both halves of the pyproject.toml entry,
+            # that entry being the only thing that can be wrong here: a
+            # bare `raise RuntimeError` said nothing at all, and this line
+            # is excluded from the coverage measure, so the message is the
+            # whole of what a maintainer would have to go on
+            msg = f"{script} defines no {ext_name}: stale cffi_modules entry"
+            raise RuntimeError(msg)
         return build_vars[ext_name]
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
@@ -123,7 +129,16 @@ class CustomBuildHook(BuildHookInterface[Any]):
             build_data["tag"] = f"py3-none-{self.dynamic_platform_tag()}"
 
     def dynamic_platform_tag(self) -> str:
-        """Platform tag of a dynamic (cffi ABI mode) wheel."""
+        """Platform tag of a dynamic (cffi ABI mode) wheel.
+
+        Raises RuntimeError on a Windows architecture this does not know,
+        rather than the KeyError a dict subscript would: the four targets
+        below are the four `scripts/cffi_build.py` aims CMake at, and the
+        two files disagreeing about which of them exist is the failure
+        this shape rules out -- `win-arm32` was in that file and not in
+        this one, so the one build that reached here would have ended in
+        a bare KeyError from a dict literal.
+        """
         if self.platform != platform.system():
             # cross-compilation: the target machine cannot be inspected;
             # x86_64 mingw Windows is the only supported cross target
@@ -134,9 +149,16 @@ class CustomBuildHook(BuildHookInterface[Any]):
         # former, as scripts/cffi_build.py explains
         machine = sysconfig.get_platform().rsplit("-", 1)[-1]
         if self.platform == "Windows":
-            return {"amd64": "win_amd64", "arm64": "win_arm64", "win32": "win32"}[
-                machine
-            ]
+            tags = {
+                "win32": "win32",
+                "amd64": "win_amd64",
+                "arm32": "win_arm32",
+                "arm64": "win_arm64",
+            }
+            if machine not in tags:
+                msg = f"no wheel tag known for the Windows architecture {machine}"
+                raise RuntimeError(msg)
+            return tags[machine]
         if self.platform == "Darwin":
             target = os.environ.get("MACOSX_DEPLOYMENT_TARGET") or platform.mac_ver()[0]
             major, _, minor = target.partition(".")


### PR DESCRIPTION
Three findings of a second audit, over the files the first one did not
reach: the CI script, the build hook, and the benchmark. Everything here
is outside `btclib_libsecp256k1/` — the boundary itself came out of the
first audit and this one found nothing new in it.

## 1. The vendored-vector re-checker crashed on the drift it exists to catch

`repos/{repo}/commits?path=` answers `[]` with a **200** when no commit
touches that path any more — renamed, moved or deleted upstream — and
`(commit,) = json.loads(...)` unpacked one commit out of it:

```text
a path that still exists:
  ('200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb', '2023-04-20')
a path upstream has renamed or deleted:
  !! ValueError: not enough values to unpack (expected 1, got 0)
```

The `ValueError` took `find_drift` down and `report` was never reached:
**red monthly run, no issue opened.** The workflow's own comment is the
argument for why that matters — *"a vendored vector is trusted without
anybody looking at it again, and that is exactly what a monthly issue is
for"* — and a pin standing on a file that is gone is exactly the thing
nobody would notice.

`_latest_commit` answers `None` there now, `Drift` carries a
`path_is_gone` that reads the encoding in one place, and the report says
`GONE` with the reason instead of naming a tip that does not exist.
Called with no README, or two, it prints its usage and exits 2 rather
than `IndexError: list index out of range` about a list nobody saw.

btclib's copy of this script is the same code and carries the same fix
with the tests (btclib-org/btclib#471 and #472). `.github/scripts` is
outside the coverage source here, so what holds this is that suite plus
the hand check above — worth knowing, and arguably worth a test module of
its own here one day.

## 2. Both failures of the build hook were mute

`get_ext_object` raised a **bare** `RuntimeError` — no message at all —
for a `cffi_modules` entry naming an object its script does not define.
The line is excluded from the coverage measure, so the message was the
whole of what a maintainer would have had to go on, and there wasn't one.

`dynamic_platform_tag` subscripted a dict of three Windows architectures
where `scripts/cffi_build.py` aims CMake at four:

```text
win32        machine=win32   cffi_build=Win32  hatch_build=win32
win-amd64    machine=amd64   cffi_build=x64    hatch_build=win_amd64
win-arm32    machine=arm32   cffi_build=ARM    hatch_build=** KeyError **
win-arm64    machine=arm64   cffi_build=ARM64  hatch_build=win_arm64
```

Both name what went wrong now, the second matching the `RuntimeError`
policy `shared_library_extension` beside it already had.

## 3. The benchmark stopped measuring python

Two of the eight rows are labelled *"through btclib's pure python
arithmetic"*. `dsa.verify_` and `ssa.verify_` delegate to **these
bindings** for secp256k1 with sha256 — which is exactly the fixture the
script sets up. Traced:

```text
dsa_btclib() reaches: ['dsa.verify']      ← the bindings
ssa_btclib() reaches: ['ssa.verify']      ← the bindings
```

| row | µs/call |
| --- | --- |
| `dsa_btclib` | 22.5 |
| `dsa_libsecp256k1` | 13.9 |
| `ssa_btclib` | 24.9 |
| `ssa_libsecp256k1` | 13.8 |
| *the python path* | *1214 / 1270* |

So `benchmark()`'s *"two orders of magnitude slower"* is true **of the
python path** and was not what those rows ran.

`python_arithmetic_only` turns the dispatch off before they do, in
**three** namespaces: `_libsecp256k1_applicable` is imported *by name*
into `ecc.dsa`, `ecc.ssa` and `curves.curve`, so patching one leaves the
other two delegating — a partial patch that still measures C and still
looks like python. The first measurement I took for this was wrong that
way, which is why the numbers above are the second set.

The two rows drop to `mult=1` (a thousand calls of a millisecond is a
second of clock, where they had been sized for twenty microseconds), and
the loop reads `perf_counter` rather than `time`.

## An audit hypothesis that did not survive

`enable = ["pypy"]` looked like it left free-threaded wheels unbuilt,
which would have made six statements false. It doesn't: PyPI serves eight
`cp314-cp314t` wheels for 0.7.1. In cibuildwheel 3.x free-threading is no
longer opt-in for stable versions. The prose is correct and no change was
needed.

## Verified

`uvx pre-commit run --all-files` exits 0, working tree clean afterwards.
Suite at 317, coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle vendored vector drift more robustly, improve build-time error reporting, and ensure the benchmark actually measures btclib’s Python arithmetic with a reliable timer.

Bug Fixes:
- Treat upstream-deleted or renamed vendored paths as a distinct drift case instead of crashing when no commits are returned for a path.
- Add usage validation to the vendored-vector checker CLI to avoid IndexError when run with missing or extra README arguments.
- Report a clear RuntimeError when a cffi_modules entry refers to an extension object not defined in its build script.
- Guard Windows dynamic platform tag resolution with explicit mappings and a RuntimeError on unknown architectures instead of an unhandled KeyError.

Enhancements:
- Include detailed GONE/BEHIND drift messaging in both issue bodies and stdout for vendored-vector checks.
- Force btclib benchmarks to use pure Python arithmetic by disabling libsecp256k1 dispatch in all relevant namespaces.
- Switch benchmark timing to time.perf_counter and adjust iteration counts so Python-path measurements remain practical and meaningful.

Build:
- Clarify build hook behavior for missing cffi extension objects and unknown Windows architectures in hatch_build’s dynamic platform tag logic.

Documentation:
- Document the build-hook error handling and Windows platform tag behavior in the changelog.
- Document the improved vendored-vector drift handling and benchmark behavior in the changelog.