### PR TITLE
Rename the repository to btclib-secp256k1, and the urls with it

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new
+    url: https://github.com/btclib-org/btclib-secp256k1/security/advisories/new
     about: >
       Never a public issue. Report it privately here, or by email as the
       security policy describes; a flaw in libsecp256k1 itself goes to

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: >
         Discussions are not enabled here, so a question is an issue. Check
-        the [README](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/README.md)
+        the [README](https://github.com/btclib-org/btclib-secp256k1/blob/main/README.md)
         first: it is the documentation of this package, and its Design and
         Wrapped modules sections answer most of what gets asked.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     # workflow, gets the build and stops there
     if: >-
       github.event_name == 'workflow_dispatch'
-      && github.repository == 'btclib-org/btclib-libsecp256k1'
+      && github.repository == 'btclib-org/btclib-secp256k1'
     needs: [test, lint, docs, macos]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -324,7 +324,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
-    if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-libsecp256k1'
+    if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-secp256k1'
     needs: [test, lint, docs, macos]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -9,7 +9,7 @@
   // and after the offending block
   // <!-- markdownlint-enable MD013 -->
 
-  // This file is the same in btclib, btclib-libsecp256k1 and
+  // This file is the same in btclib, btclib-secp256k1 and
   // bitcoin-core-rpc, deliberately: prose moves between the three, and a
   // paragraph that lints in one has to lint in the others. No rule is
   // disabled here -- what follows only names a style where markdownlint's

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1257
+        "line_number": 1282
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T12:11:01Z"
+  "generated_at": "2026-08-12T12:27:35Z"
 }

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@
 
 To see the list of btclib_secp256k1 authors for copyright purposes,
 see the revision history in source control:
