### PR TITLE
Name what is wrapped in the PyPI keywords and the repository topics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 551
+        "line_number": 587
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T18:34:15Z"
+  "generated_at": "2026-08-07T19:07:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 587
+        "line_number": 599
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T19:07:02Z"
+  "generated_at": "2026-08-07T19:08:12Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ release-notes length in the first place, and are still in
 
 ### Packaging metadata
 
-- **`keywords` names what this package wraps and what it exposes**, where
+- **`keywords` names what this package wraps and what it reaches**, where
   it said `bitcoin` and `libsecp256k1` and left the searchable name of the
   curve out along with every wrapped module: `secp256k1`, `cryptography`,
   `python-bindings`, `cffi`, `ecdsa`, `schnorr`, `bip340`, `ecdh`,
@@ -52,10 +52,22 @@ release-notes length in the first place, and are still in
   to be: the list is the repository's topics in the same order, and one
   spelling across the two is what lets them be compared. The order is by
   relevance rather than alphabetical, PyPI showing keywords as the metadata
-  gives them and GitHub sorting its own. Three candidates are left out on
-  purpose, and the comment beside the list says why: `musig2`, which is
-  not wrapped; `bip324`, whose transport is not implemented here; and
-  `elliptic-curves`, this being one curve, which `secp256k1` names.
+  gives them and GitHub sorting its own.
+- **`musig2` and `bip324` are in that list, and neither is a wrapped
+  module.** The vendored library is built with
+  `SECP256K1_ENABLE_MODULE_MUSIG` and `secp256k1_musig.h` is among the
+  headers the cdef is made of, so all of `secp256k1_musig_nonce_gen`,
+  `_nonce_agg`, `_nonce_process`, `_partial_sign` and their neighbours are
+  reachable through the `lib` this package exposes -- what MuSig2 has no
+  module for is the session its two rounds need, which is the reason
+  README's Design section gives for leaving one out. `bip324` is the
+  `ellswift` module beside it: the encoding and the x-only ECDH that BIP's
+  handshake needs of its keys, and not its transport, which is a cipher and
+  a framing layer this package has no part of. The comment beside the list
+  states both limits, so a keyword found on PyPI leads to what is here
+  rather than to what a reader would assume from the name.
+  `elliptic-curves` is the one candidate left out: this is one curve, and
+  `secp256k1` names it.
 - **this file relaxes MD024 (no-duplicate-heading) for itself**, a group
   heading repeating under every release that has an entry in that group:
   the rule reads that repeat as the accident it usually is, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<!-- markdownlint-configure-file
+  {
+    // MD024/no-duplicate-heading - a group heading repeats under every
+    // release with an entry in that group ("Packaging metadata", "The
+    // gate", "CI"), which is what keeps the page readable scrolling down
+    // it; only a duplicate under the same release heading would be the
+    // accident this rule looks for
+    "MD024": { "siblings_only": true }
+  }
+-->
+
 Every change of a release, in full: what changed, why, and what it cost.
 [HISTORY.md](./HISTORY.md) has the release notes, which say what a user has
 to act on; this file is the record behind them, and is where a claim in
@@ -29,6 +40,31 @@ release-notes length in the first place, and are still in
   and bitcoin-core-rpc carry the same two lines, which is what makes the
   three READMEs comparable; the badge sets differ only where the projects
   do, this one having no calendar version to declare.
+
+### Packaging metadata
+
+- **`keywords` names what this package wraps and what it exposes**, where
+  it said `bitcoin` and `libsecp256k1` and left the searchable name of the
+  curve out along with every wrapped module: `secp256k1`, `cryptography`,
+  `python-bindings`, `cffi`, `ecdsa`, `schnorr`, `bip340`, `ecdh`,
+  `ellswift`, `public-key-recovery` and `rfc-6979`, which is the nonce
+  `dsa.sign` uses. `RFC-6979` is spelled lowercase, as a GitHub topic has
+  to be: the list is the repository's topics in the same order, and one
+  spelling across the two is what lets them be compared. The order is by
+  relevance rather than alphabetical, PyPI showing keywords as the metadata
+  gives them and GitHub sorting its own. Three candidates are left out on
+  purpose, and the comment beside the list says why: `musig2`, which is
+  not wrapped; `bip324`, whose transport is not implemented here; and
+  `elliptic-curves`, this being one curve, which `secp256k1` names.
+- **this file relaxes MD024 (no-duplicate-heading) for itself**, a group
+  heading repeating under every release that has an entry in that group:
+  the rule reads that repeat as the accident it usually is, and
+  `siblings_only` is what tells the two apart, a duplicate under one
+  release heading still failing. It is a `markdownlint-configure-file`
+  comment here rather than a line in `.markdownlint.jsonc`, which is
+  shared with btclib and bitcoin-core-rpc and says itself that a rule one
+  file needs belongs to that file; bitcoin-core-rpc's CHANGELOG.md carries
+  the same comment.
 
 ## v0.7.1.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,33 @@ requires-python = ">=3.10"
 # above ships that file beside LICENSE so the pointer travels with the
 # distribution
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
-keywords=["bitcoin", "libsecp256k1"]
+# the GitHub repository topics, in the same order, and the order is by
+# relevance rather than alphabetical: PyPI shows keywords as the metadata
+# gives them, and GitHub sorts its own, so there the order decides only
+# which topic goes when the twenty it allows are full -- which this list
+# is well short of. Lowercase throughout, a GitHub topic being lowercase
+# or not a topic, so that one spelling serves both lists.
+#
+# Two absences are deliberate. musig2 is not wrapped, for the reason
+# README's Design section gives; and bip324 names a transport this package
+# does not implement, ellswift below being the module that is here -- the
+# encoding and the x-only ECDH BIP324 needs of its keys. elliptic-curves
+# is a third: this is one curve, and secp256k1 names it.
+keywords=[
+        "libsecp256k1",
+        "secp256k1",
+        "bitcoin",
+        "cryptography",
+        "python-bindings",
+        "cffi",
+        "ecdsa",
+        "schnorr",
+        "bip340",
+        "ecdh",
+        "ellswift",
+        "public-key-recovery",
+        "rfc-6979",
+]
 classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,18 @@ authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 # is well short of. Lowercase throughout, a GitHub topic being lowercase
 # or not a topic, so that one spelling serves both lists.
 #
