### PR TITLE
Stop naming dev and master, the branches this repository no longer keeps

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: >
         Discussions are not enabled here, so a question is an issue. Check
-        the [README](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/README.md)
+        the [README](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/README.md)
         first: it is the documentation of this package, and its Design and
         Wrapped modules sections answer most of what gets asked.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
      still checked. The suppression has to sit immediately above the
      heading, `disable-next-line` reaching exactly one line -- with this
      comment between the two it silenced the comment and MD041 still
-     fired. Targets dev; master only ever receives merges from it. -->
+     fired. Targets main, the only branch a change lands on. -->
 
 <!-- markdownlint-disable-next-line first-line-heading -->
 ## What this changes, and why

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,8 +152,8 @@ repos:
   # The default dictionaries (clear, rare) on purpose: the optional ones
   # were tried and report only what this repository means to say — code
   # and usage flag "keypair", which is the name of the upstream
-  # secp256k1_keypair type, and "master", which is a branch this
-  # repository actually has. The vendored secp256k1 tree is not seen
+  # secp256k1_keypair type, and "master", which is the branch bitcoin/bips
+  # and bitcoin-core/secp256k1 are cited at. The vendored tree is not seen
   # because pre-commit only passes files tracked here, not the submodule's
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 988
+        "line_number": 1016
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T01:02:19Z"
+  "generated_at": "2026-08-11T01:30:32Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,34 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **The prose stops naming `dev` and `master`, which no longer exist.**
+  The workflows were corrected when the branches went; the files that
+  describe how this repository is worked on were not, so RELEASING.md
+  still told a maintainer to merge `dev` into `master` and to read
+  `gh run list --commit "$(git rev-parse origin/master)"` — a command
+  that now fails on a ref that is gone, in the one file a release is
+  executed from. Two of its twelve steps described work that cannot be
+  done and are gone: realigning `dev` onto `master` after a release, and
+  opening the draft release pull request between the two branches, whose
+  job — somewhere to describe the cycle as it lands — the open sections
+  of `CHANGELOG.md` and `HISTORY.md` already do. What replaced the
+  release merge is stated rather than implied: the release pull request
+  is an ordinary one against `main`, and the ninety-two-commit squash of
+  0.7.1 cannot recur, every change now reaching `main` in its own pull
+  request as it lands. CONTRIBUTING.md, CLAUDE.md, REPOSITORY.md and the
+  pull request template follow, and REPOSITORY.md's branch protection
+  section describes `main` — where it said "the three checks", the rule
+  has named four since `docs` became one of them.
+- **Seven README links, the `changelog` metadata url and the Sphinx
+  source links pointed at `blob/master`.** They resolve, GitHub
+  redirecting a renamed branch, so nothing was broken and the `links`
+  sentinel stayed green; the `changelog` one is what an index puts behind
+  "Changelog" on the project page, and `docs/source/conf.py` builds every
+  "source" link on Read the Docs from the same string. The pre-commit.ci
+  badge was the one that had stopped meaning anything: pinned to
+  `master.svg`, it answers `passed` for a branch that has not existed
+  since the rename and can never turn red again — measured against a
+  branch name that never existed, which answers `unknown`.
 - **This file's own preamble says where it starts, not what it holds.**
   "Only v0.7.1.2 is here" was true for exactly one release, and v0.7.1.3
   landing under it made it false without anything failing; every release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
 
 ```shell
 WT=<scratchpad>/wt<issue>
-git worktree add -b <branch> "$WT" origin/dev
+git worktree add -b <branch> "$WT" origin/main
 cd "$WT" && uv sync --locked      # a second venv, and a second build of
                                   # the extension: minutes, not seconds
 # edit, gate and commit here, then
@@ -203,13 +203,14 @@ kill rate, which is the one failure mode that looks like good news.
   it shipped: step 10 of RELEASING.md, and the reason it is a step
 - **the `secp256k1` submodule moves in a change of its own,** with the
   version named in `README.md` and `HISTORY.md` moved with it
-- development happens on `dev`; a pull request targets `dev`, and `master`
-  only ever receives merges from it — with **Rebase and merge**, never
-  *Squash and merge*, which would leave one commit on `master` where `dev`
-  carried the reasoning one commit at a time. Which button GitHub has
-  selected is worth reading before it is pressed: all three are enabled,
-  and it remembers the last one used. Afterwards `dev` is realigned onto
-  `master`, both being steps of RELEASING.md and for reasons given there
+- **`main` is the only long-lived branch**, so a pull request targets it
+  and a tag on it is a release; it is protected, and every change gets
+  there through a pull request. Which button GitHub has selected is worth
+  reading before it is pressed: all three are enabled, and it remembers
+  the last one used — a merge commit is refused whichever is showing,
+  `main` requiring linear history. The `dev` this repository used to
+  develop on, and the release merge into `master` that went with it, are
+  gone; RELEASING.md is the file that describes what replaced them
 
 ## Conventions the workflows hold to
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,9 +375,8 @@ run locally.
 
 ## What a change has to satisfy
 
-Development happens on `dev`, so that is what a pull request targets;
-`master` only ever receives merges from it, and a tag on `master` is a
-release.
+`main` is the only long-lived branch, so that is what a pull request
+targets and where every change lands; a tag on `main` is a release.
 
 - **the pre-commit hooks pass.** `uv run pre-commit run --all-files` runs
   the formatter, the linters and the type checker; the `lint` workflow
@@ -535,18 +534,17 @@ commits the review is attached to: the reviewer loses the diff they read,
 one of those matrix jobs starts again from a commit nobody has seen. Add
 the fix on top, with a message saying what it fixes, and reply to the
 comment with the sha. The one force-push that stays right is the one
-carrying no new work — a `git rebase origin/dev` on a branch whose base has
-moved — and it wants the gates re-run after it, not only before, and a note
-in the pull request saying the head moved.
+carrying no new work — a `git rebase origin/main` on a branch whose base
+has moved — and it wants the gates re-run after it, not only before, and a
+note in the pull request saying the head moved.
 
-Nothing is lost in `dev`'s history by working that way, because a pull
+Nothing is lost in `main`'s history by working that way, because a pull
 request is squashed on merge: the branch lands as one commit whose subject
 is the pull request title with its number, so the review's commits are the
-record of the review and `dev` keeps one commit per landed change. All
+record of the review and `main` keeps one commit per landed change. All
 three merge buttons are enabled on this repository, so which one is used
 is a choice made at the merge rather than one GitHub enforces — check it
-before clicking, `dev` into `master` being the case that wants a different
-answer, a release having to keep the commits a tag was cut from.
+before clicking, GitHub preselecting whichever was used last.
 
 Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ bitcoin-core-rpc carry the same three lines. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib_libsecp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib_libsecp256k1)](https://pepy.tech/project/btclib_libsecp256k1)
 [![development status](https://img.shields.io/pypi/status/btclib_libsecp256k1.svg)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
-[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/LICENSE)
 [![supported Python versions](https://img.shields.io/pypi/pyversions/btclib_libsecp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib_libsecp256k1/)
 
 [![test workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
 [![docs workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/main)
 [![documentation build](https://readthedocs.org/projects/btclib-libsecp256k1/badge/?version=latest)](https://btclib-libsecp256k1.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib-libsecp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-libsecp256k1/)
@@ -218,7 +218,7 @@ type, a length, or a magnitude, all of which the caller knows already —
 so the constant-time guarantee is the C call's, and it is intact. What
 python cannot give back is what happens on either side of that call:
 `bytes` is not zeroized either, and
-[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/SECURITY.md)
+[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/SECURITY.md)
 records both limits as inherent.
 
 And there is a way past all of it: `lib` and `ffi` are exported, and a
@@ -355,7 +355,7 @@ attributes a message to the right caller.
 
 What is not protected is the secret material itself, which lives in
 Python objects for as long as the interpreter keeps them: see
-[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/SECURITY.md).
+[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/SECURITY.md).
 
 ## The vendored library is not optional
 
@@ -433,7 +433,7 @@ x86_64 only.
 How to get the submodule, set up the development environment, run the
 suite and the benchmarks, reproduce each CI job locally, and what a
 change is expected to satisfy are in
-[CONTRIBUTING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/CONTRIBUTING.md).
 
 ## Release process
 
@@ -448,4 +448,4 @@ without the index.
 
 The steps to cut a release, to rehearse one on TestPyPI, and the
 one-time setup each index needs are in
-[RELEASING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/master/RELEASING.md).
+[RELEASING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ reading `0.7.1rc1` fails there, rather than burning `0.7.1rc1` on PyPI.
 The same job checks that `uv.lock` carries the version the tree declares,
 that the libsecp256k1 release named in `README.md` is the commit the
 submodule is pinned to, that `HISTORY.md` has a section for the tag, and
-that the tagged commit is on `master`. Every invariant a release rests on
+that the tagged commit is on `main`. Every invariant a release rests on
 is checked there, before the point of no return.
 
 ## Which version string is which
@@ -30,7 +30,7 @@ hand. Telling them apart is most of what can go wrong:
   published, on either index, and the only one a human edits
 - **`0.7.1.1`**, a fourth number on an already-final version, plays two
   roles this list would otherwise leave out: right after 0.7.1 ships,
-  step 10 opens `dev` on it as a placeholder, nothing having moved the
+  step 10 opens the tree on it as a placeholder, nothing having moved the
   submodule since to renumber it; and if 0.7.1 itself shipped broken,
   "When a release turns out to be broken" ships the very same string
   as the fix, tagged. Both are typed by hand, like `0.7.1` above, and
@@ -115,21 +115,25 @@ Then:
 1. give the pull request its title and its body before merging it, not
    after. The title is the version; the body says what the release is —
    what moved, what did not, and which of the two a user would notice.
-   A rebase leaves no merge commit, so none of that reaches `master`'s
-   history: the pull request is where it stays, and where a reader of
-   any commit in it arrives. A template left unfilled, or a bot's
+   The pull request is where that stays, and where a reader of the commit
+   arrives from `main`'s history. A template left unfilled, or a bot's
    summary of the diff, is not a substitute — the summary can stay, but
    what the diff cannot say has to be written, and what a reader should
    not have to discover at the button belongs there too.
 
-   The previous cycle's step 11 opened this pull request asking for the
-   body to fill in one merged pull request at a time, and says so itself:
-   "a promise kept only if someone remembers to keep it." Check it against
-   `git log v<previous version>..dev --oneline` regardless of how current
-   it looks, rather than trust that every line landed when it should have.
-   `latest`'s result belongs here too, a line rather than a screenshot: it
-   gates nothing, and a pull request that never mentions it having run
-   reads exactly like one that skipped it.
+   What the cycle actually contained is not this pull request's diff,
+   which is a version bump and two headings: it is everything merged
+   since the last tag. Read it off the log rather than off the branch,
+
+   ```shell
+   git log v<previous version>..main --oneline
+   ```
+
+   and against the open sections of `CHANGELOG.md` and `HISTORY.md`,
+   which step 2 has just closed and which are where each change was
+   described as it landed. `latest`'s result belongs here too, a line
+   rather than a screenshot: it gates nothing, and a pull request that
+   never mentions it having run reads exactly like one that skipped it.
 
    A deliberate skip and an item nobody has gotten to yet are different
    facts and do not fit under one checkbox: 0.7.1.2's own checklist
@@ -139,38 +143,42 @@ Then:
    first. Separate lines for independent questions cost nothing and stay
    accurate without an edit.
 
-   Then merge `dev` into `master` with a green CI, using **Rebase and
-   merge** and never *Squash and merge*.
-   Which button that is has to be read before it is pressed: all three
-   methods are enabled on this repository, and GitHub preselects the one
-   used last. *Squash and merge* is what 0.7.1 got, and it left a single
-   commit on `master` where `dev` carried ninety-two, each of them the
-   record of a decision. The trees were identical, so nothing published
-   was wrong, but the history could not be put back afterwards: `master`
-   refuses force pushes with `enforce_admins` on, six of those ninety-two
-   commits were unsigned where `master` requires signatures, and the tag
+   Then merge it into `main` with a green CI. It is an ordinary pull
+   request against the only branch there is, and it merges the way every
+   other one here does; the button is still worth reading before it is
+   pressed, all three methods being enabled and GitHub preselecting the
+   one used last. A merge commit is not among the choices whichever is
+   selected: `main` requires linear history.
+
+   What that button cannot cost any more is the history of a cycle. It
+   could once: 0.7.1 was *Squash and merge* on a release pull request
+   carrying ninety-two commits from a development branch, and it left one
+   commit where ninety-two records of a decision had been. The trees were
+   identical, so nothing published was wrong, but it could not be put
+   back — the trunk refuses force pushes with `enforce_admins` on, six of
+   the ninety-two were unsigned where signatures are required, and the tag
    could not have followed a rewrite either, the PEP 740 attestation
    binding 0.7.1 to that commit and to `refs/tags/v0.7.1` alike. They are
-   kept at the tag `history/dev-0.7.1`. A merge commit is not among the
-   choices: `master` requires linear history.
+   kept at the tag `history/dev-0.7.1`. With one branch the question does
+   not arise: every change reached `main` in its own pull request as it
+   landed, and this one carries the release and nothing else.
 
-   Development happens on `dev`, and `master` only receives merges from
-   it. What has to be green is `lint` and `test` on the commit `master`
-   ends up at — a rebase leaves no merge commit of its own — which is
-   worth asking for by commit rather than reading off a branch:
+   What has to be green is `lint`, `docs` and `test` on the commit `main`
+   ends up at, which is worth asking for by commit rather than reading
+   off a branch:
 
    ```shell