-<https://github.com/btclib-org/btclib-libsecp256k1/graphs/contributors>
+<https://github.com/btclib-org/btclib-secp256k1/graphs/contributors>
 
 The vendored [libsecp256k1](https://github.com/bitcoin-core/secp256k1) is
 not this project's work: it is distributed under its own licence, by its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,16 +32,41 @@ release-notes length in the first place, and are still in
   to explain: the alternative is a distribution and a module that
   disagree forever, and 0.8.0 being unreleased is what makes this the
   cheapest it will ever be. Everything inside the API is untouched.
-- **What deliberately did not change.** The repository stays
-  `btclib-org/btclib-libsecp256k1`, so every url naming it — source,
-  issues, releases, advisories, and the branch-protection and
-  code-scanning API paths REPOSITORY.md is written in — is what it was;
-  `bitcoin-core-rpc` settled that one, having renamed the same way and
-  kept its repository. The vendored library keeps its own name wherever
-  it is the subject: the submodule, the headers the cdef is made of, the
-  `SECP256K1_*` build flags. And the entries of this file and of
-  HISTORY.md that describe releases made under the old name still name
-  it, being the record of what happened rather than of what is true now.
+- **The repository is renamed too**, to `btclib-org/btclib-secp256k1`.
+  That was left out of the first pass on the `bitcoin-core-rpc`
+  precedent, which renamed the same way and kept its repository, so that
+  no url naming it would move; it is in now because a repository called
+  after a distribution that no longer exists is the same confusion one
+  level up. GitHub redirects the old paths, the api included — a `GET` on
+  `repos/btclib-org/btclib-libsecp256k1` answers with the new
+  `full_name`, and `gh` resolves it to the numeric id — so nothing
+  outside this tree breaks on the day, and every url inside it is updated
+  regardless: an address that answers through a redirect is still the
+  wrong address to publish.
+- **Two lines of `release.yml` were the reason to do it carefully**, and
+  no redirect covers them: `github.repository == 'btclib-org/…'` guards
+  both publish jobs, and an exact comparison against a name the
+  repository no longer has does not fail — it evaluates false and the
+  jobs are *skipped*. A release would have built the whole matrix,
+  collected every artifact, and published nothing, in green.
+- **The trusted publisher is bound to the repository**, which is the
+  other half of the same care: the OIDC claim carries it, and this file
+  already records a stale registration surviving one rename and costing
+  0.7.1.2 an `invalid-publisher` at the token exchange. The pending
+  publishers for the new distribution have to name the new repository.
+- **No published artifact carries a GitHub attestation yet**, so
+  `SECURITY.md`'s verify command takes the new name with no caveat:
+  measured rather than assumed — `attest` landed in #113 on 11 August,
+  two days after v0.7.1.3, and `gh attestation verify` on that release's
+  sdist answers 404 under either name. The first attested release is
+  0.8.0.
+- **What deliberately did not change.** The vendored library keeps its
+  own name wherever it is the subject: the submodule, the headers the
+  cdef is made of, the `SECP256K1_*` build flags. And the entries of this
+  file and of HISTORY.md that describe releases made under the old
+  distribution name, or quote a command carrying the old repository,
+  still do: they are the record of what happened rather than of what is
+  true now.
 - **Nothing bridges the two names on PyPI**, by decision. A final
   `btclib-libsecp256k1` depending on the new distribution would make
   `pip install btclib-libsecp256k1` resolve forward; what it would also

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ libsecp256k1 release rather than the calendar. -->
 [![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/)
 [![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
 [![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-[![GitHub repository: btclib-org/btclib-libsecp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-libsecp256k1/)
+[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
 [![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 Thank you for investing your time in this project. What follows is how to
@@ -49,10 +49,10 @@ A vulnerability is never an issue: see the
 
 ## Opening an issue
 
-Search the [issues](https://github.com/btclib-org/btclib-libsecp256k1/issues)
-and [pull requests](https://github.com/btclib-org/btclib-libsecp256k1/pulls)
+Search the [issues](https://github.com/btclib-org/btclib-secp256k1/issues)
+and [pull requests](https://github.com/btclib-org/btclib-secp256k1/pulls)
 first, then use one of the
-[forms](https://github.com/btclib-org/btclib-libsecp256k1/issues/new/choose).
+[forms](https://github.com/btclib-org/btclib-secp256k1/issues/new/choose).
 The bug form asks which of the three artifacts is installed — a static
 wheel, a dynamic one, or a build from the sdist — because they differ in
 how libsecp256k1 is linked and a bug is rarely in all three.
@@ -579,4 +579,4 @@ Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.
 
 Once merged, your contribution is visible on the
-[contributors page](https://github.com/btclib-org/btclib-libsecp256k1/graphs/contributors).
+[contributors page](https://github.com/btclib-org/btclib-secp256k1/graphs/contributors).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,8 +39,13 @@ answered wrongly now raise instead.
   two can be installed at once while a codebase moves, the import package
   having been renamed with the distribution, so neither shadows the
   other. The documentation moves with it, to
-  [btclib-secp256k1.readthedocs.io](https://btclib-secp256k1.readthedocs.io);
-  the repository keeps its name, so every url naming it is unchanged.
+  [btclib-secp256k1.readthedocs.io](https://btclib-secp256k1.readthedocs.io),
+  and so does the repository, which is now
+  [btclib-org/btclib-secp256k1](https://github.com/btclib-org/btclib-secp256k1).
+  GitHub redirects every old path to it — a clone, a fetch, a bookmark
+  and the api alike — so nothing has to be changed to keep working; a
+  remote is worth repointing anyway, so that what it prints is where it
+  goes.
 - **Silent Payments are wrapped**, as `silentpayments`, BIP352's new
   libsecp256k1 module: `create_outputs` pays a list of addresses from the
   private keys of a transaction's inputs, `prevouts_summary` and

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ bitcoin-core-rpc carry the same three lines. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib_secp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_secp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib_secp256k1)](https://pepy.tech/project/btclib_secp256k1)
 [![development status](https://img.shields.io/pypi/status/btclib_secp256k1.svg)](https://pypi.python.org/pypi/btclib_secp256k1/)
-[![license](https://img.shields.io/github/license/btclib-org/btclib-libsecp256k1.svg)](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/btclib-org/btclib-secp256k1.svg)](https://github.com/btclib-org/btclib-secp256k1/blob/main/LICENSE)
 [![supported Python versions](https://img.shields.io/pypi/pyversions/btclib_secp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib_secp256k1/)
 
-[![test workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/test.yml)
-[![lint workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/lint.yml)
-[![docs workflow status](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib-libsecp256k1/actions/workflows/docs.yml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-libsecp256k1/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-libsecp256k1/main)
+[![test workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/test.yml)
+[![lint workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/lint.yml)
+[![docs workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/docs.yml)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-secp256k1/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-secp256k1/main)
 [![documentation build](https://readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
 
-[![GitHub repository: btclib-org/btclib-libsecp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-libsecp256k1/)
+[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
 [![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---
@@ -246,7 +246,7 @@ type, a length, or a magnitude, all of which the caller knows already —
 so the constant-time guarantee is the C call's, and it is intact. What
 python cannot give back is what happens on either side of that call:
 `bytes` is not zeroized either, and
-[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/SECURITY.md)
+[SECURITY.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/SECURITY.md)
 records both limits as inherent.
 
 And there is a way past all of it: `lib` and `ffi` are exported, and a
@@ -389,7 +389,7 @@ attributes a message to the right caller.
 
 What is not protected is the secret material itself, which lives in
 Python objects for as long as the interpreter keeps them: see
-[SECURITY.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/SECURITY.md).
+[SECURITY.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/SECURITY.md).
 
 ## The vendored library is not optional
 
@@ -467,7 +467,7 @@ x86_64 only.
 How to get the submodule, set up the development environment, run the
 suite and the benchmarks, reproduce each CI job locally, and what a
 change is expected to satisfy are in
-[CONTRIBUTING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/CONTRIBUTING.md).
 
 ## Release process
 
@@ -482,4 +482,4 @@ without the index.
 
 The steps to cut a release, to rehearse one on TestPyPI, and the
 one-time setup each index needs are in
-[RELEASING.md](https://github.com/btclib-org/btclib-libsecp256k1/blob/main/RELEASING.md).
+[RELEASING.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -274,7 +274,7 @@ Then:
    there, this one says where it came from:
 
    ```shell
-   repo=btclib-org/btclib-libsecp256k1
+   repo=btclib-org/btclib-secp256k1
    dir=$(mktemp -d)
    gh release download v0.7.1 --repo "$repo" --dir "$dir"
    gh attestation verify "$dir/btclib_secp256k1-0.7.1.tar.gz" \
@@ -394,7 +394,7 @@ without rebuilding anything.
    what asks for it.
 
    ```shell
-   repo=btclib-org/btclib-libsecp256k1
+   repo=btclib-org/btclib-secp256k1
    dir=$(mktemp -d)
    gh run download <run id> --repo "$repo" --name sdist --dir "$dir"
    gh attestation verify "$dir"/*.tar.gz \
@@ -447,7 +447,7 @@ registration before the release needs it.
 The rest of this section is here for the next index, or the next fork.
 
 - on PyPI, and on TestPyPI, project Publishing settings: add a GitHub
-  trusted publisher for `btclib-org/btclib-libsecp256k1`, workflow
+  trusted publisher for `btclib-org/btclib-secp256k1`, workflow
   `release.yml`, environment `pypi` and `testpypi` respectively. The two
   indexes are separate accounts and separate registrations, and separate
   credentials with them, TestPyPI being its own deployment of Warehouse

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -26,7 +26,7 @@ workflows with a job named the same thing produce one ambiguous check.
 What the rule holds is read from the endpoint, never assumed:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
+gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
   --jq '.required_status_checks'
 ```
 
@@ -79,19 +79,19 @@ having run. A `PATCH` dates that sentence, so read it back rather than
 trust it:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/branches/main/protection \
+gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
   --jq '[.required_status_checks.checks[] | {context, app_id}]'
 ```
 
 Which app reported what is read from the commit rather than assumed:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
+gh api repos/btclib-org/btclib-secp256k1/commits/<sha>/check-runs \
   --jq '.check_runs[] | {name, app: .app.slug, app_id: .app.id}'
 ```
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha>/check-runs \
+gh api repos/btclib-org/btclib-secp256k1/commits/<sha>/check-runs \
   --jq '[.check_runs[] | {name, app: .app.slug}] | unique_by(.app)'
 ```
 
@@ -112,7 +112,7 @@ diff. What the setting holds is read from the endpoint, `state` being the
 field that says whether it holds anything:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup
+gh api repos/btclib-org/btclib-secp256k1/code-scanning/default-setup
 ```
 
 Turning the setting off takes `state` and nothing else — the languages, the
@@ -121,7 +121,7 @@ going to run:
 
 ```shell
 gh api -X PATCH \
-  repos/btclib-org/btclib-libsecp256k1/code-scanning/default-setup \
+  repos/btclib-org/btclib-secp256k1/code-scanning/default-setup \
   -F state=not-configured
 ```
 
@@ -147,7 +147,7 @@ log, where the security analysis produced `python.sarif`. That is a
 separate setting, and the endpoint above does not report it:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/actions/workflows \
+gh api repos/btclib-org/btclib-secp256k1/actions/workflows \
   --jq '.workflows[] | select(.path | startswith("dynamic/"))
         | {name, path, state}'
 ```
@@ -156,7 +156,7 @@ What the file asks for is read off its own triggers; what was actually
 analyzed, and under which ref and category, is the API's answer:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/code-scanning/analyses \
+gh api repos/btclib-org/btclib-secp256k1/code-scanning/analyses \
   --jq '.[] | {ref, category, analysis_key, created_at}'
 ```
 
@@ -221,7 +221,7 @@ admin bypass is the only way past it without a second maintainer to add.
 
 ```shell
 gh api -X DELETE \
-  repos/btclib-org/btclib-libsecp256k1/branches/main/protection/enforce_admins
+  repos/btclib-org/btclib-secp256k1/branches/main/protection/enforce_admins
 ```
 
 Turned off after being on through the 0.7.1 release, whose squash merge
@@ -238,7 +238,7 @@ One protected branch is the whole of it, which is a consequence of there
 being one long-lived branch:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/branches \
+gh api repos/btclib-org/btclib-secp256k1/branches \
   --jq '.[] | "\(.name) protected=\(.protected)"'
 ```
 
@@ -253,7 +253,7 @@ reaches `main` through the rules above.
 `delete_branch_on_merge` is on, since 7 August 2026:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1 --jq '.delete_branch_on_merge'
+gh api repos/btclib-org/btclib-secp256k1 --jq '.delete_branch_on_merge'
 ```
 
 GitHub deletes the head branch of a pull request when it is merged, which
@@ -276,7 +276,7 @@ is protected now.
 convention CONTRIBUTING.md states:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1 \
+gh api repos/btclib-org/btclib-secp256k1 \
   --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
 ```
 
@@ -299,7 +299,7 @@ preselect, and nothing to read before pressing.
 `allow_auto_merge` is on, since 11 August 2026:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1 --jq '.allow_auto_merge'
+gh api repos/btclib-org/btclib-secp256k1 --jq '.allow_auto_merge'
 ```
 
 It bypasses nothing, and it is not the admin escape hatch above: GitHub
@@ -318,7 +318,7 @@ being true — `--rebase --admin` replays the author's commits as they were,
 unsigned — so the check is worth making on whatever landed:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/commits/<sha> \
+gh api repos/btclib-org/btclib-secp256k1/commits/<sha> \
   --jq '.commit.verification | {verified, reason}'
 ```
 
@@ -339,7 +339,7 @@ gh pr view <n> --json autoMergeRequest
 needing more declares it:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/actions/permissions/workflow \
+gh api repos/btclib-org/btclib-secp256k1/actions/permissions/workflow \
   --jq '.default_workflow_permissions'   # "read"
 ```
 
@@ -356,7 +356,7 @@ braces; keep it, it is what makes the intent readable where the job is.
 Both environments require a review, so an upload waits for a person:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/environments \
+gh api repos/btclib-org/btclib-secp256k1/environments \
   --jq '.environments[] | {name, protection_rules}'
 ```
 
@@ -415,7 +415,7 @@ saying nothing. Dependabot security updates are on.
 Some settings cannot be enabled and fail silently:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1 --jq '.security_and_analysis'
+gh api repos/btclib-org/btclib-secp256k1 --jq '.security_and_analysis'
 ```
 
 Secret scanning and push protection are enabled;
@@ -457,7 +457,7 @@ Unlike btclib, this repository serves no GitHub Pages site, so no file in
 its root is a URL anywhere:
 
 ```shell
-gh api repos/btclib-org/btclib-libsecp256k1/pages   # 404
+gh api repos/btclib-org/btclib-secp256k1/pages   # 404
 ```
 
 btclib.org is built from the btclib repository's `main` root, which is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,7 @@ The sdist is also attached to the GitHub release, and that copy carries a
 build provenance attestation of its own, signed in the run that built it:
 
 ```shell
-repo=btclib-org/btclib-libsecp256k1
+repo=btclib-org/btclib-secp256k1
 gh attestation verify btclib_secp256k1-<version>.tar.gz \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,15 @@ homepage = "https://btclib.org"
 # of docs/source, the README included in its toctree rather than left as
 # the whole of the documentation
 documentation = "https://btclib-secp256k1.readthedocs.io"
-repository = "https://github.com/btclib-org/btclib-libsecp256k1"
-download = "https://github.com/btclib-org/btclib-libsecp256k1/releases"
+repository = "https://github.com/btclib-org/btclib-secp256k1"
+download = "https://github.com/btclib-org/btclib-secp256k1/releases"
 # HISTORY.md and not CHANGELOG.md: this url is what an index puts behind
 # "Changelog", and what a user following it wants is the release notes,
 # not the record behind them. CHANGELOG.md is linked from the first line
 # of that file
-changelog = "https://github.com/btclib-org/btclib-libsecp256k1/blob/main/HISTORY.md"
-issues = "https://github.com/btclib-org/btclib-libsecp256k1/issues"
-pull_requests = "https://github.com/btclib-org/btclib-libsecp256k1/pulls"
+changelog = "https://github.com/btclib-org/btclib-secp256k1/blob/main/HISTORY.md"
+issues = "https://github.com/btclib-org/btclib-secp256k1/issues"
+pull_requests = "https://github.com/btclib-org/btclib-secp256k1/pulls"
 
 [build-system]
 # cmake builds the vendored library: it is a build requirement, not a


### PR DESCRIPTION
The repository is already renamed — `btclib-org/btclib-secp256k1`, same
id `426693723` — and this is the tree catching up.

#122's first pass left it alone, on the `bitcoin-core-rpc` precedent:
that project renamed the same way and kept its repository, so no url
naming it moved. A repository called after a distribution that no longer
exists is the same confusion one level up, so it moves too.

GitHub redirects every old path, the api included: a `GET` on
`repos/btclib-org/btclib-libsecp256k1` answers with the new `full_name`,
and `gh` resolves it to the numeric id. Nothing outside this tree breaks
today. Every url inside it moves regardless — an address that answers
through a redirect is still the wrong address to publish.

## The two lines no redirect covers

```yaml
&& github.repository == 'btclib-org/btclib-libsecp256k1'
```

That guards both publish jobs in `release.yml`. An exact comparison
against a name the repository no longer has does not fail: it evaluates
false and the jobs are **skipped**. A release would have built the whole
matrix, collected every artifact and published nothing, in green. They
are the reason to do this in a commit rather than to let the redirect
carry it.

## Measured rather than assumed

`SECURITY.md`'s `gh attestation verify --repo` takes the new name with no
caveat about artifacts published earlier, because there are none:
`attest` landed in #113 on 11 August, two days after v0.7.1.3, and
`gh attestation verify` on that release's sdist answers 404 under either
name. The first attested release is 0.8.0.

## What keeps the old name, on purpose

The distribution, in the entries describing releases made under it; the
TestPyPI account history in `RELEASING.md`; and the one changelog line
quoting an `attestation verify` command as it was written. Those are the
record of what happened.

## What a commit cannot do

The trusted publisher carries the repository in its OIDC claim. The
pending registrations for `btclib-secp256k1` on PyPI and TestPyPI have to
name `btclib-org/btclib-secp256k1`, or the release run reaches the token
exchange and stops at `invalid-publisher` having built everything —
`RELEASING.md` already records that happening once, behind the previous
rename.

## Checked

`pre-commit run --all-files` green, `pytest --cov` 433 passed at 100.00%,
`sphinx-build -W --keep-going` succeeded, all on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the project repository to btclib-org/btclib-secp256k1 and update references across documentation, metadata, and CI to match.

Enhancements:
- Align project metadata in pyproject.toml and badges with the new repository name, and document the repository rename and its implications in the changelog.

CI:
- Adjust release workflow conditions and issue templates so publishing jobs, security advisories, and issue forms target the renamed btclib-org/btclib-secp256k1 repository.

Documentation:
- Update README, CONTRIBUTING, HISTORY, CHANGELOG, RELEASING, REPOSITORY, SECURITY, and AUTHORS docs to point to the new btclib-org/btclib-secp256k1 repository and related URLs while preserving historical references to the old distribution name where appropriate.