### PR TITLE
Stop the CodeQL prose claiming a refusal that never happened

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,20 @@ name: codeql
 #       --jq '.[] | {ref, category, analysis_key}'
 #     # /language:python and /language:actions
 #
-# **While default setup is enabled GitHub refuses to run this workflow**, so
-# the pull request that adds it cannot show it passing. The switch has an
-# order, given in that pull request's own description: the branch rule drops
-# the `CodeQL` context, default setup is turned off, the checks are re-run,
-# and only then does the rule name the aggregate job at the end of this
-# file. REPOSITORY.md carries the commands, this being a rule that lives
-# outside the repository
+# **Default setup does not stop this workflow running.** It runs, the
+# analysis completes, the SARIF uploads, and processing refuses it --
+#
+#     Code Scanning could not process the submitted SARIF file:
+#     CodeQL analyses from advanced configurations cannot be processed
+#     when the default setup is enabled
+#
+# -- so while the setting is on the jobs below are red rather than absent,
+# and the pull request that adds this file cannot show it passing. That is
+# what gives the switch its order: the branch rule drops the `CodeQL`
+# context, default setup is turned off, the checks are re-run, and only
+# then does the rule name the aggregate job at the end of this file.
+# REPOSITORY.md carries the commands, this being a rule that lives outside
+# the repository
 
 on:
   pull_request:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1074
+        "line_number": 1078
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T07:33:06Z"
+  "generated_at": "2026-08-11T07:43:36Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,10 +273,14 @@ release-notes length in the first place, and are still in
   opens a copy. The aggregate is `codeql: every job passed`, for the reason
   `test.yml`'s own is: a branch rule must name an outcome and not a matrix
   cell. Turning the setting off and moving the rule are two steps only a
-  maintainer can take, in an order REPOSITORY.md gives — GitHub refuses to
-  run an advanced workflow while default setup is enabled, so the two
-  cannot overlap, and the rule has to stop naming a context nothing
-  produces before it can name the one this file does.
+  maintainer can take, in an order REPOSITORY.md gives — while default
+  setup is enabled the workflow still runs and the SARIF is refused at
+  processing, so the jobs are red rather than absent, and the rule has to
+  stop naming a context nothing produces before it can name the one this
+  file does. That exchange has been made; what outlives it is a generated
+  `dynamic/github-code-scanning/codeql` workflow uploading *code quality*
+  results, which is a separate setting the `code-scanning` endpoint does
+  not report.
 
 ### The gate
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -54,11 +54,19 @@ queue for tens of minutes, measured in `test.yml`'s header, and
 
 A check can be bound to the app that produces it — `checks` with an
 `app_id` rather than the bare `contexts` list — so that nothing else can
-satisfy it, and 15368 is Actions, which produces all four. Only
-`test: every job passed` is bound today: the endpoint above reports
-`app_id: null` for the other three, meaning any app may report them, and
-the `PATCH` below is what binds them. Which app reported what is read from
-the commit rather than assumed:
+satisfy it, and 15368 is Actions, which produces them all. The rule is not
+uniform in this: `test: every job passed` and `codeql: every job passed`
+carry the binding, while `Lint and type-check` and `Build the
+documentation` report `app_id: null`, meaning any app may satisfy those
+two, and the `PATCH` below is what binds them. A `PATCH` dates that
+sentence, so read it back rather than trust it:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
+  --jq '[.required_status_checks.checks[] | {context, app_id}]'
+```
+
+Which app reported what is read from the commit rather than assumed:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
@@ -71,10 +79,20 @@ gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
 ```
 
 **CodeQL is `.github/workflows/codeql.yml`, and code scanning's default
-setup is off** — the two are mutually exclusive, GitHub refusing to run an
-advanced workflow while the setting is configured, and the file is the one
-that can be reviewed in a diff. What the setting holds is read from the
-endpoint, `state` being the field that says whether it holds anything:
+setup is off** — the two are mutually exclusive, and what that costs is not
+a workflow GitHub declines to start. The workflow runs, the analysis
+completes, the SARIF uploads, and processing answers:
+
+```text
+Code Scanning could not process the submitted SARIF file:
+CodeQL analyses from advanced configurations cannot be processed when
+the default setup is enabled
+```
+
+So while the setting is on the analysing jobs and the aggregate are red
+rather than absent, and the file is still the one that can be reviewed in a
+diff. What the setting holds is read from the endpoint, `state` being the
+field that says whether it holds anything:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
@@ -91,13 +109,31 @@ gh api -X PATCH \
 ```
 
 The order matters in both directions, and it is the branch rule that
-decides it: while the setting is on, `codeql.yml` produces nothing, and
-while it is off, nothing produces `codeql: every job passed` until that
-workflow has run. So the rule drops the context first, the setting moves
-second, the checks are re-run, and the rule names the new context last —
-each step leaving the merge path open, where any other order closes it on a
-context nothing reports. `enforce_admins` being off is what makes that
-window survivable rather than a lock.
+decides it: while the setting is on, `codeql.yml` produces a red
+`codeql: every job passed` rather than none at all, and while it is off,
+nothing produces that context until the workflow has run. So the rule drops
+the `CodeQL` context first, the setting moves second, the checks are
+re-run, and the rule names the new context last — each step leaving the
+merge path open, where any other order closes it on a context nothing
+reports. `enforce_admins` being off is what makes that window survivable
+rather than a lock.
+
+That exchange has been made: the endpoint above answers `not-configured`,
+and the rule names `codeql: every job passed`. The order is kept here
+because the setting can be configured again.
+
+A `CodeQL` check and an `Analyze (python)` job outlive it, and neither
+comes from this tree: GitHub keeps a generated
+`dynamic/github-code-scanning/codeql` workflow, which uploads *code
+quality* results rather than security ones — `python.quality.sarif` in its
+log, where the security analysis produced `python.sarif`. That is a
+separate setting, and the endpoint above does not report it:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1/actions/workflows \
+  --jq '.workflows[] | select(.path | startswith("dynamic/"))
+        | {name, path, state}'
+```
 
 What the file asks for is read off its own triggers; what was actually
 analyzed, and under which ref and category, is the API's answer:


