### PR TITLE
Move macOS off the merge gate, and name every CI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,108 @@
+---
+name: docs
+
+# the third gate, and a question of its own: does the documentation build.
+# Nothing else in CI builds it, only read the docs does, on a service whose
+# failure is not a check on a pull request -- so invalid reStructuredText in
+# a docstring, or a module sphinx cannot import because the extension did not
+# compile, would surface after the merge and somewhere else.
+#
+# No hook can take this over: markdownlint does not read .rst, and ruff's
+# pydocstyle rules check the form of a docstring rather than whether its body
+# is valid rst.
+#
+# A workflow of its own rather than a job in lint.yml, where it started: a
+# failed docs build and a failed hook are two different verdicts about two
+# different things, and one badge and one line in the checks list each is
+# what says so. It also installs a different dependency group and needs the
+# submodule and no pre-commit cache, so the two share nothing but a checkout
+
+on:
+  push:
+    # main only, for the reason lint.yml gives at the same key: a push to a
+    # branch with an open pull request would run this twice, in two
+    # concurrency groups that do not cancel each other, and the pull_request
+    # run is the one worth keeping
+    branches: [main]
+  pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default types
+    # do not include it, and without it a readied pull request would wait
+    # for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
+  # allows the release workflow to reuse this gate
+  workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
+  # the escape hatch: a run on demand for a branch whose pull request is
+  # not open yet
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies, build scripts) can read the token, so it must not
+# be able to write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs on the same branch/PR, named literally and
+# discriminated by an input rather than left to github.ref alone, for the
+# two reasons lint.yml gives at length: release.yml calls this workflow
+# beside lint.yml and test.yml, and a group computed from github.workflow
+# would have the three cancel each other
+concurrency:
+  group: docs-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    # the name is a required check, and it did not change when this job left
+    # lint.yml: branch protection matches a context by name and not by the
+    # workflow that reported it, which is what let the move happen without
+    # touching the rule
+    name: Build the documentation
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # every automodule directive imports this package, which compiles
+          # the vendored libsecp256k1 to do that -- unlike btclib's own
+          # docs job, which builds nothing
+          submodules: true
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      # the same command .readthedocs.yaml runs and docs/README.rst
+      # documents, so what CI checks is what gets published. -W turns a
+      # module sphinx cannot import into a failed build rather than a bare
+      # heading; --keep-going reports every problem in one run
+      - name: Build the docs
+        run: >
+          uv run --locked --no-default-groups --group docs
+          sphinx-build -W --keep-going -b html docs/source docs/build/html
+
+      # the one defect the build above cannot report on itself, matching
+      # btclib's own second step and the reasoning in its docs/source/conf.py:
+      # a relative link myst cannot resolve becomes an anchor on the page it
+      # is already on -- href="#SECURITY.md", an id nothing has -- rather
+      # than a warning, which conf.py's RootFileLinks transform exists to
+      # prevent. This is the same claim made about the artifact rather than
+      # about the configuration, and what would catch a suppression added
+      # back. No "./" prefix in the pattern, unlike btclib's: the root files
+      # here link to each other by bare name ("SECURITY.md"), never "./SECURITY.md"
+      - name: Check the built pages for unresolved links
+        run: |
+          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page"
+            exit 1
+          fi

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -48,11 +48,12 @@ name: latest
 on:
   schedule:
     # Wednesday 04:37 UTC, and not on the hour, for the reason links.yml
-    # gives. Wednesday, matching btclib's own latest.yml, and the day
-    # after published.yml's Tuesday: a fixed, already-released artifact is
-    # checked first, this the more volatile question of what the newest
-    # dependency does to a tree not yet released. Thursday is left for
-    # Dependabot, opening the day after this has already reported.
+    # gives. Wednesday, matching btclib's own latest.yml, and thirty minutes
+    # after macos.yml, which shares the morning on purpose: this one moves
+    # the dependencies over every platform, that one moves the platform at
+    # the lock, and the pair reads as a difference -- red in both is macOS,
+    # red here alone is the upgrade. Thursday is left for Dependabot,
+    # opening the day after this has already reported.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "37 4 * * 3"
@@ -84,8 +85,10 @@ jobs:
   # this job green while 3.10 quietly stops being tested against what
   # everybody else runs. Dropping 3.9 was exactly that, and it had split a
   # large part of the lock in two before anybody looked
-  test-latest:
-    name: "Test ${{ matrix.python }} on ${{ matrix.os }}, deps at latest"
+  suite-latest:
+    name: >-
+      Run the suite on ${{ matrix.python }}, ${{ matrix.os }},
+      dependencies at latest
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -135,7 +138,7 @@ jobs:
   # new release of either adding a check this tree fails, on a schedule
   # rather than on somebody's branch
   lint-latest:
-    name: Lint and type-check, deps at latest
+    name: Lint and type-check, dependencies at latest
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -175,7 +178,7 @@ jobs:
   # pinned by uv.lock like everything else, and a new pyroma with a stricter
   # rating would otherwise fail --min 10 for the first time on a tag
   dist-latest:
-    name: Validate distributions, deps at latest
+    name: Build the distributions and inspect them, dependencies at latest
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ name: links
 # into something to re-run rather than something to fix. Weekly, on demand,
 # and red in the Actions tab is where this belongs -- the same division
 # published.yml already makes for what PyPI serves.
-# It therefore does not appear in master's required checks, and must not:
+# It therefore does not appear in main's required checks, and must not:
 # that rule lives outside the repository and names its checks as literal
 # strings. See REPOSITORY.md.
 
@@ -71,14 +71,9 @@ jobs:
   links:
     name: Check the documentation links
     # a draft pull request is work in progress and spends no runner
-    # here either, the release pull request excepted: dev -> master is
-    # a draft from one release to the next, and its runs are what
-    # checks a commit merged into dev. The same condition lint.yml and
-    # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    # here either: the same condition lint.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # a few hundred requests with retries; a job past this is hung on one
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,16 +10,16 @@ name: lint
 
 on:
   push:
-    # master only: a push to a branch that has an open pull request would
+    # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/dev against
+    # different concurrency groups (refs/heads/<branch> against
     # refs/pull/N/merge) so neither cancels the other. The pull_request
     # run is the one worth keeping, because it tests the merge commit and
     # is the only run a fork's pull request produces at all.
-    # master keeps a trigger of its own because a merge creates a commit
+    # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request tested, and nothing else would
     # ever test it. Tag pushes are covered by the release workflow
-    branches: [master]
+    branches: [main]
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
@@ -49,11 +49,11 @@ permissions:
 # literally, not through github.workflow: concurrency groups are
 # per-repository, and what that context resolves to inside a called
 # workflow is not documented (the explicit note covers job.workflow_ref
-# only). Were it the caller's name, this workflow and the test one would
-# compute the same group when the release workflow calls both, and
-# cancel-in-progress would have the second cancel the first: a release
-# losing either its lint gate or its whole build matrix, on a path that
-# runs once per release and where nobody is watching for a cancellation.
+# only). Were it the caller's name, this workflow and every
+# other one the release workflow calls would compute the same group, and
+# cancel-in-progress would have each cancel the last: a release losing its
+# lint gate, its docs build or its whole build matrix, on a path that runs
+# once per release and where nobody is watching for a cancellation.
 #
 # github.ref has the same shape of problem one level down, and it is why
 # the suffix is there. Inside a called workflow that context is the
@@ -77,14 +77,8 @@ jobs:
     # these checks on a tree its author is not asking anyone to review
     # yet. A run on the merge result still happens the moment the pull
     # request is marked ready, which is why ready_for_review is a
-    # trigger type above.
-    # The exception is by base branch, and it is the release pull
-    # request: dev -> master stays a draft from one release to the
-    # next, and nothing here triggers on a push to dev, so without it
-    # a commit merged into dev would be linted by nothing at all
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    # trigger type above
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -120,56 +114,3 @@ jobs:
       # matches pyproject.toml, which nothing rewrites on this path
       - name: Run pre-commit
         run: uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure
