### PR TITLE
Name the btclib module that already guards MuSig2 nonce reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,11 @@ arguments validated, so the place to enforce it is where the signing
 state already lives, in [btclib](https://github.com/btclib-org/btclib):
 its PSBT is the multi-party signing machinery MuSig2 plugs into, and the
 specifications say the same (BIP327 the protocol, BIP373 its PSBT
-fields, BIP328 its descriptors).
+fields, BIP328 its descriptors). That place already holds the session:
+`btclib.ecc.musig2.sign` zeroes the secret nonce it consumes, so a
+second call with it fails before a second signature exists, and
+`btclib.psbt.musig2.partial_sign` carries the same guarantee into a PSBT
+round.
 
 What MuSig2 needs from here is what has no state, and it is all present:
 `keys.pubkey_sort` for the key ordering and `keys.pubkey_combine` for


### PR DESCRIPTION
## Summary

- The MuSig2 section of the README said the signing state "already lives" in btclib without naming what lives there, which read as an open gap (#86) rather than a settled fact.
- Names `btclib.ecc.musig2.sign` and `btclib.psbt.musig2.partial_sign`: both zero the secret nonce on use, refusing reuse deterministically before a second signature exists.

## Test plan

- [x] `uvx pre-commit run --all-files`

## Summary by Sourcery

Documentation:
- Expand the MuSig2 README section to name the btclib signing and PSBT functions that enforce secret nonce zeroing and prevent reuse.