### PR TITLE
Track the editor's workspace, and format yaml, toml and jsonc

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -95,14 +95,12 @@ jobs:
         # free-threaded interpreter, which must select the cp314t static
         # wheel and not fall through to the py3-none dynamic one
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
         python-version: ["3.10", "3.14", "3.14t"]
         exclude:
           # CPython has no Windows arm64 build before 3.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,14 +142,12 @@ jobs:
         # Actions drops x86_64 macOS in August 2027, after which no runner
         # can build a macosx x86_64 wheel at all
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -546,29 +544,25 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
         # 3.14t, the free-threaded interpreter, matters here in particular:
         # the dynamic wheel is tagged py3-none, so it is what a
         # free-threaded interpreter installs, and unlike the static wheels
         # nothing else exercises it (cibuildwheel tests every wheel it
         # builds, including cp314t; this job has no such counterpart)
         python-version:
-          [
-            "3.10",
-            "3.11",
-            "3.12",
-            "3.13",
-            "3.14",
-            "3.14t",
-            "pypy-3.10",
-            "pypy-3.11",
-          ]
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy-3.10"
+          - "pypy-3.11"
     needs: [build-windows, build-dynamic]
 
     steps:
@@ -620,14 +614,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
         python-version:
           ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
         # cibuildwheel already runs the suite against every wheel it

--- a/.gitignore
+++ b/.gitignore
@@ -110,8 +110,13 @@ ENV/
 # mypy
 .mypy_cache/
 
