### PR TITLE
Leave dependabot's target to its default, and match btclib's file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,29 +6,33 @@
 #
 # every pull request here runs the whole build and test matrix, tens of
 # jobs compiling libsecp256k1 from source, so each ecosystem groups its
-# updates into a single pull request. Weekly, matching btclib: latest.yml
-# upgrades everything and runs that same matrix against it every
-# Wednesday, off the critical path, so a Thursday pull request is a diff
-# whose result is already known, and a smaller one is easier to read and
-# to revert than a month of drift arriving at once. That is what makes
-# the extra machine time worth it here too, tens of jobs compiling
-# libsecp256k1 from source included. Each still waits a week before
-# proposing a release regardless: a version yanked within days of
-# publication would otherwise be a pull request that opens, runs that
-# matrix, and is then closed
+# updates into a single pull request. None declares a target-branch:
+# without one dependabot opens against the default branch, which is the
+# only branch a change lands on -- and a target-branch naming a branch
+# that is not there is not an error anywhere, it is a repository where
+# nothing is ever proposed.
+#
+# Weekly, matching btclib: latest.yml upgrades everything and runs that
+# same matrix against it every Wednesday, off the critical path, so a
+# Thursday pull request is a diff whose result is already known, and a
+# smaller one is easier to read and to revert than a month of drift
+# arriving at once. That is what makes the extra machine time worth it
+# here too, tens of jobs compiling libsecp256k1 from source included.
+# Each still waits a week before proposing a release regardless: a
+# version yanked within days of publication would otherwise be a pull
+# request that opens, runs that matrix, and is then closed
 version: 2
 updates:
   # what this buys is the exact pins: every action is pinned to a commit
   # SHA, which nothing but this moves
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "thursday"
-    target-branch: "main"
+      interval: weekly
+      day: thursday
     groups:
       # one PR for all action bumps instead of one PR each
-      github-actions:
+      actions:
         patterns: ["*"]
     cooldown:
       default-days: 7
@@ -40,12 +44,11 @@ updates:
   # request are the pre-commit revisions, updated by pre-commit.ci; these
   # are what an editor and an ad hoc run see, and they should not drift
   # away from those
-  - package-ecosystem: "uv"
-    directory: "/"
+  - package-ecosystem: uv
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "thursday"
-    target-branch: "main"
+      interval: weekly
+      day: thursday
     groups:
       dev-tooling:
         patterns: ["*"]
@@ -55,11 +58,10 @@ updates:
   # signal upstream movement of the vendored secp256k1 submodule;
   # note: Dependabot tracks the upstream default branch, so releases
   # still need a manual bump to the tagged commit
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
+  - package-ecosystem: gitsubmodule
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "thursday"
-    target-branch: "main"
+      interval: weekly
+      day: thursday
     cooldown:
       default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,10 @@ ci:
   # where the workflow token cannot write and every action is pinned to
   # a commit SHA: a failing hook has to be fixed by its author
   autofix_prs: false
-  # onto main, as Dependabot targets it: the sole long-lived branch, and a
-  # branch that does not exist is a pull request with nowhere to land
-  autoupdate_branch: main
+  # no autoupdate_branch, as dependabot declares no target-branch: the
+  # default is the default branch, which is the only branch a change
+  # lands on -- and a branch named here that does not exist is a pull
+  # request with nowhere to land
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
   # the one hook pre-commit.ci cannot run, and the only entry this list


### PR DESCRIPTION
`target-branch: main` said what dependabot does with no `target-branch`
at all, on each of the three ecosystems, and `autoupdate_branch: main`
said it again for pre-commit.ci. A setting that restates a default is one
more place to keep true: a branch named here and deleted there is not an
error anywhere, it is a repository where nothing is ever proposed.

The rest of the diff is the file's shape rather than its meaning —
unquoted scalars and an `actions` group, as in btclib and
bitcoin-core-rpc — so the three configurations now differ only where the
repositories do: the vendored submodule, and the weekday the drift
sentinel reports on.

Companion pull requests: btclib-org/btclib#603, which fixes the same
setting where the branch it named is gone, and one adding the file to
checksig, which had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Dependabot and pre-commit.ci configuration with default-branch behavior while simplifying YAML formatting across ecosystems.

Enhancements:
- Remove explicit target branch settings from Dependabot and pre-commit.ci to rely on the repository default branch.
- Normalize Dependabot configuration structure (unquoted scalars, common group naming) to match btclib and related repositories.