### PR TITLE
Carry btclib's three badge lines, and open CONTRIBUTING with the toolchain

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 606
+        "line_number": 617
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T19:22:54Z"
+  "generated_at": "2026-08-07T21:04:38Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,19 +27,30 @@ release-notes length in the first place, and are still in
 - **The README badges are the ones that can turn red**, in the order the
   reader asks for them: version, downloads, development status, license
   and supported interpreters on the first line; test, lint, pre-commit.ci
-  and the documentation build on the second. The five that reported no
-  state — `uv`, `pre-commit enabled`, ruff, mypy and markdownlint-cli2 —
-  name a choice rather than measure anything, so they are in
-  CONTRIBUTING.md's "Building and testing", beside the prose that says how
-  each choice is enforced; the Slack badge is down with the repository
-  link, "where do I ask" being a question the reader has after reading.
-  The alternative text says what each badge means — "PyPI version",
-  "supported Python versions", "test workflow status" — rather than naming
-  the site that serves the image: it is the accessible name of the link,
-  and a flat list of badges has nothing else to carry the meaning. btclib
-  and bitcoin-core-rpc carry the same two lines, which is what makes the
-  three READMEs comparable; the badge sets differ only where the projects
-  do, this one having no calendar version to declare.
+  and the documentation build on the second; the repository and the Slack
+  channel on the third, "where is the code" and "where do I ask" being the
+  two questions a reader has once the first two lines have answered
+  theirs. That third line is where the repository link was already, a
+  sentence between two horizontal rules of its own; as a badge beside the
+  others it needs neither rule, and the plain-text link that read "Browse
+  GitHub Code Repository" now names the repository it opens. The badges
+  that report no state — `uv`, ruff, mypy, markdownlint-cli2 and
+  `pre-commit enabled` — name a choice rather than measure anything, so
+  they open CONTRIBUTING.md, which is the file that says how each choice
+  is enforced and what the command for it is, rather than sitting inside
+  its "Building and testing" section. ruff is three of them, its
+  formatter, its linter and its docstring rules being three gates with
+  three documentation pages and three ways to fail, where one badge
+  announced them as one; `pre-commit` closes that run because it is what
+  runs the others, and the repository and Slack badges close the line, a
+  contributor wanting both. The alternative text says what each badge
+  means — "PyPI version", "supported Python versions", "test workflow
+  status" — rather than naming the site that serves the image: it is the
+  accessible name of the link, and a flat list of badges has nothing else
+  to carry the meaning. btclib and bitcoin-core-rpc carry the same three
+  lines and the same CONTRIBUTING.md run, which is what makes the three
+  comparable; the badge sets differ only where the projects do, this one
+  having no calendar version to declare.
 
 ### Packaging metadata
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # How to contribute
 
