### PR TITLE
Retire the copyright-notice hook for ruff's own CPY001

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,27 +149,11 @@ repos:
       - id: markdownlint-cli2
         name: markdownlint-cli2 (in place fixes)
         args: [--fix]
-  - repo: https://github.com/leoll2/copyright_notice_precommit
-    rev: 0.1.1
-    hooks:
-      - id: copyright-notice
-        # --enforce-all, because without it the hook intersects the files
-        # pre-commit hands it with `git diff --staged --diff-filter=A` and
-        # checks the notice on newly *added* staged files alone. On a clean
-        # checkout that set is empty, so the run in the lint workflow --
-        # `pre-commit run --all-files`, the one that gates a pull request --
-        # was checking no file at all, whatever the pattern below matched
-        args: [--notice=COPYRIGHT, --enforce-all]
-        # "python" as a filename pattern never matched anything either. The
-        # optional i is the same miss one extension over:
-        # stubs/_btclib_libsecp256k1.pyi is a source file of this project,
-        # named in mypy_path and force-included in the sdist, and its header
-        # was the pre-MIT one for as long as nothing read it
-        files: \.pyi?$
   # ruff replaces black, isort, flake8, autoflake, pyupgrade, bandit,
-  # pydocstringformatter and yesqa: one tool, one config section in
-  # pyproject.toml, and a fraction of the runtime. The rule selection
-  # (and what each family stands in for) is documented there
+  # copyright_notice_precommit, pydocstringformatter and yesqa: one tool,
+  # one config section in pyproject.toml, and a fraction of the runtime.
+  # The rule selection (and what each family stands in for) is documented
+  # there
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,6 +434,13 @@ select = [
     # the one finding PYI has, on stubs/_btclib_libsecp256k1.pyi, is
     # exempted below rather than fixed: see per-file-ignores
     "PYI",   # flake8-pyi
+    # flake8-copyright, replacing the copyright-notice pre-commit hook:
+    # a rule living inside ruff's own file-selection logic checks
+    # whatever files it is given the same way regardless of who is
+    # asking, unlike the retired hook, which checked only staged files
+    # unless given --enforce-all -- the gap btclib's own ed6e8014 found
+    # and closed by hand there
+    "CPY",   # flake8-copyright
 ]
 # here and in per-file-ignores below, a rule is named rather than coded.
 # `select` above has no choice, a family having no name form, but an entry
@@ -548,6 +555,26 @@ max-complexity = 10
 # and the mutation counter, whose one line of output is what the workflow
 # step exists to put in the log: same exemption, same reason
 ".github/scripts/mutation_counts.py" = ["print"]
+
+[tool.ruff.lint.flake8-copyright]
+# notice-rgx is COPYRIGHT's text as one regex, anchored with ^ so a
+# match has to open the file rather than merely occur somewhere in its
+# first 4096 bytes -- unanchored, an import or a docstring placed above
+# the notice would still pass, which is not the question the retired
+# hook's substring search over the whole file asked either. No source
+# file here opens with a shebang, so nothing legitimate sits between
+# byte zero and the notice for the anchor to exclude.
+# CPY001 checks against a file's own first 4096 bytes regardless of
+# which files pre-commit was told to look at -- unlike the retired
+# hook, which needed --enforce-all or it intersected only newly *added*
+# staged files, checking nothing at all under "pre-commit run
+# --all-files", the very invocation the lint workflow runs.
+# It also needs no files: pattern of its own the way that hook did:
+# stubs/_btclib_libsecp256k1.pyi kept a pre-MIT header for as long as
+# the hook's pattern matched only \.py$ and not \.pyi$, and ruff lints
+# .pyi files by default, so there is no second extension to remember
+# this time
+notice-rgx = "^# Copyright \\(c\\) The btclib developers\\n#\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Equivalent to [btclib-org/btclib#501](https://github.com/btclib-org/btclib/pull/501) (merged) and [btclib-org/bitcoin-core-rpc#44](https://github.com/btclib-org/bitcoin-core-rpc/pull/44) (merged).

## What

Replaces `leoll2/copyright_notice_precommit` with ruff's own `CPY001` (flake8-copyright). This project already runs with `preview = true` plus `explicit-preview-rules = true` for its lint config, so `CPY` slots in the same way every other family in `select` does — no new gate to turn on:

```toml
[tool.ruff.lint]
select = [..., "CPY"]

[tool.ruff.lint.flake8-copyright]
notice-rgx = "^..."  # COPYRIGHT's text, escaped line by line, anchored to the top of the file
```

`notice-rgx` is anchored with `^`: unanchored, CPY001 is a search over a file's first 4096 bytes rather than a check that the notice opens it, so an import or docstring placed above the notice would still pass — caught in review on the btclib PR, fixed there and here identically. No source file in this project opens with a shebang, so nothing legitimate sits between byte zero and the notice for the anchor to exclude.

## Why this project specifically

Its own `.pre-commit-config.yaml` and `CHANGELOG.md` already document one incident with the retired hook, and its `files:` pattern documents a second:

- **The hook silently checked nothing.** Without `--enforce-all` it intersected the files pre-commit handed it with newly *added* staged files, so `pre-commit run --all-files` — what the lint workflow actually runs — checked zero files. `CHANGELOG.md` records this as its own entry. A rule living inside ruff's own file-selection logic checks whatever files it's given the same way regardless of who's asking, so there's no separate flag to forget in the first place.
- **The `files:` pattern missed an extension.** It matched only `\.py$` until it was widened to `\.pyi?$`, and in between, `stubs/_btclib_libsecp256k1.pyi` kept a pre-MIT header for as long as nothing was reading it. Ruff lints `.pyi` files by default, so this doesn't need a hand-tuned pattern to remember a second time.

## What's honestly different

- No autofix: a file missing the notice still needs a human to add it, same as before.
- `CPY001` checks the pattern against a file's first 4096 bytes; for a notice this size that's no practical difference from the retired hook's substring search over the whole file.

## Verification

A pre-existing, unrelated build issue on my machine (the vendored `secp256k1` CMake build failing under `uv sync` here) meant I couldn't run this repo's full `pytest`/`mypy` locally. What I did verify:

- `uvx ruff check --select CPY001 --no-cache btclib_libsecp256k1 tests stubs` — clean across every source file, including the stub.
- The regex tested in isolation against a file with the complete notice, one with only the holder line, one with none, and — after the anchor fix — one with the complete notice pushed below an unrelated import: the first passes, the other three correctly fail.
- `uvx typos`, `uvx codespell`, `uvx yamllint` against both changed files — clean.
- `git commit` itself ran this repo's actual pre-commit hooks end to end (yamllint, codespell, typos, check-hooks-apply, check-useless-excludes, uv-lock, check-manifest, pyroma, detect-secrets, etc.) — all passed; mypy/ruff/markdownlint reported "no files to check" since this change touches no `.py` file, which also means the build issue above never came into play for this specific commit.