### PR TITLE
Point dependabot.yml at main, not the deleted dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
+    target-branch: "main"
     groups:
       # one PR for all action bumps instead of one PR each
       github-actions:
@@ -45,7 +45,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
+    target-branch: "main"
     groups:
       dev-tooling:
         patterns: ["*"]
@@ -60,6 +60,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-    target-branch: "dev"
+    target-branch: "main"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- Asked to update all dependencies. `uv lock --upgrade` produces no diff and `pre-commit autoupdate` offers only the two bumps already known to be wrong (`typos` onto `v1`, a floating tag rather than a release -- the latest actual tag is still `v1.49.0`; `pyroma` onto `5.1b1`, a prerelease -- `5.1` has no tagged release yet). Both `uv.lock` and the pre-commit hook revisions were already refreshed yesterday in #101, so there is nothing to move today.
- Instead, found that `.github/dependabot.yml` still names `target-branch: "dev"` on all three ecosystems (`github-actions`, `uv`, `gitsubmodule`). `origin/dev` and `origin/master` were deleted in the 2026-08-10 rename to a single `main` branch (`gh api repos/btclib-org/btclib-libsecp256k1/branches` now lists only `main`), so Dependabot has had nowhere to land any of its scheduled Thursday pull requests since then. This PR points all three at `main`.
- Out of scope, left for a separate pass: several workflows (`lint.yml`, `test.yml`, `vendored-vectors.yml`, `links.yml`, `mutation.yml`) still carry `branches: [master]` triggers and `github.base_ref == 'master'` conditions that no longer match anything now that pull requests target `main`, and `REPOSITORY.md` still documents dependabot's target as `dev`. None of that is touched here.

## Test plan
- [x] `uv lock --upgrade` -- no diff
- [x] `uvx pre-commit run --all-files` -- all 33 hooks pass, including Dependabot config schema validation
- [x] `uv run --locked --no-default-groups --group test pytest --cov` -- 318 passed, 100.00% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update all Dependabot ecosystems (GitHub Actions, uv, git submodules) to target the main branch instead of the removed dev branch.