-   gh run list --commit "$(git rev-parse origin/master)"
+   gh run list --commit "$(git rev-parse origin/main)"
    ```
 
-   and worth waiting for rather than assuming: the push a rebase-and-merge
-   makes to `master` fires `lint` and `test` again from their `push`
-   trigger, a run of its own rather than the `pull_request` run already
-   green on the pull request a moment earlier. The red `Dependabot
-   Updates` runs sitting beside them are Dependabot's own updater failing
-   to compute an update, not a workflow of this repository, and say
-   nothing about the tree
-1. tag the tip `master` now points at, and push that tag alone:
+   and worth waiting for rather than assuming: the push the merge makes
+   to `main` fires those workflows again from their `push` trigger, runs
+   of their own rather than the `pull_request` runs already green on the
+   pull request a moment earlier. The red `Dependabot Updates` runs
+   sitting beside them are Dependabot's own updater failing to compute an
+   update, not a workflow of this repository, and say nothing about the
+   tree
+1. tag the tip `main` now points at, and push that tag alone:
 
    ```shell
    git tag v0.7.1
@@ -253,109 +261,9 @@ Then:
    asks the same question of the statement downloaded beside the file
    rather than of the attestations API, which is the form for whoever
    mirrors the page instead of trusting it live
-1. realign `dev` onto `master`, before anything else is committed to it.
-   Rebase and merge replays `dev`'s commits with new SHAs, so the moment
-   a release is merged the two branches hold the same tree through
-   different histories, and the merge base between them stops advancing.
-   Left alone this is not the cosmetic issue it looks like: it is what the
-   pull request that added this very step hit, during 0.7.1.1's own
-   release -- its branch built against `dev` before this step's own reset
-   ran, so once that reset moved `dev`, GitHub reported the pull request
-   `CONFLICTING` and `gh pr merge --rebase` on it refused with `the merge
-   commit cannot be cleanly created`. Reapplying "add this line" where a
-   rebase-and-merge already added it under a different SHA is a conflict,
-   not a no-op, and GitHub does not drop the commit the way a local
-   `git rebase` would. Archive what is about to become unreachable, then
-   move the branch:
-
-   ```shell
-   git fetch origin
-   git tag -a history/dev-0.7.1 dev -m "dev's own commits for 0.7.1"
-   git push origin history/dev-0.7.1
-   git switch dev && git reset --hard origin/master
-   git push --force-with-lease origin dev
-   ```
-
-   the tag is what keeps `dev`'s own commits readable, and it must not
-   start with `v`, `release.yml` triggering on `tags: ["v*"]`. Nothing in
-   the working tree changes, the two trees being identical, and
-   `git diff origin/master origin/dev` is how to say so rather than
-   assume it.
-
-   `git switch dev` assumes a checkout free to hold it, which the
-   convention this repository asks every session to follow — its own
-   worktree, never the primary checkout — does not give a worktree
-   already busy with a branch of its own, and should not be made to have
-   by switching branches inside it. Without a local checkout of `dev` at
-   all:
-
-   ```shell
-   git push --force-with-lease=refs/heads/dev:<old dev sha> origin \
-     origin/master:refs/heads/dev
-   ```
-
-   pushes the read-only remote-tracking ref `origin/master` straight to
-   `refs/heads/dev`, the lease keyed to the `dev` tip a `git fetch`
-   already holds rather than to a branch checked out locally.
-
-   That last push can fail on its own, distinctly from everything above
-   it: `dev`'s branch protection blocking force pushes is not one of the
-   rules `enforce_admins` being off exempts an administrator from. That
-   toggle covers required reviews, required status checks, required
-   signatures and required linear history -- what a *pull request*
-   enforces -- and force-push protection is a rule of its own that GitHub
-   applies to every push over the git protocol regardless of who is
-   pushing, admin included. 0.7.1.1 is where this was learned: the
-   maintainer's own push, run by hand, came back
-   `remote: - Cannot force-push to this branch`, and no `--admin`-like
-   flag on `git push` exists to ask around it. What worked instead was
-   flipping the one setting that governs it, immediately before the push
-   and immediately after:
-
-   ```shell
-   gh api repos/<owner>/<repo>/branches/dev/protection --jq \
-     '{required_status_checks, enforce_admins: .enforce_admins.enabled,
-       required_pull_request_reviews, restrictions,
-       required_linear_history: .required_linear_history.enabled,
-       allow_force_pushes: true, allow_deletions: .allow_deletions.enabled,
-       block_creations: .block_creations.enabled,
-       required_conversation_resolution: .required_conversation_resolution.enabled,
-       lock_branch: .lock_branch.enabled,
-       allow_fork_syncing: .allow_fork_syncing.enabled}' \
-     | gh api -X PUT repos/<owner>/<repo>/branches/dev/protection --input -
-   ```
-
-   read the four nullable fields back first (`required_status_checks`,
-   `required_pull_request_reviews`, `restrictions`, and `required_signatures`,
-   which is its own endpoint and this PUT does not touch) and carry
-   whatever they hold into the payload unchanged -- a PUT that drops one
-   silently disables it, the same warning the master section above makes
-   about reviews and signatures. On `dev` today all three are unset, which
-   is what makes the jq filter above safe to run as shown; a `dev` with
-   any of them configured needs its current values read and kept, not
-   assumed absent. Push, then set `allow_force_pushes` back to `false`
-   through the same PUT at once: the setting, not only this one push, is
-   what stands open in between, and every other push to `dev` shares that
-   window while it is.
-
-   Every branch still open against `dev` has had its base
-   moved out from under it, and reports the whole release as its own diff
-   until it is rebased:
-
-   ```shell
-   git rebase --onto origin/master <the old dev tip> <branch>
-   ```
-
-   GitHub's own `mergeable`/`mergeStateStatus` on that branch's pull
-   request can still read `CONFLICTING`/`DIRTY` for a few seconds after
-   the force-push that follows, before it finishes recomputing against
-   the new tip — worth a second look rather than read as the rebase
-   above having failed.
-
-   this comes before step 10 rather than after it: the bump step 10 makes
-   is on `dev`, and the force update above would discard it
-1. open the next version on `dev`: bump `pyproject.toml` to a fourth
-    number over what was just published — `0.7.1.1` after `0.7.1` — and
+1. open the next version, in a pull request of its own and before
+    anything else lands: bump `pyproject.toml` to a fourth number over
+    what was just published — `0.7.1.1` after `0.7.1` — and
     run `uv lock`. It is a placeholder, and step 1 renumbers it if the
     submodule moves before the next release; what it buys is a tree that
     no longer claims to be a version it is not. `__version__` reads
