### PR TITLE
Correct three comments that had stopped being the reason

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1107
+        "line_number": 1123
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -440,5 +440,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T13:28:23Z"
+  "generated_at": "2026-08-12T09:13:19Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,22 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **Three statements that were not true, found by an audit of the package
+  rather than by a failure.** Each is the kind this repository's own rule
+  is about, a comment saying *why* and the why having stopped being the
+  reason: `context._randomize` invited a caller to re-randomize "whenever
+  it wants fresh blinding", which is the one call that would take the
+  README's thread-safety guarantee away — libsecp256k1 requires exclusive
+  access to a context to mutate one, so the invitation now carries the
+  condition, and the README says the same where a user reads it.
+  `silentpayments._array` explained its NULL by "cffi will not make an
+  array of length zero", which cffi does quite happily, `keys.pubkey_sort`
+  passing one for an empty sequence; the real reason is libsecp256k1's own
+  `ARG_CHECK`, and the same wrong reason was in
+  `test_scanning_refuses_an_empty_output_list`. CLAUDE.md said the
+  sentinel crons "are on different mornings" while the table under it
+  showed two on Wednesday and two on the 1st — corrected when the
+  cadences were, and the sentence left behind.
 - **The prose stops naming `dev` and `master`, which no longer exist.**
   The workflows were corrected when the branches went; the files that
   describe how this repository is worked on were not, so RELEASING.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,13 @@ no aggregate job, is named by no branch rule, and opens no issue on failure
 (`vendored-vectors` excepted, for the reason its own header gives). That is
 deliberate in every case — each is expected to go red for a reason no pull
 request introduced, and a red check nobody can act on from a branch is
-noise. Their crons are on different mornings, because sentinels landing in
-one inbox on one morning are one sentinel, and `codeql` keeps a morning of
-its own for the same reason.
+noise. Their crons are spread out, because sentinels landing in one inbox
+on one morning are one sentinel, and `codeql` keeps a morning of its own
+for the same reason. Two pairs share a morning even so. `macos` and
+`latest` do it deliberately, and both cron comments say why: half an hour
+apart on Wednesday, they answer halves of one question and are worth
+reading together. `published` and `vendored-vectors` are the other pair,
+both monthly on the 1st.
 
 | workflow | asks | when |
 | --- | --- | --- |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,13 @@ change, and only for a caller reaching through `lib`.**
   squaring now being force-inlined. Clang, which is what the macOS wheels
   are built with, is largely unaffected; the compiled library is somewhat
   larger everywhere.
+- **Re-randomizing the shared context is documented as needing exclusive
+  access to it.** Nothing changed in the code: `context._randomize` is
+  what it was, and the bindings stay safe to call from several threads.
+  What was missing is that repeating that one call while other threads
+  are in flight is what takes that safety away — libsecp256k1 asks for a
+  read-write lock, or for randomization at creation time, which is what
+  happens at import.
 
 ## v0.7.1.3
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,12 @@ This matters on a free-threaded interpreter, for which a wheel is built
 (`cp314t`), where those calls are no longer serialized;
 `tests/test_concurrency.py` exercises it.
 
+The one way to lose that guarantee is to re-randomize the shared context
+while it is in use. `context._randomize(context.ctx)` is there for a
+caller who wants fresh blinding, and libsecp256k1 asks for exclusive
+access to a context to mutate one: call it before the threads start, or
+hold a read-write lock over every call that takes `ctx`.
+
 What `context.check()` reports is per thread: the callback recording it
 runs on the thread of the call that triggered it, which is what
 attributes a message to the right caller.

