### PR TITLE
Skip submodule-pin on pre-commit.ci, which has no vendored clone

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,16 +23,25 @@ ci:
   # request with nowhere to land
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
-  # the one hook pre-commit.ci cannot run, and the only entry this list
-  # may ever have without a reason of the same kind: pyroma rates the
-  # metadata of the source tree, which means building that metadata, and
-  # pre-commit.ci runs hooks with no network at all -- so the isolated
-  # build cannot fetch hatchling to prepare it, and the fallback to a
-  # non-isolated one has no backend in the hook environment either. The
-  # lint workflow runs this same file with a network, so what is skipped
-  # here is one of the hook's two runners rather than the hook: it still
-  # gates a commit on this machine and a pull request in that workflow
-  skip: [pyroma]
+  # the two hooks pre-commit.ci cannot run, each for something that
+  # service does not give a hook rather than for anything either hook
+  # does. pyroma rates the metadata of the source tree, which means
+  # building that metadata, and pre-commit.ci runs hooks with no network
+  # at all -- so the isolated build cannot fetch hatchling to prepare it,
+  # and the fallback to a non-isolated one has no backend in the hook
+  # environment either. submodule-pin resolves the release README.md
+  # names in the vendored clone's refs, and pre-commit.ci's checkout has
+  # no such clone with tags in it: measured on the pull request that
+  # added the hook, which went red there with the hook's own "the
+  # vendored clone has no v0.8.0 tag" while every other hook passed.
+  #
+  # In both cases the lint workflow runs this same file with what the
+  # hook needs -- a network for the first, `submodules: true` and
+  # `fetch-depth: 0` for the second -- so what is skipped here is one of
+  # two runners rather than the hook: each still gates a commit on this
+  # machine and a pull request in that workflow, which is the required
+  # check. An entry may join them for a reason of that kind and no other
+  skip: [pyroma, submodule-pin]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1184
+        "line_number": 1194
       }
     ],
     "btclib_libsecp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T10:36:09Z"
+  "generated_at": "2026-08-12T11:11:26Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,6 +363,16 @@ release-notes length in the first place, and are still in
   file drifts because upstream edits it in place, while a pin moves only
   in a commit of this repository. `lint.yml` checks out the submodule
   unshallow for the hook, tags being what a `--depth=1` clone has none of
+- **`submodule-pin` is skipped on pre-commit.ci**, which is the second
+  entry that list has ever had and was found the way the first one's
+  reason would have been: the pull request adding the hook went red
+  there, with the hook's own "the vendored clone has no v0.8.0 tag",
+  while every other hook passed. pre-commit.ci's checkout carries no
+  vendored clone with tags in it, the same way it carries no network for
+  `pyroma`, so what is skipped is one of the hook's two runners and not
+  the hook — `lint.yml` asks for `submodules: true` and `fetch-depth: 0`
+  precisely so that the runner which is a required check has what the
+  hook needs, and a commit on a developer's machine has it too
 - **Every required check names the app that produces it.** `test: every
   job passed` and `codeql: every job passed` carried `app_id: 15368` and
   the other two carried none, which REPOSITORY.md recorded as a rule that


### PR DESCRIPTION
Fixes the one thing #127 got wrong, and it went red where I did not read
it: on pre-commit.ci.

That run failed with the hook's own message —

> the vendored clone has no v0.8.0 tag. Initialize the submodule (git
> submodule update --init), and fetch its tags if the clone is shallow

— while every other hook on it passed
([run](https://results.pre-commit.ci/run/github/426693723/1786531908.8f_ner7FRzOHmVGDkwAhAA)).
pre-commit.ci's checkout carries no vendored clone with tags in it, so
the hook cannot answer its question there and would go red on every pull
request from now on.

The skip list's comment already said what an entry needs: a reason of
pyroma's kind, which is something the service does not give a hook rather
than anything the hook does. No submodule is that, where pyroma has no
network, and the comment now says so for both.

What is skipped is one of two runners and not the check: `lint.yml` asks
for `submodules: true` and `fetch-depth: 0` exactly so the runner that is
a required check has what the hook needs, and a developer's commit has it
too — the hook passes in this branch's own gate, submodule included.

This should have been caught before #127 landed. The risk was named while
the hook was written, and the plan was to read the pre-commit.ci result
from the pull request; the result arrived and I did not go back for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document that submodule-pin is skipped on pre-commit.ci alongside pyroma, clarifying that only one of each hook's runners is disabled there rather than the hook itself.