@@ -372,17 +280,9 @@ Then:
     same time, headed
     `## v<version> (work in progress, not released yet)` and empty: what
     lands next then has somewhere to be written down as it lands, which
-    is the whole of step 2
-1. open a draft pull request from `dev` to `master` for the version step
-    10 just opened, title included, and leave its body for what step 3
-    already asked for: written before the release is cut, not
-    reconstructed from the diff at the last minute. A draft one is
-    exactly what step 3 could not be until now — everything that lands on
-    `dev` between one release and the next has a place to be described as
-    it lands, rather than a promise kept only if someone remembers to keep
-    it. Marking it ready and pressing **Rebase and merge** is what step 3
-    still is; this step is what makes reaching it with a body already
-    written the ordinary case rather than the exception
+    is the whole of step 2 — and, with one branch and no long-lived
+    release pull request to hold a body, the whole of what step 3 reads
+    the cycle off at the end of it
 
 ## Rehearsing on TestPyPI
 
@@ -493,7 +393,7 @@ registration that can be wrong on its own, nor the deployment branch
 policy of the `pypi` environment, which the environment a rehearsal does
 reach has none of, nor the checks of `version-check` that need a tag: the
 version comparison, the `HISTORY.md` section, and the ancestry on
-`master`.
+`main`.
 
 ## When a release turns out to be broken
 
