### PR TITLE
0.8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
-## v0.8.0.1 (work in progress, not released yet)
+## v0.8.0.1
 
 ### Public key tweaking
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.8.0.1 (work in progress, not released yet)
+## v0.8.0.1
 
 Non-breaking. `keys.PubkeyTweakChain` is new: it adds a sequence of
 tweaks to a public key, parsing the key once rather than once per tweak,


### PR DESCRIPTION
Non-breaking: `keys.PubkeyTweakChain` is new (#138), adding a sequence of tweaks to a public key while parsing it once rather than once per tweak — a BIP32 public derivation path walked one unhardened index at a time is exactly that caller. Nothing existing changes shape or cost: `pubkey_tweak_add` still parses and serializes on every call. Full detail in the closed sections of [HISTORY.md](../blob/main/HISTORY.md) and [CHANGELOG.md](../blob/main/CHANGELOG.md).

The submodule has not moved since 0.8.0 (still libsecp256k1 v0.8.0, 6e2c8bc), so no version renumbering and no README change.

No TestPyPI rehearsal for this one: nothing in `release.yml`, the packaging metadata or the build matrix changed, and RELEASING.md says a release that only bumps versions and notes (or, as here, adds pure-Python surface with no packaging change) does not need one.

`latest` was dispatched on `main` before this PR: [run 31715247228](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31715247228) (queued at the time of this PR; check the run for its result — it gates nothing either way).

Everything merged since v0.8.0:

```

```

## Summary by Sourcery

Documentation:
- Mark v0.8.0.1 as a released version in CHANGELOG and HISTORY and describe the new public key tweak chaining helper.