-
-  # matching btclib's own second lint job: nothing else in CI builds the
-  # documentation, only read the docs does, on a service whose failure is
-  # not a check on the pull request. A separate job because the branch
-  # rule, once one names this workflow, names "Lint and type-check" as a
-  # literal string -- a step added to that job would silently change what
-  # gates a merge, where a new job gates nothing until added on purpose.
-  # It also installs a different dependency group and runs in parallel
-  docs:
-    name: Build the documentation
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # every automodule directive imports this package, which compiles
-          # the vendored libsecp256k1 to do that -- unlike btclib's own
-          # docs job, which builds nothing
-          submodules: true
-
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-
-      # the same command .readthedocs.yaml runs and docs/README.rst
-      # documents, so what CI checks is what gets published. -W turns a
-      # module sphinx cannot import into a failed build rather than a bare
-      # heading; --keep-going reports every problem in one run
-      - name: Build the docs
-        run: >
-          uv run --locked --no-default-groups --group docs
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
-
-      # the one defect the build above cannot report on itself, matching
-      # btclib's own second step and the reasoning in its docs/source/conf.py:
-      # a relative link myst cannot resolve becomes an anchor on the page it
-      # is already on -- href="#SECURITY.md", an id nothing has -- rather
-      # than a warning, which conf.py's RootFileLinks transform exists to
-      # prevent. This is the same claim made about the artifact rather than
-      # about the configuration, and what would catch a suppression added
-      # back. No "./" prefix in the pattern, unlike btclib's: the root files
-      # here link to each other by bare name ("SECURITY.md"), never "./SECURITY.md"
-      - name: Check the built pages for unresolved links
-        run: |
-          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page"
-            exit 1
-          fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,137 @@
+---
+name: macos
+
+# the platform the merge gate does not wait for. test.yml runs the suite on
+# four operating systems on every pull request and this one runs the two
+# macOS images, weekly and before a release, because macOS is where the wait
+# came from: the numbers, and the command that re-derives them, are in
+# test.yml's own header, next to the matrices these cells left.
+#
+# What runs here is not what left, and the difference is the point. The
+# cells that moved installed a wheel built earlier in the same run, which
+# would mean rebuilding those wheels here -- ten minutes of cibuildwheel per
+# image, and artifact names the release must not confuse with test.yml's.
+# This builds from the tree instead, twice per cell: the static extension a
+# CPython wheel carries, then the dynamic one, which is the same choice
+# `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
+# of `_load_lib`. Two steps of one job rather than two jobs, because the
+# queue is the cost being managed here and a second job pays it again.
+#
+# So this is the platform against the lock, on every interpreter, and
+# latest.yml is the dependencies against the platforms; the two are
+# scheduled on the same morning half an hour apart. A red macOS column in
+# latest.yml with this workflow green is an upgrade; red in both is macOS.
+# One variable each, and the pair reads as a difference.
+#
+# It gates no commit and no merge -- a macOS regression sits on main for at
+# most a week -- but release.yml calls it, so one cannot be published
+
+on:
+  schedule:
+    # Wednesday, the morning latest.yml also runs, and thirty minutes before
+    # it: the two answer halves of the same question and are worth reading
+    # together. A minute that is not the hour, as every cron here, for the
+    # reason links.yml gives, and minute 07 is shared with none of them
+    # (11, 23, 29, 37, 49).
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "07 4 * * 3"
+  # lets release.yml gate a publication on this platform too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
+  # the escape hatch: the platform on demand, for a branch that touches the
+  # build, the loader or anything a toolchain decides
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies, build scripts) can read the token, so it must not
+# be able to write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than through github.workflow, which in
+# a called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other. The suffix is the second half of the same problem,
+# github.ref inside a called workflow being the caller's ref: see lint.yml
+concurrency:
+  group: macos-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  cancel-in-progress: true
+
+jobs:
+  suite-macos:
+    name: Run the suite on ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # libsecp256k1 is compiled twice per cell, from a cache that is cold
+    # whenever the lock moved: far above what the suite itself needs, and
+    # what it bounds is a hung job rather than a slow one. The queueing this
+    # workflow exists to move happens before a job starts and is not counted
+    # here
+    timeout-minutes: 40
+    strategy:
+      # every cell to the end: which interpreter fails on which image is the
+      # whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # the two images test.yml no longer runs the suite on. Both, and not
+        # the newest alone: one is Apple silicon and the other Intel, and
+        # what differs between them is the architecture the vendored library
+        # and the extension are compiled for
+        os:
+          - macos-26-intel
+          - macos-latest
+        # the union of the interpreters the two matrices of test.yml ran
+        # here, so that the platform is the only thing this workflow moved.
+        # Spelled as uv spells them, this being uv rather than
+        # setup-python: `pypy3.11`, not the `pypy-3.11` of test.yml
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.10"
+          - "pypy3.11"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the vendored library is what gets compiled here
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # the wheels of the test group, not the extension, which is built
+          # from the tree twice below whatever the cache holds
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      # the command CONTRIBUTING.md gives a developer, and the one the
+      # coverage job of test.yml runs on ubuntu: a static build, where
+      # `_load_lib` returns the extension's own `lib`
+      - name: Run pytest against a static build
+        run: uv run --locked --no-default-groups --group test pytest
+
+      # the other branch of `_load_lib`, and the only thing that exercises
+      # the dynamic macOS wheel now that test.yml does not: cffi in ABI
+      # mode, dlopening the shared object beside the module.
+      # --reinstall-package with --no-cache because the extension already
+      # installed by the step above is the other linkage, and neither the
+      # environment nor the build cache is keyed on the variable that
+      # chooses between them
+      - name: Run pytest against a dynamic build
+        env:
+          BTCLIB_LIBSECP256K1_DYNAMIC: "true"
+        run: >
+          uv run --locked --no-default-groups --group test
+          --reinstall-package btclib_libsecp256k1 --no-cache pytest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,7 +17,7 @@ name: mutation
 # needs a number nobody has yet, and a survival rate is not a regression: a
 # mutant survives because a test is missing, so a red merge would block
 # whoever next touched a file for a hole somebody else left. It therefore
-# does not appear in master's required checks, and must not -- that rule
+# does not appear in main's required checks, and must not -- that rule
 # lives outside the repository and names its checks as literal strings. See
 # REPOSITORY.md.
 #
@@ -38,8 +38,8 @@ on:
     # entirely -- the suite's own quality, not a dependency's -- which
     # is what leaves it the weekend on its own rather than a weekday.
     # Cron runs from the default branch only, so this file does nothing
-    # until it reaches master -- on dev it is reachable through the dispatch
-    # below and nowhere else
+    # until it reaches main -- on any other branch it is reachable through
+    # the dispatch below and nowhere else
     - cron: "29 3 * * 0"
   # the escape hatch, and the way to re-measure after writing the tests a
   # survivor asked for

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -40,18 +40,37 @@ name: published
 # support, and this workflow went green on it the same day: nineteen cells
 # out of nineteen, against nineteen out of nineteen red on the scheduled
 # run the day before. That inversion is what the sentinel is for, and
-# checking it is a step of the release: see RELEASING.md
+# release.yml now calls it rather than leaving it to be remembered
 
 on:
+  # after a release, which is the one moment this workflow's answer can
+  # change: RELEASING.md documented dispatching it by hand right here, and a
+  # call does not forget. Called by release.yml rather than triggered by
+  # workflow_run, which zizmor rates a dangerous trigger and rightly -- it
+  # runs the default branch's copy of a workflow with the token of a push
+  # nobody reviewed -- where a call runs inside the release that gated it, in
+  # its graph and in its log. The caller passes the tag, and only the caller
+  # does: the monthly run and a dispatch have no particular version in mind,
+  # which is the point of them
+  workflow_call:
+    inputs:
+      version:
+        description: >
+          The tag whose version the index must serve before the matrix
+          installs anything, empty on a run with no release behind it.
+        type: string
+        default: ""
   schedule:
-    # weekly, on a minute that is not the hour: what everyone schedules on
-    # the hour queues together, and a run that waits is a failure noticed
-    # later. Tuesday, matching btclib's own published.yml, and the day
-    # after links.yml's Monday for the same reason every one of these
-    # sentinels picks a distinct morning: a fixed, already-released
-    # artifact is checked first, before latest.yml asks the more volatile
-    # question of what the newest dependency does to a tree not yet
-    # released.
+    # monthly, on the first, where this was weekly: what it watches is
+    # external rot -- a new runner image, a new interpreter, a yanked
+    # dependency, a cffi ABI change -- and nothing in this repository moves
+    # it, so a week was a sample rate without a reason. After a release the
+    # trigger above answers immediately, which is what the weekly was
+    # standing in for.
+    # A minute that is not the hour: what everyone schedules on the hour
+    # queues together, and a run that waits is a failure noticed later. The
+    # minute and the hour are the ones this workflow always had, so a
+    # comparison with an older run compares like with like.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone.
     # One caveat has no fix inside this file: GitHub suspends a schedule