@@ -551,8 +451,8 @@ next fork.
   ```
 
   What that rule constrains is the *name* of the ref, and nothing else: a
-  `v*` tag pushed on a branch head, on an old `dev` state or on a
-  fork-synced commit satisfies it exactly as the release tag does, and
-  the reviewer approving sees the tag name rather than its ancestry.
-  The ancestry is checked in `version-check` instead, which fails a tag
-  that is not on `master` before the matrix builds anything
+  `v*` tag pushed on a branch head, on a commit `main` has since moved
+  past or on a fork-synced commit satisfies it exactly as the release tag
+  does, and the reviewer approving sees the tag name rather than its
+  ancestry. The ancestry is checked in `version-check` instead, which
+  fails a tag that is not on `main` before the matrix builds anything

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -124,7 +124,7 @@ with none open but the one doing the renaming.
 
 ## Branch protection
 
-`master`, all of it read from the endpoint above: `strict` with the three
+`main`, all of it read from the endpoint above: `strict` with the four
 checks already described, one approving review with
 `dismiss_stale_reviews`, **required signatures**, linear history, no force
 pushes, no deletions, `required_conversation_resolution`, and
@@ -136,44 +136,32 @@ admin bypass is the only way past it without a second maintainer to add.
 
 ```shell
 gh api -X DELETE \
