### PR TITLE
Pin CodeQL to a workflow in the tree

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,205 @@
+---
+name: codeql
+
+# the fourth gate, and the one that used to have no file: code scanning ran
+# from GitHub's default setup, a repository setting, so the only required
+# check on main whose definition a diff could not review was the one looking
+# for vulnerabilities. Every other check here is a file with pinned SHAs, and
+# this makes CodeQL one too -- the languages, the query suite, the schedule
+# and the permissions all readable, reviewable and moved by dependabot.
+#
+# It reproduces what the setting held rather than inventing a configuration,
+# which is what keeps the alert history continuous. Read from the API before
+# this file was written:
+#
+#     gh api repos/{owner}/{repo}/code-scanning/default-setup
+#     # languages: actions, python; query_suite: default; schedule: weekly
+#
+# The one thing that cannot be reproduced is the analysis *key*: default
+# setup's runs are `dynamic/github-code-scanning/codeql:analyze`, and an
+# advanced workflow's carry this file's path. The alerts survive that,
+# because what matches an alert across runs is the category below, which is
+# spelled exactly as default setup spelled it:
+#
+#     gh api repos/{owner}/{repo}/code-scanning/analyses \
+#       --jq '.[] | {ref, category, analysis_key}'
+#     # /language:python and /language:actions
+#
+# **While default setup is enabled GitHub refuses to run this workflow**, so
+# the pull request that adds it cannot show it passing. The switch has an
+# order, given in that pull request's own description: the branch rule drops
+# the `CodeQL` context, default setup is turned off, the checks are re-run,
+# and only then does the rule name the aggregate job at the end of this
+# file. REPOSITORY.md carries the commands, this being a rule that lives
+# outside the repository
+
+on:
+  pull_request:
+    # no path filter, unlike the sentinels here: the aggregate below is a
+    # required check on main, and a required check that produces no run at
+    # all blocks the merge instead of passing it -- so a documentation-only
+    # pull request has to run this too.
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request would
+    # wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    # main only, for the reason lint.yml gives at the same key -- but with a
+    # second one this workflow does not share with the other gates: an
+    # analysis of the default branch is what an alert is measured against,
+    # so the branch every pull request is compared to has to be scanned
+    # itself, and a merge creates a commit no pull request tested
+    branches: [main]
+  schedule:
+    # Tuesday 04:33 UTC. Weekly, which is what default setup ran, and it
+    # earns the slot: a CodeQL release can find in unchanged code what the
+    # queries of the week before did not look for, so a repository that
+    # sits still is not a repository that stays clean.
+    # Not on the hour: GitHub queues scheduled workflows across every
+    # repository that asked for the same minute, and a run can be dropped
+    # outright when that queue is long. Tuesday and minute 33 are shared
+    # with no other cron here, nor with btclib's or bitcoin-core-rpc's --
+    # `grep -rn 'cron:' .github/workflows/*.yml` in each is what re-derives
+    # that, and the other days are Monday (links), Wednesday (macos,
+    # latest), Sunday (mutation) and the 1st (published, vendored vectors).
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "33 4 * * 2"
+  # the escape hatch: a scan on demand for a branch whose pull request is
+  # not open yet
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job can read
+# it, and the analysis job below is the only one that writes anything
+permissions:
+  contents: read
+
+# cancel superseded runs on the same branch/PR, named literally rather than
+# through github.workflow for the reason lint.yml gives at length. No
+# concurrency-suffix input here, unlike the three gates release.yml calls:
+# nothing calls this workflow, so github.ref is this run's own ref
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    # one job per language, so a failure says which analysis failed instead
+    # of leaving two to be told apart in a log. Default setup's own two jobs
+    # were `Analyze (actions)` and `Analyze (python)`; these are named for
+    # the question they answer, as every job here is, and neither name is a
+    # required check -- the aggregate below is
+    name: Analyze ${{ matrix.language }} with CodeQL
+    # a draft pull request is work in progress and spends no runner here
+    # either: the same condition lint.yml, docs.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    # the two analyses of default setup took 41 to 48 seconds each, measured
+    # on the last pull request it ran on, so this is tolerance for a cold
+    # tools download rather than a budget:
+    #
+    #     gh api repos/{owner}/{repo}/commits/<sha>/check-runs --paginate \
+    #       --jq '.check_runs[] | select(.name | test("Analyze"))
+    #             | {name, started_at, completed_at}'
+    timeout-minutes: 15
+    permissions:
+      # what uploads the SARIF and what the alerts are written with; the
+      # only write permission any job in this repository asks for outside
+      # release.yml
+      security-events: write
+      contents: read
+      # what CodeQL reads workflow run data with, required for a private
+      # repository and inert in a public one. Declared so that making this
+      # repository private is not also a broken required check
+      actions: read
+
+    strategy:
+      # fail-fast would cancel the other language on the first failure, and
+      # a cancelled analysis is not a verdict: the aggregate below reads
+      # `cancelled` as a failure precisely because it is no evidence either
+      # way, so leaving it on would turn one real finding into two red cells
+      # with one cause between them
+      fail-fast: false
+      matrix:
+        # exactly what default setup analyzed. `actions` is the workflows
+        # themselves, and it is worth as much here as the package is: what
+        # they do is check out a tree, run a build script and hold a
+        # publishing token, and `zizmor` is a hook rather than the only
+        # thing that reads them for a reason. The vendored C is not among
+        # them and was not before -- libsecp256k1 is upstream's code,
+        # upstream scans it, and adding `c-cpp` would report its findings on
+        # every pull request that touches a docstring
+        language: [actions, python]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # no `submodules:`, and that is the analysis default setup ran:
+          # the vendored tree is not checked out, so nothing of upstream's
+          # is scanned here, and the python extractor has less to walk
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          # nothing is compiled to be analyzed, which for these two
+          # languages is both the only mode available and the default --
+          # stated anyway, because this package *does* build C, and a reader
+          # who knows that would otherwise have to check whether the scan
+          # waits for cmake. It does not
+          build-mode: none
+          # no `queries:`, no `packs:` and no `config:`, which is how the
+          # `default` query suite default setup reported is asked for: there
+          # is no input that names it, and the suite widens the moment one
+          # of those three appears. `security-extended` would be a decision
+          # about how much noise a pull request is worth, and the setting
+          # this file replaces had not taken it
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          # the category is what ties an upload to the analyses before it,
+          # so it is spelled as default setup spelled it -- see the header.
+          # Get this wrong and every existing alert is closed as fixed while
+          # a copy of it is opened by this workflow
+          category: "/language:${{ matrix.language }}"
+
+  # one context for the branch rule, instead of the matrix's own, for the
+  # reason test.yml gives at its own aggregate: a rule naming
+  # `Analyze python with CodeQL` names a context that stops being produced
+  # the moment the matrix changes, and a required check that produces no run
+  # blocks every merge with nothing in the tree to explain why. A job added
+  # to this workflow belongs in the `needs` below or it gates nothing.
+  #
+  # The name carries the workflow because a context is keyed by name alone:
+  # two workflows with a job named `every job passed` would produce one
+  # ambiguous check
+  codeql-passed:
+    name: "codeql: every job passed"
+    needs: [analyze]
+    # not success(): a job whose dependencies failed is skipped, and a
+    # skipped check reports `skipped`, which branch protection counts as
+    # satisfied. The gate has to run to be able to fail -- and it carries
+    # the draft condition every job above carries, so a draft skips
+    # uniformly rather than tripping the skip check below
+    if: ${{ always() && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # the condition reads the whole needs context rather than testing each
+      # job by name, so a job added to needs above is covered without
+      # touching this. `skipped` is a failure here too: nothing in this
+      # workflow is conditional, so a skip means something upstream did not
+      # run
+      - name: Fail unless every job above succeeded
+        if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled') ||
+          contains(needs.*.result, 'skipped')
+        run: |
+          echo "::error::a job this gate depends on did not succeed"
+          exit 1

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1031
+        "line_number": 1050
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T06:51:11Z"
+  "generated_at": "2026-08-11T06:58:12Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,25 @@ release-notes length in the first place, and are still in
   next tag would have been stopped by it. The draft exception that let the
   release pull request through (`github.base_ref == 'master'`) can never be
   true again and is gone with them.
+- **CodeQL is `codeql.yml`, not code scanning's default setup.** It was the
+  one required check on `main` whose definition no diff could review: a
+  repository setting, so the languages it scanned, the queries it ran and
+  the day it ran them were readable only through
+  `gh api repos/{owner}/{repo}/code-scanning/default-setup`. The workflow
+  reproduces exactly what that reported — `actions` and `python`, the
+  `default` query suite, weekly — one job per language so a failure names
+  the language, `github/codeql-action` pinned to a commit SHA like every
+  other action here, and `security-events: write` declared on that job
+  alone. The category is spelled as the setting spelled it,
+  `/language:<language>`, which is what carries the existing alerts across:
+  an upload under a new category closes every one of them as fixed and
+  opens a copy. The aggregate is `codeql: every job passed`, for the reason
+  `test.yml`'s own is: a branch rule must name an outcome and not a matrix
+  cell. Turning the setting off and moving the rule are two steps only a
+  maintainer can take, in an order REPOSITORY.md gives — GitHub refuses to
+  run an advanced workflow while default setup is enabled, so the two
+  cannot overlap, and the rule has to stop naming a context nothing
+  produces before it can name the one this file does.
 
 ### The gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,14 +141,19 @@ uvx --from detect-secrets detect-secrets scan --baseline .secrets.baseline
 
 ## The workflows that gate, and the ones that do not
 
-`lint`, `docs` and `test` are the gate, and `release` reuses all three. The
-rest are sentinels: each is a workflow of its own, has no aggregate job, is
-named by no branch rule, and opens no issue on failure (`vendored-vectors`
-excepted, for the reason its own header gives). That is deliberate in every
-case — each is expected to go red for a reason no pull request introduced,
-and a red check nobody can act on from a branch is noise. Their crons are on
-different mornings, because sentinels landing in one inbox on one morning
-are one sentinel.
+`lint`, `docs`, `test` and `codeql` are the gate, and `release` reuses the
+first three. It does not reuse `codeql`, and does not have to: a tag is an
+ancestor of `main` before the matrix builds anything (`version-check` in
+`release.yml`), so the tree it publishes is one the merge gate has already
+scanned — and `codeql` is weekly besides, which is what covers the code
+nobody touched. The rest are sentinels: each is a workflow of its own, has
+no aggregate job, is named by no branch rule, and opens no issue on failure
+(`vendored-vectors` excepted, for the reason its own header gives). That is
+deliberate in every case — each is expected to go red for a reason no pull
+request introduced, and a red check nobody can act on from a branch is
+noise. Their crons are on different mornings, because sentinels landing in
+one inbox on one morning are one sentinel, and `codeql` keeps a morning of
+its own for the same reason.
 
 | workflow | asks | when |
 | --- | --- | --- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ read by every checkout of this repository.
 | --- | --- | --- |
 | `test` | pull request, push | every platform but macOS, every interpreter |
 | `lint`, `docs` | pull request, push | — |
+| `codeql` | pull request, push, Tuesday | the two scanned languages |
 | `vendored-vectors` | monthly, a change to itself | — |
 | `macos` | Wednesday, a release | both macOS images, both linkages |
 | `latest` | Wednesday | the dependencies, at their newest |
@@ -195,7 +196,7 @@ read by every checkout of this repository.
 | `published` | monthly, a release | what PyPI serves |
 | `release` | a tag | calls the gates, `macos` and `published` |
 
-The first two rows are what a merge waits for. macOS is not among them on
+The first three rows are what a merge waits for. macOS is not among them on
 purpose, and the numbers are in `test.yml`'s header: it is the one platform
 whose runners queue for tens of minutes rather than for two, so it answers
 weekly, and before a release, rather than before a review. The wheels it
@@ -204,11 +205,19 @@ suite against each one as it builds it — what waits a week is pip's
 selection among them and the dynamic build. Everything but the first two
 rows also takes `workflow_dispatch`.
 
+`codeql` is the one gate with no local command: reproducing it means the
+CodeQL CLI, a bundle GitHub distributes rather than a dependency `uv.lock`
+can pin, so what answers a finding is the run itself and the Security tab
+beside it. What it scans, with which queries and on what schedule is in the
+file, `.github/workflows/codeql.yml`; the branch rule that names its
+aggregate is in REPOSITORY.md.
+
 ### Running what CI runs
 
 Each job of the `lint`, `docs` and `test` workflows, and the local command
 that reproduces it. Two of them cannot be reproduced on a machine that is
-not the runner, and that is worth knowing before trying.
+not the runner, and that is worth knowing before trying; the fourth gate,
+`codeql`, has no command at all, for the reason above.
 
 - `Lint and type-check`
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -35,7 +35,7 @@ gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
 | `test: every job passed` | `test.yml`, aggregate over the matrix |
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
-| `CodeQL` | code scanning's default setup |
+| `codeql: every job passed` | `codeql.yml`, aggregate over the languages |
 
 `Build the documentation` is named on its own on purpose: a rule naming
 `Lint and type-check` alone would leave a red documentation build outside
@@ -52,14 +52,13 @@ the suite: what a merge no longer waits for is the platform whose runners
 queue for tens of minutes, measured in `test.yml`'s header, and
 `release.yml` calls it so that a publication still does.
 
-Each check is bound to the app that produces it — `checks` with an `app_id`
-rather than the bare `contexts` list — so nothing else can satisfy one.
-15368 is Actions and 57789 is `github-advanced-security`, which is the app
-that reports `CodeQL`: the two Actions jobs of code scanning's default setup
-are called `Analyze (actions)` and `Analyze (python)`, and the `CodeQL`
-context is a separate check run that appears seconds after both finish.
-Reading it too early is how one concludes that the rule names a context
-nothing produces:
+A check can be bound to the app that produces it — `checks` with an
+`app_id` rather than the bare `contexts` list — so that nothing else can
+satisfy it, and 15368 is Actions, which produces all four. Only
+`test: every job passed` is bound today: the endpoint above reports
+`app_id: null` for the other three, meaning any app may report them, and
+the `PATCH` below is what binds them. Which app reported what is read from
+the commit rather than assumed:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
@@ -71,32 +70,53 @@ gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
   --jq '[.check_runs[] | {name, app: .app.slug}] | unique_by(.app)'
 ```
 
-**CodeQL is code scanning's default setup, not a workflow of this
-repository** — `state: configured`, python and actions, the default query
-suite, weekly — so there is no file here to read its triggers off:
+**CodeQL is `.github/workflows/codeql.yml`, and code scanning's default
+setup is off** — the two are mutually exclusive, GitHub refusing to run an
+advanced workflow while the setting is configured, and the file is the one
+that can be reviewed in a diff. What the setting holds is read from the
+endpoint, `state` being the field that says whether it holds anything:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
 ```
 
-That absence of a file is also why the check was first left out of the
-rule, on a measurement that was the wrong one: it was taken on a pull
-request against the branch that used to sit between a contributor and the
-trunk, and default setup analyzes push events on the default branch and
-pull requests *against* it, nothing else — so a pull request like #43
-produced no CodeQL check run at all, measured, zero analyses. With `main`
-the only long-lived branch every pull request is the kind default setup
-analyzes, which is the kind #21, the 0.7.1 release merge, already was:
-its analyses are under `refs/pull/21/head`.
+Turning the setting off takes `state` and nothing else — the languages, the
+query suite and the runner it also accepts describe an analysis that is not
+going to run:
+
+```shell
+gh api -X PATCH \
+  repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup \
+  -F state=not-configured
+```
+
+The order matters in both directions, and it is the branch rule that
+decides it: while the setting is on, `codeql.yml` produces nothing, and
+while it is off, nothing produces `codeql: every job passed` until that
+workflow has run. So the rule drops the context first, the setting moves
+second, the checks are re-run, and the rule names the new context last —
+each step leaving the merge path open, where any other order closes it on a
+context nothing reports. `enforce_admins` being off is what makes that
+window survivable rather than a lock.
+
+What the file asks for is read off its own triggers; what was actually
+analyzed, and under which ref and category, is the API's answer:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/analyses \
-  --jq '.[] | {ref, category, created_at}'
+  --jq '.[] | {ref, category, analysis_key, created_at}'
 ```
 
-`Dependency Graph` is not a candidate either: its runs are `dynamic`,
-GitHub submitting the graph after a push rather than checking a pull
-request.
+The category is what ties an upload to the ones before it, so
+`codeql.yml` spells it exactly as the setting did, `/language:python` and
+`/language:actions`: an upload under a new category closes every open alert
+as fixed and opens a copy of it. The `analysis_key` is the one thing that
+does change, from `dynamic/github-code-scanning/codeql:analyze` to this
+workflow's path, and no alert is keyed on it.
+
+`Dependency Graph` is not a candidate for the rule either: its runs are
+`dynamic`, GitHub submitting the graph after a push rather than checking a
+pull request.
 
 **PATCH the sub-endpoint, never PUT the whole protection object**: a
 partial PUT drops the reviews, the signatures and the rest. And `-F`,
@@ -109,7 +129,19 @@ gh api "repos/{owner}/{repo}/$sub" -X PATCH -F strict=true \
   -F 'checks[][context]=test: every job passed' -F 'checks[][app_id]=15368' \
   -F 'checks[][context]=Lint and type-check' -F 'checks[][app_id]=15368' \
   -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368' \
-  -F 'checks[][context]=CodeQL' -F 'checks[][app_id]=57789'
+  -F 'checks[][context]=codeql: every job passed' \
+  -F 'checks[][app_id]=15368'
+```
+
+`checks[][…]` repeated is how one array of objects is written: `-F` pairs
+each `context` with the `app_id` that follows it, and sends the number as a
+number. Reading the body before sending it is a probe against a path that
+does not exist, which reports a 404 and changes nothing:
+
+```shell
+gh api --verbose -X POST "repos/{owner}/{repo}/zzz-probe" \
+  -F 'checks[][context]=A' -F 'checks[][app_id]=15368' \
+  | sed -n '/^{/,/^}/p'
 ```
 
 Renaming a required check is the one change that cannot be made in a pull


### PR DESCRIPTION
Code scanning ran from GitHub's *default setup*, a repository setting, which
made `CodeQL` the only required check on `main` whose definition a diff could
not review — while every other check here is a file with pinned SHAs.
`.github/workflows/codeql.yml` makes it one too.

## What the file reproduces, rather than invents

Read from the API before it was written:

```shell
gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
# {"state":"configured","languages":["actions","python"],
#  "query_suite":"default","threat_model":"remote","schedule":"weekly",
#  "runner_type":"standard","updated_at":"2026-07-30T00:12:40Z"}
```

- `languages: [actions, python]`, one job per language so a failure names
  the language. The vendored C is not among them and was not before.
- the `default` query suite. There is **no `query_suite` input** on
  `github/codeql-action/init` — the default suite is what runs when no
  `queries:`, `packs:` or `config:` is given, which the source states at
  `src/config-utils.ts`: "A code-scanning configuration runs only the
  (default) code-scanning suite if the default queries are not disabled, and
  no packs, queries, or query-filters are specified." So the file names none
  of the three, and says so in a comment; adding one is what would widen it.
- `weekly`, as `cron: "33 4 * * 2"`. Tuesday and minute 33 are shared with
  no other cron in this repository, nor in btclib, nor in
  bitcoin-core-rpc — `grep -rn 'cron:' .github/workflows/*.yml` in each is
  what re-derives it.
- `category: "/language:${{ matrix.language }}"`, spelled exactly as default
  setup spelled it (`/language:python`, `/language:actions`, measured from
  `code-scanning/analyses`). This is what carries the existing alerts
  across: an upload under a new category closes every open alert as fixed
  and opens a copy of it. The `analysis_key` does change, from
  `dynamic/github-code-scanning/codeql:analyze` to this file's path, and no
  alert is keyed on it.
- `permissions:` is `security-events: write`, `contents: read`,
  `actions: read` on the analysis job and nothing else; the workflow level
  keeps `contents: read` like every other file here.
- `github/codeql-action/init` and `.../analyze` pinned to
  `5595ccaf912efad79be6eef63a5619ff05969be3` — `v4.37.6`, dereferenced
  through the annotated tag:

  ```shell
  gh api repos/github/codeql-action/git/ref/tags/v4.37.6 --jq '.object.sha'
  gh api repos/github/codeql-action/git/tags/<that sha> --jq '.object.sha'
  ```

  Note that `releases/latest` answers `codeql-bundle-v2.26.2`
  (2026-07-29T12:20:23Z), which is a CodeQL *bundle* release and not the
  action's version: `v4.37.6` (2026-08-04T13:34:40Z) is the newest release
  of the action, and it is the tag dependabot moves.
- `timeout-minutes: 15` against 41 to 48 seconds measured on the last pull
  request default setup ran on (#112, head `34ae739`):

  ```shell
  gh api repos/btclib-org/btclib-libsecp256k1/commits/34ae739/check-runs \
    --paginate --jq '.check_runs[] | select(.name | test("Analyze"))
      | {name, started_at, completed_at}'
  ```

The aggregate at the end is `codeql: every job passed`, `needs` the matrix,
`if: ${{ always() && !github.event.pull_request.draft }}`, failing on
`failure`, `cancelled` or `skipped` — the pattern `test.yml`'s own aggregate
uses, and for the reason REPOSITORY.md gives: a branch rule must name an
outcome, not a matrix cell.

## The checks from this file will not appear on this pull request

**While default setup is enabled GitHub refuses to run an advanced
workflow.** Nothing is wrong when this pull request shows no CodeQL run: the
gate is `lint`, `docs` and `test`, and the new workflow is inert until the
setting is off.

Steps 1, 2 and 5 below can only be taken by a human, and in this order —
any other order closes the merge path on a context nothing reports.
`enforce_admins` is off, so the window is survivable rather than a lock.

**1. Drop `CodeQL` from the branch rule.** The current rule, read first:

```shell
gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
  --jq '.required_status_checks'
# {"checks":[{"app_id":null,"context":"Lint and type-check"},
#            {"app_id":null,"context":"CodeQL"},
#            {"app_id":null,"context":"Build the documentation"},
#            {"app_id":15368,"context":"test: every job passed"}],
#  "strict":true, ...}
```

```shell
gh api -X PATCH \
  repos/btclib-org/btclib-libsecp256k1/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{
  "strict": true,
  "checks": [
    { "context": "Lint and type-check", "app_id": 15368 },
    { "context": "Build the documentation", "app_id": 15368 },
    { "context": "test: every job passed", "app_id": 15368 }
  ]
}
JSON
```

**2. Disable default setup.**

```shell
gh api -X PATCH \
  repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup \
  -F state=not-configured
```

**3. Re-run the checks on this pull request.** They now execute
`codeql.yml` and produce `Analyze actions with CodeQL`,
`Analyze python with CodeQL` and `codeql: every job passed`. This is the
first run of the file: read it rather than assume it.

**4. Merge** (Rebase and merge, per CLAUDE.md).

**5. Add `codeql: every job passed` to the branch rule.**

```shell
gh api -X PATCH \
  repos/btclib-org/btclib-libsecp256k1/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{
  "strict": true,
  "checks": [
    { "context": "Lint and type-check", "app_id": 15368 },
    { "context": "Build the documentation", "app_id": 15368 },
    { "context": "test: every job passed", "app_id": 15368 },
    { "context": "codeql: every job passed", "app_id": 15368 }
  ]
}
JSON
```

Then read the rule back with the `--jq` command above.

A JSON body on stdin is what makes `app_id` unambiguous: `gh api`'s `-f`
sends every value as a string and the endpoint answers 422 for a string
`app_id`. `-F` does send a typed integer, and REPOSITORY.md's
`-F 'checks[][app_id]=15368'` form is equivalent — measured with a probe
against a path that does not exist, which reports 404 and changes nothing:

```shell
gh api --verbose -X POST "repos/{owner}/{repo}/zzz-probe" \
  -F 'checks[][context]=A' -F 'checks[][app_id]=15368' \
  | sed -n '/^{/,/^}/p'
# { "checks": [ { "app_id": 15368, "context": "A" } ] }
```

Two things about those commands worth deciding rather than pasting:

- they bind all three surviving contexts to `15368` (Actions). Three of the
  four carry `app_id: null` today — measured above — where REPOSITORY.md
  said each was bound to the app that produces it. Binding them is what that
  file describes, and this pull request corrects the file to say which is
  which; **to change nothing but the context list, drop the `app_id` fields
  from the two lines that have none today.** Omitting the field does not
  leave it null: GitHub then selects the app that recently provided the
  check.
- after step 2 nothing named `CodeQL` is produced by
  `github-advanced-security` (app 57789) any more, or so this expects: what
  a SARIF upload from an advanced setup posts beside the workflow's own
  checks is worth reading off
  `gh api repos/{owner}/{repo}/commits/<sha>/check-runs` at step 3 before
  the rule is touched again.

## Also in this pull request

- **REPOSITORY.md**: the required-check table row, the paragraph that said
  CodeQL is a repository setting and not a workflow, the documented
  default-setup command — now the one that *disables* it — and the app
  binding paragraph, corrected to what the endpoint reports.
- **CLAUDE.md**: `codeql` is the fourth gate, and `release.yml` does not
  reuse it. It does not have to: a tag is an ancestor of `main` before the
  matrix builds anything (`version-check`), so the tree a release publishes
  is one the merge gate has already scanned.
- **CONTRIBUTING.md**: the "What runs when" table, and the note that
  `codeql` is the one gate with no local command — the CodeQL CLI is a
  bundle GitHub distributes rather than a dependency `uv.lock` can pin.
- **CHANGELOG.md**: an entry under `### CI`.
- `.secrets.baseline`: line numbers, moved by the CHANGELOG entry, as the
  hook requires.

REPOSITORY.md is written as of step 2 being done: until a human runs it, the
endpoint still answers `state: configured`.

## Not measured

Whether a pull request from a fork produces these checks. Default setup
analyzed fork pull requests; an advanced workflow needs
`security-events: write`, which a fork's token does not get on a public
repository, and this could not be tested from a branch. Worth one look
before the rule requires the aggregate, if a fork pull request is ever
expected here.

## Gates

Run in the worktree, on `cf42d73`:

```shell
uvx pre-commit run --all-files                    # twice, second rewrote nothing
uv run --locked --no-default-groups --group test pytest --cov
# 422 passed in 4.38s, TOTAL 547 stmts 0 miss, 100.00%
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
# build succeeded, and docs.yml's grep for unresolved links finds none
```

`actionlint` and `zizmor` are hooks and both pass on the new file at zero
findings.

## Summary by Sourcery

Introduce a CodeQL workflow in the repository and make its aggregate check the fourth merge gate, replacing GitHub’s default code scanning setup with a reviewable, pinned configuration.

Enhancements:
- Add a new `codeql.yml` workflow that mirrors the previous default CodeQL setup, including languages, query suite, schedule, permissions, and pinned action SHAs.
- Update branch protection guidance to require the new `codeql: every job passed` aggregate check and to bind all required checks to the Actions app.
- Clarify how to disable the legacy default CodeQL setup and transition branch rules to the new workflow without blocking merges.
- Document CodeQL as a gating workflow in CLAUDE.md, CONTRIBUTING.md, and REPOSITORY.md, including when it runs and how it is configured.
- Record the CI change in CHANGELOG.md and adjust the secrets baseline to match shifted line numbers.

CI:
- Add and configure `.github/workflows/codeql.yml` as an advanced CodeQL workflow that runs on PRs, pushes to `main`, a weekly schedule, and manual dispatch, with an aggregate job for branch protection.