--- a/btclib_libsecp256k1/context.py
+++ b/btclib_libsecp256k1/context.py
@@ -76,8 +76,16 @@ def _randomize(context: CData) -> None:
     """Re-blind the signing precomputation of that context.
 
     Protects against side-channel leakage, as libsecp256k1 recommends,
-    and is called below on the shared context at import time. A caller
-    of its own may repeat it whenever it wants fresh blinding.
+    and is called below on the shared context at import time.
+
+    Repeating it is a caller's to do and needs exclusive access to the
+    context: this is one of the few libsecp256k1 calls that mutates one,
+    and the header says to randomize at creation time -- which is what
+    happens below -- or to hold a read-write lock. Everything else in
+    these bindings is safe to call from several threads *because* the
+    shared context is randomized once, before any of them exists, so a
+    second call on `ctx` while another thread is signing takes that
+    guarantee away. See the Thread safety section of the README.
 
     The context is an argument rather than the module-level `ctx` for
     the same reason `_load_lib` takes the module: a line called once, at

--- a/btclib_libsecp256k1/silentpayments.py
+++ b/btclib_libsecp256k1/silentpayments.py
@@ -505,9 +505,13 @@ def _array(cdecl: str, items: list[CData]) -> CData:
         items: the objects to point at, which the caller keeps alive.
 
     Returns:
-        The array, or NULL where there is nothing to point at: that is
-        what the header asks for, and cffi will not make an array of
-        length zero to pass instead.
+        The array, or NULL where there is nothing to point at, which is
+        what libsecp256k1 requires rather than merely accepts: it reads
+        the count against the pointer, and a non-NULL one with a count of
+        zero fails an ARG_CHECK -- `n_xonly_pubkeys > 0`, reported through
+        the illegal callback. cffi would hand over an array of length
+        zero quite happily, `keys.pubkey_sort` passing one for an empty
+        sequence, so it is this call that has to say NULL.
     """
     return ffi.new(cdecl, items) if items else ffi.NULL
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -686,9 +686,11 @@ def test_a_prevouts_summary_of_an_unparsable_taproot_key_is_refused() -> None:
 def test_scanning_refuses_an_empty_output_list() -> None:
     """A transaction with no taproot output pays no silent payment.
 
-    libsecp256k1 requires the found outputs array to be as long as the
-    outputs one, and an array of length zero is not something cffi will
-    make, so this is refused here rather than there.
+    libsecp256k1 requires at least one -- `n_tx_outputs > 0` is an
+    ARG_CHECK of its own -- and what a violated precondition gets a
+    caller is a bare zero return, which this wrapper can only report as
+    the scan having failed. So it is refused here instead, by the
+    argument's own name.
     """
     with pytest.raises(ValueError, match="at least one transaction output"):
         silentpayments.scan_outputs([], SP_SCAN_PRVKEY, sp_summary(), SP_SPEND_PUBKEY)


### PR DESCRIPTION
An audit read the prose of this package against what it describes. Three
statements did not survive it. None of them changes behaviour — the suite
is the same 422 tests at 100% — but each is the kind the repository's own
rule is about: a comment says *why*, so a why that is no longer the reason
is the comment to fix.

## `context._randomize` invited a call that voids the thread-safety claim

The docstring said a caller "may repeat it whenever it wants fresh
blinding". That is the one call that would take the README's Thread safety
guarantee away, and the header of the vendored library is explicit:

> A constructed context can safely be used from multiple threads
> simultaneously, but API calls that take a non-const pointer to a context
> need exclusive access to it. In particular this is the case for
> [...] `secp256k1_context_randomize`. Regarding randomization, either do
> it once at creation time (in which case you do not need any locking for
> the other calls), or use a read-write lock.

The README states the guarantee in exactly those terms — "it runs once
before any thread exists" — so the two read as contradicting each other.
The invitation now carries the condition, and the README says the same
thing where a user would look for it.

## `_array` gave a reason that is not true

> the header asks for [NULL], and cffi will not make an array of length
> zero to pass instead

cffi makes one quite happily, and `keys.pubkey_sort` passes one for an
empty sequence:

```python
>>> ffi.new("secp256k1_xonly_pubkey *[]", [])
<cdata 'struct secp256k1_xonly_pubkey *[]' owning 0 bytes>
```

The requirement is libsecp256k1's own: it reads the count against the
pointer, so a non-NULL array with a count of zero fails an ARG_CHECK,
which the illegal callback duly reports as `n_xonly_pubkeys > 0` when you
hand it one. The same wrong reason was in
`test_scanning_refuses_an_empty_output_list`, whose real one is the
ARG_CHECK on `n_tx_outputs`.

## CLAUDE.md contradicted its own table

"Their crons are on different mornings" — with, three lines below,
`macos` and `latest` both on Wednesday and `published` and
`vendored-vectors` both on the 1st. The two Wednesday crons share
deliberately and each says so where it is set; the sentence was left
behind when 4d4bd30 corrected the cadences.

## Checked

- `uvx pre-commit run --all-files`: green
- `uv run --locked --no-default-groups --group test pytest --cov`: 422
  passed, 100.00%

Note for whoever merges: this shares `.secrets.baseline`, `CHANGELOG.md`,
`HISTORY.md` and `tests/test_modules.py` with #124, in different places
of each; whichever lands second wants a rebase and the hook re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify documentation and comments so they accurately describe thread-safety guarantees, libsecp256k1 preconditions, and CI cron scheduling without changing runtime behavior.

Enhancements:
- Note the clarified context randomization requirements in HISTORY.md and CHANGELOG.md for release tracking.

Documentation:
- Document that re-randomizing the shared libsecp256k1 context requires exclusive access and can void the thread-safety guarantee if done while other threads are active.
- Correct explanations of NULL handling and ARG_CHECK requirements in silent payments documentation and tests to reflect libsecp256k1’s actual constraints.
- Update CLAUDE.md to accurately describe which CI sentinel workflows share cron schedules and why they are grouped.

Tests:
- Adjust the silent payments empty-output test description to reflect libsecp256k1’s `n_tx_outputs > 0` precondition and how the wrapper reports violations.