-  repos/btclib-org/btclib-libsecp256k1/branches/master/protection/enforce_admins
+  repos/btclib-org/btclib-libsecp256k1/branches/main/protection/enforce_admins
 ```
 
 Turned off after being on through the 0.7.1 release, whose squash merge
 (see RELEASING.md) is what the previous setting actually cost: with
 `enforce_admins` on, neither the force push nor the six unsigned commits
-among the ninety-two `dev` carried could have gone back onto `master`,
-admin included. Off would not undo that squash today either — `master`'s
-tip is the commit PyPI's PEP 740 attestations for 0.7.1 are bound to, and
-moving it now would desynchronize a published release from what it
-attests to rather than restore anything. What changed is only whether the
-next incident has the same escape hatch btclib already keeps.
+among the ninety-two the development branch carried could have gone back
+onto the trunk, admin included. Off would not undo that squash today
+either — that commit is what PyPI's PEP 740 attestations for 0.7.1 are
+bound to, and moving it now would desynchronize a published release from
+what it attests to rather than restore anything. What changed is only
+whether the next incident has the same escape hatch btclib already keeps.
 
-`dev` is protected too, minimally and identically to btclib's own:
+One protected branch is the whole of it, which is a consequence of there
+being one long-lived branch:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/branches/dev/protection \
-  --jq '{required_linear_history, allow_force_pushes, allow_deletions,
-    enforce_admins, required_conversation_resolution}'
+gh api repos/btclib-org/btclib-libsecp256k1/branches \
+  --jq '.[] | "\(.name) protected=\(.protected)"'
 ```
 
