### PR TITLE
Bind the last two required checks, and say the rule is uniform now

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1096
+        "line_number": 1107
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T07:50:43Z"
+  "generated_at": "2026-08-11T13:28:23Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,17 @@ release-notes length in the first place, and are still in
 
 ### The gate
 
+- **Every required check names the app that produces it.** `test: every
+  job passed` and `codeql: every job passed` carried `app_id: 15368` and
+  the other two carried none, which REPOSITORY.md recorded as a rule that
+  was not uniform in this. An unbound context is satisfied by *any* app
+  reporting a check run of that name, so anything installed on the
+  organization with `checks: write` could turn `Lint and type-check` green
+  with no workflow having run. Both are Actions checks -- the check-runs
+  endpoint answers 15368 for each -- so the binding changes nothing a run
+  can see, and closes that. The `PATCH` this file already documented is
+  what applied it; btclib and bitcoin-core-rpc are bound the same way, so
+  the three now read `app_id: 15368` for every context they require
 - **`pinned-rev` refuses a `rev` that does not name a released version.**
   Nothing but `pre-commit autoupdate` writes a `rev`, and it offers
   whatever tag the remote's HEAD carries: twice that was not a release —

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -54,12 +54,13 @@ queue for tens of minutes, measured in `test.yml`'s header, and
 
 A check can be bound to the app that produces it — `checks` with an
 `app_id` rather than the bare `contexts` list — so that nothing else can
-satisfy it, and 15368 is Actions, which produces them all. The rule is not
-uniform in this: `test: every job passed` and `codeql: every job passed`
-carry the binding, while `Lint and type-check` and `Build the
-documentation` report `app_id: null`, meaning any app may satisfy those
-two, and the `PATCH` below is what binds them. A `PATCH` dates that
-sentence, so read it back rather than trust it:
+satisfy it, and 15368 is Actions, which produces them all. All four carry
+that binding, and the two that did not are why it is worth stating: an
+unbound context reads `app_id: null` and is satisfied by *any* app
+reporting a check run of that name, so anything installed on the
+organization with `checks: write` could turn one green with no workflow
+having run. A `PATCH` dates that sentence, so read it back rather than
+trust it:
 
 ```shell
 gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \


### PR DESCRIPTION
`REPOSITORY.md` recorded a rule that was **not uniform in this**:
`test: every job passed` and `codeql: every job passed` carried
`app_id: 15368`, while `Lint and type-check` and `Build the documentation`
carried none.

That is not a weaker spelling of the same rule. An unbound context is
satisfied by **any** app reporting a check run of that name, so anything
installed on the organization with `checks: write` could turn one green
with no workflow having run.

Both are Actions checks, read from the commit rather than assumed:

```shell
sha=$(gh api repos/btclib-org/btclib-libsecp256k1/commits/main --jq '.sha')
gh api "repos/btclib-org/btclib-libsecp256k1/commits/$sha/check-runs" \
  --jq '[.check_runs[]
         | select(.name=="Lint and type-check"
               or .name=="Build the documentation")
         | "\(.name)@\(.app.id)"]'
# ["Build the documentation@15368","Lint and type-check@15368"]
```

So the binding changes nothing a run can see. It is applied — the rule is
a setting and not a file — with the `PATCH` this file already documents,
`-F 'checks[][app_id]=15368'` sending the number as a number:

```shell
gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
  --jq '[.required_status_checks.checks[] | select(.app_id == null)] | length'
# 0
```

The rest of the protection object is unchanged: `strict`, one approving
review with `dismiss_stale_reviews`, required signatures, linear history,
resolved conversations, `enforce_admins` off.

What is in the diff is the sentence that described the old shape, and the
`CHANGELOG.md` entry under "The gate".

Companion: btclib-org/btclib#614 does the same there, and also replaces a
rename recipe that sent `contexts` — a field with no place for an app, so
following it would have un-bound them again. This repository never had
that problem: its recipe was already `checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document that all required status checks are now bound to the GitHub Actions app and explain the security rationale for making the rule uniform.

Documentation:
- Update REPOSITORY.md to describe that all four required checks are bound to the Actions app rather than leaving some unbound.
- Add CHANGELOG entry under “The gate” explaining the app binding of required checks, its impact on security, and alignment with other repositories.