### PR TITLE
Check the submodule pin on every commit, and its signature monthly

### DIFF
--- a/.github/scripts/check_submodule_pin.py
+++ b/.github/scripts/check_submodule_pin.py
@@ -1,0 +1,217 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The vendored libsecp256k1 is the release README.md says it is.
+
+`version-check` in .github/workflows/release.yml asks this of upstream,
+over the network, and refuses to publish when the answer is no. That is
+the last gate before publication and it stays. What this is, is the same
+question asked of every commit instead of every release, so that a
+submodule bump and the prose about it cannot disagree for the length of
+a cycle -- which is the window in which CHANGELOG.md, HISTORY.md and
+README.md are written about the version nobody has confirmed.
+
+Offline is what makes it a hook rather than a workflow step. The tag is
+resolved in the vendored clone, whose refs are already on the machine, so
+nothing here reaches the network and nothing goes red because github.com
+is unreachable. The half only the network can answer -- that the tag is
+upstream's, and that its signature is a maintainer's -- is the job of the
+same name in .github/workflows/vendored-vectors.yml, which is a sentinel
+for exactly that reason.
+
+Two commands, and what they answer:
+
+    git ls-tree HEAD secp256k1          the commit this tree pins
+    git -C secp256k1 rev-parse <tag>^{commit}   what README.md's tag is
+
+Run by the `submodule-pin` hook of .pre-commit-config.yaml, and so by the
+lint workflow, on every commit rather than on the two paths that can
+break the agreement: pre-commit cannot filter on the gitlink, for the
+reason that hook's own comment gives, and two git invocations are cheap
+enough that it does not have to.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# resolved once: a bare "git" in a subprocess list is what S607 is about,
+# the same way .github/scripts/check_vendored_vectors.py resolves gh
+_GIT = shutil.which("git") or "git"
+
+# what git puts in the environment of a hook, and what has to come back
+# out of it before git is run anywhere else. These name *this*
+# repository, and `-C secp256k1` does not override them: with GIT_DIR set
+# the tag is looked for in the wrong repository and is not found. It
+# shows only from the git hook -- a `pre-commit run` in a terminal sets
+# none of them, and passed on the very tree the commit then refused
+_INHERITED = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+    "GIT_NAMESPACE",
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SUBMODULE = "secp256k1"
+
+# the release README.md names, as the url of an upstream release tag. The
+# same expression release.yml reads it with, which is what keeps the two
+# checks about one line of prose rather than two
+_NAMED = re.compile(r"secp256k1/releases/tag/(v[0-9][0-9.]*)")
+
+
+def named_release(readme: str) -> str | None:
+    """Return the libsecp256k1 release README.md names, or None.
+
+    Args:
+        readme: the text of README.md.
+
+    Returns:
+        The first release tag it links to, or None where it links to no
+        upstream release at all -- which is a failure of its own and not
+        a check that passes vacuously.
+    """
+    match = _NAMED.search(readme)
+    return match[1] if match else None
+
+
+def _git(*args: str, cwd: Path | None = None, disown: bool = False) -> str | None:
+    """Run git and return its stdout, or None where it failed.
+
+    A failure is an answer here rather than an exception: an unknown tag
+    and an uninitialized submodule both come back as one, and each is
+    reported by the caller in its own words.
+
+    Args:
+        *args: the git arguments, the executable excluded.
+        cwd: the directory to run in, the repository root by default.
+        disown: whether to drop the repository git names in the
+            environment, which a run against any other one has to.
+
+    Returns:
+        The stripped stdout, or None if git exited non-zero.
+    """
+    env = None
+    if disown:
+        env = {k: v for k, v in os.environ.items() if k not in _INHERITED}
+    result = subprocess.run(  # noqa: S603
+        [_GIT, *args],
+        cwd=cwd or _ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def pinned_commit() -> str | None:
+    """Return the commit the index pins the submodule to.
+
+    The index, and not `HEAD`: a hook runs on what is about to be
+    committed, and the commit that moves the submodule is the one this
+    check exists for. `git ls-tree HEAD` would read the pin of the
+    commit *before* it and compare that with a README.md already saying
+    the new release -- failing every bump, and for a reason that is not
+    the one it would report. The two agree in a clean tree, which is
+    every run of the lint workflow.
+
+    Read from the index rather than from the submodule's own HEAD for a
+    second reason: the gitlink is in this repository's tree, and it is
+    there whether or not the submodule has been checked out.
+
+    Returns:
+        The 40-hex commit, or None if the index has no such gitlink.
+    """
+    line = _git("ls-files", "--stage", "--", _SUBMODULE)
+    if not line:
+        return None
+    fields = line.split()
+    # mode, object, stage, path -- and 160000 is the gitlink mode, which
+    # is what tells a submodule from a file that happens to be named so
+    return fields[1] if len(fields) == 4 and fields[0] == "160000" else None
+
+
+def commit_of(tag: str) -> str | None:
+    """Return the commit a tag names in the vendored clone.
+
+    Args:
+        tag: the release tag, as README.md names it.
+
+    Returns:
+        The 40-hex commit the tag resolves to, or None where the clone
+        does not have that tag -- an uninitialized submodule, or a
+        shallow checkout carrying no tags.
+    """
+    return _git(
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        f"{tag}^{{commit}}",
+        cwd=_ROOT / _SUBMODULE,
+        # a different repository, so the hook environment goes
+        disown=True,
+    )
+
+
+def main() -> int:
+    """Compare the pin with the release the prose names.
+
+    Returns:
+        0 where they agree, 1 where they do not or where the question
+        could not be asked -- which is a failure too: a check that
+        cannot read its inputs has not passed.
+    """
+    pinned = pinned_commit()
+    if pinned is None:
+        print(f"no {_SUBMODULE} submodule in this tree", file=sys.stderr)
+        return 1
+
+    named = named_release((_ROOT / "README.md").read_text(encoding="utf-8"))
+    if named is None:
+        print(
+            "README.md links to no libsecp256k1 release: the version this"
+            " package wraps is named there, and release.yml reads it from"
+            " that same line",
+            file=sys.stderr,
+        )
+        return 1
+
+    tagged = commit_of(named)
+    if tagged is None:
+        print(
+            f"the vendored clone has no {named} tag. Initialize the"
+            " submodule (git submodule update --init), and fetch its tags"
+            " if the clone is shallow",
+            file=sys.stderr,
+        )
+        return 1
+
+    if tagged != pinned:
+        print(
+            f"README.md names {named} ({tagged[:7]}), and the submodule is"
+            f" pinned to {pinned[:7]}. The submodule moves in a change of"
+            " its own, with the version named in README.md and HISTORY.md"
+            " moved with it",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"the submodule is pinned to {named} ({pinned[:7]}), as README.md says")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,9 +83,18 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # the submodule, and unshallow, for one hook: `submodule-pin`
+      # resolves the release README.md names in the vendored clone's own
+      # refs, so it needs that clone and it needs its tags. fetch-depth 0
+      # is what gets them -- actions/checkout passes its depth down to
+      # the submodule, and a --depth=1 clone carries no tag at all -- and
+      # it is the whole cost of moving that check off the release path.
+      # Every other hook here reads files this repository owns
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -37,10 +37,16 @@ on:
       - .github/workflows/vendored-vectors.yml
       - .github/scripts/check_vendored_vectors.py
       - tests/README.md
+      # the pin job below, and the two things it is about: the gitlink is
+      # a path like any other on a pull request -- #106, which moved the
+      # submodule to 0.8.0, has `secp256k1` among its changed files -- so
+      # the run that answers whether a bump is a signed upstream release
+      # is the run on the bump itself
+      - secp256k1
+      - README.md
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: vendored-vectors-${{ github.ref }}
@@ -55,6 +61,12 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # the issue is this job's to open, close or edit, and only this
+    # job's: the pin job below reports by going red, so it keeps the
+    # workflow's own contents: read
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,3 +91,81 @@ jobs:
           ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # the network half of the submodule pin check, whose offline half is the
+  # `submodule-pin` hook. That one asks whether the tag README.md names
+  # resolves, in the vendored clone, to the commit this tree pins -- two
+  # things already on the machine, which is what lets it gate a commit.
+  # This asks the two that need somebody else to answer: whether that tag
+  # is the one upstream publishes, and whether it carries the signature of
+  # a libsecp256k1 maintainer. `version-check` in release.yml asks the
+  # first of those before publishing and neither of them earlier, which is
+  # what issue #126 is about.
+  #
+  # A sentinel and not a gate, for the reason every network check here is
+  # one: a keyserver that is down is nothing a pull request introduced. It
+  # runs on the pull request that moves the pin all the same -- the paths
+  # filter above is what does that -- because that is where the answer is
+  # wanted while acting on it is still free.
+  #
+  # It opens no issue where the job above does, and the asymmetry is in
+  # the subject rather than in the effort. A vendored vector file drifts
+  # because upstream edits it in place, with nothing here changing and
+  # nobody looking, which is exactly what a monthly issue is for. A pin
+  # cannot drift: it moves only in a commit of this repository. So the
+  # monthly run here is a backstop against upstream retagging, or a
+  # signature that stops verifying, and a red run says all of that.
+  pin:
+    name: Check the pinned libsecp256k1 release
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # shallow is enough: the one tag this needs is fetched below,
+          # from upstream, which is the point of fetching it at all
+          submodules: true
+
+      # the fingerprints are libsecp256k1's own, the table in its
+      # SECURITY.md, recorded here rather than read out of the vendored
+      # tree at check time: a key list taken from the same place as the
+      # tag is a list whoever controls that place also writes. Upstream
+      # asks a human for the same separation in step 2 of its README,
+      # cross-referencing each fingerprint against a source its owner
+      # controls. keys.openpgp.org because that is the keyserver its
+      # SECURITY.md names in the command it gives
+      - name: Import the libsecp256k1 maintainer keys
+        env:
+          # Pieter Wuille, Tim Ruffing, Sebastian Falbesoner
+          FINGERPRINTS: >-
+            133EAC179436F14A5CF1B794860FEB804E669320
+            09E03F871092E40E106E902B33BC86AB80FF5516
+            6A8F9C266528E25AEB1D7731C2371D91CB716EA7
+        run: |
+          read -ra fingerprints <<< "$FINGERPRINTS"
+          for fingerprint in "${fingerprints[@]}"; do
+            gpg --keyserver hkps://keys.openpgp.org --recv-keys "$fingerprint"
+          done
+
+      # `git tag -v` and not `git ls-remote`: the second answers which
+      # commit a tag names today, which is what release.yml compares and
+      # is a claim by whoever served the answer. The signature is on the
+      # tag object, so the object has to be fetched to be verified
+      - name: The pin is the signed upstream release README.md names
+        run: |
+          named=$(sed -n 's|.*secp256k1/releases/tag/\(v[0-9][0-9.]*\).*|\1|p' README.md | head -1)
+          pinned=$(git ls-tree HEAD secp256k1 | awk '{print $3}')
+          if [ -z "$named" ]; then
+            echo "::error::README.md names no libsecp256k1 release"
+            exit 1
+          fi
+          git -C secp256k1 fetch --force origin "refs/tags/$named:refs/tags/$named"
+          git -C secp256k1 tag -v "$named"
+          tagged=$(git -C secp256k1 rev-parse "$named^{commit}")
+          echo "upstream's $named is $tagged; the submodule is pinned to $pinned"
+          if [ "$tagged" != "$pinned" ]; then
+            echo "::error::the submodule is pinned to $pinned, which is not $named"
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,42 @@ repos:
         language: pygrep
         entry: '^ *rev: "?v?([0-9]+|[0-9][0-9.]*(a|b|rc|dev)[0-9]+)"?$'
         files: ^\.pre-commit-config\.yaml$
+  # the vendored library is the release the prose names it to be.
+  # release.yml asks upstream the same question before publishing, which
+  # is the last gate and stays; what it cannot be is the only one, a
+  # submodule bump otherwise reaching main and waiting for a release to be
+  # compared with the version README.md claims -- the window in which the
+  # changelog and the release notes about that version are written. This
+  # asks it of every commit instead, and offline: the tag is resolved in
+  # the vendored clone's own refs, so no hook here reaches the network.
+  # The half that needs one -- that the tag is upstream's, and signed by a
+  # maintainer -- is a job of vendored-vectors.yml, a sentinel because a
+  # keyserver that is down is nothing a pull request did.
+  # always_run, and no `files`, because a `files` pattern cannot reach
+  # this one. git reports the gitlink as a staged path like any other --
+  # `git diff --staged --name-only` prints `secp256k1` for the commit that
+  # moves it -- but pre-commit drops from its file list everything that is
+  # not a regular file, and a submodule is a directory on disk: measured
+  # by staging a bump and asking for the hook by name, which answered
+  # "(no files to check)" even at `--files secp256k1`. A pattern would
+  # therefore have been a hook that never ran on the one commit it is for,
+  # and the pattern would have looked right. GitHub's own `paths:` filter
+  # is not the same code and does see it, which is what lets the sentinel
+  # in vendored-vectors.yml key on it (#106 has `secp256k1` among its
+  # changed files).
+  # The price of always_run is two git invocations per commit.
+  # language: python rather than system for the interpreter: the entry is
+  # a stdlib-only script, and a venv pre-commit builds has a `python` on
+  # every machine, where a bare `python` on the PATH is not something a
+  # uv-managed checkout guarantees
+  - repo: local
+    hooks:
+      - id: submodule-pin
+        name: the submodule is the libsecp256k1 release README.md names
+        language: python
+        entry: python .github/scripts/check_submodule_pin.py
+        always_run: true
+        pass_filenames: false
   # .github/dependabot.yml is validated by nothing else, and a typo in it
   # updates nothing and says nothing: the whole point of that file is to
   # move the pins this repository depends on for its security updates.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1156
+        "line_number": 1184
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -197,6 +197,22 @@
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
         "line_number": 351
+      }
+    ],
+    "tests/test_submodule_pin.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_submodule_pin.py",
+        "hashed_secret": "4a6048a42a12da6f4a4c7d080b4bf892f8bbdba2",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_submodule_pin.py",
+        "hashed_secret": "1ecb97dd82fe44dee912a7542f20de2af6c2e8fb",
+        "is_verified": false,
+        "line_number": 36
       }
     ],
     "tests/test_vectors.py": [
@@ -440,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T10:08:49Z"
+  "generated_at": "2026-08-12T10:36:09Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,34 @@ release-notes length in the first place, and are still in
 
 ### The gate
 
+- **The submodule pin is checked on every commit, and its signature
+  monthly** (#126). `version-check` in `release.yml` resolved the release
+  `README.md` names against upstream and refused to publish a tree pinned
+  to anything else — the last gate before publication, and until now the
+  only one, so a bump reaching `main` waited for a release to be compared
+  with the version the prose claimed. That is the window in which the
+  changelog and the release notes about that version get written. The
+  check now exists twice more, split by what each half needs:
+  `.github/scripts/check_submodule_pin.py` resolves the tag in the
+  vendored clone's own refs, which is offline and therefore a hook —
+  `submodule-pin`, on every commit, because a `files` pattern cannot
+  reach it: pre-commit drops from its file list everything that is not a
+  regular file, and a submodule is a directory, so a hook filtered on
+  `secp256k1` would never have run on the one commit it is for. Measured
+  rather than assumed, by staging a bump and asking for the hook by name.
+  GitHub's `paths:` filter is other code and does see the gitlink, which
+  is what the sentinel keys on; and a `pin` job in
+  `vendored-vectors.yml` fetches the tag object from upstream and runs
+  `git tag -v` against the three maintainer fingerprints recorded from
+  libsecp256k1's own `SECURITY.md`, which nothing here had ever verified.
+  That half is a sentinel because a keyserver that is down is nothing a
+  pull request did, and it runs on the pull request that moves the pin
+  regardless: a gitlink is a path like any other in a `paths` filter, as
+  #106 shows, having `secp256k1` among its changed files. It opens no
+  issue where its neighbour does, and the reason is the subject: a vector
+  file drifts because upstream edits it in place, while a pin moves only
+  in a commit of this repository. `lint.yml` checks out the submodule
+  unshallow for the hook, tags being what a `--depth=1` clone has none of
 - **Every required check names the app that produces it.** `test: every
   job passed` and `codeql: every job passed` carried `app_id: 15368` and
   the other two carried none, which REPOSITORY.md recorded as a rule that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -559,6 +559,10 @@ max-complexity = 10
 # and the mutation counter, whose one line of output is what the workflow
 # step exists to put in the log: same exemption, same reason
 ".github/scripts/mutation_counts.py" = ["print"]
+# and the submodule pin check, which is a hook before it is anything
+# else: what it prints is what pre-commit shows the developer whose
+# commit it just refused, and stderr is where all of that goes
+".github/scripts/check_submodule_pin.py" = ["print"]
 
 [tool.ruff.lint.flake8-copyright]
 # notice-rgx is COPYRIGHT's text as one regex, anchored with ^ so a

--- a/tests/test_submodule_pin.py
+++ b/tests/test_submodule_pin.py
@@ -1,0 +1,205 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the submodule pin check of `.github/scripts`.
+
+The check is a pre-commit hook, so what it says about the real tree is
+answered on every commit and in the lint workflow, by the hook itself.
+What cannot be answered that way is how it behaves when the answer is no
+-- a pin that is not what README.md names, a README naming nothing, a
+submodule nobody initialized -- because a tree in any of those states is
+a tree the gate refuses. Those are the cases here, built by hand.
+
+There is deliberately no test that the real tree passes: that is the
+hook's own job, it runs on every commit, and a copy of it here would have
+to be skipped wherever the suite runs outside a git checkout -- the sdist
+jobs, which unpack a tarball with no `.git` in it -- which is a test
+reporting success on the strength of having not run.
+
+The script is loaded by path, `.github/scripts` being no package, and
+once: `monkeypatch` undoes what each test does to it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_PINNED = "6e2c8bc4ecdc6e71dbe7a368f360d8d453ce435d"
+_OTHER = "1a53f4907d5b8f7b0e5b1d3e33e3e50b0e1f0d5c"
+_README = (
+    "wraps ([v0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0))."
+)
+
+
+def _load() -> ModuleType:
+    """Import the check by path.
+
+    Returns:
+        The module.
+    """
+    path = Path(__file__).parents[1] / ".github" / "scripts" / "check_submodule_pin.py"
+    spec = importlib.util.spec_from_file_location("check_submodule_pin", path)
+    assert spec
+    assert spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+
+def _tree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    readme: str = _README,
+    pinned: str | None = _PINNED,
+    tagged: str | None = _PINNED,
+) -> None:
+    """Stand a tree up in the three answers the check reads.
+
+    The defaults are the agreeing case, so each test below names the one
+    answer it changes and the reader sees which that is.
+
+    Args:
+        monkeypatch: the fixture the substitutions are made through.
+        tmp_path: where the README the check reads is written.
+        readme: its text.
+        pinned: what the gitlink says, or None for no submodule at all.
+        tagged: what the tag resolves to, or None for a tag the vendored
+            clone does not have.
+    """
+    (tmp_path / "README.md").write_text(readme, encoding="utf-8")
+    monkeypatch.setattr(check, "_ROOT", tmp_path)
+    monkeypatch.setattr(check, "pinned_commit", lambda: pinned)
+    monkeypatch.setattr(check, "commit_of", lambda _tag: tagged)
+
+
+def test_the_release_is_read_off_the_url() -> None:
+    """The tag is the one README.md links to, and the first of them."""
+    assert check.named_release(_README) == "v0.8.0"
+    assert check.named_release("v0.7.1 in prose, no link") is None
+    assert check.named_release("") is None
+    # the first link wins: the sentence naming what is wrapped opens the
+    # file, and a later link to an older release is prose about history
+    older = "[v0.7.1](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.7.1)"
+    assert check.named_release(f"{_README} up from {older}") == "v0.8.0"
+
+
+def test_a_pin_matching_the_named_release_passes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The case the tree is in, and the only one that exits zero."""
+    _tree(monkeypatch, tmp_path)
+    assert check.main() == 0
+
+
+def test_a_pin_that_is_not_the_named_release_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A submodule moved without the prose, or prose without the submodule.
+
+    Both abbreviations are in the message, because which of the two
+    happened is not something the check can know, and is the whole of
+    what its reader has to decide.
+    """
+    _tree(monkeypatch, tmp_path, pinned=_OTHER)
+
+    assert check.main() == 1
+    error = capsys.readouterr().err
+    assert "v0.8.0" in error
+    assert _PINNED[:7] in error
+    assert _OTHER[:7] in error
+
+
+def test_a_readme_naming_no_release_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Nothing to compare against is a failure, not a pass.
+
+    This is the shape in which a check quietly stops being one: with the
+    link gone, an implementation that skipped when it found no tag would
+    report success on every commit thereafter.
+    """
+    _tree(monkeypatch, tmp_path, readme="no link here")
+
+    assert check.main() == 1
+    assert "links to no libsecp256k1 release" in capsys.readouterr().err
+
+
+def test_a_submodule_nobody_initialized_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A clone without the tag says how to get one, rather than passing."""
+    _tree(monkeypatch, tmp_path, tagged=None)
+
+    assert check.main() == 1
+    assert "git submodule update --init" in capsys.readouterr().err
+
+
+def test_a_tree_with_no_submodule_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The gitlink is the first thing read, and its absence is the answer."""
+    _tree(monkeypatch, tmp_path, pinned=None)
+
+    assert check.main() == 1
+    assert "no secp256k1 submodule" in capsys.readouterr().err
+
+
+def test_the_submodule_is_read_with_the_hook_environment_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`-C secp256k1` does not override GIT_DIR, so the environment must.
+
+    git hands a hook GIT_DIR and GIT_INDEX_FILE naming the repository
+    being committed to, and they win over `-C`: the tag is then looked
+    for in this repository, which has none of libsecp256k1's, and comes
+    back missing. It shows from the git hook and nowhere else -- a
+    `pre-commit run` in a terminal sets neither, and passed on the very
+    tree the commit then refused -- so what holds it is here rather than
+    a run that would have to be made from one.
+
+    The other direction is asserted too: the call that reads the pin
+    keeps the environment, GIT_INDEX_FILE being how git tells a hook
+    which index is about to be committed.
+
+    Args:
+        monkeypatch: the fixture the environment and the stub are set
+            through.
+    """
+    captured: list[dict[str, str] | None] = []
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+
+    def fake_run(_args: list[str], **kwargs: Any) -> _Result:
+        env: dict[str, str] | None = kwargs.get("env")
+        captured.append(env)
+        return _Result()
+
+    monkeypatch.setenv("GIT_DIR", "/elsewhere/.git")
+    monkeypatch.setenv("GIT_INDEX_FILE", "/elsewhere/.git/index")
+    monkeypatch.setattr(check.subprocess, "run", fake_run)
+
+    check.commit_of("v0.8.0")
+    submodule_env = captured[-1]
+    assert submodule_env is not None, "the submodule call passes an environment"
+    assert "GIT_DIR" not in submodule_env
+    assert "GIT_INDEX_FILE" not in submodule_env
+    # something is left: the environment is filtered, not emptied
+    assert submodule_env
+
+    check.pinned_commit()
+    assert captured[-1] is None, "the pin is read from the index git names"


### PR DESCRIPTION
Closes #126.

`version-check` in `release.yml` resolved the libsecp256k1 release
`README.md` names against upstream and refused to publish a tree pinned
to anything else. It stays — it is the last gate before publication —
but it was the only one, so a bump reaching `main` waited for a release
to be compared with the version the prose claimed, and that window is
where the changelog and the release notes about that version get
written. Nothing anywhere verified the signature on the tag being
vendored.

The check now exists twice more, split by what each half needs.

## Offline, and so a hook

`.github/scripts/check_submodule_pin.py` resolves the tag in the vendored
clone's own refs and compares it with the gitlink. No network, so it can
gate a commit.

Three things about it were measured rather than reasoned, and each had
looked right until it was run:

- **it reads the pin from the index, not from `HEAD`.** That is the whole
  difference between checking the commit being made and the one before
  it: with `git ls-tree HEAD` every bump fails, on a disagreement
  manufactured by reading the two halves from different commits.
- **it runs on every commit, not on a `files` pattern.** git reports the
  gitlink as a staged path like any other, but pre-commit drops from its
  file list everything that is not a regular file, and a submodule is a
  directory. Staging a bump and asking for the hook by name answers
  `(no files to check)` — at `--files secp256k1` too. A pattern would
  have been a hook that never ran on the one commit it exists for, and it
  would have read as though it did. Two git invocations are cheap enough
  not to need one.
- **it drops `GIT_DIR` and its neighbours before running git in the
  submodule**, because `-C secp256k1` does not override them. git sets
  them for a hook, they name *this* repository, and the tag is then
  looked for where there is none. This one shows from the git hook and
  nowhere else: `pre-commit run` in a terminal passed on the very tree
  the commit then refused.

Watched failing and passing, in that order:

```
$ git -C secp256k1 checkout v0.7.1 && git add secp256k1
$ pre-commit run submodule-pin
the submodule is the libsecp256k1 release README.md names...............Failed
README.md names v0.8.0 (6e2c8bc), and the submodule is pinned to 1a53f49.
$ # and with README.md moved to v0.7.1 as well
the submodule is the libsecp256k1 release README.md names...............Passed
```

`lint.yml` checks the submodule out unshallow for it, tags being what a
`--depth=1` clone has none of. That is the whole cost of moving the check
off the release path.

## Online, and so a sentinel

A `pin` job in `vendored-vectors.yml` fetches the tag **object** from
upstream — `ls-remote` answers a commit, and the signature is on the
object — imports the three maintainer keys by the fingerprints
libsecp256k1's own `SECURITY.md` publishes, and runs `git tag -v`.
Verified locally against a throwaway `GNUPGHOME`, so nothing was imported
into a real keyring:

```
gpg: Good signature from "Sebastian Falbesoner (theStack) <...>"
with the keys -> exit 0
empty keyring -> exit 1
```

It is a sentinel because a keyserver that is down is nothing a pull
request did. It runs on the pull request that moves the pin all the same:
GitHub's `paths:` filter is not pre-commit's code and does see the
gitlink — #106, which moved the submodule to 0.8.0, has `secp256k1` among
its changed files.

It opens no issue where its neighbour in that workflow does, and the
asymmetry is in the subject rather than the effort: a vendored vector
file drifts because upstream edits it in place with nobody looking, which
is what a monthly issue is for, while a pin moves only in a commit of
this repository. `issues: write` moves down to the job that has always
had it, the new one keeping the workflow's `contents: read`.

## Checked

- `uvx pre-commit run --all-files`: green, the new hook included
- `uv run --locked --no-default-groups --group test pytest --cov`: 431
  passed, 100.00%
- the two `git tag -v` runs above, and the two hook runs above

The fingerprints and the two new hex constants in the test are why
`.secrets.baseline` moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add continuous verification that the vendored libsecp256k1 submodule matches the release documented in README, with offline enforcement on every commit and online signature verification in CI.

Enhancements:
- Introduce a pre-commit hook script that verifies the libsecp256k1 submodule pin against the release tag referenced in README on every commit.
- Add a CI job that fetches the upstream libsecp256k1 release tag and verifies its GPG signature with maintainer keys, ensuring the pinned commit matches the signed tag.
- Update the lint workflow to check out the submodule unshallow so tag-based checks can run outside the release pipeline.
- Document the new submodule pin and signature checks in the changelog.

CI:
- Refine vendored-vectors workflow permissions and paths, and add a monthly sentinel job for upstream-signed libsecp256k1 release verification.

Tests:
- Add unit tests covering the submodule pin check script’s behaviour across mismatched pins, missing tags, uninitialized submodules, and missing README release links.