### PR TITLE
Correct the two cadences the schedules already contradicted

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1016
+        "line_number": 1031
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T01:30:32Z"
+  "generated_at": "2026-08-11T06:51:11Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,21 @@ release-notes length in the first place, and are still in
   fails `-W` under the other is found after the merge, on the service
   whose failure is not a check on the pull request. The file already said
   it matches btclib's, and btclib's moved.
+- **Two documented cadences the schedules contradicted.** CLAUDE.md said
+  "Dependabot is monthly here on purpose", where
+  `.github/dependabot.yml` has declared `interval: weekly` with
+  `day: thursday` on all three ecosystems since it was moved there to
+  match btclib; and RELEASING.md's step 7 said `published` "runs weekly
+  on its own", where its cron is `23 6 1 * *` and this file's own v0.8.0
+  entry records the move from weekly to monthly. Neither is a claim
+  anything checks, which is why both survived the change they describe.
+  The CLAUDE.md sentence was making an argument as well as a statement —
+  that `latest` covers for an infrequent Dependabot — and the argument
+  was the wrong way round: `latest` runs on the Wednesday *before*
+  Dependabot proposes on the Thursday, so what it buys is a diff whose
+  result is already known. What it covers that nothing else does is
+  `[build-system] requires`, resolved at build time and pinned by no
+  lock file, so Dependabot never moves it at any interval.
 
 ### Packaging metadata
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,13 @@ does.
 elsewhere passes `--locked`, the dependency groups declare no version, and
 the one runtime dependency is cffi — which this package does not merely
 import but *compiles against*, so a cffi, setuptools or cmake release can
-break the build rather than a test. Dependabot is monthly here on purpose,
-that being a cost decision now rather than a visibility one, and this is why.
+break the build rather than a test — and none of those three is something
+Dependabot moves, `[build-system] requires` being resolved at build time
+and pinned by no lock file. Dependabot is weekly, on the Thursday after
+this runs, which is the other half of the arrangement: the sentinel
+answers on Wednesday, so the pull requests that arrive the next morning
+are a diff whose result is already known. `.github/dependabot.yml` carries
+that reasoning where the day is set.
 
 `mutation` is scoped by `.github/mutation/bindings.toml`, which is also
 what a local run reads, so there is one statement of what is mutated and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -232,7 +232,8 @@ Then:
 1. run the `published` workflow from the Actions tab, and expect it green:
    it installs from PyPI what was just uploaded, on every platform and at
    both ends of the supported interpreter range, and verifies BIP340
-   vector 0 with it. From then on it runs weekly on its own, and a failure
+   vector 0 with it. From then on it runs monthly on its own, on the
+   first, and a failure
    means the outside world moved, not this repository — which is why it is
    a workflow of its own rather than a job of this one, besides its
    racing the index if it ran straight after the upload. On 0.7.1 it went


### PR DESCRIPTION
Two documented cadences that the things they describe disagree with.
Neither is a claim anything checks, which is how both survived the change
they describe: the schedule moved, the sentence stayed, and nothing went
red.

## Dependabot is not monthly

`CLAUDE.md` said "Dependabot is monthly here on purpose, that being a cost
decision now rather than a visibility one". It has not been monthly since
a576a23 ("Move Dependabot to weekly, matching btclib"), and the file says
so on all three ecosystems:

```yaml
    schedule:
      interval: weekly
      day: thursday
```

btclib's own declares the same pair, with the same comment about the day.

**The sentence was also making an argument, and the argument was the wrong
way round.** It read as `latest` covering for an infrequent Dependabot;
`latest` runs Wednesday and Dependabot proposes Thursday, so what the
pairing actually buys is a pull request whose result the sentinel reported
the morning before — which is what `dependabot.yml` says where the day is
set. What `latest` covers that nothing else does is the build backend:
`[build-system] requires` is resolved at build time and pinned by no lock
file, so Dependabot never moves it at any interval, and a cffi, setuptools
or cmake release can break a build that no test would have caught. That is
the gap, and the corrected sentence names it.

## `published` is not weekly

`RELEASING.md`'s step 7 said it "runs weekly on its own". Its cron is
`23 6 1 * *`, and this repository's own v0.8.0 CHANGELOG entry is the one
that moved it: "**`published.yml` is monthly, where it was weekly.**"

## Checked while I was in there

The other schedule claims hold: CLAUDE.md's sentinel table and
CONTRIBUTING.md's workflow table agree with every cron
(`links` Mon, `macos`/`latest` Wed, `mutation` Sun, `published` and
`vendored-vectors` the 1st), and RELEASING.md's "the weekly cron was days
off" is about `mutation`, which is weekly.

## Verification, and one note for whoever merges

`uvx pre-commit run --all-files` green, exit 0.

This touches `.secrets.baseline` for the usual reason — one line number of
an existing CHANGELOG entry — and so do #114 and #115. Whichever of them
merges second will conflict on that single line; regenerating the baseline
is the fix, not a hand edit. The prose hunks do not overlap: #114's
`CLAUDE.md` change is the workflow-gate paragraph, #115's are the worktree
command and the branch-model bullet, and this one is the `latest`
paragraph between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align documentation with actual workflow schedules and clarify how the latest sentinel complements Dependabot updates and build-system changes.

Bug Fixes:
- Correct documented Dependabot cadence to match the weekly Thursday schedule
- Correct documented published workflow cadence to match the monthly first-of-month schedule

Enhancements:
- Clarify documentation around the relationship between the weekly latest sentinel run and Dependabot updates, including build-system coverage

Documentation:
- Update changelog to record the correction of schedule documentation for Dependabot and the published workflow

Chores:
- Regenerate the secrets baseline due to shifted changelog line numbers