### PR TITLE
Preserve diagnostics when dynamic library loading fails

### DIFF
--- a/btclib_libsecp256k1/__init__.py
+++ b/btclib_libsecp256k1/__init__.py
@@ -50,7 +50,9 @@ def _load_lib(module: Any) -> Any:
 
     Raises:
         ImportError: if the extension carries no linked-in library and
-            no shared object beside it can be loaded.
+            no shared object beside it can be loaded. Chains the last
+            loader error, if any candidate was rejected rather than
+            merely absent.
     """
     # a static extension has the library linked in
     if hasattr(module, "lib"):
@@ -59,15 +61,21 @@ def _load_lib(module: Any) -> Any:
     # a dynamic one (cffi ABI mode) has to find, at run time, the shared
     # object shipped beside it
     path = pathlib.Path(module.__file__).parent
+    rejected: list[tuple[str, OSError]] = []
     for suffix in (".dll", ".so", ".dylib"):
         for file in path.glob(f"libsecp256k1*{suffix}*"):
             try:
                 return ffi.dlopen(str(file))
-            except OSError:
+            except OSError as exc:
                 # a file the loader rejects does not end the search: a
                 # wheel repaired by auditwheel or delocate can ship more
-                # than one match, only one of which is the library
-                pass
+                # than one match, only one of which is the library --
+                # but its error is worth keeping, in case none is
+                rejected.append((file.name, exc))
+    if rejected:
+        tried = ", ".join(f"{name} ({exc})" for name, exc in rejected)
+        msg = f"no loadable shared libsecp256k1 found in {path}, tried: {tried}"
+        raise ImportError(msg) from rejected[-1][1]
     msg = f"no loadable shared libsecp256k1 found in {path}"
     raise ImportError(msg)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -91,11 +91,24 @@ def test_load_lib_unloadable_candidate(tmp_path: pathlib.Path) -> None:
     It is skipped and the search continues, so what the caller is told is
     that the directory holds no loadable libsecp256k1 -- rather than the
     dlopen failure of one candidate, which would report the first
-    accident as the whole answer.
+    accident as the whole answer. But that accident is not thrown away:
+    it is the one diagnostic that says *why*, and it has to survive to
+    the final ImportError, both named in its message and chained as
+    __cause__, for a dynamic wheel's import failure to be debuggable
+    rather than just "no loadable shared libsecp256k1 found".
     """
-    # a file matching the glob that the loader rejects is skipped, and
-    # the directory as a whole is reported as holding no library
+    # two files matching the glob, both rejected by the loader: a wheel
+    # repaired by auditwheel or delocate can ship more than one match, and
+    # the diagnostic of each rejected candidate has to reach the final
+    # failure, not just the last one tried
     (tmp_path / "libsecp256k1.so").write_bytes(b"not a shared object")
+    (tmp_path / "libsecp256k1.so.1").write_bytes(b"not a shared object either")
     module = types.SimpleNamespace(__file__=str(tmp_path / "_extension.py"))
-    with pytest.raises(ImportError, match="no loadable shared libsecp256k1"):
+    with pytest.raises(
+        ImportError, match="no loadable shared libsecp256k1"
+    ) as exc_info:
         _load_lib(module)
+    message = str(exc_info.value)
+    assert "libsecp256k1.so" in message
+    assert "libsecp256k1.so.1" in message
+    assert isinstance(exc_info.value.__cause__, OSError)


### PR DESCRIPTION
## Summary
- `_load_lib` now records each rejected candidate's name and `OSError` while searching the dynamic (cffi ABI) build's shared object.
- If every candidate fails to load, the final `ImportError` names all tried candidates and chains the last loader error as its cause, instead of only reporting "no loadable shared libsecp256k1 found".
- The concise message is unchanged for a directory holding no matching candidate at all, and the fallback search behavior across multiple candidates is unchanged.

## Test plan
- [x] `uv run --locked --no-default-groups --group test pytest --cov` — 318 passed, 100% coverage
- [x] `uvx pre-commit run --all-files` — all hooks pass
- [x] Extended `test_load_lib_unloadable_candidate` to reject two candidates and assert both names appear in the message and that `__cause__` is the last `OSError`

Closes #88

## Summary by Sourcery

Preserve and surface detailed diagnostics from dynamic library loading failures for the CFFI-based extension.

Bug Fixes:
- Ensure ImportError raised when dynamic shared objects fail to load includes all tried candidate filenames and chains the last loader OSError as its cause.

Enhancements:
- Improve _load_lib error messaging to distinguish between absent shared objects and rejected candidates while retaining the concise message for the no-candidate case.

Tests:
- Extend extension loading tests to cover multiple rejected shared object candidates and assert that their names and the final loader error are reflected in the ImportError and its __cause__.