### PR TITLE
Say why pubkey_from_prvkey is two libsecp256k1 calls, not one

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ same libsecp256k1 version, a fourth number is appended:
 
 These bindings are a boundary, not a library: every function is one
 libsecp256k1 call, with its arguments validated first and its return
-code checked. The cryptography — the algorithms, the constant-time
+code checked. A function returning a key or a signature calls it twice:
+libsecp256k1 hands back an opaque object — a `secp256k1_pubkey`, a
+`secp256k1_ecdsa_signature` — that only a second call serializes into
+bytes, no libsecp256k1 call producing them directly.
+`keys.pubkey_from_prvkey` is `secp256k1_ec_pubkey_create` followed by
+`secp256k1_ec_pubkey_serialize`; every other function returning a key or
+a signature has the same shape, the second call being the serialization
+the first cannot do rather than a second decision. The cryptography —
+the algorithms, the constant-time
 implementation, the side-channel hardening — is upstream's, and none of
 it is reimplemented, extended or second-guessed here. Wrappers of the
 same C library cannot honestly differ in what it computes, nor in how


### PR DESCRIPTION
## Summary
- The Design section claims every function is one libsecp256k1 call. It wasn't said that a function returning a key or a signature is two: libsecp256k1 hands one back as an opaque object, and only a second call serializes it into bytes.
- Names `pubkey_from_prvkey`'s two calls (`secp256k1_ec_pubkey_create`, `secp256k1_ec_pubkey_serialize`) as the shape every other producer of a key or a signature shares.

## Test plan
- [x] `uvx pre-commit run --files README.md` (markdownlint, codespell, typos, detect-secrets, pyroma) — all passed

## Summary by Sourcery

Clarify README design documentation around libsecp256k1 call patterns for functions that return keys or signatures.

Documentation:
- Explain that functions returning keys or signatures use two libsecp256k1 calls: one to create an opaque object and one to serialize it into bytes.
- Document `keys.pubkey_from_prvkey` as the canonical example of this two-call pattern shared by other key and signature-producing functions.