### PR TITLE
Close the second mutation session, and keep it off the release gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 488
+        "line_number": 530
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T08:33:55Z"
+  "generated_at": "2026-08-07T09:31:41Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -429,6 +429,48 @@ branch has to edit.
   `tests/README.md`, as the ones before them are, so the monthly
   `vendored-vectors` workflow re-checks them.
 
+### Mutation testing
+
+- **The inert third of a session is skipped before it runs, not counted
+  after it does** (#70). Every module here opens with
+  `from __future__ import annotations`, so a mutant of the `|` inside a
+  `bytes | int` signature — `bytes >> int` and ten more — is unreachable
+  by any test, nothing ever evaluating the annotation as an expression.
+  Unfiltered, a session paid the whole suite for that shape on 352 of 777
+  mutants before reaching the 13 that were real: 365 survivors in five
+  minutes, against 352 skipped and the same 13 in two once
+  `[cosmic-ray.filters.operators-filter]` excluded the `BitOr` family by
+  operator — in `bindings.toml` itself, which already says what is
+  mutated and what judges it, rather than a `# pragma: no mutate` on each
+  of the 26 lines it would otherwise mark and on every one a later
+  signature adds. `cr-rate` cannot report a filtered session: its
+  `is_killed` counts a skip as a kill, so it divided by every enumerated
+  mutant and read 1.67%, where the 13 that survived the 425 that ran are
+  3.06% of them. `.github/scripts/mutation_counts.py` prints killed,
+  survived and skipped instead, with the rate over what actually ran, and
+  fails on a worker outcome that is no verdict at all rather than
+  reporting it as either.
+- **Two of the three real shapes a session survivor list held are
+  answered in the code instead of read past** (#71). Six of the 13 #70
+  measured were an output buffer whose size was written more than once —
+  a serialization, the capacity handed to libsecp256k1 and the length
+  unpacked back, as up to three separate literals where `keys.serialize`
+  already wrote it once; the other seven were `secrets.token_bytes(32)`,
+  a length not observable in an aux value or a shared secret hashed
+  before use. `ffi.sizeof` now derives every buffer size across the
+  eighteen call sites in eight modules that used to write it by hand, and
+  where the randomness is copied into a fixed-size array instead of hashed
+  — `ssa.sign_`'s `char[32]` — the longer half of that pair already died
+  on cffi's own bound, `ffi.new` there refusing 33 octets and taking 31.
+- **A third, unrelated shape survived a private module's own size
+  check.** `_scalar.octets`'s `len(value_bytes) != size` mutated to
+  `is not` passed the whole suite, no wrapper here ever asking for a size
+  past CPython's cached range for small ints, where an equal pair is the
+  same object and the two operators cannot be told apart.
+  `test_octets_size_check_compares_by_value` drives the check directly at
+  300 octets — past the cache, and past every size a wrapper reaches —
+  where `!=` and `is not` stop agreeing.
+
 ### The gate
 
 - **The README quickstart is executed again** (#74). Fencing the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,15 @@ knowing before rather than during.
 which a release does not change the answer to, and a session is measured
 in minutes to hours against a schedule already built for the weekend it
 runs on regardless. Dispatching it as part of cutting a release conflates
-two independent activities for no question a release-timing answers.
+two independent activities for no question a release-timing answers. A
+release pull request's own checklist is not exempt from that argument: an
+item asking whether a mutation run is "owed" before marking it ready
+reintroduces the same coupling under a different name, one more session
+gating a button it does not answer anything for. 0.7.1.2 ran one anyway,
+by hand and out of band — the weekly cron was days off and two merged
+pull requests had changed wrappers a survivor list had not seen since —
+and that is the right shape for it: read on its own terms, the sqlite
+kept or discarded on its own schedule, never a condition of the tag.
 
 Then:
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,7 @@ import secrets
 import pytest
 
 from btclib_libsecp256k1 import (
+    _scalar,
     context,
     dsa,
     ellswift,
@@ -314,6 +315,22 @@ def test_size_checks_refuse_both_sides() -> None:
     # the check and its mutant refuse that value
     with pytest.raises(ValueError, match="fit in 32 bytes"):
         dsa.sign(msg, 2**256 + 1)
+
+
+def test_octets_size_check_compares_by_value() -> None:
+    """`_scalar.octets`'s size check is `!=`, not `is not`.
+
+    No wrapper here ever asks for a size past 256, which is exactly why a
+    mutant turning that `!=` into `is not` survived a mutation session:
+    every size this package checks -- 32, 33, 65 -- sits inside CPython's
+    cached range for small ints, where two equal ones are the same object
+    and the two operators cannot be told apart. 300 does not, and `size`
+    stays referenced for the whole call, so the object `len(value_bytes)`
+    computes cannot be allocated at its address once it is freed --
+    `!=` accepts it, `is not` would refuse it as a false mismatch.
+    """
+    value = bytes(300)
+    assert _scalar.octets(value, "value", len(value)) == value
 
 
 def test_der_reaches_all_72_octets() -> None:


### PR DESCRIPTION
A hand run over the current tree, done while cutting 0.7.1.2, found one
real survivor `_scalar.octets` had missed: `!= size` mutated to
`is not size` passes every existing test, because no wrapper here ever
asks for a size past CPython's small-int cache. New:
`test_octets_size_check_compares_by_value`, driving the check at 300
octets, where the two operators stop agreeing — verified by hand-applying
the mutation and watching it fail, then restoring and watching it pass.

#70 and #71 had landed the rest of that session's findings — the operator
filter and the two real shapes it found — without a CHANGELOG entry.
Both are recorded now, together with this one, under a new "Mutation
testing" heading.

RELEASING.md gets a clarifying line: the document already argues that
dispatching `mutation` as part of cutting a release conflates two
independent activities, but the current release's own draft pull request
checklist asked whether a run was "owed" before marking it ready —
reintroducing exactly that coupling. The run happened anyway, by hand and
out of band, which is the shape RELEASING.md now says is the right one.

## Summary by Sourcery

Document recent mutation testing outcomes and decouple mutation runs from the release gate.

Enhancements:
- Capture previous mutation session outcomes in a dedicated CHANGELOG "Mutation testing" section, including operator filtering and buffer size derivations across call sites.

Documentation:
- Clarify RELEASING guidance so mutation testing runs are performed independently of the release process rather than gating release readiness.

Tests:
- Add a regression test that drives `_scalar.octets` size checking beyond CPython's small-int cache to ensure comparisons are done by value, not identity.