### PR TITLE
Ignore .venv-3.10, so the sdist stops shipping it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,15 @@ celerybeat-schedule
 # dotenv
 .env
 
-# virtualenv
-.venv
+# virtualenv. `.venv*/` and not `.venv`: a suffix makes a different name,
+# and `UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache
+# pytest` -- CONTRIBUTING.md's other-interpreter run, kept from replacing
+# the default environment -- creates one. Nothing downstream catches it: uv
+# writes a `.gitignore` holding `*` inside the environment, so `git status`
+# is clean, while hatchling reads this file alone and ships the directory in
+# the sdist, where `bin/python` is a link to an absolute path that `pyroma`
+# refuses to extract
+.venv*/
 venv*/
 ENV/
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 895
+        "line_number": 923
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T00:10:40Z"
+  "generated_at": "2026-08-11T00:28:50Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,34 @@ release-notes length in the first place, and are still in
   after would have done the same. Where the file starts is the fact it
   was reaching for, and that one does not move.
 
+### Packaging metadata
+
+- **`.gitignore` matches a versioned environment, and the sdist stops
+  shipping one.** `.venv`, `venv/` and `venv*/` between them do not match
+  `.venv-3.10`, which is what
+  `UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache pytest`
+  creates — the way of trying another interpreter that keeps the default
+  environment rather than replacing it, and CONTRIBUTING.md now gives it
+  beside the run that replaces one. Nothing downstream caught the leftover:
+  uv writes a `.gitignore` holding `*` inside the environment it creates, so
+  `git status` was clean, while hatchling builds the sdist from the root file
+  alone and shipped the directory — 377 paths against 297 and 13,132,264
+  bytes against 3,076,714, measured on `38ee75b` with the environment present
+  either way (`tar -tzf dist/*.tar.gz | wc -l`), the rest of the archive
+  identical. The totals move with the vendored library and the difference
+  does not: it is the environment's `bin` and the four files beside it,
+  `lib/` being matched already by the Distribution section above.
+  `twine check --strict` passed on it; `pyroma --min 10` raised
+  `tarfile.AbsoluteLinkError` on `.venv-3.10/bin/python`, the tarfile data
+  filter refusing a link to an absolute path, so the packaging gate failed
+  on one symlink rather than on the stray paths, which are the difference
+  between those two counts. `check-manifest` names every one of them — it
+  compares the sdist with what git tracks — and is not in the `check` group;
+  the pattern states the same fact where a file becomes invisible rather
+  than where an archive is built. It is `.venv*/`, in place of the `.venv`
+  beside `venv*/`: a directory of that exact name is matched by it, and by
+  the stock `# Environments` block above.
+
 ## v0.7.1.3
 
 ### Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,16 @@ installs it as a managed one, and `uv sync` then prefers it to a system
 3.14, so `uv python install 3.14` is what makes the default environment
 reproducible again.
 
+Naming the environment keeps the default one instead, at the price of a
+second build of the extension:
+
+```shell
+UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache pytest
+```
+
+`.gitignore` matches that name with `.venv*/`, the comment beside the
+pattern saying what ships the environment when nothing matches it.
+
 ### The editor
 
 `.vscode/settings.json` and `.vscode/extensions.json` are tracked, and they


### PR DESCRIPTION
`.gitignore` covered `.venv`, `venv/` and `venv*/`, none of which matches
`.venv-3.10`. Nothing in the tree noticed: uv writes a `.gitignore`
holding `*` inside every environment it creates, so `git status` stays
clean, while hatchling builds the sdist from the root file alone and
shipped the whole directory.

## Reproduced, then fixed, with the environment on disk both times

`.venv-3.10` created by the command below, then `uv build --sdist`, in a
worktree of `38ee75b`:

| measurement | command | before | after |
| --- | --- | --- | --- |
| paths in the sdist | `tar -tzf dist/*.tar.gz \| wc -l` | 377 | 297 |
| paths matching venv | `tar -tzf dist/*.tar.gz \| grep -c venv` | 80 | 0 |
| archive bytes | `stat -f%z dist/*.tar.gz` | 13132264 | 3076714 |
| `pyroma --min 10` | as in CONTRIBUTING.md | exit 1 | exit 0, 10/10 |
| `twine check --strict` | as in CONTRIBUTING.md | exit 0 | exit 0 |
| `check-wheel-contents` | as in CONTRIBUTING.md | exit 0 | exit 0 |
| `uvx check-manifest` | not a gate here | exit 1 | exit 0 |

