### PR TITLE
Refuse a memoryview of wider items, and wipe a half-built label cache

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1107
+        "line_number": 1128
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T13:28:23Z"
+  "generated_at": "2026-08-12T09:08:02Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,23 @@ release-notes length in the first place, and are still in
   already said a key that is not a valid scalar raises; what changed is
   which keys libsecp256k1 calls invalid.
 
+### What the boundary answers
+
+- **A memoryview of items wider than an octet is refused.** `octets` takes
+  the three types that state a value and a width, and a memoryview states
+  its width in *items*: `memoryview(array("I", [1, 2, 3, 4, 5, 6, 7, 8]))`
+  is eight of them, and the 32 octets `bytes` reads underneath them passed
+  the size check as a private key nobody wrote — one that a big endian
+  build of the same program would have read differently. It is the one
+  shape in which the argument for converting rather than refusing does not
+  hold, so it raises `TypeError` naming what it is, and `.cast("B")` is how
+  a caller says the octets are what they meant. Nothing else about the
+  shape is asked: where the items are octets, `bytes` answers the ones the
+  view logically holds, through a stride and over every dimension, so the
+  length checked is the length libsecp256k1 will read. mypy cannot see any
+  of this — `memoryview` is the annotated type whatever its items are —
+  which is why the check is at run time, like the `bool` one beside it
+
 ### Silent Payments
 
 - **`silentpayments` wraps BIP352**, the module libsecp256k1 0.8.0 adds,
@@ -100,10 +117,14 @@ release-notes length in the first place, and are still in
   public key and its label by value, and each has to reach its own
   serializer as a pointer.
 - **The secrets are taken back.** A found output holds the tweak that
-  spends it, and the sender's keypairs and secret keys hold private keys:
-  all are wiped, and the two key lists are built *inside* the `try` whose
-  `finally` wipes them, an invalid key later in the list being able to
-  raise between them.
+  spends it, the sender's keypairs and secret keys hold private keys, and
+  the recipient's label cache holds the tweak of every label: all are
+  wiped, and each collection is filled *inside* the `try` whose `finally`
+  wipes it, an entry later in it being able to raise between them. The
+  cache is filled entry by entry for that reason and not built by a
+  comprehension, which drops the buffers it already made along with the
+  exception — a malformed second label left the first one's tweak in
+  memory this package had stopped pointing at.
 
 ### Mutation testing
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,8 @@ a tag is generated from.
 [libsecp256k1 0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)
 (6e2c8bc), up from 0.7.1: a minor version of the wrapped library, so a
 minor version here, the numbers tracking each other. **One breaking
-change, and only for a caller reaching through `lib`.**
+change, and only for a caller reaching through `lib`; two arguments that
+used to be answered wrongly now raise instead.**
 
 - **Silent Payments are wrapped**, as `silentpayments`, BIP352's new
   libsecp256k1 module: `create_outputs` pays a list of addresses from the
@@ -35,6 +36,13 @@ change, and only for a caller reaching through `lib`.**
   key now raises `ValueError` naming an invalid private key, which is
   what the docstring already said it did. No securely generated key is
   affected: the probability of one landing there is about 2**-128.
+- **A `memoryview` of items wider than an octet is refused**, everywhere
+  bytes cross, where it used to be read as the octets underneath those
+  items — 32 of them for eight `uint32`, which is a value the caller never
+  wrote and not the same one on a big endian machine. It now raises
+  `TypeError`; `.cast("B")` is how a caller who does mean those octets
+  says so. `bytes`, a `bytearray` and a `memoryview` of bytes are
+  unaffected, a stride and extra dimensions included.
 - **ECDSA and BIP340 verification are faster on GCC and MSVC**, by up to
   about 11% upstream's measure, the 64-bit field multiplication and
   squaring now being force-inlined. Clang, which is what the macOS wheels

--- a/btclib_libsecp256k1/_scalar.py
+++ b/btclib_libsecp256k1/_scalar.py
@@ -43,11 +43,30 @@ def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
         The value as bytes: itself, if that is what it already was.
 
     Raises:
-        TypeError: if the value is not one of those three types.
+        TypeError: if the value is not one of those three types, or is a
+            memoryview whose items are wider than an octet.
         ValueError: if a size is given and the value is not that long.
     """
     if not isinstance(value, (bytes, bytearray, memoryview)):
         raise TypeError(f"the {name} must be bytes, not {type(value).__name__}")
+    # a memoryview states its width in items, and `bytes` of one reads the
+    # octets underneath them: eight uint32 are 32 octets of whatever this
+    # machine's byte order made of them, which passes the size check below
+    # as a scalar nobody wrote -- the one way in which a memoryview does
+    # not state the width this reads it for. Refused rather than
+    # reinterpreted, for the reason a 20-octet value is: `value.cast("B")`
+    # is how a caller says that the octets are what they meant.
+    #
+    # Nothing else about the shape needs asking. Where the items are
+    # octets, `bytes` answers the ones the view logically holds -- through
+    # a stride, and over every dimension of a multidimensional view -- so
+    # the length checked below is the length libsecp256k1 will read
+    if isinstance(value, memoryview) and value.itemsize != 1:
+        msg = (
+            f"the {name} must be a memoryview of bytes, "
+            f"not of {value.itemsize}-byte items"
+        )
+        raise TypeError(msg)
     # bytes of bytes is bytes, so nothing is copied in the ordinary case
     value_bytes = bytes(value)
     if size is not None and len(value_bytes) != size:

--- a/btclib_libsecp256k1/silentpayments.py
+++ b/btclib_libsecp256k1/silentpayments.py
@@ -390,8 +390,27 @@ def scan_outputs(
     ]
     n_found = ffi.new("uint32_t *")
 
-    cache = _label_cache(labels)
+    # the cache is filled inside the try, not built before it: every
+    # entry carries a tweak and the next one can raise, so what wipes them
+    # has to already be in force while they are being made -- create_outputs
+    # builds its two key lists the same way and for the same reason. A
+    # `dict` filled entry by entry is what makes that reachable, where a
+    # comprehension would drop the ones already made along with the
+    # exception
+    cache: dict[bytes, CData] = {}
+    # a NULL lookup is how libsecp256k1 is told no label is in play, and
+    # it is not the same as one that never matches: with it the scan skips
+    # the label branch altogether. What decides it is `labels`, an empty
+    # mapping being a cache with nothing in it rather than the absence of
+    # one; the callback is held in a local because it has to outlive the
+    # call it is passed to
+    lookup = ffi.NULL
     try:
+        if labels is not None:
+            _fill_label_cache(labels, cache)
+            lookup = ffi.callback(
+                "secp256k1_silentpayments_label_lookup", _lookup(cache)
+            )
         scanned = lib.secp256k1_silentpayments_recipient_scan_outputs(
             ctx,
             ffi.new("secp256k1_silentpayments_found_output *[]", found_objs),
@@ -401,12 +420,7 @@ def scan_outputs(
             scan_prvkey_bytes,
             summary,
             spend_pubkey,
-            # a NULL lookup is how libsecp256k1 is told no label is in
-            # play, and it is not the same as one that never matches:
-            # with it the scan skips the label branch altogether
-            ffi.NULL
-            if cache is None
-            else ffi.callback("secp256k1_silentpayments_label_lookup", _lookup(cache)),
+            lookup,
             ffi.NULL,
         )
         if not scanned:
@@ -416,13 +430,13 @@ def scan_outputs(
         # every found output carries the tweak that spends it, and the
         # cache the tweaks of the labels: both are secrets in memory this
         # package owns, and so both are taken back
-        for buffer in (*found_objs, *(cache or {}).values()):
+        for buffer in (*found_objs, *cache.values()):
             wipe(buffer)
 
 
-def _label_cache(
-    labels: Mapping[bytes, BytesLike] | None,
-) -> dict[bytes, CData] | None:
+def _fill_label_cache(
+    labels: Mapping[bytes, BytesLike], cache: dict[bytes, CData]
+) -> None:
     """Copy a label cache into the buffers the lookup will hand back.
 
     Every tweak is copied into memory this package owns before the scan