-# vscode
-.vscode/
+# vscode: the workspace files are tracked, and the rest of what the editor
+# writes there is not. The directory itself cannot be the pattern -- git does
+# not descend into an excluded directory, so a negation under `.vscode/` never
+# matches -- which is why this excludes the contents and re-admits two names
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 
 # PyCharm
 .idea/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,5 +1,4 @@
 {
-
   // rules https://github.com/DavidAnson/markdownlint
 
   // See https://github.com/DavidAnson/markdownlint-cli2 and
@@ -35,7 +34,7 @@
   // MD007/ul-indent - Unordered list indentation
   "MD007": {
     // Spaces for indent
-    "indent": 4
+    "indent": 4,
   },
 
   // MD029/ol-prefix - every item numbered "1.", the renderer numbering
@@ -57,6 +56,5 @@
   // MD049/MD050 - asterisks for both, so that *emphasis* and **strong**
   // are told apart by how many rather than by which character
   "MD049": { "style": "asterisk" },
-  "MD050": { "style": "asterisk" }
-
+  "MD050": { "style": "asterisk" },
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,13 @@ repos:
       # the vector files are json: a malformed one is worth a red hook
       # rather than a test error that reads like a failing assertion
       - id: check-json
+        # `.vscode` is jsonc and not json: VSCode reads a comment in its own
+        # settings.json and extensions.json, and what those two files carry
+        # besides the settings is the reason for each of them. A json parser
+        # rejects the file at the first one. It is not a gap: prettier below
+        # is given that directory and fails on what it cannot parse, which
+        # is the question this hook asks
+        exclude: ^\.vscode/
       # off, and the reason is the two files it would reach: the only json
       # tracked here is tests/ecdsa_sig.json and
       # tests/ecdsa_custom_nonce_sig.json, whose bytes are recorded in
@@ -149,6 +156,46 @@ repos:
       - id: markdownlint-cli2
         name: markdownlint-cli2 (in place fixes)
         args: [--fix]
+  # what ruff-format is for Python, on the structured files ruff does not
+  # read: yaml, and the jsonc that carries a comment. Before yamllint above
+  # in effect and not in order -- pre-commit runs this file top to bottom, so
+  # the linter here reads what the previous run formatted, which is the same
+  # file either way once both hooks are green.
+  #
+  # Not the archived pre-commit/mirrors-prettier, which stopped at prettier
+  # 2. The default configuration and no .prettierrc: what this tree already
+  # writes is what prettier writes, the exception being an inline sequence
+  # long enough to be exploded, and a block sequence -- which prettier
+  # leaves alone -- is the spelling that keeps one entry per line whatever
+  # the width.
+  #
+  # `files` is an allow list and not an exclude, because prettier reads more
+  # than it should be given here: markdown is markdownlint's, whose config
+  # settles the styles prettier would also have an opinion about, and
+  # .secrets.baseline is detect-secrets' own output. The vendored secp256k1
+  # is a submodule and therefore not a file this repository tracks, so no
+  # pattern has to say so. What is in scope is the yaml, `.vscode` and
+  # .markdownlint.jsonc, and prettier is also what parses the last two --
+  # check-json cannot read a comment
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
+    hooks:
+      - id: prettier
+        name: prettier (yaml and jsonc, in place fixes)
+        files: ^(.*\.ya?ml|\.vscode/.*\.json|\.markdownlint\.jsonc)$
+  # the same for toml, which here is pyproject.toml and the mutation
+  # session under .github: .taplo.toml holds the formatting choices and the
+  # reasoning for them, as .yamllint.yaml does for the width of a yaml line.
+  # uv.lock is toml to identify and therefore matched by the hook's own
+  # types, and it is uv's file to write. taplo-lint is not enabled beside
+  # this: it validates against a schema catalogue it fetches, and pyroma
+  # below reads the metadata offline
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        name: taplo (toml, in place fixes)
+        exclude: ^uv\.lock$
   # ruff replaces black, isort, flake8, autoflake, pyupgrade, bandit,
   # copyright_notice_precommit, pydocstringformatter and yesqa: one tool,
   # one config section in pyproject.toml, and a fraction of the runtime.

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,19 @@
+# taplo's configuration, in a file of its own for the same reason
+# .yamllint.yaml is one: the reasoning below needs more room than a hook
+# argument has. taplo finds this file by name in the directory it runs from,
+# which for a pre-commit hook is the repository root, so the hook needs no
+# flag.
+#
+# What is *not* set matters as much: reorder_keys stays at its default of
+# false, the order of a table here being an argument rather than an accident
+# -- [project] reads top to bottom, and the ruff rule sets are grouped by
+# what they cover rather than sorted.
+[formatting]
+# four spaces, which is what pyproject.toml already uses and what
+# ruff-format writes in the Python beside it; taplo's own default is two
+indent_string = "    "
+# an array that is exploded stays exploded: one entry per line is what makes
+# adding a rule set, or a module to the mutation session, a one-line diff,
+# and the default would collapse a short array onto one line and expand it
+# again when it outgrows the width -- churn driven by a column count
+array_auto_collapse = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,56 @@
+{
+  // one entry per tool the lint gate already runs, so the editor reports
+  // what .pre-commit-config.yaml would report at commit time. Nothing here
+  // is a tool the gate does not have: an extension with no hook behind it
+  // is a second opinion, and a finding no workflow enforces is noise
+  "recommendations": [
+    // ruff-check and ruff-format
+    "charliermarsh.ruff",
+    // the mypy hook; the extension reads the project environment rather than
+    // the hook's isolated one, for the reason settings.json gives
+    "ms-python.mypy-type-checker",
+    // the interpreter, the test explorer and the debugger under them
+    "ms-python.python",
+    "ms-python.debugpy",
+    // the markdownlint-cli2 hook, reading this repository's own
+    // .markdownlint.jsonc with no further configuration
+    "DavidAnson.vscode-markdownlint",
+    // the typos hook, the same tool as a language server, reading
+    // [tool.typos] in pyproject.toml. There is no equivalent for codespell,
+    // the other spell checker: what exists on the marketplace carries its
+    // own dictionary rather than codespell's builtin, and a different
+    // dictionary is a different set of findings
+    "tekumara.typos-vscode",
+    // check-yaml, and the schemas check-dependabot and check-readthedocs
+    // validate against: this attaches them by filename, so a key
+    // dependabot.yml or .readthedocs.yaml does not accept is flagged where
+    // it is typed
+    "redhat.vscode-yaml",
+    // the workflows: expression and syntax checking in the editor. Not
+    // actionlint, which the gate also runs and no maintained extension
+    // wraps -- shellcheck inside a `run:` block stays a hook finding
+    "github.vscode-github-actions",
+    // the prettier hook, so what formats yaml and jsonc on save is the tool
+    // that formats it at commit time and not the copy the yaml extension
+    // embeds
+    "esbenp.prettier-vscode",
+    // check-toml, the pyproject.toml schema over it, and the taplo hook:
+    // this extension *is* taplo, and it reads .taplo.toml
+    "tamasfe.even-better-toml",
+    // docs/source is reStructuredText and the lint workflow builds it with
+    // sphinx -W. Highlighting only, deliberately: the heavier
+    // reStructuredText extensions want esbonio, doc8 or rstcheck installed
+    // to say anything, none of which is in the gate
+    "trond-snekvik.simple-rst"
+  ],
+  // the reflex installs that would each fight a hook: ruff formats, ruff
+  // sorts the imports with "I", and ruff's "PL" set is the pylint rules the
+  // gate selected. A second formatter on save reformats what ruff-format
+  // just wrote, and the commit hook writes it back
+  "unwantedRecommendations": [
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.flake8",
+    "ms-python.pylint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,108 @@
+{
+  // this file mirrors .pre-commit-config.yaml, which is the lint gate: what
+  // the editor fixes on save is what the hook would have fixed, so nothing
+  // reaches `git commit` for the first time there. extensions.json beside it
+  // names the tool each setting drives. What no extension wraps -- codespell,
+  // yamllint, actionlint, zizmor, detect-secrets, pydoclint, pyroma -- is
+  // only ever seen by
+  //
+  //   uvx pre-commit run --all-files
+  //
+  // A machine-local preference does not belong here, this file being tracked
+  // and read by every checkout: what belongs is a choice this project has
+  // made and an editor cannot read from pyproject.toml
+
+  // no pyright among the hooks, and mypy is the type gate. Pylance's own
+  // default rather than "strict", which on a binding to a C library reports
+  // what mypy strict does not: every value crossing ctypes is Unknown to it,
+  // and Unknown-hunting is not a rule this project adopted. The default
+  // reports nothing on this tree today, measured with
+  //
+  //   uvx pyright --pythonpath .venv/bin/python btclib_libsecp256k1 tests
+  "python.analysis.typeCheckingMode": "standard",
+
+  // the gate's mypy is the mirrors hook, pinned and isolated, and its
+  // additional_dependencies are what an isolated environment needs. The
+  // editor cannot use that environment: `import btclib_libsecp256k1` there
+  // is a compiled extension, and only the .venv uv sync builds it into has
+  // one. So the extension reads the project environment -- the same mypy
+  // version the lock pins, on a tree where the import resolves
+  "mypy-type-checker.importStrategy": "fromEnvironment",
+  // reportingScope stays at its default: the extension checks the file in
+  // the editor, the hook checks everything outside docs/
+
+  // the two ruff hooks, `ruff-check --fix` and `ruff-format`, on save.
+  // "always" rather than "explicit" because an auto-save on focus change is
+  // not an explicit save -- with "explicit" the formatter would run there
+  // and the fixes would not. `source.organizeImports.ruff` is absent on
+  // purpose: "I" is in the selected rule set, so the import order is
+  // already one of the fixes
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "always"
+    },
+    // the one place here that copies a number instead of naming a tool, so
+    // it is the one to revisit when either moves: 88 is what ruff-format
+    // reflows code to, and 80 is [tool.ruff.lint.pycodestyle]
+    // max-doc-length, which W505 holds a comment and a docstring to
+    "editor.rulers": [80, 88]
+  },
+
+  // `markdownlint-cli2 --fix`, which arrives as a code action and not as a
+  // formatter: the extension registers no document formatter, and the fix
+  // corrects rule violations rather than reflowing a paragraph. The ruler is
+  // MD013, tables included, and it is where the wrapping stays a judgement
+  // -- markdownlint reports a long line and rewraps no prose
+  "[markdown]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "always"
+    },
+    "editor.rulers": [80]
+  },
+
+  // the prettier and taplo hooks, on save and by the same two tools:
+  // prettier for yaml and for the jsonc that carries a comment, taplo for
+  // toml, reading the .taplo.toml the hook reads. `yaml.format.enable` stays
+  // off -- the yaml extension embeds a prettier of its own version, and two
+  // of them formatting one file is how a diff the hook did not ask for gets
+  // in
+  "yaml.format.enable": false,
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  // json and jsonc are two languages to the editor, and only the second is
+  // in the prettier hook's allow list: nothing here formats a .json, so
+  // neither does the editor
+  "[json]": {
+    "editor.formatOnSave": false
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml",
+    "editor.formatOnSave": true
+  },
+  // the vendored secp256k1 is upstream's, byte for byte, and a submodule
+  // rather than a copy so that it can be seen to be: an editor reformatting
+  // a file in there would make this repository the author of a line bitcoin
+  // core wrote
+  "[c]": {
+    "editor.formatOnSave": false
+  },
+
+  // trailing-whitespace, end-of-file-fixer and `mixed-line-ending --fix=lf`.
+  // The first hook passes no --markdown-linebreak-ext, so a hard break
+  // spelled as two trailing spaces does not survive it either, and trimming
+  // one here is no loss
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.eol": "\n",
+  // fix-byte-order-marker: "utf8bom" writes the mark that hook removes
+  "files.encoding": "utf8"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,19 @@ installs it as a managed one, and `uv sync` then prefers it to a system
 3.14, so `uv python install 3.14` is what makes the default environment
 reproducible again.
 
