### PR TITLE
Update the lock: pre-commit 4.6.2 and virtualenv 21.7.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2172,7 +2172,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2181,9 +2181,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]
@@ -3204,7 +3204,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.3"
+version = "21.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3213,9 +3213,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/10/8b7a5454efc032be50c1c5641467dbb5d31314500205212b2aa66d3c8af4/virtualenv-21.7.3.tar.gz", hash = "sha256:5e9e287f5c808070eea3b40403d3368248e64b24f1b60bd9a36e85ac841d2c3e", size = 5525482, upload-time = "2026-08-08T14:43:20.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/2a/83d779d2dfb61f101d7b1c10073d18984e37262d8b4f171c99911a952430/virtualenv-21.7.3-py3-none-any.whl", hash = "sha256:26dfda3c34f29bf1a3ca167426a67658d59979b9954e705aef60a5f724ce1773", size = 5504590, upload-time = "2026-08-08T14:43:18.57Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A full dependency refresh, and the lock is all of it that moved:
`pre-commit` 4.6.1 -> 4.6.2 and `virtualenv` 21.7.3 -> 21.7.4, both
development tooling. The one runtime dependency here is cffi, and it did
not move.

What was checked and did not move:

- **every hook rev in `.pre-commit-config.yaml`** — `pre-commit autoupdate`
  reports every repo already up to date, save the two it gets wrong (below)
- **every action SHA** — each of the eight is the latest release tag
- **the versions pinned by hand**, which nothing else moves: the mypy hook's
  `cffi==2.1.1`, `types-cffi==2.0.0.20260518`, `hatchling==1.31.0`,
  `pytest==9.1.1` and actionlint's `shellcheck-py==0.11.0.1` are each the
  newest release on PyPI, and uv 0.12.3 is both the newest and what
  `required-version` asks for
- **123 of the 126 locked packages** are at their newest release. The three
  that are not are capped upstream rather than drifting here: `docutils`
  0.22.4 (sphinx 9.1.0 asks for `<0.23`), `pydantic-core` 2.46.4 (pydantic
  pins it exactly) and `wheel-filename` 1.4.2 (check-wheel-contents asks
  for `~=1.1`)

`autoupdate` again offered `v1` for typos and `5.1b1` for pyroma. The
`pinned-rev` hook 35c6931 added is what refused them this time: handed those
two revs on purpose it names both lines and exits 1, so the correction is no
longer a thing a reviewer has to notice, and there is nothing to change in
that file.

Verified locally on arm64 macOS, CPython 3.14.6: `uvx pre-commit run
--all-files` green (36 hooks), and `uv run --locked --no-default-groups
--group test pytest --cov` 318 passed at 100.00% coverage.

The vendored `secp256k1` submodule is untouched — a separate branch is
moving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh development tooling lockfile versions for pre-commit and virtualenv while keeping runtime dependencies unchanged.

Build:
- Update uv.lock to bump pre-commit to 4.6.2 and virtualenv to 21.7.4 for development workflows.

Chores:
- Regenerate dependency lockfile to align with latest allowed dev tool releases without altering pinned runtime packages.