+<!-- The toolchain badges are here rather than in the README because they
+report no state: each names a choice, and this is the file that says how
+the choice is enforced and what the command for it is. The README keeps the
+badges that can turn red. btclib and bitcoin-core-rpc do the same, with a
+cal_ver badge this project has no use for: the version tracks the vendored
+libsecp256k1 release rather than the calendar. -->
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![format: ruff](https://img.shields.io/badge/format-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/formatter/)
+[![lint: ruff](https://img.shields.io/badge/lint-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/)
+[![docstrings: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d)
+[![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/)
+[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
+[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![GitHub repository: btclib-org/btclib-libsecp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-libsecp256k1/)
+[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
+
 Thank you for investing your time in this project. What follows is how to
 build, test and benchmark these bindings, and what this repository
 expects of a change. What the build itself does on each platform is in
@@ -45,16 +61,6 @@ Issues are not assigned to anyone: if one interests you, you are welcome
 to open a pull request for it.
 
 ## Building and testing
-
-<!-- The toolchain badges are here rather than in the README because they
-report no state: each names a choice, and this is the section that says how
-the choice is enforced and what the command for it is. The README keeps the
-badges that can turn red. btclib and bitcoin-core-rpc do the same. -->
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-[![lint and format: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![type check: mypy](https://img.shields.io/badge/type--check-mypy-yellowgreen.svg?logo=mypy)](http://mypy-lang.org/)
-[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
 
 The btclib_libsecp256k1 project includes
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # btclib_libsecp256k1
 
 <!-- The badges are what the reader decides with: the first line says what
-this is and whether it can be used, the second whether it works. A badge
-that reports no state -- "we use ruff", "we use uv" -- reports a choice
-instead, and those are in CONTRIBUTING.md, beside the prose that says how
-the choice is enforced. One badge per line keeps a change to one line and
-every line inside MD013, whose 80 columns bind only where a space follows
-them. btclib and bitcoin-core-rpc carry the same two lines. -->
+this is and whether it can be used, the second whether it works, the third
+where the code is and where to ask about it. A badge that reports no state
+-- "we use ruff", "we use uv" -- reports a choice instead, and those are in
+CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
+badge per line keeps a change to one line and every line inside MD013,
+whose 80 columns bind only where a space follows them. btclib and
+bitcoin-core-rpc carry the same three lines. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib_libsecp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib_libsecp256k1)](https://pepy.tech/project/btclib_libsecp256k1)
 [![development status](https://img.shields.io/pypi/status/btclib_libsecp256k1.svg)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
@@ -18,9 +19,7 @@ them. btclib and bitcoin-core-rpc carry the same two lines. -->
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/master)
 [![documentation build](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
 
----
-
-[Browse GitHub Code Repository](https://github.com/btclib-org/btclib-libsecp256k1/)
+[![GitHub repository: btclib-org/btclib-libsecp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-libsecp256k1/)
 [![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---


### PR DESCRIPTION
The repository link and the Slack badge already sat together below the two
badge lines, fenced off by a horizontal rule above and below them. That is
btclib's third line in everything but form: where the code is and where to
ask, the two questions a reader has once "what is this" and "does it work"
are answered. As badges beside the others they need neither rule, and the
plain-text "Browse GitHub Code Repository" becomes a badge naming the
repository it opens.

The toolchain badges move from "Building and testing" to the top of
CONTRIBUTING.md, which is what btclib now does. The prose that enforces
each choice has not moved; what the old placement cost was the answer to
"what is this built with", asked on opening the file rather than after the
section explaining which of three repositories an issue belongs in. The
comment says why there is no `cal_ver` badge here where the siblings have
one: the version tracks the vendored libsecp256k1 release, not the
calendar.

Three spellings change with the move, all three to btclib's:

- **ruff is three badges where it was one** — formatter, linter and
  docstring rules, three gates with three documentation pages and three
  ways to fail. The combined endpoint badge linked to none of them,
  pointing at the ruff repository instead
- **mypy's label reads "type check"**, which is the alternative text the
  link already carried; `type--check` rendered a literal dash. The link is
  https
- **`pre-commit` closes the run** rather than opening it: it is what runs
  the others

The CHANGELOG entry for the badges is edited rather than joined by a
second — v0.7.1.3 has not shipped, and one release describing one
arrangement twice would be a record of the branch rather than of the
release.

`.secrets.baseline` moves the CHANGELOG.md line number of its one entry
down by the lines the entry above it gained.

## Gates run on this tree

```shell
uv run pre-commit run --all-files                             # pass
git submodule update --init
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
uv run --locked --no-default-groups --group test pytest --cov # 318 passed, 100%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align project badges and contribution docs with btclib conventions by restructuring README/CONTRIBUTING badges and updating related metadata.

Documentation:
- Restructure README badges into three lines, adding GitHub and Slack badges as a third line and converting the GitHub link to a badge.
- Move toolchain badges to the top of CONTRIBUTING and expand them to separate ruff formatter, linter, and docstring badges, while clarifying their purpose in comments.
- Adjust CHANGELOG description of README and CONTRIBUTING badges to reflect the new three-line layout and toolchain badge placement.

Chores:
- Update .secrets.baseline to account for shifted line numbers in CHANGELOG.md.