### PR TITLE
Try submodules: true on pre-commit.ci, and record that it is not enough

### DIFF
--- a/.github/scripts/check_submodule_pin.py
+++ b/.github/scripts/check_submodule_pin.py
@@ -166,6 +166,44 @@ def commit_of(tag: str) -> str | None:
     )
 
 
+def why_no_tag(tag: str) -> str:
+    """Say which of the three states a clone without that tag is in.
+
+    One message for all three used to be enough for a developer, who has
+    one of them; it is not enough for a checkout somebody else makes,
+    where which state it is *is* the finding. pre-commit.ci is that
+    checkout: told to take the submodule it takes it, and the hook failed
+    all the same, with a message that could not say whether the clone was
+    missing or merely shallow.
+
+    Args:
+        tag: the release tag that could not be resolved.
+
+    Returns:
+        A sentence naming the state and what would change it.
+    """
+    if _git("rev-parse", "--git-dir", cwd=_ROOT / _SUBMODULE, disown=True) is None:
+        return (
+            f"the {_SUBMODULE} submodule is not checked out, so nothing here"
+            " can resolve a tag: git submodule update --init"
+        )
+    if (
+        _git(
+            "rev-parse", "--is-shallow-repository", cwd=_ROOT / _SUBMODULE, disown=True
+        )
+        == "true"
+    ):
+        return (
+            f"the vendored clone is shallow and carries no {tag} tag:"
+            " git -C secp256k1 fetch --unshallow --tags, or check the"
+            " submodule out with fetch-depth 0"
+        )
+    return (
+        f"the vendored clone has no {tag} tag, though it is neither absent"
+        " nor shallow: git -C secp256k1 fetch --tags"
+    )
+
+
 def main() -> int:
     """Compare the pin with the release the prose names.
 
@@ -191,12 +229,7 @@ def main() -> int:
 
     tagged = commit_of(named)
     if tagged is None:
-        print(
-            f"the vendored clone has no {named} tag. Initialize the"
-            " submodule (git submodule update --init), and fetch its tags"
-            " if the clone is shallow",
-            file=sys.stderr,
-        )
+        print(why_no_tag(named), file=sys.stderr)
         return 1
 
     if tagged != pinned:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,25 +23,24 @@ ci:
   # request with nowhere to land
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
-  # the two hooks pre-commit.ci cannot run, each for something that
-  # service does not give a hook rather than for anything either hook
-  # does. pyroma rates the metadata of the source tree, which means
-  # building that metadata, and pre-commit.ci runs hooks with no network
-  # at all -- so the isolated build cannot fetch hatchling to prepare it,
-  # and the fallback to a non-isolated one has no backend in the hook
-  # environment either. submodule-pin resolves the release README.md
-  # names in the vendored clone's refs, and pre-commit.ci's checkout has
-  # no such clone with tags in it: measured on the pull request that
-  # added the hook, which went red there with the hook's own "the
-  # vendored clone has no v0.8.0 tag" while every other hook passed.
-  #
-  # In both cases the lint workflow runs this same file with what the
-  # hook needs -- a network for the first, `submodules: true` and
-  # `fetch-depth: 0` for the second -- so what is skipped here is one of
-  # two runners rather than the hook: each still gates a commit on this
-  # machine and a pull request in that workflow, which is the required
-  # check. An entry may join them for a reason of that kind and no other
-  skip: [pyroma, submodule-pin]
+  # `submodule-pin` reads the vendored clone, and pre-commit.ci checks out
+  # no submodule unless asked: the run against #127 went red there with
+  # that hook's own "the vendored clone has no v0.8.0 tag" while every
+  # other hook passed. #130 answered it by skipping the hook, which is the
+  # cheaper answer and the worse one -- it leaves the check to `lint.yml`
+  # alone. This is the answer #131 asks for instead: give the service the
+  # clone, so the hook runs everywhere the others do
+  submodules: true
+  # the one hook pre-commit.ci cannot run, and the only entry this list
+  # may ever have without a reason of the same kind: pyroma rates the
+  # metadata of the source tree, which means building that metadata, and
+  # pre-commit.ci runs hooks with no network at all -- so the isolated
+  # build cannot fetch hatchling to prepare it, and the fallback to a
+  # non-isolated one has no backend in the hook environment either. The
+  # lint workflow runs this same file with a network, so what is skipped
+  # here is one of the hook's two runners rather than the hook: it still
+  # gates a commit on this machine and a pull request in that workflow
+  skip: [pyroma]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,24 +23,31 @@ ci:
   # request with nowhere to land
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
-  # `submodule-pin` reads the vendored clone, and pre-commit.ci checks out
-  # no submodule unless asked: the run against #127 went red there with
-  # that hook's own "the vendored clone has no v0.8.0 tag" while every
-  # other hook passed. #130 answered it by skipping the hook, which is the
-  # cheaper answer and the worse one -- it leaves the check to `lint.yml`
-  # alone. This is the answer #131 asks for instead: give the service the
-  # clone, so the hook runs everywhere the others do
-  submodules: true
-  # the one hook pre-commit.ci cannot run, and the only entry this list
-  # may ever have without a reason of the same kind: pyroma rates the
-  # metadata of the source tree, which means building that metadata, and
-  # pre-commit.ci runs hooks with no network at all -- so the isolated
-  # build cannot fetch hatchling to prepare it, and the fallback to a
-  # non-isolated one has no backend in the hook environment either. The
-  # lint workflow runs this same file with a network, so what is skipped
-  # here is one of the hook's two runners rather than the hook: it still
-  # gates a commit on this machine and a pull request in that workflow
-  skip: [pyroma]
+  # the two hooks pre-commit.ci cannot run, each for something that
+  # service does not give a hook rather than for anything either hook
+  # does. pyroma rates the metadata of the source tree, which means
+  # building that metadata, and pre-commit.ci runs hooks with no network
+  # at all -- so the isolated build cannot fetch hatchling to prepare it,
+  # and the fallback to a non-isolated one has no backend in the hook
+  # environment either.
+  #
+  # submodule-pin resolves the release README.md names in the vendored
+  # clone's refs, and there are no refs to resolve it against there.
+  # `submodules: true` is the documented `ci:` key for that -- "whether to
+  # recursively check out submodules" -- and it was tried, on #132, rather
+  # than argued about: with it the clone arrives, and the hook still
+  # fails, now saying which of the three states it is in. "the vendored
+  # clone is shallow and carries no v0.8.0 tag". There is no `fetch-depth`
+  # key to ask that service for, so the key bought a clone nothing can use
+  # and is not kept. REPOSITORY.md records the residual gap.
+  #
+  # In both cases the lint workflow runs this same file with what the hook
+  # needs -- a network for the first, `submodules: true` and
+  # `fetch-depth: 0` for the second -- so what is skipped here is one of
+  # two runners rather than the hook: each still gates a commit on this
+  # machine and a pull request in that workflow, which is the required
+  # check. An entry may join them for a reason of that kind and no other
+  skip: [pyroma, submodule-pin]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1243
+        "line_number": 1257
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T11:54:55Z"
+  "generated_at": "2026-08-12T12:11:01Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,13 +415,27 @@ release-notes length in the first place, and are still in
 - **`submodule-pin` is skipped on pre-commit.ci**, which is the second
   entry that list has ever had and was found the way the first one's
   reason would have been: the pull request adding the hook went red
-  there, with the hook's own "the vendored clone has no v0.8.0 tag",
-  while every other hook passed. pre-commit.ci's checkout carries no
-  vendored clone with tags in it, the same way it carries no network for
-  `pyroma`, so what is skipped is one of the hook's two runners and not
-  the hook — `lint.yml` asks for `submodules: true` and `fetch-depth: 0`
-  precisely so that the runner which is a required check has what the
-  hook needs, and a commit on a developer's machine has it too
+  there, with the hook's own message, while every other hook passed
+  (#130). Skipping was the cheap answer, and #131 asked for the other
+  one — `submodules: true`, a documented key of the `ci:` block — so it
+  was tried rather than argued about (#132). With it the clone arrives
+  and the hook fails all the same: **the vendored clone is shallow and
+  carries no `v0.8.0` tag**, and there is no `fetch-depth` key to ask
+  that service for. So the key bought a clone nothing can use and is not
+  kept, the skip stays, and REPOSITORY.md now records the gap beside the
+  checks the branch rule deliberately leaves out — one third-party check
+  this repository cannot make agree with `lint.yml`. What it costs is one
+  of the hook's two runners: the required one, `Lint and type-check`,
+  checks the submodule out with `fetch-depth: 0` precisely so it has what
+  the hook needs, and a developer's own commit has it too
+- **The hook says which of the three states a clone without the tag is
+  in**: not checked out, checked out but shallow, or a full clone that
+  simply lacks the tag — one sentence each, each naming what would change
+  it. One message covered all three and told them apart for nobody, which
+  is fine for a developer, who has one of them and knows which, and not
+  fine for a checkout somebody else makes, where which one it is *is* the
+  finding. That is exactly how the pre-commit.ci answer above stopped
+  being an inference: the second run of #132 came back naming `shallow`
 - **Every required check names the app that produces it.** `test: every
   job passed` and `codeql: every job passed` carried `app_id: 15368` and
   the other two carried none, which REPOSITORY.md recorded as a rule that

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -44,6 +44,22 @@ without the rule changing, which is worth knowing before renaming
 anything — a context is matched by name, not by the workflow that reported
 it, so moving a job is free and renaming one is not.
 
+`pre-commit.ci` is not in the rule either, and it is the one check here
+this repository cannot make agree with `lint.yml`. It runs the hooks of
+`.pre-commit-config.yaml` from a checkout of its own, and one hook needs
+more than that checkout gives: `submodule-pin` resolves the release
+`README.md` names in the vendored clone's refs. `submodules: true` under
+`ci:` is the documented key for the clone, and it was tried on #132 rather
+than reasoned about — with it the submodule arrives and the hook still
+fails, `the vendored clone is shallow and carries no v0.8.0 tag`. There is
+no `fetch-depth` key to ask that service for, so the hook is in the `ci:`
+`skip` list beside `pyroma`, which needs a network that service also does
+not give. What that costs is one of the hook's two runners: the one the
+rule names, `Lint and type-check`, checks the submodule out with
+`fetch-depth: 0` precisely so it has what the hook needs, and so does a
+developer's own commit. Re-read that skip list before adding to it: an
+entry may join for a reason of that kind and no other.
+
 Neither `macos.yml`, `latest.yml`, `links.yml`, `mutation.yml`,
 `published.yml` nor `vendored-vectors.yml` appears in the rule, and none of
 them must: each is expected to go red for a reason no pull request

--- a/tests/test_submodule_pin.py
+++ b/tests/test_submodule_pin.py
@@ -137,14 +137,45 @@ def test_a_readme_naming_no_release_fails(
     assert "links to no libsecp256k1 release" in capsys.readouterr().err
 
 
-def test_a_submodule_nobody_initialized_fails(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize(
+    "answers, expected",
+    [
+        ({}, "is not checked out"),
+        ({"--git-dir": ".git", "--is-shallow-repository": "true"}, "is shallow"),
+        (
+            {"--git-dir": ".git", "--is-shallow-repository": "false"},
+            "neither absent nor shallow",
+        ),
+    ],
+)
+def test_a_clone_without_the_tag_says_which_of_the_three_it_is(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    answers: dict[str, str],
+    expected: str,
 ) -> None:
-    """A clone without the tag says how to get one, rather than passing."""
+    """No tag has three causes, and one message for all three said none.
+
+    A developer has one of the three and knows which; a checkout somebody
+    else makes does not, and there which one it is *is* the finding. It
+    was pre-commit.ci that made that concrete: told to take the submodule
+    it takes it, and the hook failed anyway with a message that could not
+    say whether the clone was missing or merely shallow.
+
+    Args:
+        monkeypatch: the fixture the substitutions are made through.
+        tmp_path: where the README the check reads is written.
+        capsys: the captured streams.
+        answers: what git answers each question, by its last argument; a
+            question missing from it is a git that exited non-zero.
+        expected: the clause the message has to carry.
+    """
     _tree(monkeypatch, tmp_path, tagged=None)
+    monkeypatch.setattr(check, "_git", lambda *args, **_kwargs: answers.get(args[-1]))
 
     assert check.main() == 1
-    assert "git submodule update --init" in capsys.readouterr().err
+    assert expected in capsys.readouterr().err
 
 
 def test_a_tree_with_no_submodule_fails(


### PR DESCRIPTION
Closes #131.

#131 named one concrete step — `submodules: true` under `ci:`, the
documented key: *"whether to recursively check out submodules"* — and one
open question the documentation cannot answer: whether that checkout
carries tags, which is what the hook actually needs. This pull request
tried the step and answered the question, and the answer is the second
branch of the issue's own proposal.

## The measurement

The first push added `submodules: true` and took `submodule-pin` out of
`skip`. pre-commit.ci came back red with the same sentence as before, and
that sentence could not say whether the submodule was missing or merely
shallow — reading a diagnosis into it would have been inference, where
#131 asks for a fact.

So the second push made the hook say which of the three states it is in:
no git dir, a shallow clone, or a full clone that simply lacks the tag.
The run then said it:

> the vendored clone is shallow and carries no v0.8.0 tag: git -C
> secp256k1 fetch --unshallow --tags, or check the submodule out with
> fetch-depth 0

So `submodules: true` does what it says — the clone arrives — and it is
not enough, because there is no `fetch-depth` key to ask that service
for. The option bought a clone nothing here can use, and it goes back
out; `skip: [pyroma, submodule-pin]` stays as #130 left it.

## What lands

- **the record #131 asks for in that case.** REPOSITORY.md now names
  pre-commit.ci beside the checks the branch rule deliberately leaves
  out, as the one third-party check this repository cannot make agree
  with `lint.yml`, with what was tried and what it costs: one of the
  hook's two runners, where the required one has `fetch-depth: 0`
  precisely so it does not.
- **the three-way diagnostic**, which is worth keeping on its own: one
  message for three states told them apart for nobody. It is fine for a
  developer, who has one of them and knows which; it is not fine for a
  checkout somebody else makes, where which one it is *is* the finding.
  Three parametrized cases hold it.
- the `ci:` comment and the changelog say all of the above, so the next
  reader does not re-run the experiment.

## Checked

`pre-commit run --all-files` green, `pytest --cov` 433 passed at 100.00%,
`sphinx-build -W --keep-going` succeeded — all on the final commit.

pre-commit.ci will be red on this pull request and green once it lands:
the run that measures the gap is made with the skip removed, which is the
state this branch does not keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)