### PR TITLE
Stop targeting dev in dependabot.yml, and update all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@
 # proposing a release regardless: a version yanked within days of
 # publication would otherwise be a pull request that opens, runs that
 # matrix, and is then closed
+#
+# none of the three declares a target-branch: without one Dependabot
+# opens against the default branch, main, which is also the only branch
+# this repository has -- matching bitcoin-core-rpc's own dependabot.yml,
+# which gives the same reason
 version: 2
 updates:
   # what this buys is the exact pins: every action is pinned to a commit
@@ -25,7 +30,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
     groups:
       # one PR for all action bumps instead of one PR each
       github-actions:
@@ -45,7 +49,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
     groups:
       dev-tooling:
         patterns: ["*"]
@@ -60,6 +63,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
     cooldown:
       default-days: 7

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 712
+        "line_number": 726
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-08T23:54:31Z"
+  "generated_at": "2026-08-10T22:10:48Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ release-notes length in the first place, and are still in
   after would have done the same. Where the file starts is the fact it
   was reaching for, and that one does not move.
 
+### CI
+
+- **Dependabot's three ecosystems no longer name `target-branch: "dev"`.**
+  That branch does not exist: `main` is this repository's only branch,
+  and also its default, so leaving `target-branch` unset already opens
+  every update against it — the same choice bitcoin-core-rpc's own
+  `dependabot.yml` already makes, for the same reason.
+
+### Dependencies
+
+- **`pre-commit` moves to 4.6.2, from 4.6.1**: `uv lock --upgrade`, the
+  only locked package with a newer compatible release right now. No
+  `pyproject.toml` change.
+
 ## v0.7.1.3
 
 ### Documentation

--- a/uv.lock
+++ b/uv.lock
@@ -2172,7 +2172,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2181,9 +2181,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml`'s three ecosystems (`github-actions`, `uv`,
  `gitsubmodule`) declared `target-branch: "dev"`. That branch does not
  exist any more — `main` is this repository's only branch, and also its
  default — so the setting was naming a base Dependabot cannot open a
  pull request against. All three now leave `target-branch` unset,
  matching `bitcoin-core-rpc`'s own `dependabot.yml`, which already made
  that choice and states the same reason.
- `uv lock --upgrade`: moves every dependency-group package to its
  latest version compatible with the existing constraints. Only
  `pre-commit` had one available, 4.6.1 -> 4.6.2. No `pyproject.toml`
  change.

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass, including
      `Validate Dependabot Config (v2)` and `uv-lock`
- [x] `uv run pytest --cov` — 318 passed, 100% coverage
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — builds clean
- [x] `uv build --sdist` — builds clean

## Summary by Sourcery

Align Dependabot configuration with the main branch and refresh locked dependencies.

Bug Fixes:
- Fix Dependabot configuration by removing references to the non-existent dev target branch so updates open against main.

Enhancements:
- Update locked dependencies, including bumping pre-commit to 4.6.2, and document these changes in the changelog.