### PR TITLE
Refuse a tag whose release notes are still titled "work in progress"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,22 +148,60 @@ jobs:
       # that is not there is a ::warning:: with generated notes as the
       # fallback -- correct there, PyPI having accepted the upload
       # already, and no use at all as the place the omission is found.
-      # The same awk, on the same push path as the tag comparison, so
-      # release day starts with all four green. The fallback downstream
-      # stays: it covers the release deleted by hand and recreated
-      - name: Check that HISTORY.md has a section for the tag
+      # The fallback downstream stays: it covers the release deleted by
+      # hand and recreated.
+      #
+      # Existence is not the whole question, and asking only that is what
+      # this step used to do. That fallback fires on an *empty* section,
+      # and "## v0.8.0 (work in progress, not released yet)" is not empty:
+      # it matches github-release's heading regex too, the tag being
+      # followed by a space, so a forgotten retitle publishes the
+      # work-in-progress text as the release notes and nothing says a
+      # word. Step 2 of RELEASING.md is what drops those five words, and
+      # until now nothing checked that it had been done.
+      #
+      # CHANGELOG.md is checked beside it because RELEASING.md retitles
+      # the two together, and HISTORY.md's section points at CHANGELOG.md
+      # for the detail: a heading left open there makes that a link into
+      # nothing. Matching btclib and bitcoin-core-rpc, which carry this
+      # same step -- the awk is theirs, and the three repositories now
+      # refuse the same tag for the same three reasons.
+      #
+      # Release-only, like the comparison above and for the same reason: a
+      # rehearsal is what runs *before* the retitle, so requiring it there
+      # would forbid the dry run it exists to be. The tag rather than
+      # `uv version --short`, which the step above has just proven equal
+      # to it, so the errors below name the ref that was pushed.
+      # String comparison rather than a regex, so that the dots of the
+      # version match dots and not any character, and awk rather than
+      # grep, one pass answering all three questions
+      - name: Check that the release notes are retitled for the tag
         if: github.event_name == 'push'
         run: |
