### PR TITLE
Sign the release tag, and verify it before pushing it

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1050
+        "line_number": 1074
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T06:58:12Z"
+  "generated_at": "2026-08-11T07:33:06Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0 (work in progress, not released yet)
 
+### The release path
+
+- **The release tag is signed.** `git tag v0.7.1` made a lightweight tag:
+  a name pointing at a commit, with no signature, no tagger and no date of
+  its own. That is the wrong shape for the one ref a release is identified
+  by — the PEP 740 attestation binds to it, the GitHub release is created
+  from it, and `version-check` refuses a tree that does not match it — so
+  it is the thing most worth being able to attest, and a lightweight tag
+  cannot be attested at all. `git tag -s -m`, with `git tag -v` before the
+  push rather than after, the push being what starts the workflow acting
+  on it. libsecp256k1 signs its own release tags and documents verifying
+  them in `secp256k1/README.md`, so this is the vendored library's
+  standard applied to the wrapper.
+- **`-s` explicitly, not `tag.gpgsign`.** The setting belongs in a git
+  config, where this document cannot show it; the command here is the
+  instruction, and it has to be right on a machine whose config nobody
+  has checked. `-m` comes with it: signing implies annotating, and an
+  annotated tag without a message opens an editor, which a release step
+  must not do.
+- Checked rather than assumed: nothing in `release.yml` reads the tag as
+  anything but `github.ref_name`, which is the same for a lightweight and
+  an annotated tag. The one `refs/tags/...^{}` in that file dereferences
+  *bitcoin-core*'s tags, not this repository's.
+
 ### The wrapped library
 
 - **libsecp256k1 moves from 0.7.1 (1a53f49) to 0.8.0 (6e2c8bc)**, and the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -178,12 +178,33 @@ Then:
    sitting beside them are Dependabot's own updater failing to compute an
    update, not a workflow of this repository, and say nothing about the
    tree
-1. tag the tip `main` now points at, and push that tag alone:
+1. tag the tip `main` now points at, signed, and push that tag alone:
 
    ```shell
-   git tag v0.7.1
+   git tag -s v0.7.1 -m "btclib_libsecp256k1 v0.7.1"
+   git tag -v v0.7.1        # Good signature, before anything is pushed
    git push origin v0.7.1
    ```
+
+   `-s` rather than a bare `git tag`, which makes a lightweight tag: a
+   name pointing at a commit, carrying no signature, no tagger and no
+   date of its own. That is the wrong shape for the one ref this release
+   is identified by — the PEP 740 attestation binds to it, the GitHub
+   release is created from it, and `version-check` refuses a tree that
+   does not match it — so the tag is the thing most worth being able to
+   attest, and a lightweight one cannot be. libsecp256k1 itself tags this
+   way, and `secp256k1/README.md` documents verifying it with
+   `git tag -v`; this repository holds itself to what it vendors.
+
+   `-s` explicitly rather than relying on `tag.gpgsign` being true in the
+   git config: a global setting is not visible in this document, and the
+   command here is the instruction. `-m` because signing implies
+   annotating, and an annotated tag with no message opens an editor,
+   which is not what a release step should do.
+
+   `git tag -v` before the push, not after: a tag that has been pushed is
+   a tag the release workflow has already started acting on, and the
+   signature is the one thing about it that no later check looks at.
 
    `git push --tags` would push whatever other local tags happen to
    exist. The workflow then builds and tests every artifact the release


### PR DESCRIPTION
Step 11 of RELEASING.md said `git tag v0.7.1`, which makes a **lightweight**
tag: a name pointing at a commit, carrying no signature, no tagger and no
date of its own.

That is the wrong shape for the one ref a release is identified by:

- the PEP 740 attestation binds to it
- the GitHub release is created from it
- `version-check` refuses a tree that does not match it

So it is the thing most worth being able to attest, and a lightweight tag
cannot be attested at all. It becomes:

```shell
git tag -s v0.8.0 -m "btclib_libsecp256k1 v0.8.0"
git tag -v v0.8.0        # Good signature, before anything is pushed
git push origin v0.8.0
```

**libsecp256k1 already does this.** `secp256k1/doc/release-process.md` tags
with `git tag -s ... -m ...`, and `secp256k1/README.md` tells a user to
check it with `git tag -v v0.7.1 | grep -C 3 'Good signature'`. This is the
vendored library's own standard applied to the wrapper, not a new idea.

## Three choices in it, each with its reason in the file

**`-s` explicitly, not `tag.gpgsign`.** The setting belongs in a git config,
where this document cannot show it; the command here is what someone
follows, and it has to be right on a machine whose config nobody has
checked.

**`-m` comes with `-s`.** Signing implies annotating, and an annotated tag
with no message opens an editor — which a release step must not do. Without
`-m` this change would hang the release rather than improve it.

**`git tag -v` before the push, not after.** A pushed tag is one the release
workflow has already started acting on, and the signature is the one thing
about it that no later check looks at.

## Checked rather than assumed

Nothing in `release.yml` reads the tag as anything but `github.ref_name`,
which is identical for a lightweight and an annotated tag — so no job
changes behaviour. The one `refs/tags/...^{}` in that file, which *would*
behave differently between the two, dereferences **bitcoin-core's** tags in
the README-versus-submodule check, not this repository's.

`uvx pre-commit run --all-files` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the release process to use signed, verified Git tags for releases and document the change in the changelog.

Documentation:
- Revise RELEASING.md to require creating a signed, annotated release tag, verifying its signature before pushing, and explain the rationale for explicit signing and verification.
- Add v0.8.0 changelog notes describing the move to signed release tags, explicit use of `-s -m`, and confirmation that CI behaves identically for annotated versus lightweight tags.