### PR DESCRIPTION
Three places here say GitHub declines to *run* an advanced workflow while
code scanning's default setup is enabled. It does not, and the difference
decides whether the analysing jobs are red or absent while the setting is
on — which is the whole reason the switch has an order.

## What actually happens

The workflow runs, the analysis completes, the SARIF uploads, and
processing refuses it:

```text
Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when
the default setup is enabled
```

Read off a log rather than a docs page:
[bitcoin-core-rpc run 31449444251](https://github.com/btclib-org/bitcoin-core-rpc/actions/runs/31449444251),
whose `Initialize CodeQL` succeeded — the database was built — and whose
`Analyze` failed, for both `actions` and `python`.

The three:

- **`codeql.yml`** — "**While default setup is enabled GitHub refuses to
  run this workflow**".
- **`REPOSITORY.md`** — "GitHub refusing to run an advanced workflow while
  the setting is configured", and, further down, "while the setting is on,
  `codeql.yml` produces nothing". It produces a red
  `codeql: every job passed`.
- **`CHANGELOG.md`** — "GitHub refuses to run an advanced workflow while
  default setup is enabled".

btclib already carries the corrected version of this same paragraph; this
brings the two into agreement.

## Two more, from reading the rule back

```shell
gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
  --jq '[.required_status_checks.checks[] | {context, app_id}]'
```

| context | `app_id` |
| --- | --- |
| `Lint and type-check` | `null` |
| `Build the documentation` | `null` |
| `test: every job passed` | 15368 |
| `codeql: every job passed` | 15368 |

- "Only `test: every job passed` is bound today: the endpoint above reports
  `app_id: null` for the other three" is wrong twice —
  `codeql: every job passed` carries the binding too, and the two that
  report null are `Lint and type-check` and `Build the documentation`. The
  paragraph now names them rather than counting them, and carries the
  command that re-derives it, since a `PATCH` dates any such sentence.
- The switch is described as still ahead of us.
  `code-scanning/default-setup` answers `not-configured` and the rule names
  `codeql: every job passed`, so it has been made. The five-step order stays
  — the setting can be configured again.

## What outlives the switch

Recorded because a reader meets it with nothing in the tree to explain it:
a generated `dynamic/github-code-scanning/codeql` workflow is still
`active` and still runs, but it now uploads **code quality** results —
`python.quality.sarif` in its log, where the security analysis produced
`python.sarif`. It is a separate setting, and the `code-scanning` endpoint
does not report it:

```shell
gh api repos/btclib-org/btclib-libsecp256k1/actions/workflows \
  --jq '.workflows[] | select(.path | startswith("dynamic/"))
        | {name, path, state}'
```

No claim is made here about the `CodeQL` check's conclusion after the
switch: it reads `success` on this repository's pull request heads and
`neutral` on two sibling repositories', and that difference is not
understood well enough to write down.

## Gates

`.secrets.baseline` moves by one line number, which the CHANGELOG edit
shifts. Two `pre-commit` passes, exit 0 both; `actionlint` and `zizmor` at
zero findings; `sphinx-build -W --keep-going` exit 0. Nothing here touches
Python, so the suite is unchanged.

## Summary by Sourcery

Clarify how CodeQL’s advanced workflow and code scanning default setup interact, and update documentation and metadata to reflect the current branch protection and workflow behavior.

Documentation:
- Correct documentation about which required status checks are bound to GitHub Actions and provide a command to re-derive their bindings from the branch protection API.
- Update explanations of CodeQL default setup to note that workflows still run and analyses are refused at processing, resulting in red jobs instead of missing checks, and describe the correct order for changing the setting and branch rule.
- Document the surviving generated `dynamic/github-code-scanning/codeql` workflow that now uploads code quality results separately from security scanning.

Chores:
- Refresh the secrets baseline to account for shifted line numbers after documentation edits.