+### The editor
+
+`.vscode/settings.json` and `.vscode/extensions.json` are tracked, and they
+hold no preference: the recommended extensions are the tools
+`.pre-commit-config.yaml` already runs, and the settings put the fixing ones
+on save. Installing them is optional and changes nothing about what a commit
+enforces — what they buy is learning of a finding while typing rather than
+at the commit that trips over it.
+
+Anything machine-local — an interpreter path, a telemetry answer, a theme —
+belongs in the editor's own user settings instead, those two files being
+read by every checkout of this repository.
+
 ### Running what CI runs
 
 Each job of the `lint` and `test` workflows, and the local command that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name="btclib_libsecp256k1"
-version="0.7.1.4"
-description="Simple python bindings to libsecp256k1"
+name = "btclib_libsecp256k1"
+version = "0.7.1.4"
+description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the
 # deprecated license table and the License :: classifier
@@ -36,50 +36,50 @@ authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 # cipher and a framing layer this package has no part of.
 #
 # elliptic-curves stays out: this is one curve, and secp256k1 names it.
-keywords=[
-        "libsecp256k1",
-        "secp256k1",
-        "bitcoin",
-        "cryptography",
-        "python-bindings",
-        "cffi",
-        "ecdsa",
-        "schnorr",
-        "bip340",
-        "musig2",
-        "ecdh",
-        "ellswift",
-        "bip324",
-        "public-key-recovery",
-        "rfc-6979",
+keywords = [
+    "libsecp256k1",
+    "secp256k1",
+    "bitcoin",
+    "cryptography",
+    "python-bindings",
+    "cffi",
+    "ecdsa",
+    "schnorr",
+    "bip340",
+    "musig2",
+    "ecdh",
+    "ellswift",
+    "bip324",
+    "public-key-recovery",
+    "rfc-6979",
 ]
-classifiers=[
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Natural Language :: English",
-        # the three systems the wheels are built for, and not
-        # "OS Independent": this package is platform-specific compiled
-        # wheels, eleven kinds of them, and the classifier PyPI filters on
-        # should say so rather than the opposite
-        "Operating System :: POSIX",
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "Topic :: Security :: Cryptography",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        # btclib_libsecp256k1/py.typed is in the wheel, and the typed cffi
-        # boundary is the design point README.md leads with
-        "Typing :: Typed",
-    ]
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Natural Language :: English",
+    # the three systems the wheels are built for, and not
+    # "OS Independent": this package is platform-specific compiled
+    # wheels, eleven kinds of them, and the classifier PyPI filters on
+    # should say so rather than the opposite
+    "Operating System :: POSIX",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    # btclib_libsecp256k1/py.typed is in the wheel, and the typed cffi
+    # boundary is the design point README.md leads with
+    "Typing :: Typed",
+]
 # the wrappers call ffi.unpack on every path, which cffi grew in 1.6;
 # below 3.13 any cffi new enough to compile for the interpreter already
 # satisfies that, so 1.6 is the honest floor there. The two newest