-No force pushes, no deletions, linear history, resolved conversations —
-and nothing beyond that: no required check, no review, no signature, so a
-direct push still works, which is what Dependabot and pre-commit.ci both
-rely on, and where every branch here is cut from. Requiring signatures
-would reject every bot commit outright, and one approving review cannot
-be satisfied by the author on a single-maintainer repository.
-`enforce_admins` off is what keeps the first two rules from becoming a
-lock: the release process (see RELEASING.md) force-pushes `dev` to
-realign it with `master` after every release, and only an admin bypass
-lets that step run at all — the rule still stops anyone, and any
-compromised token, that is not.
-
-Before this, `dev` had no protection at all — a branch cut from and
-pushed to by two bots, force-pushable or deletable under an open pull
-request. What btclib answers with a minimal rule, this repository
-answered with none, which is the gap this section used to describe
-instead of closing.
+The minimal rule that used to sit on the development branch — no force
+pushes, no deletions, linear history, and nothing else — went with the
+branch it protected. Nothing was weakened by that: what it guarded was a
+trunk a pull request did not have to pass through, and every change now
+reaches `main` through the rules above.
 
 ## Head branches after a merge
 
@@ -187,14 +175,15 @@ GitHub deletes the head branch of a pull request when it is merged, which
 is what keeps the branch list a list of live work rather than a history of
 every change ever made. It was turned on after a sweep that removed five
 merged head branches from here, none of which anybody could tell from live
