### PR TITLE
Kill the three silentpayments mutants no test noticed

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 923
+        "line_number": 950
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T00:28:50Z"
+  "generated_at": "2026-08-11T00:36:44Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,33 @@ release-notes length in the first place, and are still in
   `finally` wipes them, an invalid key later in the list being able to
   raise between them.
 
+### Mutation testing
+
+- **A session over the new module found three mutants no test killed**,
+  and the three are in tests/ now. The scope needed no change —
+  `module-path` is the package, so a module added to it is in scope — and
+  what the session cost was worth having:
+    - `0 <= m < 2**32` mutated to `0 <= m != 2**32` survived a test that
+    drove *both ends* of the bound. `-1` fails the first comparison and
+    `2**32` fails the second, so both still raise; the one input that
+    tells `<` from `!=` is a value above the bound, and `2**32 + 1` is now
+    in the parametrization with the reason written beside it.
+    - the two `finally` loops that wipe a secret survived being turned into
+    `for buffer in []`, which is a new shape here: every other wipe in the
+    package is one statement about one buffer, and these are the first
+    over a list. The buffers are locals, invisible from any answer, so
+    what kills the mutant is a spy on `wipe` — recording each buffer and
+    wiping it for real, then asserting one per secret the call was given
+    and every one of them zeroed. The sender's refusal path is asserted
+    too: an invalid key later in the list has to leave the ones before it
+    wiped, which is why both lists are built inside the `try`.
+- **Run it with the filter, or read 110 survivors that mean nothing.**
+  `cr-filter-operators` between `init` and `exec` is a step of the
+  workflow and not of the toml, so a hand-run session that skips it
+  reports every `bytes | int` annotation mutant as a survivor — 110 of
+  113 on the first pass here. With it: 94 executed, **0 survived**, 110
+  skipped.
+
 ### External vectors
 
 - **`tests/bip352_send_and_receive_test_vectors.json`**, vendored from

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -24,6 +24,7 @@ import hashlib
 import pytest
 
 from btclib_libsecp256k1 import (
+    _secret,
     context,
     dsa,
     ecdh,
@@ -631,8 +632,15 @@ def test_a_label_m_outside_four_bytes_is_refused() -> None:
     Left to cffi the answer is `OverflowError`, which is neither how this
     package reports an argument out of domain nor a message naming the
     argument.
+
+    `2**32 + 1` is here because the two ends of the bound are not enough,
+    which a mutation session said: with `<` mutated to `!=` the check
+    reads `0 <= m != 2**32`, and both ends still raise -- `-1` fails the
+    first comparison and `2**32` fails the second. A value *above* the
+    bound is the one input that tells the two apart, so it is the one
+    that kills that mutant.
     """
-    for m in (-1, 2**32):
+    for m in (-1, 2**32, 2**32 + 1):
         with pytest.raises(ValueError, match="the label m must fit in 4 bytes"):
             silentpayments.label(SP_SCAN_PRVKEY, m)
 
@@ -741,3 +749,125 @@ def test_scanning_refuses_a_malformed_label_cache(
             SP_SPEND_PUBKEY,
             labels=labels,
         )
+
+
+def spy_on_wipe(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    """Record every buffer `silentpayments` wipes, and wipe it for real.
+
+    The buffers holding a secret in these wrappers are locals, gone by the
+    time a caller could look at one, so a spy is the only way to hold what
+    was wiped and check it. What it holds is the buffer itself, wiped: the
+    assertions below read it after the call.
+
+    The spy goes onto `silentpayments` and the real one is read from
+    `_secret`, which is not interchangeable: the module does
+    `from ._secret import wipe`, so it holds a reference of its own and
+    patching `_secret.wipe` would not reach it.
+
+    Args:
+        monkeypatch: the fixture, whose undo is what keeps this local to
+            one test.
+
+    Returns:
+        The list the spy appends to, in the order the wrapper wipes.
+    """
+    wiped: list[object] = []
+
+    def recording_wipe(buffer: object) -> None:
+        wiped.append(buffer)
+        _secret.wipe(buffer)
+
+    monkeypatch.setattr(silentpayments, "wipe", recording_wipe)
+    return wiped
+
+
+def zeroed(buffer: object) -> bool:
+    """Whether a cffi buffer holds nothing but zeros."""
+    memory = ffi.buffer(buffer)
+    return bytes(memory) == bytes(len(memory))
+
+
+def test_the_sender_wipes_every_private_key_it_copied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both kinds of key are wiped, one buffer each, and on the way out.
+
+    A taproot key becomes a `secp256k1_keypair` and any other a 32-octet
+    buffer; both are memory this package owns and both carry the secret,
+    so both are taken back. The count is what a loop that ran no
+    iterations would fail -- which is what a mutation session turned this
+    wipe into, and nothing noticed.
+
+    Args:
+        monkeypatch: the fixture the spy is installed through.
+    """
+    wiped = spy_on_wipe(monkeypatch)
+
+    silentpayments.create_outputs(
+        [(SP_SCAN_PUBKEY, SP_SPEND_PUBKEY)],
+        SP_OUTPOINT,
+        taproot_prvkeys=[SP_INPUT_PRVKEY],
+        prvkeys=[SP_SPEND_PRVKEY],
+    )
+
+    assert len(wiped) == 2, "one buffer per private key given, and no more"
+    assert all(zeroed(buffer) for buffer in wiped)
+
+
+def test_the_sender_wipes_the_keys_it_had_when_a_later_one_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key that cannot be made does not leave the ones before it behind.
+
+    Which is why the two lists are built inside the `try` rather than
+    before it: the second key here is invalid, so `_keypair` raises with
+    the first already made, and the `finally` has to be in force for it.
+
+    Args:
+        monkeypatch: the fixture the spy is installed through.
+    """
+    wiped = spy_on_wipe(monkeypatch)
+
+    with pytest.raises(ValueError, match="invalid private key"):
+        silentpayments.create_outputs(
+            [(SP_SCAN_PUBKEY, SP_SPEND_PUBKEY)],
+            SP_OUTPOINT,
+            taproot_prvkeys=[SP_INPUT_PRVKEY, 0],
+        )
+
+    assert len(wiped) == 1, "the key made before the refusal"
+    assert all(zeroed(buffer) for buffer in wiped)
+
+
+def test_scanning_wipes_the_tweaks_and_the_label_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every found output and every cached label tweak is taken back.
+
+    The found outputs are wiped whether libsecp256k1 wrote to them or
+    not -- the array is as long as the outputs one and it says through
+    `n_found` how much of it it used -- so the count is one per
+    transaction output plus one per label in the cache.
+
+    Args:
+        monkeypatch: the fixture the spy is installed through.
+    """
+    label, label_tweak = silentpayments.label(SP_SCAN_PRVKEY, 1)
+    labeled = silentpayments.labeled_spend_pubkey(SP_SPEND_PUBKEY, label)
+    outputs = silentpayments.create_outputs(
+        [(SP_SCAN_PUBKEY, labeled), (SP_SCAN_PUBKEY, SP_SPEND_PUBKEY)],
+        SP_OUTPOINT,
+        prvkeys=[SP_INPUT_PRVKEY],
+    )
+    summary = sp_summary()
+    wiped = spy_on_wipe(monkeypatch)
+
+    found = silentpayments.scan_outputs(
+        outputs, SP_SCAN_PRVKEY, summary, SP_SPEND_PUBKEY, labels={label: label_tweak}
+    )
+
+    assert len(found) == 2, "both outputs are this recipient's"
+    assert len(wiped) == len(outputs) + 1, "every found output slot, and the one label"
+    assert all(zeroed(buffer) for buffer in wiped)
+    # the tweaks reached the caller before the buffers were zeroed
+    assert all(tweak != bytes(32) for _, tweak, _ in found)


### PR DESCRIPTION
Follow-up to #108, which merged while this session's mutation run was still
going. `main` has the module; these are the three tests the session asked
for, and none of the module changed.

## What the session found

Scoped to `btclib_libsecp256k1/silentpayments.py`, `cr-filter-operators`
between `init` and `exec`: **94 mutants executed, three surviving.** Two
shapes:

**A bound tested only *on* its ends.** `0 <= m < 2**32` mutated to
`0 <= m != 2**32` survived a test that drove both `-1` and `2**32`: `-1`
fails the first comparison and `2**32` fails the second, so both still
raise. The one input that tells `<` from `!=` is a value *above* the bound,
and `2**32 + 1` is now in the parametrization with that reason beside it.

**Two `finally` loops that wipe a secret**, both surviving
`for buffer in []`. This is a shape new to the package: every other wipe
here is one statement about one buffer, and these are the first over a
list, so `ZeroIterationForLoop` had nothing to bite on before. The buffers
are locals, invisible from any answer, so what kills the mutant is a spy on
`wipe` — recording each buffer and wiping it for real, then asserting one
per secret the call was given and every one of them zeroed. The sender's
*refusal* path is asserted too: an invalid key later in the list has to
leave the ones before it wiped, which is the reason both lists are built
inside the `try` rather than before it.

The spy goes onto `silentpayments` and the real `wipe` is read from
`_secret`, and that is not interchangeable — the module does
`from ._secret import wipe`, so patching `_secret.wipe` would not reach it.
The docstring says so, because the next person will try the other one.

## Read a hand-run session with the filter, or not at all

`cr-filter-operators` is a step of `mutation.yml` and not of the toml, so a
session run by hand without it reports every `bytes | int` annotation mutant
as a survivor: **110 of the first 113 here.** That is documented in
`.github/mutation/bindings.toml` as a decision but not as a command to run,
which is what made it easy to skip. After the filter and these tests: 94
executed, **0 survived**, 110 skipped.

`bindings.toml` also lost a stated mutant count in #108 — `module-path` is
the package, so a module added to it is in scope, and the number was a line
every such change would have had to edit.

## Verified rather than reasoned about

- each of the three mutations applied **by hand** and the suite watched to
  fail: 2, 1 and 1 test respectively. `PYTHONDONTWRITEBYTECODE=1`
  throughout, with a passing baseline before and a passing control run
  after — the `.pyc` hazard CLAUDE.md records is real for exactly this
- 422 tests, coverage still 100% with nothing excluded
- `uvx pre-commit run --all-files` clean, `mypy --strict` included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tests to cover previously undetected mutation cases in the silentpayments module and document the mutation-testing findings.

Bug Fixes:
- Extend label range validation test to cover values above the 4-byte upper bound, preventing mutations on the comparison from surviving.

Enhancements:
- Add spy-based tests to ensure sender and scanner functions wipe all sensitive key and tweak buffers, including error paths.
- Document the mutation-testing session results and guidance for running the filtered mutation workflow in the changelog.

Documentation:
- Describe the discovered silentpayments mutants and the new tests and mutation-testing setup in the changelog.

Tests:
- Add a new label-boundary test case for values above 2**32 to distinguish strict inequality from non-equality comparisons.
- Introduce helper utilities and tests that spy on the wipe function to assert that all secret-holding buffers are wiped in normal and failure paths in silentpayments.