### PR TITLE
Move the vendored libsecp256k1 to 0.8.0, and the version with it

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 790
+        "line_number": 818
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-10T23:42:09Z"
+  "generated_at": "2026-08-11T00:08:45Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,35 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
-## v0.7.1.4 (work in progress, not released yet)
+## v0.8.0 (work in progress, not released yet)
+
+### The wrapped library
+
+- **libsecp256k1 moves from 0.7.1 (1a53f49) to 0.8.0 (6e2c8bc)**, and the
+  package version with it, the two tracking each other by the rule in the
+  README's Versioning section. The submodule bump is what decides that
+  number, so it is what carries it: `pyproject.toml`, this file and
+  HISTORY.md all say 0.8.0, and the fourth-number placeholder 0.7.1.4 that
+  was open is gone rather than released — nothing had shipped under it.
+- **The symbols upstream removed were not used here.** Checked rather
+  than assumed: `secp256k1_context_no_precomp` and the
+  `secp256k1_schnorrsig_sign` alias appear nowhere in the package, the
+  stubs or the tests, `ssa` having always called `sign32` and
+  `sign_custom`. The macro `SECP256K1_GNUC_PREREQ` is also gone from the
+  headers, which matters here only in that the headers are preprocessed
+  into the cffi definitions: `gcc -E` expands what it finds, and it no
+  longer finds that.
+- **`ellswift.xdh`'s refusal of an out-of-range key is upstream's**, and
+  the suite did not have to change for it. The wrapper already raised
+  `ValueError("invalid private key")` on a zero return, and the docstring
+  already said a key that is not a valid scalar raises; what changed is
+  which keys libsecp256k1 calls invalid.
+- **The new `silentpayments` module is not enabled by this change.** It is
+  a module of libsecp256k1 0.8.0, and this repository asks for every
+  module it wraps explicitly rather than taking upstream's defaults, so
+  turning it on belongs with the binding that uses it. Until then it is
+  absent from the build, which is why the surface this change adds is
+  none: the same entry points, minus the two symbols upstream removed.
 
 ### CI
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,35 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.7.1.4 (work in progress, not released yet)
+## v0.8.0 (work in progress, not released yet)
+
+[libsecp256k1 0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)
+(6e2c8bc), up from 0.7.1: a minor version of the wrapped library, so a
+minor version here, the numbers tracking each other. **One breaking
+change, and only for a caller reaching through `lib`.**
+
+- **Two libsecp256k1 symbols are gone**, removed upstream after being
+  deprecated: `secp256k1_context_no_precomp`, whose replacement is
+  `secp256k1_context_static`, and the `secp256k1_schnorrsig_sign` alias,
+  whose replacement is `secp256k1_schnorrsig_sign32`. Nothing in these
+  bindings used either, so code calling only the wrappers is unaffected;
+  code reaching for one of the two through `lib` has to move to its
+  replacement, and will fail to import the attribute rather than
+  misbehave.
+- **`ellswift.xdh` refuses a private key at or above the group order**,
+  where it used to reduce it modulo the order and answer. That was
+  upstream's bug and is upstream's fix; what changes here is that such a
+  key now raises `ValueError` naming an invalid private key, which is
+  what the docstring already said it did. No securely generated key is
+  affected: the probability of one landing there is about 2**-128.
+- **ECDSA and BIP340 verification are faster on GCC and MSVC**, by up to
+  about 11% upstream's measure, the 64-bit field multiplication and
+  squaring now being force-inlined. Clang, which is what the macOS wheels
+  are built with, is largely unaffected; the compiled library is somewhat
+  larger everywhere.
+- **A new libsecp256k1 module, `silentpayments`, is not wrapped by this
+  release** — it is compiled in and reachable through `lib`, and the
+  binding for it lands separately.
 
 ## v0.7.1.3
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bitcoin-core-rpc carry the same three lines. -->
 
 Simple python bindings to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
-([v0.7.1](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.7.1)).
+([v0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)).
 As used by the
 [btclib](https://github.com/btclib-org/btclib) library.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btclib_libsecp256k1"
-version = "0.7.1.4"
+version = "0.8.0"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ wheels = [
 
 [[package]]
 name = "btclib-libsecp256k1"
-version = "0.7.1.4"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
Supersedes #104, which is dependabot's bump of the same submodule and
nothing else. Dependabot tracks the upstream *default branch*, so its pin
landing on a tagged commit was a coincidence of timing — `6e2c8bc` happens
to be `v0.8.0` — and its pull request carries none of what a version bump
here also has to move.

## What this is

`secp256k1` goes from 0.7.1 (`1a53f49`) to 0.8.0 (`6e2c8bc`), and by the
rule in the README's Versioning section that decides the package version
too: a release wrapping vM.N.P is M.N.P. So the `0.7.1.4` placeholder
opened after 0.7.1.3 is spent rather than released — nothing shipped under
it — and `pyproject.toml`, `uv.lock`, HISTORY.md and CHANGELOG.md all say
0.8.0.

## One breaking change, and only through `lib`

Upstream removed two deprecated symbols. Neither was used here — checked,
not assumed: `secp256k1_context_no_precomp` and the
`secp256k1_schnorrsig_sign` alias appear nowhere in the package, the stubs
or the tests, `ssa` having always called `sign32` and `sign_custom`. A
caller reaching for either through `lib` has to move to
`secp256k1_context_static` and `secp256k1_schnorrsig_sign32`, and gets an
`AttributeError` rather than a misbehaviour.

`ellswift.xdh` now refuses a private key at or above the group order where
it used to reduce it modulo the order and answer. That is upstream's fix to
upstream's bug; the wrapper already raised on a zero return and its
docstring already said an invalid scalar raises, so nothing here changed
for it.

## What is deliberately not in it

libsecp256k1 0.8.0 adds a `silentpayments` module. This change leaves it
out of the build: every module is asked for explicitly here rather than
taken from upstream's defaults, so enabling it belongs with the binding
that uses it — #108.

## Verified rather than reasoned about

- the whole suite passes at 100% coverage against 0.8.0 with **no test
  changed**
- `uv build --sdist`, `twine check --strict` and `pyroma --min 10` pass,
  the last at 10/10
- `uvx pre-commit run --all-files` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the btclib_libsecp256k1 package and vendored libsecp256k1 to v0.8.0, documenting the upstream changes and their impact on callers while leaving the new silentpayments module unwrapped for now.

New Features:
- Expose libsecp256k1 v0.8.0, including its new silentpayments module via the raw `lib` interface, while keeping high-level bindings unchanged.

Enhancements:
- Align the Python package versioning with libsecp256k1 v0.8.0 and remove the unused 0.7.1.4 placeholder release.
- Document the upstream performance improvements and behavioural changes (including key validity checks) introduced in libsecp256k1 0.8.0.

Build:
- Update pyproject metadata and lockfile to target btclib_libsecp256k1 v0.8.0 and the corresponding vendored libsecp256k1 revision.

Documentation:
- Update README, CHANGELOG, and HISTORY to reflect libsecp256k1 v0.8.0 and describe the breaking changes for callers that reach through `lib`.