### PR TITLE
Stop trusting the release body, and record what latest found

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -118,6 +118,15 @@ Then:
    what the diff cannot say has to be written, and what a reader should
    not have to discover at the button belongs there too.
 
+   The previous cycle's step 11 opened this pull request asking for the
+   body to fill in one merged pull request at a time, and says so itself:
+   "a promise kept only if someone remembers to keep it." Check it against
+   `git log v<previous version>..dev --oneline` regardless of how current
+   it looks, rather than trust that every line landed when it should have.
+   `latest`'s result belongs here too, a line rather than a screenshot: it
+   gates nothing, and a pull request that never mentions it having run
+   reads exactly like one that skipped it.
+
    Then merge `dev` into `master` with a green CI, using **Rebase and
    merge** and never *Squash and merge*.
    Which button that is has to be read before it is pressed: all three


### PR DESCRIPTION
btclib-bitcoin-core-rpc's own RELEASING.md, modeled on this file's
section of the same name, surfaced a gap this file has too during its
v2026.8.7 release walkthrough. Step 3 already admits the release-body
mechanism is "a promise kept only if someone remembers to keep it," and
nothing asks to check it against anything when that promise was not
kept -- the sibling's cycle carried seventeen commits and the body was
still unwritten at release time. This adds that check, against the
merged-commit log rather than trust.

`latest` gates nothing by design, the same reasoning `mutation` gets
immediately above it in this file. Unlike `mutation`, `latest` is a step
of cutting a release -- and like `mutation`, nothing records that it ran.
Its result now belongs in the pull request step 3 already writes, the
same way the rehearsal's own checks belong in step 5's install.

Not ported from the sibling: its other two fixes were about a
griffe-style public-API diff (this repository has no equivalent check)
and a TestPyPI rehearsal version-string ambiguity this file already
resolves ("Nothing has to be done to the version first").

Gates run on this tree:

- `uv run pre-commit run --all-files` -- every hook passes
- `uv run pytest --cov` -- 318 passed, coverage 100%

## Summary by Sourcery

Clarify the release process documentation to verify the release body against the merged commit log and to record that the latest check has been run.

Documentation:
- Document verifying the release body against `git log v<previous version>..dev --oneline` instead of trusting it was kept up to date.
- Note that the `latest` step’s outcome should be recorded in the pull request body as part of the release process.