### PR TITLE
Set the repository topics, and record where they have to agree

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 599
+        "line_number": 606
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T19:08:12Z"
+  "generated_at": "2026-08-07T19:22:54Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ release-notes length in the first place, and are still in
   rather than to what a reader would assume from the name.
   `elliptic-curves` is the one candidate left out: this is one curve, and
   `secp256k1` names it.
+- **the repository now carries those entries as its topics**, where it
+  carried none: the pull request above could write the list and not apply
+  it, the repository settings living outside the tree. REPOSITORY.md has
+  them, as it has every other setting nothing in the tree can recover, and
+  with the command that diffs the two lists and exits nonzero when they
+  have drifted apart — sorted on both sides, GitHub returning an order of
+  its own.
 - **this file relaxes MD024 (no-duplicate-heading) for itself**, a group
   heading repeating under every release that has an entry in that group:
   the rule reads that repeat as the accident it usually is, and

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -244,6 +244,31 @@ leaves them off — **do not read that 200 as success.** The
 `detect-secrets` hook is the compensating control, and CONTRIBUTING.md
 carries what maintaining its baseline costs.
 
+## Topics
+
+The topics are `pyproject.toml`'s `keywords`, entry for entry: one list
+spelled in two places, and the same spelling in both is what lets a drift
+between them be seen at all. Lowercase throughout, a GitHub topic being
+lowercase or not a topic. They were set on 7 August 2026, from the list #81
+wrote: that pull request could change the packaging metadata and not the
+repository, these settings living outside the tree, which is why it landed
+with the topics still empty.
+
+Nothing in the tree holds the two lists together, so this is the command
+that does: it prints the difference and exits nonzero on one.
+
+```shell
+diff <(gh api repos/{owner}/{repo} --jq '.topics[]' | sort) \
+     <(sed -n '/^keywords=\[/,/^]/s/^ *"\(.*\)",$/\1/p' pyproject.toml \
+       | sort)
+```
+
+Both sides are sorted because GitHub returns the topics in an order of
+its own rather than the one it was given: a reordering there is not
+drift, and only `pyproject.toml`'s order is the deliberate one. The
+comment above the `keywords` list says what decided it, and why `musig2`
+and `bip324` are in a list of what this package wraps.
+
 ## No website
 
 Unlike btclib, this repository serves no GitHub Pages site, so no file in


### PR DESCRIPTION
The repository had no topics. [#81](https://github.com/btclib-org/btclib-libsecp256k1/pull/81) wrote the list they were to be — its `keywords` comment says so in as many words — but could not apply it: the topics live outside the tree, and a pull request that changes `pyproject.toml` leaves them as it found them. They are set now, from that list, entry for entry.

`REPOSITORY.md` gets the section, that file being where every setting nothing in the tree can recover already is, and it carries the command that holds the two lists together:

```shell
diff <(gh api repos/{owner}/{repo} --jq '.topics[]' | sort) \
     <(sed -n '/^keywords=\[/,/^]/s/^ *"\(.*\)",$/\1/p' pyproject.toml \
       | sort)
```

Both sides are sorted because GitHub returns an order of its own rather than the one it was given, so a reordering there is not drift; only `pyproject.toml`'s order is the deliberate one, and its comment says what decided it.

The command was run before it was written down — exit 0, no output — and then handed a list with one topic removed, to watch it name the difference and exit 1.

`.secrets.baseline` moves one line number, the CHANGELOG entry above having shifted the vector it points at.

Gate on this tree: `uvx pre-commit run --all-files`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and align repository topics with pyproject keywords, and record how to detect drift between them.

Documentation:
- Add REPOSITORY.md documentation describing repository topics, their origin, and how to compare them with pyproject keywords.
- Update CHANGELOG to record that repository topics are now set from the pyproject keywords list.

Chores:
- Update .secrets.baseline to reflect shifted line numbers after documentation changes.