### PR TITLE
Record auto-merge, and the method it commits to in advance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -555,6 +555,14 @@ three merge buttons are enabled on this repository, so which one is used
 is a choice made at the merge rather than one GitHub enforces — check it
 before clicking, GitHub preselecting whichever was used last.
 
+Auto-merge moves that check earlier rather than removing it: the method is
+picked in the dialog that switches it on, so a pull request set to merge
+itself once the checks go green has already answered this, and the answer
+is `gh pr view <n> --json autoMergeRequest`. Enabling it is the way to not
+wait for a matrix that compiles C on every platform; GitHub only offers it
+while something is still pending, and it merges nothing the branch rule
+would not have let through by hand.
+
 Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -217,6 +217,47 @@ branch is never deleted, protection winning over it — which used to reach
 the release pull request, whose head branch was protected. No head branch
 is protected now.
 
+## Auto-merge
+
+`allow_auto_merge` is on, since 11 August 2026:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1 --jq '.allow_auto_merge'
+```
+
+It bypasses nothing, and it is not the admin escape hatch above: GitHub
+offers the button **only on a pull request that cannot be merged
+immediately**, and then merges it when the last thing blocking it clears —
+one of the four required checks, the approving review, an unresolved
+conversation. Where nothing is pending there is nothing to wait for and the
+button is not offered at all, so this setting does something here precisely
+because the rule on `main` is what it is: the matrix is tens of jobs
+compiling C, and `test.yml`'s header measures what waiting for it costs.
+
+**Required signatures survive it**, measured rather than assumed, because
+GitHub composes the squash commit server-side and signs it with its own key
+exactly as the merge button does. A merge from the CLI is where that stops
+being true — `--rebase --admin` replays the author's commits as they were,
+unsigned — so the check is worth making on whatever landed:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha> \
+  --jq '.commit.verification | {verified, reason}'
+```
+
+**The merge method is chosen when auto-merge is switched on, not when the
+merge happens.** All three buttons are enabled, so which one runs is a
+choice rather than something GitHub enforces (CONTRIBUTING.md has the rest,
+including that GitHub preselects whichever was used last) — and the dialog
+that enables auto-merge carries that same dropdown. The answer is therefore
+given once, possibly hours before anything merges, by whoever switched it
+on, and nothing asks again. What a pull request is holding is readable, and
+reading it is the only way to catch a wrong method before it lands:
+
+```shell
+gh pr view <n> --json autoMergeRequest
+```
+
 ## Token permissions
 
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job


### PR DESCRIPTION
`allow_auto_merge` was turned on across every repository of btclib-org and
checksig-custody. This repository's settings are documented in
[REPOSITORY.md](REPOSITORY.md) or nowhere — the branch rules and the
repository settings live outside the tree, so a setting nobody wrote down is
one nobody can read back — which is what this adds, beside the command that
reads it, in the shape the neighbouring sections already use.

What earns a section rather than a line is the trap: **the merge method is
chosen when auto-merge is switched on, not when the merge happens.** All
three buttons are enabled here and GitHub preselects whichever was used
last, so the answer is given once, by whoever enabled it, possibly hours
before anything lands, and nothing asks again. `gh pr view <n> --json
autoMergeRequest` is what reads it back.

Two claims in the new text were measured rather than reasoned about:

- GitHub offers the button only on a pull request that cannot be merged
  immediately, so the setting does something here because of what the rule
  on `main` requires, and nothing at all on a repository with no pending
  requirement;
- required signatures survive an auto-merge, because GitHub composes the
  squash commit server-side and signs it with its own key. The three most
  recent commits on `main` are `verified: true, valid` by that route;
  `gh pr merge --rebase --admin` is the case where it stops holding, and
  the verification command sits next to the claim.

CONTRIBUTING.md gets the contributor-facing half, next to the paragraph that
already tells you to check the merge button before clicking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document repository auto-merge settings and their implications for merge methods and signature verification.

Documentation:
- Add REPOSITORY.md documentation explaining when GitHub auto-merge is offered, how it interacts with branch protections and required signatures, and how to inspect auto-merge configuration via gh.
- Extend CONTRIBUTING.md to explain that auto-merge chooses the merge method at enable time, how to review that choice, and how it relates to long-running CI matrices.