-work without comparing each against `dev` commit by commit.
+work without comparing each against the trunk commit by commit.
 
-Two cases it does not cover, both deliberate. A protected branch is never
-deleted, protection winning over this setting, so the release pull request
-that merges `dev` into `master` leaves `dev` where it is. And a pull
-request **closed without merging** keeps its head branch: GitHub cannot
-know whether that work was abandoned or is waiting, so those are the ones
-still worth looking at now and then.
+The case it does not cover is deliberate: a pull request **closed without
+merging** keeps its head branch, GitHub having no way to know whether that
+work was abandoned or is waiting, so those are the ones still worth
+looking at now and then. The setting has a second exception — a protected
+branch is never deleted, protection winning over it — which used to reach
+the release pull request, whose head branch was protected. No head branch
+is protected now.
 
 ## Token permissions
 
@@ -256,12 +245,14 @@ fails again with `invalid-publisher`, that is the first thing to check.
 
 ## Dependabot
 
-Three ecosystems, and all three target `dev`, `master` only receiving
-merges from it:
+Three ecosystems, and none of them names a target: with no
+`target-branch` Dependabot opens against the default branch, which is the
+only branch a change lands on. A setting that names nothing cannot name
+something that is gone, which is what the `dev` it used to name became.
 
 ```shell
 gh api repos/{owner}/{repo}/contents/.github/dependabot.yml \
-  --jq '.content' | base64 -d | grep -E 'package-ecosystem|target'
+  --jq '.content' | base64 -d | grep -E 'package-ecosystem|target-branch'
 ```
 
 `github-actions` moves the SHA pins, `uv` the locked dependencies, and
