### PR TITLE
0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
-## v0.8.0 (work in progress, not released yet)
+## v0.8.0
 
 ### The name
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.8.0 (work in progress, not released yet)
+## v0.8.0
 
 [libsecp256k1 0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)
 (6e2c8bc), up from 0.7.1: a minor version of the wrapped library, so a


### PR DESCRIPTION
libsecp256k1 moves from 0.7.1 to [0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0), and this bindings package with it. What a user notices: the package itself is renamed, `btclib_libsecp256k1` to `btclib_secp256k1` (README's "The name" section has the two-line diff); besides that, one breaking change for a caller reaching through `lib` (two removed deprecated symbols) and two arguments that used to be answered wrongly now raise instead. Silent Payments (BIP352) are wrapped, as `silentpayments`. Full detail in the closed sections of [HISTORY.md](../blob/main/HISTORY.md) and [CHANGELOG.md](../blob/main/CHANGELOG.md).

What did not move: everything inside the API besides the two behavior fixes above — modules, functions, `ffi` and `lib` are what they were.

`latest` was dispatched on `main` before this PR: [run 31606380835](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31606380835), red on `uv-lock` — sqlalchemy, tomlkit, types-setuptools and typing-inspection all have newer releases than `uv.lock` pins. It gates nothing and this release ships what the lock pins; it says the next dependency bump is work, not that this tree is wrong.

`mutation` is not owed for this cycle: #134 already ran one by hand on 2026-08-12 and recorded its one equivalent-mutant finding.

Two things outside this tree, both still open as of this PR:
- the PyPI and TestPyPI trusted publisher for the renamed project (`btclib-secp256k1`) — neither index has a project under that name yet (both answer 404), so whether the pending-publisher registration is done is what the TestPyPI rehearsal after this merges will answer
- the Read the Docs project behind the new slug — `btclib-secp256k1.readthedocs.io` answers 404 today

Everything merged since v0.7.1.3:

```
6c7f019 Rename the repository to btclib-secp256k1, and the urls with it (#133)
4a0d41b Try submodules: true on pre-commit.ci, and record that it is not enough (#132)
c314385 Rename the package to btclib_secp256k1 (#129)
80e63e3 Skip submodule-pin on pre-commit.ci, which has no vendored clone (#130)
d53f142 Check the submodule pin on every commit, and its signature monthly (#127)
5a1b39a Document the review requirement and main's signature ruleset
a4074c2 Correct three comments that had stopped being the reason (#125)
3b3e4f2 Refuse a memoryview of wider items, and wipe a half-built label cache (#124)
111858e Make squash the only merge method, and say so where it is decided (#123)
453e99b Bind the last two required checks, and say the rule is uniform now
93d672b Record auto-merge, and the method it commits to in advance
9482f02 Refuse a tag whose release notes are still titled "work in progress"
331c55a Stop the CodeQL prose claiming a refusal that never happened (#118)
e37669e Sign the release tag, and verify it before pushing it (#117)
4f7b710 Pin CodeQL to a workflow in the tree (#114)
4d4bd30 Correct the two cadences the schedules already contradicted (#116)
ea9f3f1 Stop naming dev and master, the branches this repository no longer keeps (#115)
bc135bf Sign the sdist the GitHub release attaches (#113)
b099966 Build the docs on one interpreter, here and on the website (#112)
47450ce Leave dependabot's target to its default, and match btclib's file (#111)
9abcde1 Kill the three silentpayments mutants no test noticed (#110)
ecec527 Ignore .venv-3.10, so the sdist stops shipping it (#109)
38ee75b Wrap the silentpayments module of libsecp256k1 0.8.0, as BIP352 (#108)
4993760 Update the lock: pre-commit 4.6.2 and virtualenv 21.7.4
534f5f3 Move the vendored libsecp256k1 to 0.8.0, and the version with it
35c6931 Move macOS off the merge gate, and name every CI job
d4a7034 Point dependabot.yml at main, not the deleted dev
d8b44f6 Track the editor's workspace, and format yaml, toml and jsonc (#100)
23623ba Update the pinned tooling, hook revisions and lock (#101)
4c5fc70 Carry the draft condition into the workflows that lacked it
6297737 Exempt the release pull request from the draft condition
610ba30 Put the condition after the whole name, block scalar included
6f8dd60 Stop spending the matrix on a draft pull request
8f8b133 Say where CHANGELOG.md starts, not how many releases it holds
27d45a2 Open 0.7.1.4
```