### PR TITLE
Make squash the only merge method, and say so where it is decided

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1107
+        "line_number": 1119
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T13:28:23Z"
+  "generated_at": "2026-08-12T08:12:46Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ release-notes length in the first place, and are still in
   anything but `github.ref_name`, which is the same for a lightweight and
   an annotated tag. The one `refs/tags/...^{}` in that file dereferences
   *bitcoin-core*'s tags, not this repository's.
+- **Squash is the only merge method the repository enables**, for a release
+  pull request and every other one. The merge commit was refused by
+  `main`'s required linear history already, so turning it off takes away a
+  button that could not have worked; the rebase merge could have, and what
+  it would have done is replay a branch's commits onto a trunk where one
+  change is one commit. What a single method takes away is the dropdown:
+  GitHub preselects whichever was used last and the dialog that switches
+  auto-merge on carries the same one, so the answer could be given hours
+  before anything merged, by whoever switched it on, with nothing asking
+  again -- which is what REPOSITORY.md's auto-merge section warned about
+  and now records as gone. `btclib` and `bitcoin-core-rpc` carry the same
+  setting and the same prose.
 
 ### The wrapped library
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -550,15 +550,15 @@ note in the pull request saying the head moved.
 Nothing is lost in `main`'s history by working that way, because a pull
 request is squashed on merge: the branch lands as one commit whose subject
 is the pull request title with its number, so the review's commits are the
-record of the review and `main` keeps one commit per landed change. All
-three merge buttons are enabled on this repository, so which one is used
-is a choice made at the merge rather than one GitHub enforces — check it
-before clicking, GitHub preselecting whichever was used last.
+record of the review and `main` keeps one commit per landed change. It is
+the only merge button this repository enables, so which one is used is a
+setting rather than a choice made at the merge; REPOSITORY.md has that
+setting and what the other two would have cost.
 
-Auto-merge moves that check earlier rather than removing it: the method is
-picked in the dialog that switches it on, so a pull request set to merge
-itself once the checks go green has already answered this, and the answer
-is `gh pr view <n> --json autoMergeRequest`. Enabling it is the way to not
+Auto-merge had that choice to make earlier and no longer does, the dialog
+that switches it on carrying one method: what a pull request set to merge
+itself once the checks go green is holding is still
+`gh pr view <n> --json autoMergeRequest`. Enabling it is the way to not
 wait for a matrix that compiles C on every platform; GitHub only offers it
 while something is still pending, and it merges nothing the branch rule
 would not have let through by hand.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -149,10 +149,10 @@ Then:
 
    Then merge it into `main` with a green CI. It is an ordinary pull
    request against the only branch there is, and it merges the way every
-   other one here does; the button is still worth reading before it is
-   pressed, all three methods being enabled and GitHub preselecting the
-   one used last. A merge commit is not among the choices whichever is
-   selected: `main` requires linear history.
+   other one here does: with the squash button, which is the only one the
+   repository enables — a merge commit was refused by `main`'s required
+   linear history anyway, and REPOSITORY.md has what the rebase merge
+   would have cost.
 
    What that button cannot cost any more is the history of a cycle. It
    could once: 0.7.1 was *Squash and merge* on a release pull request

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -254,6 +254,30 @@ branch is never deleted, protection winning over it — which used to reach
 the release pull request, whose head branch was protected. No head branch
 is protected now.
 
+## Merge methods
+
+**Squash is the only method enabled**, so it is a setting and not only the
+convention CONTRIBUTING.md states:
+
+```shell
+gh api repos/btclib-org/btclib-libsecp256k1 \
+  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
+```
+
+answers `true` for the first and `false` for the other two.
+
+The merge commit was refused by `main`'s required linear history already,
+so turning it off takes away a button that could not have worked. The
+rebase merge could have, and that is the one this removes: it replays a
+branch's commits onto `main`, where one change is one commit and the steps
+of a review belong to the pull request that carries them.
+
+What a single method takes away is the dropdown. GitHub preselects
+whichever method was used last, and the dialog below carries the same one,
+so the answer could be given hours before anything merged and by whoever
+switched auto-merge on. One method is one entry: there is no wrong one to
+preselect, and nothing to read before pressing.
+
 ## Auto-merge
 
 `allow_auto_merge` is on, since 11 August 2026:
@@ -282,14 +306,12 @@ gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha> \
   --jq '.commit.verification | {verified, reason}'
 ```
 
-**The merge method is chosen when auto-merge is switched on, not when the
-merge happens.** All three buttons are enabled, so which one runs is a
-choice rather than something GitHub enforces (CONTRIBUTING.md has the rest,
-including that GitHub preselects whichever was used last) — and the dialog
-that enables auto-merge carries that same dropdown. The answer is therefore
-given once, possibly hours before anything merges, by whoever switched it
-on, and nothing asks again. What a pull request is holding is readable, and
-reading it is the only way to catch a wrong method before it lands:
+**The merge method was chosen here, when auto-merge was switched on rather
+than when the merge happened.** That dropdown carries one entry now, squash
+being the only method enabled — "Merge methods" above is the setting and
+the reason — so switching auto-merge on answers nothing a reviewer has to
+catch before it lands. What a pull request is holding is still worth
+reading, the wait itself being what this bypasses:
 
 ```shell
 gh pr view <n> --json autoMergeRequest


### PR DESCRIPTION
`main`'s required linear history already refused a merge commit, so turning
that method off takes away a button that could not have worked. The rebase
merge could have worked, and what it would have done is replay a branch's
commits onto a trunk where one change is one commit.

What a single method takes away is the dropdown REPOSITORY.md's auto-merge
section warned about: GitHub preselects whichever method was used last, the
dialog that switches auto-merge on carries the same one, and the answer was
therefore given hours before anything merged, by whoever switched it on,
with nothing asking again. One entry is no wrong entry to preselect.

The setting is already patched, this being a rule that lives outside the
repository:

```shell
gh api repos/btclib-org/btclib-libsecp256k1 \
  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
```

answers `true`, `false`, `false`. `btclib` and `bitcoin-core-rpc` carry the
same patch and the same prose, all three having said the same thing about
three methods being enabled.

- `REPOSITORY.md` gains a "Merge methods" section above "Auto-merge", and
  that section's last paragraph records the hazard as gone rather than
  describing it.
- `CONTRIBUTING.md`'s "all three merge buttons are enabled" and the
  auto-merge paragraph under it, and `RELEASING.md`'s release-merge step,
  say what holds instead.
- `.secrets.baseline` moves by one line number, the CHANGELOG entry above
  the recorded finding having grown.

Gates, run locally with the submodule initialized: `pre-commit run
--all-files` and `sphinx-build -W` both exit 0. Markdown only, so the suite
and the extension are untouched.

## Summary by Sourcery

Document that squash is the only allowed merge method and that auto-merge now always uses squash.

Documentation:
- Add a Merge methods section explaining the configured GitHub settings and why only squash merges are allowed.
- Update CONTRIBUTING and RELEASING to reflect that only squash merges are permitted and how this affects auto-merge and release pull requests.
- Record in the CHANGELOG that squash is now the sole merge method for this repository and aligned sibling repositories.

Chores:
- Update the secrets baseline metadata to account for the expanded CHANGELOG entry.