@@ -389,39 +389,39 @@ preview = true
 preview = true
 explicit-preview-rules = true
 select = [
-    "F",     # pyflakes
-    "E",     # pycodestyle errors
-    "W",     # pycodestyle warnings
-    "I",     # isort
-    "UP",    # pyupgrade
-    "B",     # flake8-bugbear
-    "C4",    # flake8-comprehensions
-    "C90",   # mccabe complexity
-    "S",     # flake8-bandit
-    "SIM",   # flake8-simplify
-    "PTH",   # flake8-use-pathlib
-    "RET",   # flake8-return
-    "D",     # pydocstyle
-    "PL",    # pylint
-    "RUF",   # ruff-specific
+    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "C90", # mccabe complexity
+    "S",   # flake8-bandit
+    "SIM", # flake8-simplify
+    "PTH", # flake8-use-pathlib
+    "RET", # flake8-return
+    "D",   # pydocstyle
+    "PL",  # pylint
+    "RUF", # ruff-specific
     # ISC earns its place here: a test vector too long for one line is
     # written as adjacent string literals, which is what a list of vectors
     # missing a comma also looks like
-    "ISC",   # flake8-implicit-str-concat
-    "PT",    # flake8-pytest-style
-    "PGH",   # pygrep-hooks: a blanket noqa or type: ignore
-    "TRY",   # tryceratops
-    "FURB",  # refurb
-    "PIE",   # flake8-pie
+    "ISC",  # flake8-implicit-str-concat
+    "PT",   # flake8-pytest-style
+    "PGH",  # pygrep-hooks: a blanket noqa or type: ignore
+    "TRY",  # tryceratops
+    "FURB", # refurb
+    "PIE",  # flake8-pie
     # also selected in btclib's own pyproject.toml; added here to match,
     # each measured zero-finding on this tree with `uv run ruff check
     # --select <code> --no-cache btclib_libsecp256k1 tests`
-    "A",     # flake8-builtins: a name that shadows a builtin
-    "BLE",   # flake8-blind-except
-    "ERA",   # eradicate: code that was commented out instead of deleted
-    "RSE",   # flake8-raise
-    "T20",   # flake8-print: a library writes to no stream of its own
-    "TID",   # flake8-tidy-imports: absolute, so the layering is readable
+    "A",   # flake8-builtins: a name that shadows a builtin
+    "BLE", # flake8-blind-except
+    "ERA", # eradicate: code that was commented out instead of deleted
+    "RSE", # flake8-raise
+    "T20", # flake8-print: a library writes to no stream of its own
+    "TID", # flake8-tidy-imports: absolute, so the layering is readable
     # a fresh survey, of rule sets neither project had named before:
     # FA, FIX, FLY and T10 are clean here too. TD is the other
     # zero-finding set it turned up and is not selected, matching
@@ -431,20 +431,20 @@ select = [
     # the opposite reason from btclib: it checks tuple and NamedTuple
     # subclasses specifically, and this package has none, so selecting
     # it would enforce nothing rather than ratchet something clean
-    "FA",    # flake8-future-annotations
-    "FIX",   # flake8-fixme: a TODO left behind is a thing not finished
-    "FLY",   # flynt: string concatenation ruff can turn into an f-string
-    "T10",   # flake8-debugger: a breakpoint() left in
+    "FA",  # flake8-future-annotations
+    "FIX", # flake8-fixme: a TODO left behind is a thing not finished
+    "FLY", # flynt: string concatenation ruff can turn into an f-string
+    "T10", # flake8-debugger: a breakpoint() left in
     # the one finding PYI has, on stubs/_btclib_libsecp256k1.pyi, is
     # exempted below rather than fixed: see per-file-ignores
-    "PYI",   # flake8-pyi
+    "PYI", # flake8-pyi
     # flake8-copyright, replacing the copyright-notice pre-commit hook:
     # a rule living inside ruff's own file-selection logic checks
     # whatever files it is given the same way regardless of who is
     # asking, unlike the retired hook, which checked only staged files
     # unless given --enforce-all -- the gap btclib's own ed6e8014 found
     # and closed by hand there
-    "CPY",   # flake8-copyright
+    "CPY", # flake8-copyright
 ]
 # here and in per-file-ignores below, a rule is named rather than coded.
 # `select` above has no choice, a family having no name form, but an entry


### PR DESCRIPTION
The same change [bitcoin-core-rpc#67](https://github.com/btclib-org/bitcoin-core-rpc/pull/67)
and [btclib#595](https://github.com/btclib-org/btclib/pull/595) make, adapted:
this repository has no `check-manifest`, no `pretty-format-json`, an isolated
mypy hook rather than a local one, and a C submodule.

## The editor is told what the gate enforces

`.vscode/settings.json` and `.vscode/extensions.json` are tracked — `.gitignore`
excludes the *contents* of that directory, git not descending into an excluded
one. One recommendation per tool the gate runs; black, isort, flake8 and pylint
are unwanted rather than absent. Pylance runs at its own default, which reports
nothing here (`uvx pyright --pythonpath .venv/bin/python btclib_libsecp256k1 tests`).

Two settings are this repository's rather than the family's:

- **the mypy extension reads the project environment, not the hook's.** The gate
  runs `mirrors-mypy`, isolated, with its dependencies declared — and `import
  btclib_libsecp256k1` in an isolated environment has no compiled extension to
  find, while the `.venv` `uv sync` builds does.
- **`[c]` does not format on save.** The vendored secp256k1 is upstream's byte
  for byte, a submodule rather than a copy so it can be seen to be; a reformat
  there would make this repository the author of a line bitcoin core wrote.

## yaml, toml and jsonc get a formatter

- **prettier** for yaml and jsonc, and not yamlfix: yamlfix rewrites the space
  before a trailing comment, moving every `uses: <sha> # <tag>` pin away from
  what dependabot writes — the reason `.yamllint.yaml` leaves the `comments`
  rule off — and drops the blank line between comment blocks.
- The five workflow matrices become **block sequences**, a shape prettier leaves
  alone, so one entry per line is structural.
- **taplo** for toml, configured in `.taplo.toml`. It has the most to say here of
  the three repositories: `pyproject.toml` wrote `name="btclib_libsecp256k1"`
  without spaces around `=` in some tables and with them in others, and indented
  arrays with eight spaces. A formatter settles that instead of a reviewer.
  Arrays stay exploded, keys are not reordered, `uv.lock` is excluded by name.

## Gates

```shell
uvx pre-commit run --all-files                                  # 0, and 0 on a second pass
uv run --locked --no-default-groups --group test pytest --cov    # 0, 318 passed, 100.00%
git submodule update --init && uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # 0
uv build --sdist && uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz  # 0
```

Note for anyone reproducing this in a worktree: `git worktree add` does not
populate the submodule, so `uv sync` fails at the cmake step until
`git submodule update --init --recursive` has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Track editor workspace configuration in version control and add automated formatting for YAML, TOML, and JSONC alongside existing tooling.

New Features:
- Track VSCode workspace configuration via .vscode/settings.json and .vscode/extensions.json to align the editor with the project’s linting and formatting gates.
- Introduce pre-commit formatting for YAML and JSONC using prettier and for TOML using taplo, with project-specific scope and rules.
- Add dedicated taplo formatting configuration to standardize pyproject.toml and other TOML files across the repository.

Enhancements:
- Normalize pyproject.toml formatting for keys, arrays, and ruff configuration to match the new TOML formatting conventions and reduce review noise.
- Reshape GitHub Actions workflow matrices into block sequences to keep one entry per line and cooperate with YAML formatting tooling.

CI:
- Adjust workflow YAML structure to be compatible with automated YAML formatting while preserving existing CI behavior.

Documentation:
- Extend CONTRIBUTING.md with guidance on the tracked editor configuration and how it relates to the enforced checks and CI workflows.

Chores:
- Update pre-commit configuration to exclude VSCode JSONC files from check-json and route them through prettier instead, keeping hook behavior consistent with the editor setup.