### PR TITLE
Add keys.PubkeyTweakChain, so a public derivation path parses once

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1284
+        "line_number": 1308
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T17:24:39Z"
+  "generated_at": "2026-08-13T11:51:10Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.1 (work in progress, not released yet)
 
+### Public key tweaking
+
+- **`keys.PubkeyTweakChain` adds a sequence of tweaks to a public key,
+  parsing it once** (#138), rather than once per tweak. `pubkey_tweak_add`
+  parses its argument and serializes its result on every call, which is
+  the right cost for one tweak and a wasted one for a caller who is about
+  to feed the result straight back in as the next call's argument — a
+  BIP32 path walked one unhardened index at a time, reported at
+  <https://github.com/btclib-org/btclib/issues/685>, needs exactly that:
+  each step's tweak is a hash of the previous step's serialized key, so
+  the bytes have to exist at every step, and the point they parse back
+  into is the one the step before had already built and only serialized
+  because its own caller — btclib's derivation loop — needed those bytes.
+  `PubkeyTweakChain` holds the parsed point across the calls instead: the
+  first tweak is the only one that pays for a parse, and every step still
+  returns the bytes its caller needs. `pubkey_tweak_add` itself is
+  unchanged in behaviour and cost, now sharing its point-addition step
+  with the chain through the new `pubkey_tweak_add_`, the inner half of
+  it that skips parsing and validating what the caller already has.
+  btclib decided against holding the parsed key itself and reaching for
+  `lib`/`ctx` directly, which would have left `_BIP32KeyData` holding a
+  cffi object where "the key is its serialization" is what keeps that
+  loop readable — hence the wrapper landing here rather than there.
+
 ## v0.8.0
 
 ### The name

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,13 @@ a tag is generated from.
 
 ## v0.8.0.1 (work in progress, not released yet)
 
+Non-breaking. `keys.PubkeyTweakChain` is new: it adds a sequence of
+tweaks to a public key, parsing the key once rather than once per tweak,
+for a caller who is about to feed each result back in as the next tweak's
+argument — a BIP32 public derivation path is exactly that. Nothing
+existing changes shape or cost: `pubkey_tweak_add` still parses and
+serializes on every call, which is the right cost for one tweak.
+
 ## v0.8.0
 
 [libsecp256k1 0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -168,13 +168,40 @@ def pubkey_negate(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
     return serialize(pubkey, compressed)
 
 
+def pubkey_tweak_add_(pubkey: CData, tweak_bytes: bytes) -> CData:
+    """Add the generator multiplied by the tweak, to an already-parsed key.
+
+    The inner half of `pubkey_tweak_add`, for a caller who already holds
+    both a parsed key and a validated tweak and so has no validation left
+    to redo: `PubkeyTweakChain` is the one, walking a BIP32 path one
+    tweak at a time without parsing the point back out of its own
+    serialization at every step.
+
+    Args:
+        pubkey: the already-parsed public key, as `parse` returns.
+            Mutated in place.
+        tweak_bytes: the tweak, already 32 bytes, as `scalar` returns.
+
+    Returns:
+        The same object passed in, tweaked.
+
+    Raises:
+        ValueError: if the tweak or the resulting public key is invalid.
+    """
+    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, tweak_bytes):
+        raise ValueError("invalid tweak or resulting public key")
+    return pubkey
+
+
 def pubkey_tweak_add(
     pubkey_bytes: BytesLike, tweak: BytesLike | int, compressed: bool = True
 ) -> bytes:
     """Add the generator multiplied by the tweak to a public key.
 
     This is the public-key side of BIP32 derivation: the key of
-    `prvkey_tweak_add(k, t)` is `pubkey_tweak_add(pubkey(k), t)`.
+    `prvkey_tweak_add(k, t)` is `pubkey_tweak_add(pubkey(k), t)`. Adding
+    more than one tweak to the same key is `PubkeyTweakChain`, which
+    parses the key once rather than once per tweak.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.
@@ -193,9 +220,67 @@ def pubkey_tweak_add(
     """
     pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
-    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, tweak_bytes):
-        raise ValueError("invalid tweak or resulting public key")
+    pubkey_tweak_add_(pubkey, tweak_bytes)
     return serialize(pubkey, compressed)
+
+
+class PubkeyTweakChain:
+    """Add a sequence of tweaks to a public key, parsing it only once.
+
+    `pubkey_tweak_add` parses its argument and serializes its result, so
+    a caller adding tweak after tweak to its own output -- a BIP32 path
+    walked one index at a time, each needing the previous step's
+    serialized key to hash into the next tweak -- re-parses at every step
+    the very point the step before had already built, and only
+    serialized because *that* step's caller needed the bytes. This holds
+    the parsed point across the calls instead: the first tweak is the
+    only one that pays for a parse, and every step still returns the
+    bytes its caller needs.
+
+    Args:
+        pubkey_bytes: the public key the chain starts from, 33 or 65
+            bytes.
+
+    Raises:
+        ValueError: if the public key is not a valid point.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, mult
+        >>> generator = mult.mult_(1)
+        >>> chain = keys.PubkeyTweakChain(generator)
+        >>> step1 = chain.tweak_add(2)
+        >>> step2 = chain.tweak_add(3)
+        >>> step1 == keys.pubkey_tweak_add(generator, 2)
+        True
+        >>> step2 == keys.pubkey_tweak_add(step1, 3)
+        True
+    """
+
+    # pydoclint (DOC301) asks that this carry no docstring of its own,
+    # the class docstring above being where the constructor is documented
+    def __init__(self, pubkey_bytes: BytesLike) -> None:  # noqa: D107
+        self._pubkey = parse(pubkey_bytes)
+
+    def tweak_add(self, tweak: BytesLike | int, compressed: bool = True) -> bytes:
+        """Add the generator multiplied by the tweak, to the held key.
+
+        Args:
+            tweak: the tweak, 32 bytes or an int below 2**256.
+            compressed: whether to return 33 bytes rather than 65.
+
+        Returns:
+            The serialized point, with this tweak and every earlier one
+            already added.
+
+        Raises:
+            ValueError: if the tweak is not 32 bytes or does not fit in
+                them, or if the tweak or the resulting key is invalid.
+            RuntimeError: if libsecp256k1 fails to serialize the result,
+                which no valid input can make it do.
+        """
+        tweak_bytes = scalar(tweak, "tweak")
+        pubkey_tweak_add_(self._pubkey, tweak_bytes)
+        return serialize(self._pubkey, compressed)
 
 
 def pubkey_tweak_mul(

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -159,10 +159,22 @@ MODULES = {
     "xonly": xonly,
 }
 
-# the two that take no argument crossing as a bare pointer: `parse` takes
-# one and is covered through every wrapper above, `serialize` takes the
-# libsecp256k1 object `parse` hands back and no bytes at all
-NOT_SWEPT = {"keys.serialize", "keys.parse"}
+# the ones that take no argument crossing as a bare pointer, or nothing
+# this sweep has not already exercised: `parse` takes one and is covered
+# through every wrapper above, `serialize` takes the libsecp256k1 object
+# `parse` hands back and no bytes at all. `pubkey_tweak_add_` is the same
+# shape as `serialize`, an already-parsed key and the already-32-byte
+# output of `scalar`, neither retyped here. `PubkeyTweakChain` calls
+# `parse` on construction and `scalar` on every `tweak_add`, so its own
+# bytes-like handling is `keys.pubkey_tweak_add`'s above, not a call this
+# sweep can equality-check across instances that are never equal to begin
+# with
+NOT_SWEPT = {
+    "keys.serialize",
+    "keys.parse",
+    "keys.pubkey_tweak_add_",
+    "keys.PubkeyTweakChain",
+}
 
 
 def retyped(value: Any, kind: type) -> Any:

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -134,6 +134,41 @@ def test_pubkey_algebra() -> None:
         keys.pubkey_combine([pubkey_a, keys.pubkey_negate(pubkey_a)])
 
 
+def test_pubkey_tweak_chain() -> None:
+    """Chained tweaks match the same tweaks added one call at a time.
+
+    `PubkeyTweakChain` parses the starting key once and carries the
+    parsed point across every `tweak_add`, rather than `pubkey_tweak_add`
+    re-parsing what the step before it just serialized; the two are
+    checked to answer the same bytes at every step, compressed and
+    uncompressed both, and to refuse the same invalid tweak and the same
+    landing on the point at infinity.
+    """
+    pubkey_bytes = mult.mult_(3)
+    tweaks = (5, N - 1, 11)
+
+    chain = keys.PubkeyTweakChain(pubkey_bytes)
+    key = pubkey_bytes
+    for tweak in tweaks:
+        key = keys.pubkey_tweak_add(key, tweak)
+        assert chain.tweak_add(tweak) == key
+
+    # the uncompressed form, from a chain that has not run out of state
+    uncompressed_chain = keys.PubkeyTweakChain(pubkey_bytes)
+    assert uncompressed_chain.tweak_add(5, False) == keys.pubkey_tweak_add(
+        pubkey_bytes, 5, False
+    )
+
+    # an invalid starting key, an invalid tweak, and the one sum that has
+    # no public key, all refused the same way pubkey_tweak_add refuses them
+    with pytest.raises(ValueError, match="public key"):
+        keys.PubkeyTweakChain(b"\x02" + b"\x00" * 32)
+    with pytest.raises(ValueError, match="tweak must be 32 bytes"):
+        keys.PubkeyTweakChain(pubkey_bytes).tweak_add(b"\x01" * 33)
+    with pytest.raises(ValueError, match="tweak or resulting public key"):
+        keys.PubkeyTweakChain(mult.mult_(7)).tweak_add(N - 7)
+
+
 def test_pubkey_serialization() -> None:
     """Both serialized forms parse, and either converts to the other.
 


### PR DESCRIPTION
## Summary

- `keys.pubkey_tweak_add` parses its public key argument and serializes
  its result on every call. A BIP32 public derivation path walks one
  unhardened index at a time, and each step's tweak is a hash of the
  previous step's *serialized* key — so the bytes have to exist at every
  step, but the point they get parsed back into at the next step is the
  one the previous step had already built, and only serialized because
  its own caller needed the bytes. `cProfile` over a BIP44 address counts
  `secp256k1_ec_pubkey_parse` four times, two of them there.
- Adds `keys.PubkeyTweakChain`, which parses a public key once and holds
  the parsed point across a sequence of `tweak_add` calls, so only the
  first tweak of a chain pays for a parse.
- `pubkey_tweak_add` is unchanged in behaviour and cost; it now shares its
  point-addition step with the chain through a new `pubkey_tweak_add_`,
  the inner half of it that already has a parsed key and a validated
  tweak and so has no validation left to redo.

## Why here and not in btclib

Refs btclib-org/btclib#685, where the option of btclib holding the
parsed key itself and calling `lib`/`ctx` directly was decided against:
it would be the first place in that library to reach for the raw
bindings rather than a wrapper function, and it would put a cffi object
in `_BIP32KeyData`'s hands, or in a local across the derivation loop,
where "the key is its serialization" is what currently keeps that loop
readable. `PubkeyTweakChain` keeps the parsed state inside this package;
btclib calls it exactly as it calls every other wrapper here, seeing
only bytes in and bytes out.

## Test plan

- [x] `uv run pytest --cov` — 100% coverage, 434 passed
- [x] `uv run pre-commit run --all-files` — zero findings
- [x] `sphinx-build -W --keep-going` — builds clean, new class and
      function documented via the existing `keys` automodule page
- [x] New `test_pubkey_tweak_chain` checks the chain against the same
      tweaks applied one `pubkey_tweak_add` call at a time, compressed
      and uncompressed, and the same three refusals (invalid starting
      key, invalid tweak, landing on the point at infinity)
- [x] `PubkeyTweakChain` and `pubkey_tweak_add_` added to
      `test_bytes_like.py`'s `NOT_SWEPT`, with the same reasoning already
      given there for `parse`/`serialize`: their bytes-like arguments are
      exercised through the wrappers they call, not through instance
      equality this sweep cannot check

No new libsecp256k1 call is wrapped here — same C function
(`secp256k1_ec_pubkey_tweak_add`), same math, restructured to parse once
per chain instead of once per call — so this doesn't add a case to
`tests/test_vectors.py`'s external-vector list; correctness rests on the
differential test against `pubkey_tweak_add`, which is itself vector-
tested elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reusable public-key tweak chain to support efficient BIP32-style public derivation without changing existing behaviour.

New Features:
- Add keys.PubkeyTweakChain to apply a sequence of tweaks to a public key while parsing the key only once.
- Expose an internal pubkey_tweak_add_ helper for reuse by both pubkey_tweak_add and PubkeyTweakChain.

Enhancements:
- Update pubkey_tweak_add to delegate its core point-addition logic to the new pubkey_tweak_add_ helper without altering its interface or cost.

Documentation:
- Document PubkeyTweakChain and the new tweak chaining behaviour in CHANGELOG.md and HISTORY.md for the upcoming v0.8.0.1 release.

Tests:
- Add test_pubkey_tweak_chain to validate chained tweaking against repeated pubkey_tweak_add calls, including compressed/uncompressed output and error conditions.
- Extend test_bytes_like NOT_SWEPT set to cover pubkey_tweak_add_ and PubkeyTweakChain, documenting why their bytes-like handling is exercised indirectly.