### PR TITLE
Sign the sdist the GitHub release attaches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,17 +315,101 @@ jobs:
       # generates PEP 740 attestations by default
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  # only after PyPI has accepted the upload: a GitHub release announces
-  # what can already be installed, and the download url in pyproject.toml
-  # points at the page this creates
-  github-release:
-    name: Attach the files to the GitHub release
-    needs: publish-pypi
+  # the sdist reaches users by two routes and only one of them carried
+  # provenance: the publish job above attaches a PEP 740 attestation to
+  # the copy on the index, while the copy github-release attaches below
+  # carried nothing at all. This job signs it, and the digest is the
+  # index's own, the artifact being downloaded here rather than rebuilt.
+  # The sdist alone, and not every file published: the wheels are attached
+  # to no release, so their only public copy is the one PyPI already
+  # attests, and a second attestation of a file nobody can obtain
+  # elsewhere closes no gap.
+  # A job of its own rather than two more permissions on github-release:
+  # this workflow elevates one job at a time, and the one that writes
+  # releases has no reason to also hold an OIDC token. Not in the build
+  # matrix for the stronger form of the same reason -- those jobs compile
+  # the vendored library and run the build backend, and a token minted
+  # there is minted beside everything a build resolves.
+  # After a publish rather than after the build, so that a run reaching
+  # here is one the environment approval already let through: without
+  # that, a dispatch from any branch would sign whatever that branch
+  # built. Whichever publish ran, though -- the rehearsal signs its own
+  # .dev sdist, and that is the point of running it there: everything in
+  # this job is a permission and an API that would otherwise be exercised
+  # for the first time on release day, where a failure lands after PyPI
+  # has the files and the tag can no longer be moved
+  attest:
+    name: Attest the source distribution
+    needs: [publish-pypi, publish-testpypi]
+    # always(), the other publish job being skipped rather than run, and a
+    # skipped job is one `needs` treats as failed
+    if: >-
+      always() && (needs.publish-pypi.result == 'success' ||
+      needs.publish-testpypi.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # the one job that writes to the repository, and what it writes is a
-      # release
+      # OIDC for the short-lived Sigstore signing certificate, and the
+      # write that persists the attestation against the repository
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sdist
+          path: dist
+
+      # actions/attest, and not the attest-build-provenance wrapper: that
+      # one is a composite whose only step is this action, pinned there to
+      # v4.2.1, so calling it would leave the version that signs decided
+      # by somebody else's pin rather than by the line below. No predicate
+      # input is what selects SLSA build provenance, which is what the
+      # wrapper's own name promises
+      - name: Sign a build provenance statement for the sdist
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: dist/*
+
+      # the bundle is the signed statement itself, and the job below
+      # attaches it to the release: that is what lets `gh attestation
+      # verify --bundle` read it from disk instead of asking the
+      # attestations API, for whoever mirrors the releases page rather
+      # than trusting it live.
+      # Copied into the workspace rather than uploaded where the action
+      # left it, under $RUNNER_TEMP: an upload takes its layout from the
+      # paths it matched, and one outside the workspace is one more thing
+      # to be right about than a fixed name here
+      - name: Collect the attestation bundle
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: cp "$BUNDLE_PATH" attestation.jsonl
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: attestation
+          path: attestation.jsonl
+
+  # only after PyPI has accepted the upload: a GitHub release announces
+  # what can already be installed, and the download url in pyproject.toml
+  # points at the page this creates.
+  # Both jobs above in `needs`, and not attest alone: attest runs in a
+  # rehearsal too, so naming it by itself would make this job -- which has
+  # no `if` of its own -- cut a release from a dispatch, where publish-pypi
+  # is skipped and a skipped need is what keeps this to the tag. attest
+  # earns its place in the list by producing the bundle attached below; a
+  # failure there leaves the version published and no release cut, which
+  # `gh run rerun --failed` finishes without rebuilding anything
+  github-release:
+    name: Attach the files to the GitHub release
+    needs: [publish-pypi, attest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # the one job that writes to the repository through its token, and
+      # what it writes is a release; the statement the job above signed
+      # went to the attestations API under permissions of its own
       contents: write
 
     steps:
@@ -341,6 +425,13 @@ jobs:
           name: sdist
           path: dist
 
+      # into a directory of its own, so that the dist/* glob below stays
+      # the distribution files and nothing else
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: attestation
+          path: attestation
+
       - name: Create the release, with HISTORY.md as its notes
         env:
           GH_TOKEN: ${{ github.token }}
@@ -354,12 +445,17 @@ jobs:
             /^## / && found {exit}
             found {print}
           ' HISTORY.md > "$RUNNER_TEMP/notes.md"
+          # named for the tag only here, where the ref is one: nothing
+          # inside the bundle says which release it belongs to, the way
+          # the sdist's own file name does
+          bundle="$GITHUB_REF_NAME.attestation.jsonl"
+          cp attestation/attestation.jsonl "$bundle"
           if [ -s "$RUNNER_TEMP/notes.md" ]; then
-            gh release create "$GITHUB_REF_NAME" dist/* \
+            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
               --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/notes.md"
           else
             echo "::warning::HISTORY.md has no $GITHUB_REF_NAME section"
-            gh release create "$GITHUB_REF_NAME" dist/* \
+            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
               --title "$GITHUB_REF_NAME" --generate-notes
           fi
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 957
+        "line_number": 988
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T00:45:19Z"
+  "generated_at": "2026-08-11T01:02:19Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,37 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **The sdist attached to a GitHub release carries provenance** (#97),
+  where only the copy on PyPI did: the publish job generates a PEP 740
+  attestation for what it uploads to the index, and the byte-identical
+  file on the releases page carried nothing, so whoever pinned to a
+  release asset url or mirrored the page had no way to check where it
+  came from. `release.yml` gains an `attest` job — `actions/attest`, one
+  SLSA build provenance statement, signed with a short-lived Sigstore
+  certificate — and `gh attestation verify <file> --repo
+  btclib-org/btclib-libsecp256k1 --signer-workflow …` is what checks it,
+  the last flag being what makes the answer name a workflow rather than
+  accept any attestation this repository has. The signed bundle is
+  attached to the release too, as `<tag>.attestation.jsonl`, so
+  `--bundle` verifies the same signature without asking the attestations
+  API for it. The digest is the index's own, the job downloading the
+  `sdist` artifact rather than rebuilding it. The wheels are not signed
+  a second time: they are attached to no release, so their only public
+  copy is the one PyPI already attests. A job of its own and not two more
+  permissions on `github-release`: `id-token: write` and `attestations:
+  write` stay off the job that writes releases, and further off the
+  matrix that compiles the vendored library. It runs after whichever
+  publish job ran, so a dispatch from an arbitrary branch signs nothing
+  an environment approval did not let through — and the TestPyPI
+  rehearsal exercises it, which on the release path would otherwise
+  happen for the first time after PyPI has the files and the tag can no
+  longer be moved. `github-release` names both `publish-pypi` and
+  `attest` in `needs`: naming `attest` alone would let a dispatch cut a
+  release, that job running in a rehearsal too. Not the
+  `attest-build-provenance` wrapper the issue proposed, which is a
+  composite whose only step is `actions/attest` pinned there to v4.2.1 —
+  calling the action directly is what leaves the version that signs
+  pinned here.
 - **The macOS suite cells left the merge gate for `macos.yml`.** Over six
   pull request runs of `test.yml`, ninety-eight jobs each and thirty-five of
   them on the two macOS images, a macOS job waited 20.8 and 19.0 minutes on

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ went:
 - provenance is checkable: every wheel and the sdist are built and
   tested in public CI from the pinned source, and published by the
   workflow itself through Trusted Publishing with PEP 740 attestations
-  — no long-lived token, and no maintainer laptop in the path
+  — no long-lived token, and no maintainer laptop in the path. The sdist
+  attached to the GitHub release carries a build provenance attestation
+  besides, which `gh attestation verify` checks; SECURITY.md has the
+  command
 
 ## What the boundary checks
 
@@ -439,7 +442,9 @@ Releases are published to PyPI by the `release` GitHub workflow using
 no long-lived PyPI token exists anywhere; PyPI trusts the workflow
 itself (via GitHub OIDC) and hands out a short-lived upload token at
 run time. Wheels and sdist are uploaded with PEP 740 attestations, so
-their provenance can be verified on PyPI.
+their provenance can be verified on PyPI; the sdist attached to the
+GitHub release is signed a second time, so that copy can be verified
+without the index.
 
 The steps to cut a release, to rehearse one on TestPyPI, and the
 one-time setup each index needs are in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,6 +7,9 @@ it uploads is not an input to choose at dispatch time: a `v*` tag
 publishes to PyPI, a manual run publishes to TestPyPI. Both go through
 [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so no
 long-lived token exists anywhere, and both upload PEP 740 attestations.
+The `attest` job then signs a build provenance statement for the sdist,
+which is the file the GitHub release attaches and therefore the one copy
+the index's attestation says nothing about.
 
 The version published is the one in `pyproject.toml`; the tag only
 decides which index is reached. The `version-check` job cross-checks
@@ -229,9 +232,27 @@ Then:
    installable to find the day before
 1. check the GitHub release the workflow created once PyPI had accepted
    the upload: its notes are the tag's section of `HISTORY.md`, and the
-   sdist is attached. A run that warns `HISTORY.md has no v0.7.1 section`
-   generated the notes from the merged pull requests instead, and they
-   are worth replacing by hand
+   sdist is attached, with `<tag>.attestation.jsonl` beside it. A run
+   that warns `HISTORY.md has no v0.7.1 section` generated the notes from
+   the merged pull requests instead, and they are worth replacing by hand
+1. verify the sdist on the releases page, which is the copy PyPI's
+   attestation says nothing about — the step above says the file is
+   there, this one says where it came from:
+
+   ```shell
+   repo=btclib-org/btclib-libsecp256k1
+   dir=$(mktemp -d)
+   gh release download v0.7.1 --repo "$repo" --dir "$dir"
+   gh attestation verify "$dir/btclib_libsecp256k1-0.7.1.tar.gz" \
+     --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+   ```
+
+   `--signer-workflow` is the flag that makes it say *which* workflow
+   signed: without it a valid attestation from any workflow in this
+   repository passes. Adding `--bundle "$dir/v0.7.1.attestation.jsonl"`
+   asks the same question of the statement downloaded beside the file
+   rather than of the attestations API, which is the form for whoever
+   mirrors the page instead of trusting it live
 1. realign `dev` onto `master`, before anything else is committed to it.
    Rebase and merge replays `dev`'s commits with new SHAs, so the moment
    a release is merged the two branches hold the same tree through
@@ -441,14 +462,32 @@ without rebuilding anything.
    under `/integrity/<project>/<version>/<filename>/provenance`, whose
    `attestation_bundles[].publisher` should name this repository and
    `release.yml`
+1. check the statement the `attest` job signed, which on this path has no
+   release to be attached to: it went to the attestations API all the
+   same, keyed by the digest of the file, so the sdist the run built is
+   what asks for it.
+
+   ```shell
+   repo=btclib-org/btclib-libsecp256k1
+   dir=$(mktemp -d)
+   gh run download <run id> --repo "$repo" --name sdist --dir "$dir"
+   gh attestation verify "$dir"/*.tar.gz \
+     --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+   ```
+
+   This is the whole reason `attest` runs in a rehearsal at all: the
+   permissions and the API it needs are exercised here, where a failure
+   costs a dispatch, rather than for the first time on release day, where
+   it lands after PyPI has the files and the tag can no longer be moved
 
 There is no version commit to revert, and nothing to clean up: the
 suffix only ever exists inside the run that built it.
 
 What the rehearsal covers is the OIDC exchange, the approval gate, the
 artifacts the publish job collects — sixty-three wheels and one sdist, at
-0.7.1 — the PEP 740 attestations, and a real Warehouse accepting the
-metadata, which is more than `twine check --strict` can say. What it
+0.7.1 — the PEP 740 attestations, the Sigstore signature `attest` writes,
+and a real Warehouse accepting the metadata, which is more than
+`twine check --strict` can say. What it
 cannot cover is the trusted publisher on PyPI itself, a separate
 registration that can be wrong on its own, nor the deployment branch
 policy of the `pypi` environment, which the environment a rehearsal does

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -207,10 +207,12 @@ gh api repos/btclib-org/btclib-libsecp256k1/actions/permissions/workflow \
 ```
 
 Only `release.yml` asks for more: `contents: write` on `github-release`,
-and `id-token: write` on the two publish jobs, which is what Trusted
-Publishing exchanges. The workflow-level `permissions: contents: read` in
-every file is belt and braces; keep it, it is what makes the intent
-readable where the job is.
+`id-token: write` on the two publish jobs, which is what Trusted
+Publishing exchanges, and `id-token: write` with `attestations: write` on
+`attest`. One elevation per job is the shape to keep — the job that writes
+releases holds no OIDC token, and the job that signs writes no release.
+The workflow-level `permissions: contents: read` in every file is belt and
+braces; keep it, it is what makes the intent readable where the job is.
 
 ## Publishing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,23 @@ Wheels and sdist are published with PEP 740 attestations, so that a
 distribution can be traced back to the workflow run and the commit it
 was built from.
 
+The sdist is also attached to the GitHub release, and that copy carries a
+build provenance attestation of its own, signed in the run that built it:
+
+```shell
+repo=btclib-org/btclib-libsecp256k1
+gh attestation verify btclib_libsecp256k1-<version>.tar.gz \
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+```
+
+`--signer-workflow` is what makes that say which workflow signed, rather
+than accepting any attestation this repository has. The signed statement
+is attached to the release as well, as `<tag>.attestation.jsonl`, so
+`--bundle <tag>.attestation.jsonl` runs the same check reading it from
+disk instead of asking GitHub for it — the form for whoever mirrors the
+releases page rather than trusting it live. The wheels are on PyPI and
+nowhere else, so what verifies them is their PEP 740 attestation there.
+
 ## Limitations of the binding layer
 
 These are known and inherent, not vulnerabilities:


### PR DESCRIPTION
Closes #97, mirroring what btclib is about to ship (its `attest` job is on
`main` and in its CHANGELOG's unreleased section) rather than inventing a
second shape for the same problem.

## What was missing

The sdist reaches users by two routes and only one carried provenance:
`pypa/gh-action-pypi-publish` attaches a PEP 740 attestation to the copy on
PyPI, while the byte-identical copy on the releases page carried nothing.
Whoever pins to an asset url, or mirrors the page, had nothing to check it
against.

## What this adds

An `attest` job in `release.yml`: `actions/attest` over the `sdist`
artifact, one SLSA build provenance statement signed with a short-lived
Sigstore certificate, and the bundle attached to the release beside the
file it covers, so `--bundle` verifies the same signature without asking
the attestations API for it. The digest is the index's own — the artifact
is downloaded, not rebuilt.

```shell
repo=btclib-org/btclib-libsecp256k1
gh attestation verify btclib_libsecp256k1-<version>.tar.gz \
  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
```

## The decisions worth reading, not skimming

- **the sdist alone, not `dist/*`.** Issue #97 was written believing every
  wheel was a release asset; the sdist has been the only one since 0.7.1
  (`git log -S` puts that comment in 9563ebb). The wheels' only public copy
  is the one PyPI already attests, so signing them again closes no gap.
- **a job of its own, not two permissions more on `github-release`.** This
  workflow elevates one job at a time: `id-token: write` and
  `attestations: write` stay off the job that writes releases, and further
  off the matrix that compiles the vendored library.
- **after a publish, not after the build**, so a run reaching it is one an
  environment approval already let through — and it runs in the TestPyPI
  rehearsal too, which is the point: otherwise the permissions and the API
  would be exercised for the first time after PyPI has the files and the
  tag can no longer be moved.
- **`github-release` needs both `publish-pypi` and `attest`.** Naming
  `attest` alone would let a dispatch cut a release, that job running in a
  rehearsal.
- **`actions/attest`, not `actions/attest-build-provenance`** as the issue
  proposed: the wrapper is a composite whose only step is this action,
  pinned there to v4.2.1, so calling it directly is what leaves the version
  that signs pinned here. Verified against the upstream `action.yml`, and
  `1e69f48` is v4.2.2's own commit.

## Verification, and its limit

`uvx pre-commit run --all-files` is green, exit 0 — `actionlint` and
`zizmor` included, and `.secrets.baseline` moved by one line number, which
is a CHANGELOG entry shifting rather than a new finding.

What no one can claim yet is that this has *run*: btclib's copy landed
after its last release, so its `v2026.8.9` assets carry no bundle either.
The first real answer comes from a TestPyPI rehearsal, and RELEASING.md now
carries the `gh run download` + `gh attestation verify` that reads it.

## Documentation

SECURITY.md gains the verify command, REPOSITORY.md's token-permissions
section gains `attest`, RELEASING.md gains a release step and a rehearsal
step, README.md says the release copy is signed a second time, and
CHANGELOG.md records it under v0.8.0's CI section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add provenance signing and verification for the source distribution attached to GitHub releases, ensuring the release asset copy of the sdist can be independently validated.

Enhancements:
- Introduce an attest job in the release workflow that signs the built sdist with a Sigstore-backed SLSA build provenance attestation and uploads the bundle as an artifact.
- Attach the attestation bundle to GitHub releases alongside the sdist asset, and wire the release job dependencies so releases are only cut when publishing and attestation have succeeded.
- Clarify workflow permissions by isolating OIDC and attestation write access to the new attest job while keeping the release job limited to repository writes.

CI:
- Extend release.yml with an attest job that runs after PyPI/TestPyPI publish, downloads the sdist artifact, signs it using actions/attest, and exposes the generated bundle for the release job.

Documentation:
- Update RELEASING.md with steps and commands for verifying the signed sdist from both real releases and TestPyPI rehearsals.
- Document the new sdist build provenance attestation and verification commands in SECURITY.md.
- Describe the additional signing of the GitHub release sdist and its verification in README.md.
- Expand REPOSITORY.md to reflect the new workflow permission model including the attest job.

Chores:
- Refresh the secrets baseline to account for documentation line shifts without introducing new findings.