The two listings are identical once the venv paths are removed from the
first, so nothing wanted left with them. The totals move with the
vendored library — the same measurement on `35c6931`, before 0.8.0
landed, gave 363 against 283 and 12724699 against 2673113 — and the
difference does not: `.venv-3.10/bin` and the four files beside it, `lib/`
being matched by the Distribution section of `.gitignore` already, which
is why 80 paths ship out of the 7692 `find .venv-3.10 | wc -l` counts.

The one gate that caught it caught it by accident: `twine check --strict`
passes on the polluted archive, and `pyroma --min 10` fails on a symlink
rather than on the stray paths —

```text
tarfile.AbsoluteLinkError: 'btclib_libsecp256k1-0.8.0/.venv-3.10/bin/python'
is a link to an absolute path
```

## The pattern, and MANIFEST.in

`.venv*/` replaces the `.venv` beside `venv*/`, which it subsumes:
`git check-ignore -v` matches `.venv/`, `.venv-3.10/` and `.venv-3.14t/`
on it, and the bare `.venv` in the stock `# Environments` block above
still covers a plain file of that name.

Neither `MANIFEST.in` nor `[tool.check-manifest]` exists in this
repository, and neither is needed: `git ls-files | grep -i venv` exits 1,
so no wanted file starts with `.venv`, and `uvx check-manifest` reports
"lists of files in version control and sdist match" after the change
where the pre-fix file gives exit 1 with 79 of those paths under
"missing from VCS". check-manifest is not in the `check` group, which is
why nothing named them before pyroma tripped over the symlink.

## One documentation change, and why it is here

The report behind this fix said CONTRIBUTING.md documents
`UV_PROJECT_ENVIRONMENT=.venv-3.10`. It does not — that is btclib and
bitcoin-core-rpc, where CLAUDE.md and CONTRIBUTING.md both give it. Here
the only other-interpreter command is
`uv run --python 3.10 --no-cache pytest`, whose paragraph warns that it
replaces `.venv` and leaves it replaced. So the named-environment form is
now in that paragraph: the `.gitignore` comment names the command it
protects against, and the command exists where a reader will look for it.

## Follow-up, not fixed here

Both siblings have the same ignore hole — `git check-ignore .venv-3.10`
exits 1 in a checkout of each, `.venv` and `venv*/` being their patterns
too — and both document the variable that creates one, so the leftover
directory is invisible there as well. Whether it reaches an sdist is a
second question and wants measuring rather than assuming: both build with
setuptools from an allow-list `MANIFEST.in` (`include *.md`,
`include *.yaml`, …) rather than from `.gitignore`, and neither discovers
packages by a pattern a dotted directory could match — bitcoin-core-rpc
names its one package, btclib has `include = ["btclib*"]`. Both gate on
`check-manifest`, which is what names an untracked file that lands in an
sdist, so there the archive is the part that is probably safe and the
working tree is the part that is not.

Two things found in passing, neither touched here:

- CLAUDE.md and CONTRIBUTING.md still describe development on `dev` with
  `master` receiving merges, including the worktree recipe's
  `git worktree add -b <branch> "$WT" origin/dev`. `origin/HEAD` is
  `origin/main`, `dev` is deleted (`d4a7034` points dependabot.yml at
  `main`), and CHANGELOG.md's own v0.8.0 entries say `main`
- CLAUDE.md says of the `.venv` replacement that "The README says so, at
  the end of a long section". `grep -n '\.venv\|uv sync' README.md`
  matches nothing; CONTRIBUTING.md is where that fact lives

## Gates

Run in a worktree of `38ee75b`, exit codes read rather than output
filtered: `uvx pre-commit run --all-files` twice, both 0 (a first pass
wanted `.secrets.baseline` restaged, its one CHANGELOG.md line number
moving 895 → 923); `uv run --locked --no-default-groups --group test
pytest --cov`, 419 passed at 100.00%; the sphinx `-W --keep-going` build;
`uv build --sdist`, `uv build --wheel`, and `twine check --strict`,
`check-wheel-contents` and `pyroma --min 10` from the pinned `check`
group. `UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache
pytest` passed 419 as well, that being the command that creates the
directory this pattern ignores.

The head moved once: the branch was opened on `35c6931` and rebased onto
`38ee75b` when 0.8.0 landed, which is also where the numbers above were
re-taken. The only conflict was `.secrets.baseline`, resolved by taking
the base's file and letting the hook rewrite the line number.

No branch rule or required check is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