@@ -59,7 +78,7 @@ on:
     # quiet period a sentinel exists to cover, and announces it only by
     # email. A silence from this workflow is worth a look at the Actions
     # tab before it is read as green
-    - cron: "23 6 * * 2"
+    - cron: "23 6 1 * *"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -68,16 +87,16 @@ on:
 permissions:
   contents: read
 
-# never cancel a sentinel, unlike every other workflow here: the manual
-# run RELEASING.md dispatches right after a release and the weekly one
-# share this group, each is a sample worth keeping, and neither is
-# superseded by the other. A concurrent run queues instead
+# never cancel a sentinel, unlike every other workflow here: the run a
+# release calls, the monthly one and a dispatch share this group, each is a
+# sample worth keeping, and none supersedes the others. A concurrent run
+# queues instead
 concurrency:
   group: published-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  test-published:
+  install-published:
     name: >-
       ${{ matrix.no-binary && 'Build' || 'Install' }}
       ${{ matrix.python-version }} from PyPI on ${{ matrix.os }}
@@ -125,6 +144,35 @@ jobs:
             kind: dynamic
 
     steps:
+      # the index does not serve a new file the instant the upload returns,
+      # and every cell below installs whatever the resolver picks: a run that
+      # starts too early tests the *previous* version and reports a pass for
+      # it, which is worse than reporting nothing. So the release path waits
+      # for the version its tag names, and fails if it never arrives rather
+      # than measuring the wrong thing. Only there: the input is empty on
+      # every other trigger.
+      # Twenty attempts fifteen seconds apart, i.e. five minutes: an upload
+      # PyPI has accepted is served in seconds, and what this bounds is the
+      # case where it is not served at all
+      - name: Wait for the index to serve the released version
+        if: inputs.version != ''
+        shell: bash
+        env:
+          TAG: ${{ inputs.version }}
+        run: |
+          version="${TAG#v}"
+          for attempt in $(seq 20); do
+            if curl -sf --max-time 10 -o /dev/null \
+                "https://pypi.org/pypi/btclib_libsecp256k1/${version}/json"; then
+              echo "the index serves ${version}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${version} is not served yet"
+            sleep 15
+          done
+          echo "::error::${version} never appeared on the index"
+          exit 1
+
       # no checkout on purpose: nothing from this repository takes part,
       # which is also what guarantees that the import below resolves to
       # what pip installed and not to a source tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,22 @@ on:
 permissions:
   contents: read
 
+# never cancel a release, unlike the gates it calls: what cancel-in-progress
+# is right about elsewhere is that the subject of a run is a commit, which a
+# newer commit supersedes. A publication is not -- a version is consumed by
+# the upload that carries it, and a run cancelled between the two uploads
+# leaves TestPyPI holding a version PyPI never got. Two tags pushed in a row
+# queue instead. Named literally, for the reason lint.yml gives at length
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  # the same gate a push gets: a release is not the moment to discover
-  # that the tagged commit does not lint
+  # the same gates a push gets, all three of them: a release is not the
+  # moment to discover that the tagged commit does not lint, does not build
+  # its documentation, or does not pass the suite on a platform
   lint:
+    name: Run the lint workflow
     uses: ./.github/workflows/lint.yml
     with:
       # what keeps this run out of the branch concurrency groups: inside a
@@ -31,6 +43,24 @@ jobs:
       # branch share a group and cancel each other. The reasoning is in
       # lint.yml, next to the group; the value only has to be a string no
       # branch group can contain
+      concurrency-suffix: "-release"
+
+  docs:
+    name: Run the docs workflow
+    uses: ./.github/workflows/docs.yml
+    with:
+      # see the lint job above
+      concurrency-suffix: "-release"
+
+  # the platform test.yml does not run the suite on, for the reason its own
+  # header measures: a week is the right sample rate for a regression that
+  # can sit on main for a week, and the wrong one for a version that cannot
+  # be unpublished
+  macos:
+    name: Run the macos workflow
+    uses: ./.github/workflows/macos.yml
+    with:
+      # see the lint job above
       concurrency-suffix: "-release"
 
   # what a version cannot survive being wrong about, checked before
@@ -93,24 +123,24 @@ jobs:
           fi
 
       # CONTRIBUTING.md and RELEASING.md both say a release is a tag on
-      # the merge commit on master; nothing enforced it. The deployment
-      # tag policy of the pypi environment constrains the *name* of the
-      # ref and nothing else, so a v* tag on a branch head, on an old dev
-      # state or on a fork-synced commit reaches the environment exactly
+      # a commit on main; nothing enforced it. The deployment tag policy
+      # of the pypi environment constrains the *name* of the ref and
+      # nothing else, so a v* tag on a branch head, on a stale state or
+      # on a fork-synced commit reaches the environment exactly
       # as the release tag does -- and the reviewer approving sees the
       # tag name, not its ancestry. This is the ancestry, before the
       # matrix builds anything.
-      # origin/master rather than a fetch of its own: the checkout above
+      # origin/main rather than a fetch of its own: the checkout above
       # takes the whole history, remote-tracking branches included, and a
-      # missing origin/master fails the step, which is the safe way round
-      - name: Check that the tag is on master
+      # missing origin/main fails the step, which is the safe way round
+      - name: Check that the tag is on main
         if: github.event_name == 'push'
         run: |
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
-            echo "::error::$GITHUB_REF_NAME is on $GITHUB_SHA, which is not on master"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::$GITHUB_REF_NAME is on $GITHUB_SHA, which is not on main"
             exit 1
           fi
-          echo "$GITHUB_SHA is on master"
+          echo "$GITHUB_SHA is on main"
 
       # the fourth invariant, and the last one that was checked only
       # after the point of no return: github-release reads the tag's
@@ -188,7 +218,8 @@ jobs:
 
   # reuse the whole build/test pipeline: every artifact the release ships
   # is built and tested here, by the very matrices that run on a push
-  build:
+  test:
+    name: Run the test workflow
     # a minute of checking, ahead of an hour of building: a tag that does
     # not match the tree is worth discovering before the matrices start
     needs: version-check
@@ -222,7 +253,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       && github.repository == 'btclib-org/btclib-libsecp256k1'
-    needs: [lint, build]
+    needs: [test, lint, docs, macos]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -256,7 +287,7 @@ jobs:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-libsecp256k1'
-    needs: [lint, build]
+    needs: [test, lint, docs, macos]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -288,7 +319,7 @@ jobs:
   # what can already be installed, and the download url in pyproject.toml
   # points at the page this creates
   github-release:
