### PR TITLE
Stop spending the matrix on a draft pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,11 @@ on:
     # ever test it. Tag pushes are covered by the release workflow
     branches: [master]
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
   # allows the release workflow to reuse this gate
   workflow_call:
     inputs:
@@ -68,6 +73,12 @@ concurrency:
 jobs:
   lint:
     name: Lint and type-check
+    # a draft pull request is work in progress: every push to one runs
+    # these checks on a tree its author is not asking anyone to review
+    # yet. A run on the merge result still happens the moment the pull
+    # request is marked ready, which is why ready_for_review is a
+    # trigger type above
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -113,6 +124,7 @@ jobs:
   # It also installs a different dependency group and runs in parallel
   docs:
     name: Build the documentation
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,9 +326,9 @@ jobs:
   # carry for it is not what a POSIX build reads
   test-sdist:
     name: >-
-    if: ${{ !github.event.pull_request.draft }}
       Test sdist install on ${{ matrix.os }}${{
       matrix.architecture && format(' ({0})', matrix.architecture) }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ on:
     # ever test it. Tag pushes are covered by the release workflow
     branches: [master]
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
     inputs:
@@ -55,6 +60,12 @@ jobs:
   # pyproject.toml is what makes the number mean something
   coverage:
     name: Coverage
+    # a draft pull request is work in progress: every push to one spends
+    # the whole matrix on a tree its author is not asking anyone to
+    # review yet. The gate below carries the same condition, so a draft
+    # skips uniformly and the gate does not read that skip as a job that
+    # should have run
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # every job below caps its own runtime, this one included: the default
     # is six hours, and with tens of jobs compiling C a single hang is
@@ -92,6 +103,7 @@ jobs:
 
   build-cibuildwheel:
     name: Build wheels on ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # the interpreter uv runs the build tools with is the one setup-python
@@ -181,6 +193,7 @@ jobs:
 
   build-dynamic:
     name: Build dynamic wheel on ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     # see build-cibuildwheel; here the platform tag of the wheel is the
@@ -256,6 +269,7 @@ jobs:
 
   build-sdist:
     name: Build sdist
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # see build-cibuildwheel
@@ -312,6 +326,7 @@ jobs:
   # carry for it is not what a POSIX build reads
   test-sdist:
     name: >-
+    if: ${{ !github.event.pull_request.draft }}
       Test sdist install on ${{ matrix.os }}${{
       matrix.architecture && format(' ({0})', matrix.architecture) }}
     runs-on: ${{ matrix.os }}
@@ -376,6 +391,7 @@ jobs:
 
   build-windows:
     name: "Build on Linux for Windows"
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # see build-cibuildwheel
@@ -424,6 +440,7 @@ jobs:
   # only be yanked and burnt
   check-dist:
     name: Validate distributions
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-cibuildwheel, build-dynamic, build-sdist, build-windows]
@@ -502,6 +519,7 @@ jobs:
 
   test-dynamic:
     name: "Test ${{ matrix.python-version }} on ${{ matrix.os }}"
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -573,6 +591,7 @@ jobs:
 
   test-static:
     name: "Test ${{ matrix.python-version }} on ${{ matrix.os }}"
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -654,7 +673,9 @@ jobs:
   # too, a superseded run being no evidence either way
   tests-passed:
     name: tests-passed
-    if: always()
+    # and the draft condition every job above carries, so a draft
+    # skips uniformly rather than tripping the skip check below
+    if: ${{ always() && !github.event.pull_request.draft }}
     needs:
       - coverage
       - build-cibuildwheel


### PR DESCRIPTION
`test.yml` and `lint.yml` ran in full on every push to a draft pull
request -- the whole matrix, on a tree its author is not asking anyone
to review yet. Both now skip while the pull request is a draft.

`ready_for_review` joins the trigger types, because the default set
does not include it: without it, a pull request marked ready would
carry the skipped checks until its next push rather than being checked
at the moment it starts asking for review.

The gate job carries the same condition rather than being left with a
bare `always()`. It fails on a `skipped` dependency deliberately --
"nothing in this workflow is conditional, so a skip means something
upstream did not run" -- so leaving it running while the jobs above it
skip would turn every draft red, which is the opposite of the point.
With the condition on all of them a draft skips uniformly, and branch
protection reads a skipped check as satisfied. On every non-draft run
the gate behaves exactly as it does today.

**The push triggers are untouched.** `branches: [master]` is there for
the reason the comment above it gives -- a push to a branch with an
open pull request would run twice, in two concurrency groups that do
not cancel each other, and the `pull_request` run is the one worth
keeping. Adding `dev` there would reintroduce exactly that, permanently,
because the release pull request from `dev` is always open.

Two things considered and deliberately left out:

- a `concurrency` group on `release.yml`: with `github.ref` it would
  not serialize two different tags anyway, since their refs differ, and
  a constant group on a publishing pipeline is a call for its owner to
  make;
- `actions/attest-build-provenance` on the built artifacts, which the
  OIDC already in place would make cheap, but which belongs in its own
  change to the publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Skip full test and lint workflows on draft pull requests while still running them when a draft is marked ready for review.

CI:
- Update test and lint workflows to trigger on ready_for_review pull request events so checks run immediately when drafts are marked ready.
- Add conditional execution to test, build, lint, and docs jobs so they do not run for draft pull requests, including the tests gate job.