### PR TITLE
Open 0.8.0.1

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1282
+        "line_number": 1284
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T12:27:35Z"
+  "generated_at": "2026-08-12T17:24:39Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
+## v0.8.0.1 (work in progress, not released yet)
+
 ## v0.8.0
 
 ### The name

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
+## v0.8.0.1 (work in progress, not released yet)
+
 ## v0.8.0
 
 [libsecp256k1 0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btclib_secp256k1"
-version = "0.8.0"
+version = "0.8.0.1"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ wheels = [
 
 [[package]]
 name = "btclib-secp256k1"
-version = "0.8.0"
+version = "0.8.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
Step 10 of RELEASING.md, right after 0.8.0 shipped (https://github.com/btclib-org/btclib-secp256k1/releases/tag/v0.8.0): a placeholder fourth number, so the tree stops claiming a version it already published. The submodule has not moved since 0.8.0, so nothing renumbers this if a submodule bump lands before the next release — it stays 0.8.0.1.

## Summary by Sourcery

Introduce a placeholder 0.8.0.1 work-in-progress release and bump the project version accordingly.

New Features:
- Declare the upcoming 0.8.0.1 work-in-progress release in CHANGELOG and HISTORY.

Enhancements:
- Update the package version metadata to 0.8.0.1 in pyproject.toml to reflect the new placeholder release.