-    name: Create the GitHub release
+    name: Attach the files to the GitHub release
     needs: publish-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -331,3 +362,21 @@ jobs:
             gh release create "$GITHUB_REF_NAME" dist/* \
               --title "$GITHUB_REF_NAME" --generate-notes
           fi
+
+  # the sentinel on what users can install, run at the one moment its answer
+  # changes -- and a call rather than a workflow_run trigger, which zizmor
+  # rates dangerous and rightly: that one runs the default branch's copy of a
+  # workflow with a token nobody reviewed, where a call runs inside the
+  # release that gated it, in its graph and in its log.
+  # It waits for the index to serve the version this tag names before
+  # installing anything, so it cannot pass by testing the release before this
+  # one, and it runs beside github-release rather than before it: a release
+  # announcing files that do not install is worse than a release announced a
+  # few minutes later, but the announcement is not what makes them
+  # installable
+  published:
+    name: Install the published version from PyPI
+    needs: publish-pypi
+    uses: ./.github/workflows/published.yml
+    with:
+      version: ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,43 @@
 ---
 name: test
 
+# the merge gate: everything this package ships, built and then tested on
+# the platforms it claims, minus the one platform a reviewer would wait for.
+#
+# macOS is that platform, and the split is a measurement rather than a
+# preference. Over six pull request runs of this workflow, ninety-eight jobs
+# each, thirty-five of them on the two macOS images: a macOS job waited 20.8
+# and 19.0 minutes on average for a runner, against 2.1 to 2.6 elsewhere,
+# and the wait grows with the number of cells asking at once -- in the
+# slowest of the six the macOS suite cells took the last thirty places
+# before the aggregate, their queue rising from 16.7 to 70.2 minutes, and
+# the run took 95 minutes for 105 minutes of work spread over 98 jobs. The
+# command that re-derives it, for whoever doubts the split later:
+#
+#     id=$(gh run list --workflow=test.yml --limit 1 \
+#         --json databaseId --jq '.[0].databaseId')
+#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# So the macOS *suite* cells moved to macos.yml, which runs them weekly and
+# before a release. The macOS *wheel builds* stay here, and the same
+# measurement is why: the release publishes the artifacts of this run, so a
+# macOS wheel not built here is a macOS wheel not on PyPI -- and those four
+# jobs are not what stretched the run, finishing at 24.6 minutes against the
+# 23.5 of the ubuntu-latest build beside them. Four macOS jobs queue;
+# thirty-one contend.
+
 on:
   push:
-    # master only: a push to a branch that has an open pull request would
+    # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/dev against
+    # different concurrency groups (refs/heads/<branch> against
     # refs/pull/N/merge) so neither cancels the other. The pull_request
     # run is the one worth keeping, because it tests the merge commit and
     # is the only run a fork's pull request produces at all.
-    # master keeps a trigger of its own because a merge creates a commit
+    # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request tested, and nothing else would
     # ever test it. Tag pushes are covered by the release workflow
-    branches: [master]
+    branches: [main]
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
@@ -59,19 +84,15 @@ jobs:
   # platform: measuring it once is enough, and the fail_under ratchet in
   # pyproject.toml is what makes the number mean something
   coverage:
-    name: Coverage
+    name: Measure coverage, gated at 100%
     # a draft pull request is work in progress: every push to one spends
     # the whole matrix on a tree its author is not asking anyone to
     # review yet. The gate below carries the same condition, so a draft
     # skips uniformly and the gate does not read that skip as a job that
-    # should have run.
-    # The exception is by base branch, and it is the release pull
-    # request: dev -> master stays a draft from one release to the
-    # next, and nothing here triggers on a push to dev, so without it
-    # a commit merged into dev would be tested by nothing at all
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    # should have run. A run on the merge result still happens the moment
+    # the pull request is marked ready, which is why ready_for_review is a
+    # trigger type above
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # every job below caps its own runtime, this one included: the default
     # is six hours, and with tens of jobs compiling C a single hang is
@@ -109,9 +130,7 @@ jobs:
 
   build-cibuildwheel:
     name: Build wheels on ${{ matrix.os }}
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # the interpreter uv runs the build tools with is the one setup-python
@@ -199,9 +218,7 @@ jobs:
 
   build-dynamic:
     name: Build dynamic wheel on ${{ matrix.os }}
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     # see build-cibuildwheel; here the platform tag of the wheel is the
@@ -277,9 +294,7 @@ jobs:
 
   build-sdist:
     name: Build sdist
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # see build-cibuildwheel
@@ -334,19 +349,20 @@ jobs:
   # is least like the others: MSVC compiles the extension while a gcc on
   # the PATH preprocesses the headers for cffi, and what the sdist has to
   # carry for it is not what a POSIX build reads
-  test-sdist:
+  suite-sdist:
     name: >-
-      Test sdist install on ${{ matrix.os }}${{
+      Install from the sdist and run the suite on ${{ matrix.os }}${{
       matrix.architecture && format(' ({0})', matrix.architecture) }}
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS is macos.yml's, for the reason the header gives; what that
+        # workflow runs there is a source build of the same tree, which is
+        # what an install from the sdist is
+        os: [ubuntu-latest, windows-latest]
         # the wheel jobs all build with an interpreter of the runner's own
         # architecture, so nothing else exercises a build whose target is
         # not the host: an emulated x86-64 interpreter on Windows arm64,
@@ -403,9 +419,7 @@ jobs:
 
   build-windows:
     name: "Build on Linux for Windows"
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # see build-cibuildwheel
@@ -453,10 +467,8 @@ jobs:
   # that does not render cannot be fixed by reuploading, a version can
   # only be yanked and burnt
   check-dist:
-    name: Validate distributions
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    name: Inspect the distribution files and install one
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-cibuildwheel, build-dynamic, build-sdist, build-windows]
@@ -533,21 +545,26 @@ jobs:
       - name: Rate the packaging metadata
         run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
 
-  test-dynamic:
-    name: "Test ${{ matrix.python-version }} on ${{ matrix.os }}"
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+  suite-dynamic:
+    # the linkage is in the name, and it has to be: this job and the one
+    # below run the same interpreters on the same images against two
+    # different wheels, so one name for both produced two check runs
+    # called the same thing -- and a branch rule matches a context by name
+    # alone, which is what makes an ambiguous one worth avoiding even where
+    # no rule names it today
+    name: >-
+      Run the suite on the dynamic wheel,
+      ${{ matrix.python-version }}, ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
+        # the two macOS images are macos.yml's; see the header
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-26-intel
-          - macos-latest
           - windows-latest
         # 3.14t, the free-threaded interpreter, matters here in particular:
         # the dynamic wheel is tagged py3-none, so it is what a
@@ -603,21 +620,26 @@ jobs:
       - name: Test
         run: pytest
 
-  test-static:
-    name: "Test ${{ matrix.python-version }} on ${{ matrix.os }}"
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+  suite-static:
+    # the linkage is in the name: see suite-dynamic
+    name: >-
+      Run the suite on the static wheel,
+      ${{ matrix.python-version }}, ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
+        # the two macOS images are macos.yml's; see the header. What is
+        # given up here is narrower than elsewhere, and cibuildwheel is
+        # why: it runs the suite against every wheel it builds, on the
+        # runner that built it, so the macOS wheels this workflow ships are
+        # still tested by the job that produces them. What moves is pip's
+        # selection among them
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-26-intel
-          - macos-latest
           - windows-latest
           - windows-11-arm
         python-version:
@@ -673,35 +695,38 @@ jobs:
         run: pytest
 
   # one context for the branch rule, instead of the matrix's own. A rule
-  # naming `Test 3.10 on ubuntu-latest` names a context that stops being
-  # produced the moment the matrix changes, and a required check that
-  # produces no run blocks every merge with nothing in the tree to explain
-  # why -- the rule living outside the repository. So the rule names this
-  # job, and a job added to this workflow belongs in the `needs` below or
-  # it gates nothing. REPOSITORY.md carries the branch rule itself.
+  # naming `Run the suite on the static wheel, 3.10, ubuntu-latest` names a
+  # context that stops being produced the moment the matrix changes, and a
+  # required check that produces no run blocks every merge with nothing in
+  # the tree to explain why -- the rule living outside the repository. So
+  # the rule names this job, and a job added to this workflow belongs in
+  # the `needs` below or it gates nothing. REPOSITORY.md carries the branch
+  # rule itself.
+  #
+  # The name carries the workflow because a context is keyed by name alone:
+  # two workflows with a job named the same thing produce one ambiguous
+  # check, and macos.yml is a second workflow over the same matrix shape.
   #
   # `if: always()` because a job with unmet `needs` is skipped, and a
   # skipped check is not a failed one: without it a failing matrix cell
   # would leave this context reported as skipped, which satisfies a
   # required check rather than blocking on it. Cancelled is a failure here
   # too, a superseded run being no evidence either way
-  tests-passed:
-    name: tests-passed
+  test-passed:
+    name: "test: every job passed"
     # and the draft condition every job above carries, so a draft
     # skips uniformly rather than tripping the skip check below
-    if: >-
-      ${{ always() && (!github.event.pull_request.draft
-      || github.base_ref == 'master') }}
+    if: ${{ always() && !github.event.pull_request.draft }}
     needs:
       - coverage
       - build-cibuildwheel
       - build-dynamic
       - build-sdist
-      - test-sdist
+      - suite-sdist
       - build-windows
       - check-dist
-      - test-dynamic
-      - test-static
+      - suite-dynamic
+      - suite-static
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -50,14 +50,9 @@ jobs:
   check:
     name: Check vendored vectors against upstream
     # a draft pull request is work in progress and spends no runner
-    # here either, the release pull request excepted: dev -> master is
-    # a draft from one release to the next, and its runs are what
-    # checks a commit merged into dev. The same condition lint.yml and
-    # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    # here either: the same condition lint.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,9 @@ ci:
   # where the workflow token cannot write and every action is pinned to
   # a commit SHA: a failing hook has to be fixed by its author
   autofix_prs: false
-  # onto dev, as Dependabot does: master only receives merges from it
-  autoupdate_branch: dev
+  # onto main, as Dependabot targets it: the sole long-lived branch, and a
+  # branch that does not exist is a pull request with nowhere to land
+  autoupdate_branch: main
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
   # the one hook pre-commit.ci cannot run, and the only entry this list
@@ -103,6 +104,25 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  # a rev is a released version, and nothing but pre-commit autoupdate
+  # writes one: it offers whatever tag the remote's HEAD carries, which
+  # twice was not a release -- `v1`, a floating major tag its owner moves
+  # under the pin, and `5.1b1`, a prerelease with no `5.1` behind it. Both
+  # were merged before anybody read the diff, so the review is not the
+  # check. A tag that names a major version alone can change what a hook
+  # does without changing this file, and a prerelease is a hook whose
+  # findings its own author has not committed to yet. pre-commit says so
+  # itself for the moving tag -- a [WARNING] about a mutable reference --
+  # and a warning is not an exit code, which is the gap this closes.
+  # pygrep, so the pattern is the whole hook: a bare integer with an
+  # optional v, or a version carrying a PEP 440 pre-release segment
+  - repo: local
+    hooks:
+      - id: pinned-rev
+        name: every pre-commit rev names a released version
+        language: pygrep
+        entry: '^ *rev: "?v?([0-9]+|[0-9][0-9.]*(a|b|rc|dev)[0-9]+)"?$'
+        files: ^\.pre-commit-config\.yaml$
   # .github/dependabot.yml is validated by nothing else, and a typo in it
   # updates nothing and says nothing: the whole point of that file is to
   # move the pins this repository depends on for its security updates.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 712
+        "line_number": 790
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-08T23:54:31Z"
+  "generated_at": "2026-08-10T23:42:09Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,84 @@ release-notes length in the first place, and are still in
 
 ## v0.7.1.4 (work in progress, not released yet)
 
+### CI
+
+- **The macOS suite cells left the merge gate for `macos.yml`.** Over six
+  pull request runs of `test.yml`, ninety-eight jobs each and thirty-five of
+  them on the two macOS images, a macOS job waited 20.8 and 19.0 minutes on
+  average for a runner against 2.1 to 2.6 elsewhere — and the wait grows
+  with the number of cells asking at once, so in the slowest of the six the
+  thirty-one macOS suite cells took the last thirty places before the
+  aggregate, their queue rising from 16.7 to 70.2 minutes and the run taking
+  95 minutes for 105 minutes of work. The command that re-derives all of it
+  is in `test.yml`'s header, next to the matrices those cells left. What
+  moved is the suite; the macOS
+  *wheel builds* stay, because the release publishes the artifacts of that
+  run and the same measurement clears them — they finished at 24.6 minutes
+  against the 23.5 of the ubuntu-latest build beside them. Four macOS jobs
+  queue, thirty-one contend. `macos.yml` runs the two images over every
+  interpreter `test.yml` ran there, half an hour before `latest.yml` on the
+  same morning, so the pair reads as a difference: red in both is the
+  platform, red in `latest` alone is the upgrade. It builds from the tree
+  twice per cell, static and then dynamic, rather than rebuilding the
+  wheels the cells used to install — ten minutes of `cibuildwheel` per
+  image, and artifact names a release must not confuse with `test.yml`'s.
+  It gates nothing, so a macOS regression can sit on `main` for a week;
+  `release.yml` calls it, so it cannot be published.
+- **The documentation build is `docs.yml`, not the second job of
+  `lint.yml`.** A failed docs build and a failed hook are two different
+  verdicts about two different things, and one badge and one line in the
+  checks list each is what says so — the badge being a `docs` one added to
+  the second README row, beside `test` and `lint`, where the row already
+  ends with what read the docs makes of the same source. The job's display
+  name is unchanged,
+  which is what let it move without touching the branch rule: a required
+  context is matched by name, not by the workflow that reported it.
+- **Every job is named for the question it answers, and the aggregate is
+  `test: every job passed`.** `Coverage` said which job it was rather than
+  what it gates; the two suite matrices were *both* named
+  `Test <version> on <os>`, so every run produced pairs of check runs with
+  one name between them, which is the ambiguity a branch rule cannot see
+  past — the linkage is in the name now. Renaming the aggregate renames a
+  required check, the one change a pull request cannot make on its own:
+  REPOSITORY.md carries the `PATCH` that moves the rule first.
+- **`release.yml` calls every gate, and the published sentinel after
+  itself.** It called `lint` and `test`; `docs` and `macos` are gates it
+  was not waiting for, and `published` answers, at the one moment its
+  answer changes, whether what was just uploaded can be installed. That
+  last one waits for the index to serve the version the tag names before
+  installing anything, so it cannot report a pass for the release before
+  this one. A call rather than a `workflow_run` trigger, which zizmor rates
+  dangerous and rightly: that one runs the default branch's copy of a
+  workflow with a token nobody reviewed. The workflow also has a
+  concurrency group at last, and it is the one here that must not cancel:
+  a version is consumed by the upload that carries it.
+- **`published.yml` is monthly, where it was weekly.** What it watches is
+  external rot, which nothing in this repository moves, so a week was a
+  sample rate without a reason — and the release now asks immediately,
+  which is what the weekly was standing in for.
+- **The workflows no longer name `master` and `dev`.** Neither branch
+  exists. Two of those references were not merely stale: `branches:
+  [master]` meant no push to `main` ran the gate at all, and the release
+  workflow's ancestry check runs `git merge-base --is-ancestor
+  "$GITHUB_SHA" origin/master`, which fails on a ref that is gone — the
+  next tag would have been stopped by it. The draft exception that let the
+  release pull request through (`github.base_ref == 'master'`) can never be
+  true again and is gone with them.
+
+### The gate
+
+- **`pinned-rev` refuses a `rev` that does not name a released version.**
+  Nothing but `pre-commit autoupdate` writes a `rev`, and it offers
+  whatever tag the remote's HEAD carries: twice that was not a release —
+  `v1`, a floating major tag its owner moves under the pin, and `5.1b1`, a
+  prerelease with no `5.1` behind it — and both were merged before anybody
+  read the diff, so the review is not the check. pre-commit says as much
+  itself for the moving tag, a `[WARNING]` about a mutable reference, and a
+  warning is not an exit code. A `pygrep` hook, so the pattern is the whole
+  hook, and it was verified in both directions: it names no `rev` this file
+  holds, and it names those two by line when they are put back.
+
 ### Documentation
 
 - **This file's own preamble says where it starts, not what it holds.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,22 +139,31 @@ uv lock
 uvx --from detect-secrets detect-secrets scan --baseline .secrets.baseline
 ```
 
-## The workflows that gate, and the four that do not
+## The workflows that gate, and the ones that do not
 
-`lint` and `test` are the gate, and `release` reuses both. The other four
-are sentinels: each is a workflow of its own, has no aggregate job, is named
-by no branch rule, and opens no issue on failure. That is deliberate in
-every case — each is expected to go red for a reason no pull request
-introduced, and a red check nobody can act on from a branch is noise. Their
-crons are on four different mornings, because four sentinels landing in one
-inbox on one morning are one sentinel.
+`lint`, `docs` and `test` are the gate, and `release` reuses all three. The
+rest are sentinels: each is a workflow of its own, has no aggregate job, is
+named by no branch rule, and opens no issue on failure (`vendored-vectors`
+excepted, for the reason its own header gives). That is deliberate in every
+case — each is expected to go red for a reason no pull request introduced,
+and a red check nobody can act on from a branch is noise. Their crons are on
+different mornings, because sentinels landing in one inbox on one morning
+are one sentinel.
 
 | workflow | asks | when |
 | --- | --- | --- |
-| `published` | can the world install what PyPI serves | Mon |
-| `links` | do the URLs in the prose still resolve | Tue |
-| `latest` | does the tree survive every dependency at its newest | Fri |
-| `mutation` | would the suite notice a wrong line | Sat |
+| `links` | do the URLs in the prose still resolve | Mon |
+| `macos` | does the suite pass on macOS | Wed, and a release |
+| `latest` | does the tree survive every dependency at its newest | Wed |
+| `mutation` | would the suite notice a wrong line | Sun |
+| `published` | can the world install what PyPI serves | 1st, a release |
+| `vendored-vectors` | do the vendored vectors still match upstream | 1st |
+
+`macos` is the one sentinel a pull request would otherwise have waited for,
+and the reason it is one is measured in `test.yml`'s header: the macOS
+runners queue for tens of minutes where every other platform queues for two.
+A release calls it, so what a merge no longer waits for a publication still
+does.
 
 `latest` is the one that covers a gap nothing else does. Every uv command
 elsewhere passes `--locked`, the dependency groups declare no version, and
@@ -245,9 +254,10 @@ findings.
   API call that shows each still off: the two secret-scanning extensions
   are the ones that answer a PATCH with 200 and change nothing. Do not
   spend a session rediscovering them
-- **`release.yml` and `published.yml` are inert until they are on
-  `master`**: `schedule` and `workflow_dispatch` only run from the default
-  branch, so a rehearsal cannot be dispatched from `dev`
+- **every `schedule` and `workflow_dispatch` here is inert off `main`**:
+  both only run from the default branch, so a rehearsal of `release.yml`
+  cannot be dispatched from a branch, and `macos.yml`, `latest.yml` and the
+  other sentinels are reachable there through nothing at all until merged
 - **a hand-applied mutation can outlive its restore.** `(0, 1, 2, 3)` and
   `(0, 1, 1, 3)` are the same length, so restoring the file with `cp` in the
   same second leaves mtime *and* size matching what the `.pyc` recorded, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,11 +172,33 @@ Anything machine-local — an interpreter path, a telemetry answer, a theme —
 belongs in the editor's own user settings instead, those two files being
 read by every checkout of this repository.
 
+### What runs when
+
+| workflow | when | what it varies |
+| --- | --- | --- |
+| `test` | pull request, push | every platform but macOS, every interpreter |
+| `lint`, `docs` | pull request, push | — |
+| `vendored-vectors` | monthly, a change to itself | — |
+| `macos` | Wednesday, a release | both macOS images, both linkages |
+| `latest` | Wednesday | the dependencies, at their newest |
+| `links`, `mutation` | weekly | — |
+| `published` | monthly, a release | what PyPI serves |
+| `release` | a tag | calls the gates, `macos` and `published` |
+
+The first two rows are what a merge waits for. macOS is not among them on
+purpose, and the numbers are in `test.yml`'s header: it is the one platform
+whose runners queue for tens of minutes rather than for two, so it answers
+weekly, and before a release, rather than before a review. The wheels it
+ships are still built on every pull request, `cibuildwheel` running the
+suite against each one as it builds it — what waits a week is pip's
+selection among them and the dynamic build. Everything but the first two
+rows also takes `workflow_dispatch`.
+
 ### Running what CI runs
 
-Each job of the `lint` and `test` workflows, and the local command that
-reproduces it. Two of them cannot be reproduced on a machine that is not
-the runner, and that is worth knowing before trying.
+Each job of the `lint`, `docs` and `test` workflows, and the local command
+that reproduces it. Two of them cannot be reproduced on a machine that is
+not the runner, and that is worth knowing before trying.
 
 - `Lint and type-check`
 
@@ -184,17 +206,24 @@ the runner, and that is worth knowing before trying.
   uvx pre-commit run --all-files
   ```
 
-- `Coverage`
+- `Measure coverage, gated at 100%`
 
   ```shell
   uv run --locked --no-default-groups --group test pytest --cov
   ```
 
-- `Test <version> on <os>`, one row of the matrix
+- `Run the suite on the static wheel, <version>, <os>`, and its dynamic
+  counterpart, one row of either matrix
 
   ```shell
   uv run --python 3.10 --no-cache pytest
+  BTCLIB_LIBSECP256K1_DYNAMIC=true uv run --python 3.10 --no-cache \
+      --reinstall-package btclib_libsecp256k1 pytest
   ```
+
+  the two steps of `macos.yml`'s own cells are these two, in this order and
+  for the same reason: neither the environment nor the build cache is keyed
+  on the variable that chooses the linkage
 
 - `Build wheels on <os>`, for this platform only
 
@@ -227,14 +256,15 @@ the runner, and that is worth knowing before trying.
   values and the reasoning behind them are in `test.yml`, next to the
   step that exports them
 
-- `Build sdist`, and `Test sdist install on <os>` after it
+- `Build sdist`, and `Install from the sdist and run the suite on <os>`
+  after it
 
   ```shell
   uv build --sdist
   python -m pip install --verbose dist/*.tar.gz   # in a fresh venv
   ```
 
-- `Validate distributions`
+- `Inspect the distribution files and install one`
 
   ```shell
   uv run --locked --only-group check twine check --strict dist/*
@@ -259,9 +289,13 @@ the runner, and that is worth knowing before trying.
 The `published` workflow has no local equivalent by design: what it
 installs is what PyPI serves.
 
-The three sentinels beside it gate nothing, so a red one is read in the
-Actions tab rather than fixed on a branch. Each is dispatchable, and two of
-them run locally.
+The sentinels beside it gate nothing, so a red one is read in the Actions
+tab rather than fixed on a branch. Each is dispatchable, and all but `links`
+run locally.
+
+- `macos`, which is the suite on the two macOS images and reproducible only
+  on a Mac. Both linkages, the commands being the pair given above under
+  the suite job
 
 - `latest`, which resolves every dependency at its newest before running
   the suite. The upgrade rewrites `uv.lock`, so restore it afterwards with

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ bitcoin-core-rpc carry the same three lines. -->
 
 [![test workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
+[![docs workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/master)
 [![documentation build](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -10,31 +10,61 @@ repository, so this file is the whole of them: nothing here can be
 recovered by reading the tree. Every value below was read from the API,
 and the command that reads it is beside it.
 
-## Required checks on master
+## Required checks on main
 
 **Never name matrix contexts in a branch rule.** The rule lives outside
 the repository, so a context that stops being produced blocks every merge
 with nothing in the tree to explain why — and the matrix here is
-`Test ${{ matrix.python-version }} on ${{ matrix.os }}`, whose contexts
-change with every interpreter added or dropped. `tests-passed` is the
-aggregate job at the end of `test.yml` that `needs` every other job in
-it; a job added to that workflow belongs in its `needs` list, or it gates
-nothing.
+`Run the suite on the static wheel, ${{ matrix.python-version }},
+${{ matrix.os }}`, whose contexts change with every interpreter added or
+dropped. `test: every job passed` is the aggregate job at the end of
+`test.yml` that `needs` every other job in it; a job added to that
+workflow belongs in its `needs` list, or it gates nothing. The name
+carries the workflow because a context is keyed by name alone: two
+workflows with a job named the same thing produce one ambiguous check.
 
-`master` requires three checks, bound to the app that produces each —
-`checks` with an `app_id` rather than the bare `contexts` list, so nothing
-else can satisfy one:
+What the rule holds is read from the endpoint, never assumed:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/branches/master/protection \
+gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
   --jq '.required_status_checks'
 ```
 
 | Check | Produced by |
 | --- | --- |
-| `tests-passed` | `test.yml`, aggregate over the matrix |
+| `test: every job passed` | `test.yml`, aggregate over the matrix |
 | `Lint and type-check` | `lint.yml`, its only job |
+| `Build the documentation` | `docs.yml`, its only job |
 | `CodeQL` | code scanning's default setup |
+
+`Build the documentation` is named on its own on purpose: a rule naming
+`Lint and type-check` alone would leave a red documentation build outside
+the required checks entirely. It moved from `lint.yml` to `docs.yml`
+without the rule changing, which is worth knowing before renaming
+anything — a context is matched by name, not by the workflow that reported
+it, so moving a job is free and renaming one is not.
+
+Neither `macos.yml`, `latest.yml`, `links.yml`, `mutation.yml`,
+`published.yml` nor `vendored-vectors.yml` appears in the rule, and none of
+them must: each is expected to go red for a reason no pull request
+introduced. `macos.yml` is the one worth naming twice, because it does run
+the suite: what a merge no longer waits for is the platform whose runners
+queue for tens of minutes, measured in `test.yml`'s header, and
+`release.yml` calls it so that a publication still does.
+
+Each check is bound to the app that produces it — `checks` with an `app_id`
+rather than the bare `contexts` list — so nothing else can satisfy one.
+15368 is Actions and 57789 is `github-advanced-security`, which is the app
+that reports `CodeQL`: the two Actions jobs of code scanning's default setup
+are called `Analyze (actions)` and `Analyze (python)`, and the `CodeQL`
+context is a separate check run that appears seconds after both finish.
+Reading it too early is how one concludes that the rule names a context
+nothing produces:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
+  --jq '.check_runs[] | {name, app: .app.slug, app_id: .app.id}'
+```
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
@@ -50,14 +80,14 @@ gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
 ```
 
 That absence of a file is also why the check was first left out of the
-rule, on a measurement that was the wrong one: every ordinary pull
-request targets `dev`, and default setup analyzes push events on the
-default branch and pull requests *against* it, nothing else, so a pull
-request like #43 produces no CodeQL check run at all — measured, zero
-analyses. But the rule protects `master`, and the pull request that
-matters there is the other kind, `dev` into `master`; #21, the 0.7.1
-release merge, has CodeQL analyses under `refs/pull/21/head`. That is
-the pull request this rule actually gates, and CodeQL runs on it:
+rule, on a measurement that was the wrong one: it was taken on a pull
+request against the branch that used to sit between a contributor and the
+trunk, and default setup analyzes push events on the default branch and
+pull requests *against* it, nothing else — so a pull request like #43
+produced no CodeQL check run at all, measured, zero analyses. With `main`
+the only long-lived branch every pull request is the kind default setup
+analyzes, which is the kind #21, the 0.7.1 release merge, already was:
+its analyses are under `refs/pull/21/head`.
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/analyses \
@@ -74,12 +104,23 @@ not `-f`, for `strict` — `gh api`'s `-f` sends every value as a string,
 and GitHub refuses `"true"` where a boolean is declared:
 
 ```shell
-sub=branches/master/protection/required_status_checks
+sub=branches/main/protection/required_status_checks
 gh api "repos/{owner}/{repo}/$sub" -X PATCH -F strict=true \
-  -F 'checks[][context]=tests-passed' -F 'checks[][app_id]=15368' \
+  -F 'checks[][context]=test: every job passed' -F 'checks[][app_id]=15368' \
   -F 'checks[][context]=Lint and type-check' -F 'checks[][app_id]=15368' \
+  -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368' \
   -F 'checks[][context]=CodeQL' -F 'checks[][app_id]=57789'
 ```
+
+Renaming a required check is the one change that cannot be made in a pull
+request. The rule names a context by the job's display name, so the pull
+request that renames the job stops producing the old name and never
+produces the one the rule is still waiting for. The rule moves first,
+against the branch, and then the pull request that renames the job reports
+the name the rule now wants; `enforce_admins` being off is what makes the
+window survivable rather than a lock. Every open pull request that predates
+the rename is blocked until it is rebased, which is the reason to do it
+with none open but the one doing the renaming.
 
 ## Branch protection
 
@@ -197,10 +238,10 @@ been built, and no rehearsal would reveal it, reaching the other
 environment.
 
 What that rule constrains is the *name* of the ref and nothing else. A
-`v*` tag pushed on a branch head, on an old `dev` state or on a
-fork-synced commit satisfies it exactly as the release tag does, so it is
-not the check that a release is a release: the `version-check` job of
-`release.yml` fails a tag that is not an ancestor of `master`, before the
+`v*` tag pushed on a branch head, on a stale state or on a fork-synced
+commit satisfies it exactly as the release tag does, so it is not the
+check that a release is a release: the `version-check` job of
+`release.yml` fails a tag that is not an ancestor of `main`, before the
 matrix builds anything. [RELEASING.md](RELEASING.md) has the rest,
 including what a mismatched trusted publisher looks like and why
 self-review stays allowed.


### PR DESCRIPTION
One CI revision, ported from `bitcoin-core-rpc` and adapted where this
repository's workflows are genuinely different: here `test.yml` builds the
wheels a release publishes, so "drop macOS from the matrix" could not mean
what it meant there.

## What was measured first

Six pull request runs of `test.yml`, the last six completed at the time
(`31438977136`, `31437311519`, `31427913912`, `31427899442`, `31424005524`,
`31326241647`), 98 jobs each:

```shell
gh run list --repo btclib-org/btclib-libsecp256k1 --workflow=test.yml \
  --limit 12 --json databaseId,status,conclusion
gh api "repos/btclib-org/btclib-libsecp256k1/actions/runs/<id>/jobs?per_page=100"
```

| runner | jobs | mean queue | max queue | mean compute | max compute |
| --- | --- | --- | --- | --- | --- |
| `macos-latest` | 108 | 20.8 | 70.2 | 0.8 | 7.2 |
| `macos-26-intel` | 102 | 19.0 | 68.0 | 1.5 | 13.3 |
| `windows-11-arm` | 42 | 2.6 | 8.1 | 2.7 | 10.2 |
| `windows-latest` | 96 | 2.4 | 9.7 | 1.3 | 10.8 |
| `ubuntu-latest` | 138 | 2.4 | 19.2 | 0.7 | 8.0 |
| `ubuntu-24.04-arm` | 102 | 2.1 | 10.8 | 0.7 | 6.8 |

Minutes. Per run: 104 to 109 minutes of compute, 42 to 1959 minutes of
queueing, 13 to 95 minutes of wall clock. So macOS is the bottleneck here
too, as in `bitcoin-core-rpc` and `btclib` — but with a difference that
changed the plan:

- 35 of the 98 jobs are on the two macOS images, and **31 of them are suite
  cells, 4 are wheel builds**.
- In the slowest run (95 minutes) the macOS suite cells took **the last
  thirty places before the aggregate**, their queue rising from 16.7 to 70.2
  minutes as they contended with each other.
- The macOS **wheel builds** finished at **24.6 minutes**, against **23.5**
  for the `ubuntu-latest` build beside them. They are not what stretches the
  run.

Four macOS jobs queue; thirty-one contend. That is the whole argument for
moving the suite cells and keeping the builds.

## The matrix

`macos-26-intel` and `macos-latest` are gone from `suite-static`,
`suite-dynamic` and `suite-sdist`, and kept in `build-cibuildwheel` and
`build-dynamic` — because `release.yml` publishes the artifacts of the
`test.yml` run it calls, so a macOS wheel not built there is a macOS wheel
not on PyPI.

`macos.yml` therefore cannot be a copy of the moved cells: those install a
wheel built earlier in the same run, and rebuilding them would cost ten
minutes of `cibuildwheel` per image and give a release two artifacts of the
same name. It builds from the tree instead, twice per cell — the static
extension, then `BTCLIB_LIBSECP256K1_DYNAMIC=true` — so both branches of
`_load_lib` run on both images on every interpreter `test.yml` ran there.
Both commands were checked on an arm64 Mac first: CPython 3.14 and 3.14t,
PyPy 3.10 and 3.11, 318 passed each (317 + 1 skip on PyPY, which has
`_cffi_backend` built in).

Triggers: `schedule` at `07 4 * * 3` — Wednesday, thirty minutes before
`latest.yml`'s `37 4 * * 3`, on a minute no other cron here uses (11, 23,
29, 37, 49) — plus `workflow_call` and `workflow_dispatch`; `permissions:
contents: read`; `concurrency: macos-${{ github.ref }}${{
inputs.concurrency-suffix }}` with `cancel-in-progress: true`;
`timeout-minutes: 40`. It gates nothing, and `release.yml` calls it.

## Names

| workflow | before | after (id, name) |
| --- | --- | --- |
| `test` | `coverage` / `Coverage` | `coverage` / `Measure coverage, gated at 100%` |
| `test` | `test-static` / `Test <v> on <os>` | `suite-static` / `Run the suite on the static wheel, <v>, <os>` |
| `test` | `test-dynamic` / `Test <v> on <os>` | `suite-dynamic` / `Run the suite on the dynamic wheel, <v>, <os>` |
| `test` | `test-sdist` / `Test sdist install on <os>` | `suite-sdist` / `Install from the sdist and run the suite on <os>` |
| `test` | `check-dist` / `Validate distributions` | `check-dist` / `Inspect the distribution files and install one` |
| `test` | `tests-passed` / `tests-passed` | `test-passed` / `test: every job passed` |
| `macos` | — | `suite-macos` / `Run the suite on <v>, <os>` |
| `latest` | `test-latest` / `Test <v> on <os>, deps at latest` | `suite-latest` / `Run the suite on <v>, <os>, dependencies at latest` |
| `latest` | `lint-latest` / `… deps at latest` | `lint-latest` / `Lint and type-check, dependencies at latest` |
| `latest` | `dist-latest` / `Validate distributions, deps at latest` | `dist-latest` / `Build the distributions and inspect them, dependencies at latest` |
| `published` | `test-published` | `install-published` |
| `release` | `lint` (unnamed) | `Run the lint workflow` |
| `release` | `build` → `test.yml` | `test` / `Run the test workflow` |
| `release` | — | `docs` / `Run the docs workflow` |
| `release` | — | `macos` / `Run the macos workflow` |
| `release` | `github-release` / `Create the GitHub release` | `Attach the files to the GitHub release` |
| `release` | — | `published` / `Install the published version from PyPI` |

Every job in every workflow now has an explicit `name:`, verified by a yaml
parse rather than by reading.

Two renames were corrections rather than vocabulary: `tests-passed` named
itself, and `test-static` and `test-dynamic` were **both** called
`Test <version> on <os>`, so every run produced pairs of check runs with one
name between them — the ambiguity REPOSITORY.md warns about. The linkage is
in the name now.

Adapted, and why: this repository has no `test-py`/`dist-py` to rename (no
`-py` suffixes exist), `check-dist` inspects and installs distributions
rather than building one, and `dist-latest` builds an sdist *and* a wheel,
so both keep the plural this repository uses everywhere. There is no
`attest` job — `gh-action-pypi-publish` generates PEP 740 attestations
itself.

## The documentation build

`Build the documentation` was the second job of `lint.yml` and is now the
only job of `docs.yml`, moved verbatim. **Its display name is unchanged, so
branch protection keeps matching it**: a required context is keyed by name,
not by the workflow that reported it. Same trigger set as `lint.yml` plus
`workflow_call`, its own literal group `docs-${{ github.ref }}${{
inputs.concurrency-suffix }}`, and `release.yml` calls it.

## Required checks — please run this before merging

The rule still requires `tests-passed`, which this branch no longer
produces. Current rule:

```shell
gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
  --jq '.required_status_checks'
```

It answers `strict: true` with four contexts, **each with `app_id: null`** —
so nothing is bound to an app today, although REPOSITORY.md says otherwise.
The command below closes that gap as well as renaming the one check, both app
ids having been measured on this repository's own check runs: 15368 is
Actions, and 57789 is `github-advanced-security`, which is what reports
`CodeQL` (the two Actions jobs of default setup are `Analyze (actions)` and
`Analyze (python)`; the `CodeQL` context is a separate check run that appears
seconds after both finish — this PR's own head carries all three).

```shell
sub=branches/main/protection/required_status_checks
gh api "repos/btclib-org/btclib-libsecp256k1/$sub" -X PATCH -F strict=true \
  -F 'checks[][context]=test: every job passed' -F 'checks[][app_id]=15368' \
  -F 'checks[][context]=Lint and type-check' -F 'checks[][app_id]=15368' \
  -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368' \
  -F 'checks[][context]=CodeQL' -F 'checks[][app_id]=57789'
```

To rename the check and nothing else, drop the four `app_id` pairs; the rule
then keeps the unbound shape it has today.

Direct link, to read the rule in the UI first:
<https://github.com/btclib-org/btclib-libsecp256k1/settings/branch_protection_rules>

Only `tests-passed` → `test: every job passed` changes; the other three keep
the names they have. `Build the documentation` needs nothing, having kept its
name across the move.

## Release, published, and the dead branches

- `release.yml` gets `concurrency: release-${{ github.ref }}` with
  `cancel-in-progress: false` — a publication's subject is not a commit a
  newer one supersedes, and a run cancelled between the two uploads leaves
  TestPyPI holding a version PyPI never got. It calls `test`, `lint`, `docs`
  and `macos`, all four in the `needs` of both publish jobs, and `published`
  after `publish-pypi`. Not `latest` (unlocked dependencies make the same tag
  pass today and fail tomorrow) and not `links` (a dead third-party link must
  not stop a release).
- `published.yml` takes an optional `version` input and, first of all, polls
  `https://pypi.org/pypi/btclib_libsecp256k1/<version>/json` with
  `curl -sf --max-time 10`, 20 attempts 15 seconds apart, failing if the
  version never appears — so a release-triggered run cannot pass by testing
  the previous version. Both name spellings and the 200/404 behaviour were
  checked against the live index. `workflow_call`, never `workflow_run`,
  which zizmor rates a dangerous trigger. Its schedule goes weekly →
  monthly, same minute and hour, day-of-month 1: `23 6 1 * *`.
- **Two dead references were live faults, not stale prose.** `test.yml` and
  `lint.yml` had `branches: [master]`, so **no push to `main` ran the gate at
  all**, and `version-check` runs `git merge-base --is-ancestor
  "$GITHUB_SHA" origin/master`, which fails on a ref that no longer exists —
  **the next tag would have been stopped by it**. Both fixed, along with
  every `github.base_ref == 'master'` draft exception (10 in `test.yml`, and
  one each in `lint.yml`, `links.yml`, `vendored-vectors.yml`) and the prose
  around them.

## The `pinned-rev` hook

Added after `- repo: meta`, and verified both ways rather than asserted:

- as the file stands, `uvx pre-commit run pinned-rev --all-files` → exit 0.
- with the two revisions pre-commit.ci actually offered put back — `typos` at
  `v1` and `pyroma` at `5.1b1`, both tags that exist upstream — → exit 1,
  naming `.pre-commit-config.yaml:167` and `.pre-commit-config.yaml:395`.

(The first attempt used `rev: v1` on `pre-commit/pre-commit-hooks`, which has
no such tag: pre-commit then fails to clone and the hook never runs, which
would have been a test of nothing.)

`autoupdate_branch: dev` also pointed at the deleted branch and now says
`main`, matching `dependabot.yml` after #103.

## No live-node analogue to promote

There is nothing here like `rpc-smoke`: no workflow starts a service.
`vendored-vectors.yml` is the closest, and it is cheap enough to qualify on
cost — 8 seconds of compute in its last run
(`gh api repos/btclib-org/btclib-libsecp256k1/actions/runs/31427899445/jobs`)
— but its subject is a third-party upstream, its verdict is drift nobody on
the branch introduced or can fix, and it holds `issues: write`. Promoting it
would block merges for somebody else's commit, which is the rule this
revision applies to `links` too. Left as a sentinel.

## What this gives up

- **The dynamic macOS wheel is no longer installed and tested on every pull
  request.** `build-dynamic` still builds it and `check-dist` still inspects
  it, but nothing on the gate imports it. `macos.yml` covers the same
  `_load_lib` branch from a source build, weekly and before a release.
- **pip's selection among the static macOS wheels moves off the gate.** Less
  than it sounds: `cibuildwheel` runs the suite against every wheel it
  builds, on the runner that built it, so the macOS wheels are still tested
  by the job that produces them on every pull request. What waits is the
  "given a directory of all of them, pip picks the right one" check.
- **Installing from the sdist on macOS moves off the gate.** `macos.yml`
  compiles the same tree on both images instead, which is the part that can
  fail; the packaging-list question the sdist job really asks is still asked
  on ubuntu and windows.
- **A macOS regression can sit on `main` for up to a week.** It cannot be
  published: `release.yml` calls `macos.yml`.
- **`macos.yml` compiles libsecp256k1 twice per cell**, so its own runs are
  slower than the cells they replace. It waits for nobody.

## Gates, with exit codes

```shell
uvx pre-commit run --all-files                      # 0, and 0 again on a second pass
uv run --locked --no-default-groups --group test pytest --cov   # 0, 100.00%, 318 passed
git submodule update --init && uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # 0
uv build --sdist                                    # 0
uv run --locked --only-group check twine check --strict dist/*     # 0
uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz   # 0, 10/10
```

`actionlint` and `zizmor` are hooks in that first command, and both report
zero findings on the new files. The workflow graph — triggers, crons, matrix
shapes, `needs`, and every job's `name` — was verified by parsing the yaml,
not by reading it.

CI on the first push of this branch, before a force-push superseded it,
already ran the new shape end to end: `docs`, `lint`, `links` and
`vendored-vectors` green, and of the `test` run's 43 jobs, 34 succeeded, 8
were cancelled by the force-push, and `test: every job passed` reported
failure for exactly that reason — cancellation being no evidence either way,
which is what that job's `always()` is for. 27 of the renamed suite cells
passed, and the run held four macOS jobs, all of them wheel builds.

## Found while doing this, not fixed here

`.gitignore` ignores `.venv` and `venv*/` but not `.venv-*`, and
`CLAUDE.md`/`CONTRIBUTING.md` both tell a developer to create
`.venv-3.10`-style environments. `uv build --sdist` then ships them: 77 paths
under `.venv-3.14t/` in the sdist built here, and `pyroma` died on
`tarfile.AbsoluteLinkError` for `.venv-3.14t/bin/python` rather than rating
anything. One line in `.gitignore` fixes it, and it belongs in a change of
its own — this one touches no packaging input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