-# Two absences are deliberate. musig2 is not wrapped, for the reason
-# README's Design section gives; and bip324 names a transport this package
-# does not implement, ellswift below being the module that is here -- the
-# encoding and the x-only ECDH BIP324 needs of its keys. elliptic-curves
-# is a third: this is one curve, and secp256k1 names it.
+# Two of them name what is reachable rather than what is wrapped, and the
+# difference is worth knowing before either is trusted. musig2 has no
+# module of its own -- the two-round protocol needs a session whose secret
+# nonce cannot be reused, which belongs where the signing state lives --
+# but the vendored library is built with SECP256K1_ENABLE_MODULE_MUSIG and
+# secp256k1_musig.h is among the headers the cdef is made of, so the whole
+# of that api is reachable through the `lib` this package exposes. bip324
+# is the ellswift module beside it: the encoding and the x-only ECDH that
+# BIP's handshake needs of its keys, and not its transport, which is a
+# cipher and a framing layer this package has no part of.
+#
+# elliptic-curves stays out: this is one curve, and secp256k1 names it.
 keywords=[
         "libsecp256k1",
         "secp256k1",
@@ -39,8 +46,10 @@ keywords=[
         "ecdsa",
         "schnorr",
         "bip340",
+        "musig2",
         "ecdh",
         "ellswift",
+        "bip324",
         "public-key-recovery",
         "rfc-6979",
 ]


### PR DESCRIPTION
`keywords` said `bitcoin` and `libsecp256k1`, which left out the searchable
name of the curve and every wrapped module. The GitHub repository has no
topics at all, so the list below is what goes there too — same entries,
same order, lowercase throughout, a topic being lowercase or not a topic.

```
libsecp256k1, secp256k1, bitcoin, cryptography, python-bindings, cffi,
ecdsa, schnorr, bip340, musig2, ecdh, ellswift, bip324,
public-key-recovery, rfc-6979
```

The order is by relevance rather than alphabetical: PyPI shows keywords as
the metadata gives them, and GitHub sorts its own, so there the order
decides only which topic goes when the twenty it allows are full — which
fifteen is short of, so nothing had to be left out for room.

## `musig2` and `bip324` name what is reachable, not what is wrapped

Neither has a module of its own, and the comment beside the list says so,
because a keyword found on PyPI should lead to what is here:

- the vendored library is built with `SECP256K1_ENABLE_MODULE_MUSIG` and
  `secp256k1_musig.h` is among the headers the cdef is made of, so
  `secp256k1_musig_nonce_gen`, `_nonce_agg`, `_nonce_process`,
  `_partial_sign` and their neighbours are reachable through the `lib` this
  package exposes — measured on the built extension, not read off the build
  flags. What MuSig2 has no module for is the session its two rounds need,
  which is the reason README's Design section gives for leaving one out
- `bip324` is the `ellswift` module: the encoding and the x-only ECDH that
  BIP's handshake needs of its keys, and not its transport, which is a
  cipher and a framing layer this package has no part of. The module's own
  docstring already says "according to BIP324"

`elliptic-curves` is the one candidate left out: this is one curve, and
`secp256k1` names it.

`CHANGELOG.md` also relaxes MD024 for itself: `Packaging metadata` is the
first group heading to repeat under a second release, #82's `Documentation`
entry already under v0.7.1.3 having no counterpart in v0.7.1.2 and so
having asked nothing of the rule — with the comment removed, markdownlint
reports that one heading and no other.
`siblings_only` tells that repeat from a duplicate under one release, which
still fails, and the setting is a `markdownlint-configure-file` comment in
the file rather than a line in the `.markdownlint.jsonc` shared with btclib
and bitcoin-core-rpc — which says itself that a rule one file needs belongs
to that file. `.secrets.baseline` follows the line numbers.

The topics themselves are a repository setting, not part of this branch.

Rebased onto `dev` at c62b7ce. Both sides had added a section under the
`v0.7.1.3` heading and both had renumbered `.secrets.baseline`; the
resolution keeps `Documentation` ahead of `Packaging metadata`, the order
v0.7.1.2 uses, and the baseline was regenerated rather than merged, line
numbers being what it records. The content changes against `dev` are
byte-identical to the pre-rebase branch, `.secrets.baseline` aside.

Gates run on the rebased tree: `uv run pre-commit run --all-files`, the
coverage suite (318 passed, 100.00%), the docs build with `-W`, and `uv
build --sdist` with `twine check --strict` and `pyroma --min 10` (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
