### PR TITLE
Build the docs on one interpreter, here and on the website

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,11 +20,13 @@ submodules:
   recursive: false
 
 # the interpreter is declared rather than left to whatever read the docs
-# defaults to, matching btclib's own file
+# defaults to, matching btclib's own file and `.python-version` here: these
+# docs are built twice, on the website and by docs.yml, and one interpreter
+# is what keeps the two from being different questions
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   # build.commands rather than the sphinx: and python: keys, which cannot
   # express installing this package's own dependency group and are
   # rejected when it is present. uv installs the docs group from

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 950
+        "line_number": 957
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T00:36:44Z"
+  "generated_at": "2026-08-11T00:45:19Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,13 @@ release-notes length in the first place, and are still in
   landing under it made it false without anything failing; every release
   after would have done the same. Where the file starts is the fact it
   was reaching for, and that one does not move.
+- **Read the docs builds on the interpreter `docs.yml` builds on**, 3.14,
+  which is what `.python-version` says. These docs are built twice, once
+  for the website and once as a required check, and two interpreters make
+  those two different questions -- a docstring that renders under one and
+  fails `-W` under the other is found after the merge, on the service
+  whose failure is not a check on the pull request. The file already said
+  it matches btclib's, and btclib's moved.
 
 ### Packaging metadata
 


### PR DESCRIPTION
`.readthedocs.yaml` asked for 3.13 where `.python-version` says 3.14, so
`docs.yml` and read the docs built the same sources twice under two
interpreters. That makes them two questions rather than one: a docstring
that renders under 3.13 and fails `-W` under 3.14 is found after the
merge, on the service whose failure is not a check on the pull request.

The comment in that file already said it matches btclib's, and btclib's
now names 3.14 for this reason, so the two move together.

`.secrets.baseline` records a line number, and the CHANGELOG entry above
moved the line it points at.

Nothing else here has an update to take: `uv lock --upgrade` resolves the
lock unchanged, every action SHA is its action's latest release, the
vendored libsecp256k1 is upstream's latest at 0.8.0, and `pre-commit
autoupdate` offered only typos on `v1` and pyroma on 5.1b1 -- the floating
major and the prerelease the `pinned-rev` hook refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align documentation builds to use a single Python interpreter version and update supporting metadata accordingly.

Build:
- Configure Read the Docs to use Python 3.14, matching `.python-version` and the CI docs workflow.

Documentation:
- Document that Read the Docs now builds on Python 3.14 to match the CI docs build and avoid divergent interpreter behavior.

Chores:
- Refresh the secrets baseline to account for shifted line numbers in the changelog.