@@ -321,5 +312,5 @@ its root is a URL anywhere:
 gh api repos/btclib-org/btclib-libsecp256k1/pages   # 404
 ```
 
-btclib.org is built from the btclib repository's `master` root, which is
+btclib.org is built from the btclib repository's `main` root, which is
 why that project's README is also a web page and this one's is not.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,10 +129,10 @@ def included(shim: Path) -> tuple[str, str]:
 
 # repository-relative path -> the docname whose page renders it
 INCLUDED = dict(map(included, sorted(Path(__file__).parent.glob("*_link.md"))))
-# master, not a permalink pinned to a commit: these are navigation links
-# to files that keep changing, and a reader following one wants the file
-# as it stands
-BLOB = f"{PYPROJECT['project']['urls']['repository']}/blob/master/"
+# the branch, not a permalink pinned to a commit: these are navigation
+# links to files that keep changing, and a reader following one wants the
+# file as it stands
+BLOB = f"{PYPROJECT['project']['urls']['repository']}/blob/main/"
 
 
 class RootFileLinks(SphinxPostTransform):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ download = "https://github.com/btclib-org/btclib-libsecp256k1/releases"
 # "Changelog", and what a user following it wants is the release notes,
 # not the record behind them. CHANGELOG.md is linked from the first line
 # of that file
-changelog = "https://github.com/btclib-org/btclib-libsecp256k1/blob/master/HISTORY.md"
+changelog = "https://github.com/btclib-org/btclib-libsecp256k1/blob/main/HISTORY.md"
 issues = "https://github.com/btclib-org/btclib-libsecp256k1/issues"
 pull_requests = "https://github.com/btclib-org/btclib-libsecp256k1/pulls"
 


### PR DESCRIPTION
The workflows were corrected when the branches went (v0.8.0's CI section);
the prose was not, and the prose is what a person follows.

## The one that would have cost a release

`RELEASING.md` is the file a release is executed from, and it still said
to merge `dev` into `master` and to read the CI off

```shell
gh run list --commit "$(git rev-parse origin/master)"
```

which now fails on a ref that is gone — at the step where the next thing
to happen is a tag.

**Two of its twelve steps described work that cannot be done**, and are
gone rather than reworded: realigning `dev` onto `master` after a release,
and opening the draft release pull request between the two branches. The
second had a real job — somewhere to describe the cycle *while* it lands —
and the open sections of `CHANGELOG.md` and `HISTORY.md` already do it, so
step 10 says so where the draft pull request used to be promised.

What replaced the release merge is stated rather than left to be inferred:
the release pull request is an ordinary one against `main`, and the
ninety-two-commit squash of 0.7.1 cannot recur — every change now reaches
`main` in its own pull request as it lands. The `history/dev-*` tags keep
the commits that squash cost, and are still where the text points (all
four verified present on the remote).

## The rest of the prose

`CONTRIBUTING.md`, `CLAUDE.md`, `REPOSITORY.md` and the pull request
template follow. `REPOSITORY.md`'s branch protection section now describes
`main` and drops the minimal rule that protected `dev`; the settings it
quotes were re-read from the API rather than carried over, which is how
**"the three checks" turned out to be four** — `docs` became a required
context and the sentence never moved. `btclib.org is built from btclib's
master root` is now `main`, checked against that repository's Pages
source.

## The links, and the badge that had stopped meaning anything

Seven README links, the `changelog` url in `pyproject.toml` — what an
index puts behind "Changelog" — and the `BLOB` prefix
`docs/source/conf.py` builds every Read the Docs source link from all
pointed at `blob/master`. They resolve, GitHub redirecting a renamed
branch, so nothing was broken and the `links` sentinel stayed green.

The pre-commit.ci badge is the exception, and it is the repository's own
failure mode — a check that has stopped checking reads exactly like one
that passes:

```
master.svg             -> aria-label="pre-commit.ci: passed"
no-such-branch-xyz.svg -> aria-label="pre-commit.ci: unknown"
```

`master` has not existed since the rename, and that badge can never turn
red again. The nonexistent branch is what tells a frozen record apart from
a fallback to the default branch.

## Left alone, deliberately

`master` in the `bitcoin/bips` and `bitcoin-core/secp256k1` citations —
that is those repositories' own default branch, checked — and the `dev`
dependency group, which is a group and not a branch. The `.dev<run>`
version suffix likewise.

## Verification

`uvx pre-commit run --all-files` green, exit 0. `.secrets.baseline` moved
by one line number again: the same CHANGELOG entry shifting, read before
staging.

Not in scope, and worth its own look: `.github/dependabot.yml` declares
`interval: weekly` on all three ecosystems, while CLAUDE.md's `latest`
section says "Dependabot is monthly here on purpose".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation and metadata to reflect `main` as the single long-lived branch and remove references to obsolete `dev`/`master` workflow steps.

Enhancements:
- Ensure Dependabot configuration and branch protection narrative reflect a single protected default branch and current CI checks.
- Retarget pre-commit.ci badge and GitHub blob links from `master` to `main` so monitoring and navigation align with the current default branch.

Documentation:
- Revise RELEASING.md to describe the release process against `main`, drop dev/master realignment steps, and clarify how to summarize a release cycle.
- Update CONTRIBUTING.md, CLAUDE.md, REPOSITORY.md, README, issue and pull request templates, and Sphinx config to reference `main` and current branch protection and workflow behavior.
- Adjust CHANGELOG documentation section to note the branch naming changes and link behavior for changelog and Read the Docs source URLs.