-          notes=$(awk -v tag="$GITHUB_REF_NAME" '
-            $0 ~ "^## " tag "( |$)" {found=1; next}
-            /^## / && found {exit}
-            found {print}
-          ' HISTORY.md)
-          if [ -z "$notes" ]; then
-            echo "::error::HISTORY.md has no $GITHUB_REF_NAME section to release with"
-            exit 1
-          fi
-          echo "HISTORY.md documents $GITHUB_REF_NAME"
+          for file in HISTORY.md CHANGELOG.md; do
+            awk -v tag="$GITHUB_REF_NAME" -v file="$file" '
+              $0 == "## " tag {heading = NR; next}
+              index($0, "## " tag " ") == 1 {heading = NR; extra = $0; next}
+              /^## / && heading {exit}
+              heading && NF {body = 1}
+              END {
+                if (!heading) {
+                  printf "::error::%s has no \"## %s\" section\n", file, tag
+                  exit 1
+                }
+                if (extra) {
+                  printf "::error::%s:%d is \"%s\"; the heading must be \"## %s\" alone\n",
+                    file, heading, extra, tag
+                  exit 1
+                }
+                if (!body) {
+                  printf "::error::%s section \"## %s\" is empty\n", file, tag
+                  exit 1
+                }
+                printf "%s has a non-empty \"## %s\" section\n", file, tag
+              }
+            ' "$file"
+          done
 
       # the version of the wrapped library is a second thing this package
       # declares twice: the tag named in README.md, and the commit the

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1078
+        "line_number": 1096
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T07:43:36Z"
+  "generated_at": "2026-08-11T07:50:43Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,24 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`version-check` refuses a tag whose release notes are still titled
+  "work in progress".** The check it replaces asked only that
+  `HISTORY.md` had a section for the tag, and
+  `## v0.8.0 (work in progress, not released yet)` *is* a section for the
+  tag: it matches `github-release`'s heading regex too, the tag being
+  followed by a space, so a forgotten step 2 of RELEASING.md would have
+  published the release notes with the five words still on them and
+  nothing would have said a word. Measured on this very tree before the
+  retitle, where the old check passed and the new one fails on
+  `HISTORY.md:8`. It now asks three things of `HISTORY.md` **and**
+  `CHANGELOG.md` — a section for the tag, a heading carrying the tag and
+  nothing else, and a body that is not empty — and it is btclib's and
+  bitcoin-core-rpc's step verbatim, so the three repositories refuse the
+  same tag for the same three reasons. The string comparison rather than
+  a regex is what keeps `v0.8.0` from matching `## v0.8.0.1`, which here
+  is the neighbouring heading rather than a hypothetical: the fourth
+  number a release opens as its placeholder. Release-only, like the tag
+  comparison beside it: a rehearsal is what runs *before* the retitle.
 - **The sdist attached to a GitHub release carries provenance** (#97),
   where only the copy on PyPI did: the publish job generates a PEP 740
   attestation for what it uploads to the index, and the byte-identical

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,9 +17,10 @@ them, and runs before anything is built: a `v0.7.1` tag on a tree still
 reading `0.7.1rc1` fails there, rather than burning `0.7.1rc1` on PyPI.
 The same job checks that `uv.lock` carries the version the tree declares,
 that the libsecp256k1 release named in `README.md` is the commit the
-submodule is pinned to, that `HISTORY.md` has a section for the tag, and
-that the tagged commit is on `main`. Every invariant a release rests on
-is checked there, before the point of no return.
+submodule is pinned to, that `HISTORY.md` and `CHANGELOG.md` each carry a
+section headed by the tag alone and not empty, and that the tagged commit
+is on `main`. Every invariant a release rests on is checked there, before
+the point of no return.
 
 ## Which version string is which
 
@@ -106,9 +107,12 @@ Then:
    section of both against `git log`, drop the
    `(work in progress, not released yet)` from each heading, and
    renumber them if step 1 renumbered the version. `version-check`
-   refuses a tag whose `HISTORY.md` section is missing, so an omission
-   stops the release before the matrix builds anything — it does not
-   read `CHANGELOG.md`, which is the one of the two nothing enforces.
+   refuses a tag whose section in either file is missing, empty, or still
+   carrying anything after the version in its heading, so a forgotten
+   retitle stops the release before the matrix builds anything. Dropping
+   those five words is the whole of what that check asks, and it asks it
+   of both files: it is the step this one exists to be, not a formality
+   downstream of it.
    If the vendored libsecp256k1 moved, update the version named at the
    top of `README.md` too (`grep -n 'wraps libsecp256k1' README.md`
    finds the line without a search through the prose)


### PR DESCRIPTION
btclib and bitcoin-core-rpc already carry this step. This repository did
not, and the release being cut today is the one it would have caught.

## The gap, measured

The check being replaced asked that `HISTORY.md` had a section for the
tag. `## v0.8.0 (work in progress, not released yet)` **is** a section for
the tag — it matches `github-release`'s heading regex too, the tag being
followed by a space — so the notes would have been lifted from under it
and published with the five words still on them. The `::warning::`
fallback fires only on an *empty* section, which that is not.

Run against `main` as it stands right now, before the retitle:

```
old check -> notes non-empty, exit 0
new check -> ::error::HISTORY.md:8 is "## v0.8.0 (work in progress, not
             released yet)"; the heading must be "## v0.8.0" alone
```

## What it asks now

Three questions, of `HISTORY.md` **and** `CHANGELOG.md`: a section for the
tag, a heading carrying the tag and nothing else, a body that is not
empty. `CHANGELOG.md` is in because RELEASING.md retitles the two together
and `HISTORY.md`'s section points at `CHANGELOG.md`'s for the detail, so a
heading left open there makes that a link into nothing.

The awk is btclib's and bitcoin-core-rpc's verbatim, so the three
repositories now refuse the same tag for the same three reasons.

## Verified by handing it something bad

| case | result |
| --- | --- |
| this tree today, `v0.8.0` | **fails** — `HISTORY.md:8`, heading not alone |
| the old check, same tree | passes — the gap was real |
| after the retitle, both files | passes |
| section missing from `CHANGELOG.md` | fails, naming the file |
| section present but empty | fails |
| `v0.8.0` against a tree holding only `## v0.8.0.1` | fails, no false match |

That last one is why the string comparison matters more here than in the
siblings: `v0.8.0.1` is not a hypothetical, it is the placeholder step 10
opens right after a release, and it sits in the heading immediately below.
A regex would also let the dots of the version match any character.

## Prose corrected with it

RELEASING.md said `version-check` "does not read `CHANGELOG.md`, which is
the one of the two nothing enforces" — false as of this commit — and its
header listed the weaker invariant. Both now say what the job does.

## Ordering, for today

This wants to be merged **before** the release pull request. Then the
retitle lands, and the tag finds a check that agrees with it. The other
way round, the check arrives after the tag it was meant to stop.

It is release-only (`if: github.event_name == 'push'`), so a TestPyPI
rehearsal is unaffected: a rehearsal is what runs *before* the retitle.

`uvx pre-commit run --all-files` green, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten the release workflow’s version-check so releases are blocked when HISTORY.md or CHANGELOG.md still have “work in progress” headings or empty sections for the tagged version.

Bug Fixes:
- Prevent publishing release notes whose section headings still include "work in progress" text for the tagged version.
- Ensure a missing or empty release-notes section in HISTORY.md or CHANGELOG.md fails the release check.

Enhancements:
- Extend the release notes check to validate both HISTORY.md and CHANGELOG.md headings and bodies for the tag, matching behavior in sibling repositories.
- Clarify RELEASING.md documentation to accurately describe the strengthened version-check invariants and its role in enforcing retitled release notes.

CI:
- Update the release CI workflow step to enforce that HISTORY.md and CHANGELOG.md each have a non-empty section headed by the tag alone, with stricter error reporting.

Documentation:
- Document the new release-note enforcement behavior in CHANGELOG.md under CI changes.
- Correct and expand RELEASING.md to describe the updated version-check semantics and its requirements for retitling release-note headings.