### PR TITLE
Split the README badges by whether they can turn red

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 532
+        "line_number": 551
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T12:40:18Z"
+  "generated_at": "2026-08-07T18:34:15Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ release-notes length in the first place, and are still in
 
 ## v0.7.1.3 (work in progress, not released yet)
 
+### Documentation
+
+- **The README badges are the ones that can turn red**, in the order the
+  reader asks for them: version, downloads, development status, license
+  and supported interpreters on the first line; test, lint, pre-commit.ci
+  and the documentation build on the second. The five that reported no
+  state — `uv`, `pre-commit enabled`, ruff, mypy and markdownlint-cli2 —
+  name a choice rather than measure anything, so they are in
+  CONTRIBUTING.md's "Building and testing", beside the prose that says how
+  each choice is enforced; the Slack badge is down with the repository
+  link, "where do I ask" being a question the reader has after reading.
+  The alternative text says what each badge means — "PyPI version",
+  "supported Python versions", "test workflow status" — rather than naming
+  the site that serves the image: it is the accessible name of the link,
+  and a flat list of badges has nothing else to carry the meaning. btclib
+  and bitcoin-core-rpc carry the same two lines, which is what makes the
+  three READMEs comparable; the badge sets differ only where the projects
+  do, this one having no calendar version to declare.
+
 ## v0.7.1.2
 
 Grouped, and the order runs from what a caller sees to what only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ to open a pull request for it.
 
 ## Building and testing
 
+<!-- The toolchain badges are here rather than in the README because they
+report no state: each names a choice, and this is the section that says how
+the choice is enforced and what the command for it is. The README keeps the
+badges that can turn red. btclib and bitcoin-core-rpc do the same. -->
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![lint and format: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![type check: mypy](https://img.shields.io/badge/type--check-mypy-yellowgreen.svg?logo=mypy)](http://mypy-lang.org/)
+[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
+
 The btclib_libsecp256k1 project includes
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
 as submodule in the secp256k1 folder.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # btclib_libsecp256k1
 
-[![status](https://img.shields.io/pypi/status/btclib_libsecp256k1.svg)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
-[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/LICENSE)
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![pypi](https://img.shields.io/pypi/v/btclib_libsecp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
+<!-- The badges are what the reader decides with: the first line says what
+this is and whether it can be used, the second whether it works. A badge
+that reports no state -- "we use ruff", "we use uv" -- reports a choice
+instead, and those are in CONTRIBUTING.md, beside the prose that says how
+the choice is enforced. One badge per line keeps a change to one line and
+every line inside MD013, whose 80 columns bind only where a space follows
+them. btclib and bitcoin-core-rpc carry the same two lines. -->
+[![PyPI version](https://img.shields.io/pypi/v/btclib_libsecp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib_libsecp256k1)](https://pepy.tech/project/btclib_libsecp256k1)
-[![python](https://img.shields.io/pypi/pyversions/btclib_libsecp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
-[![lint and format: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
-[![type-check: mypy](https://img.shields.io/badge/type--check-mypy-yellowgreen.svg?logo=mypy)](http://mypy-lang.org/)
-[![docs](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![development status](https://img.shields.io/pypi/status/btclib_libsecp256k1.svg)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
+[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/LICENSE)
+[![supported Python versions](https://img.shields.io/pypi/pyversions/btclib_libsecp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
+
+[![test workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
+[![lint workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/master)
-[![lint](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
-[![test](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
-[![slack](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
+[![documentation build](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
 
 ---
 
 [Browse GitHub Code Repository](https://github.com/btclib-org/btclib-libsecp256k1/)
+[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---
 


### PR DESCRIPTION
Follows #78, which put the three READMEs of the org in one order. It left a flat list of fifteen badges in which five report no state — `uv`, "pre-commit enabled", ruff, mypy and markdownlint-cli2 each name a choice. Beside a workflow badge they carry the same weight and the same colour, so the eye cannot tell what CI just said from what the project decided.

**The nine that report state stay in the README**, on two lines: version, downloads, development status, license and supported interpreters first; test, lint, pre-commit.ci and the documentation build second. Version and downloads are adjacent, both being PyPI reading back the same project; `test` precedes `lint`, a red suite and a red linter not weighing the same.

**The five that report a choice move to CONTRIBUTING.md**, under "Building and testing" — the section that says how each choice is enforced and what the command for it is. The Slack badge goes beside the repository link: "where do I ask" is a question the reader has after reading.

The alternative text now says what each badge means — "PyPI version", "supported Python versions", "test workflow status" — instead of naming the site that serves the image, that text being the accessible name of the link.

btclib (btclib-org/btclib#488) and bitcoin-core-rpc take the same two lines, which is what makes the three READMEs comparable; the badge sets still differ where the projects do, this one having no calendar version to declare. `.secrets.baseline` moves one line number, the CHANGELOG entry having shifted the vector it points at.

Gates run on this tree: `uv run --locked --only-group lint pre-commit run --all-files`, the docs build with `-W` and its unresolved-link grep (README.md is a page of it, through `docs/source/readme_link.md`), and `uv run pytest` — 318 passed, the README’s own doctest among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reorganize project badges so the README highlights status-indicating badges while toolchain choices move to CONTRIBUTING, and improve badge accessibility and consistency across READMEs.

Enhancements:
- Move toolchain and linting badges into CONTRIBUTING under the building and testing section, keeping related guidance and tooling in one place.
- Relocate the Slack badge alongside the repository link to better surface contributor support information.

Documentation:
- Update README badges to only include status badges that can change state and clarify their alt text for accessibility.
- Document the badge reorganization and rationale in the changelog, aligning this README’s layout with other btclib projects.