@@ -430,34 +444,29 @@ def _label_cache(
     there has to stay valid until libsecp256k1 is done with it, and a
     buffer made on the way out would be owned by nothing.
 
-    Args:
-        labels: the caller's mapping of 33-byte labels to 32-byte
-            tweaks, or None.
+    The dictionary is filled rather than returned, so that a tweak copied
+    before a later entry is refused is one the caller can still wipe: see
+    `scan_outputs`, which owns it and does.
 
-    Returns:
-        The same mapping with each tweak in a cffi buffer, or None where
-        None was given -- which is not an empty cache but the absence of
-        one, and reaches libsecp256k1 as a NULL lookup function.
+    Args:
+        labels: the caller's mapping of 33-byte labels to 32-byte tweaks.
+        cache: the dictionary to fill, keyed on the same labels.
 
     Raises:
         TypeError: if a label or a tweak is not bytes.
         ValueError: if a label is not 33 bytes, or a tweak not 32.
     """
-    if labels is None:
-        return None
-    return {
-        octets(label_bytes, "label", LABEL_SIZE): ffi.new(
+    for label_bytes, tweak_bytes in labels.items():
+        cache[octets(label_bytes, "label", LABEL_SIZE)] = ffi.new(
             "unsigned char[32]", octets(tweak_bytes, "label tweak", 32)
         )
-        for label_bytes, tweak_bytes in labels.items()
-    }
 
 
 def _lookup(cache: dict[bytes, CData]) -> Callable[[CData, CData], CData]:
     """Build the label lookup libsecp256k1 calls back into.
 
     Args:
-        cache: the labels of `_label_cache`, keyed on their 33 bytes.
+        cache: the labels of `_fill_label_cache`, keyed on their 33 bytes.
 
     Returns:
         A function of the C signature libsecp256k1 declares. It cannot

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ replaced by do-nothing stubs, instead of the abort()ing upstream ones
 that would take the hosting Python process down with them.
 """
 
+import array
 import secrets
 
 import pytest
@@ -274,6 +275,39 @@ def test_a_bool_is_not_a_scalar() -> None:
     sig_bytes, recid = recovery.sign(msg, 7)
     assert recid in (0, 1)
     assert recovery.recover(msg, sig_bytes, bool(recid)) == keys.pubkey_from_prvkey(7)
+
+
+def test_a_memoryview_of_wider_items_is_not_octets() -> None:
+    """A memoryview states its width in items, and only octets are octets.
+
+    The other type whose acceptance could not be seen in the answer, and
+    the argument for taking a `bytearray` and a `memoryview` at all does
+    not reach it: eight `uint32` state eight items, and the 32 octets
+    `bytes` reads underneath them are whatever this machine's byte order
+    made of the value -- a private key nobody wrote, of exactly the
+    length the size check asks for, and a different one on a big endian
+    build of the same program.
+
+    Nor could the type checker say so, so neither call below needs a
+    `type: ignore`: `memoryview` is the annotated type whatever its items
+    are. That is the whole argument for the check being made at run time.
+
+    What is refused is the reinterpretation and not the shape: a view of
+    octets is the argument it always was, a stride included, `bytes` of
+    one answering the octets it logically holds.
+    """
+    wider = memoryview(array.array("I", [1, 2, 3, 4, 5, 6, 7, 8]))
+    assert wider.itemsize == 4
+    assert len(bytes(wider)) == 32, "it would pass the size check"
+
+    with pytest.raises(TypeError, match="private key must be a memoryview of bytes"):
+        keys.prvkey_verify(wider)
+    with pytest.raises(TypeError, match="message hash must be a memoryview of bytes"):
+        dsa.sign(wider, 7)
+
+    # the same octets, said to be octets, and a strided view of octets
+    assert keys.prvkey_verify(wider.cast("B"))
+    assert keys.prvkey_verify(memoryview(b"\x07\x00" * 32)[::2])
 
 
 def test_size_checks_refuse_both_sides() -> None:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -871,3 +871,39 @@ def test_scanning_wipes_the_tweaks_and_the_label_cache(
     assert all(zeroed(buffer) for buffer in wiped)
     # the tweaks reached the caller before the buffers were zeroed
     assert all(tweak != bytes(32) for _, tweak, _ in found)
+
+
+def test_scanning_wipes_the_tweaks_it_had_when_a_later_label_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache entry that cannot be made does not leave the ones before it.
+
+    The recipient's side of
+    `test_the_sender_wipes_the_keys_it_had_when_a_later_one_is_refused`,
+    and the reason is the same one: the cache is filled inside the `try`,
+    so a tweak copied before the refusal is wiped on the way out rather
+    than dropped where it was. Built before the `try` -- or by a
+    comprehension, which drops what it had along with the exception --
+    this counted one buffer, the output slot, and the tweak was released
+    in the clear.
+
+    Args:
+        monkeypatch: the fixture the spy is installed through.
+    """
+    label, label_tweak = silentpayments.label(SP_SCAN_PRVKEY, 1)
+    summary = sp_summary()
+    wiped = spy_on_wipe(monkeypatch)
+
+    with pytest.raises(ValueError, match="label tweak must be 32 bytes"):
+        silentpayments.scan_outputs(
+            [SP_INPUT_PUBKEY[1:]],
+            SP_SCAN_PRVKEY,
+            summary,
+            SP_SPEND_PUBKEY,
+            # insertion order is what the cache is filled in, so the
+            # refusal comes after the tweak that has to be taken back
+            labels={label: label_tweak, bytes(silentpayments.LABEL_SIZE): bytes(31)},
+        )
+
+    assert len(wiped) == 2, "the one output slot, and the tweak made before the refusal"
+    assert all(zeroed(buffer) for buffer in wiped)


### PR DESCRIPTION
Two things the argument boundary was answering rather than refusing. Both
came out of a read of the package, not of a failure, and each new test
was watched failing on the code it is written against.

## A memoryview states its width in items

`_scalar.octets` takes bytes, a bytearray and a memoryview because each
states a value *and* a width. A memoryview states that width in items,
and it is the one shape where the argument does not hold:

```python
>>> keys.prvkey_verify(memoryview(array("I", [1, 2, 3, 4, 5, 6, 7, 8])))
True   # the key 0100000002000000...08000000, which nobody wrote
```

`bytes` of that view is 32 octets of whatever this machine's byte order
made of the value, so it passed the size check as a private key the
caller never asked for -- and a different one on a big endian build.
mypy cannot object, `memoryview` being the annotated type whatever its
items are, which is the same argument that puts the `bool` check at run
time.

It now raises `TypeError`, and `.cast("B")` is how a caller who does mean
those octets says so. Nothing else about the shape is asked: where the
items are octets, `bytes` answers the ones the view logically holds --
through a stride, and over every dimension -- so the length checked is
the length libsecp256k1 reads.

## A refused label cache left a tweak behind

`silentpayments.scan_outputs` built its label cache *before* the `try`
whose `finally` wipes it, and built it with a comprehension, which drops
the buffers it already made along with the exception. A cache whose
second entry is malformed therefore left the first entry's tweak -- a
secret, in memory this package owns -- unwiped and unreachable. Measured
with the spy the sender's own tests use: zero calls to `wipe`.

`create_outputs` does not have the bug, and its comment says why: "each
element carries a private key and the next one can raise, so what wipes
them has to already be in force while they are being made". The cache is
now filled entry by entry inside the `try`, the same way, and the test is
the recipient's counterpart of the sender's own.

## Checked

- `uvx pre-commit run --all-files`: green
- `uv run --locked --no-default-groups --group test pytest --cov`: 424
  passed, 100.00%
- both new tests fail against the previous sources, restored under
  `PYTHONDONTWRITEBYTECODE=1`

Note for whoever merges: `.secrets.baseline` moved line numbers here, and
#123 touches that file too, so whichever lands second wants the hook re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten handling of byte-like inputs and Silent Payments label caching to avoid misinterpreted scalars and unwiped secrets.

New Features:
- Refuse memoryviews whose items are wider than a byte when converting to octets, requiring callers to explicitly cast to byte views.

Bug Fixes:
- Ensure Silent Payments recipient label caches are filled inside the wipe-guarded block so tweaks from earlier labels are always wiped even if a later label is invalid.

Enhancements:
- Clarify Silent Payments scan behaviour by explicitly distinguishing between the absence of a label lookup and an empty label cache.

Documentation:
- Update CHANGELOG and HISTORY to describe the new memoryview boundary behaviour and the corrected Silent Payments label cache wiping semantics.

Tests:
- Add tests covering refusal of non-byte memoryviews as scalar inputs and verifying that label cache tweaks are wiped when a later label entry is rejected.