### PR TITLE
Fix github-release skipping every real release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,15 +433,35 @@ jobs:
   # what can already be installed, and the download url in pyproject.toml
   # points at the page this creates.
   # Both jobs above in `needs`, and not attest alone: attest runs in a
-  # rehearsal too, so naming it by itself would make this job -- which has
-  # no `if` of its own -- cut a release from a dispatch, where publish-pypi
-  # is skipped and a skipped need is what keeps this to the tag. attest
-  # earns its place in the list by producing the bundle attached below; a
-  # failure there leaves the version published and no release cut, which
-  # `gh run rerun --failed` finishes without rebuilding anything
+  # rehearsal too, so naming it by itself would make this job cut a
+  # release from a dispatch, where publish-pypi is skipped and a skipped
+  # need is what keeps this to the tag.
+  # The `if` is explicit and checks only these two `.result`s, which is
+  # not the same thing as leaving it to the implicit default -- this job
+  # used to, and that was a bug, not a simplification. attest's own `if`
+  # above is `always()`, so the implicit default here does not stop at
+  # this job's direct needs: with no arguments it looks at the whole
+  # dependency graph, and publish-testpypi -- two hops back, through
+  # attest's always()-guarded edge -- is *always* skipped on a real tag,
+  # only running on a dispatch. The implicit default treats a skipped
+  # job found that way the same as a failed direct need, so this job was
+  # skipped on every real release regardless of whether publish-pypi and
+  # attest themselves succeeded. They did, twice: v0.8.0 and v0.8.0.1
+  # both published clean and both left no GitHub release, which is how
+  # this was found. `needs.attest.result == 'success'` asks the one
+  # question that matters -- did the job actually succeed -- without
+  # asking the implicit default's much larger question about a job this
+  # one has no reason to care about.
+  # A failure in either named job still leaves the version published and
+  # no release cut, which `gh run rerun --failed` finishes without
+  # rebuilding anything, same as before this fix; what is different is
+  # that a *success* on both no longer risks a skip
   github-release:
     name: Attach the files to the GitHub release
     needs: [publish-pypi, attest]
+    if: >-
+      needs.publish-pypi.result == 'success' &&
+      needs.attest.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1310
+        "line_number": 1333
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T19:14:49Z"
+  "generated_at": "2026-08-13T19:45:12Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.2 (work in progress, not released yet)
 
+### CI
+
+- **`github-release` no longer risks a skip on a release that actually
+  succeeded.** Its `if` used to be the implicit default, and that default
+  has no arguments: it does not stop at this job's own `needs`
+  (`[publish-pypi, attest]`), it looks at the whole graph reachable
+  through them. `attest`'s own `if` is `always()`, needed so it can run
+  past a skipped sibling — `publish-testpypi` is always skipped on a real
+  tag, `publish-pypi` on a dispatch — and the implicit default treats a
+  skipped job found two hops back through that `always()`-guarded edge
+  the same as a failed direct one. That skipped `github-release` on every
+  real release regardless of what `publish-pypi` and `attest` themselves
+  did: both v0.8.0 and v0.8.0.1 published clean and neither produced a
+  GitHub release, found only because the release was missing rather than
+  because anything failed loudly. The `if` is explicit now,
+  `needs.publish-pypi.result == 'success' && needs.attest.result ==
+  'success'`, asking only the two questions this job has a reason to ask.
+  RELEASING.md's "Cutting a release" section carries the recovery this
+  cost both times — recreating the release by hand from the run's own
+  `sdist` and `attestation` artifacts — for a release that predates the
+  fix, or for a `github-release` failure of its own that `gh run rerun
+  --failed` still reaches directly
+
 ## v0.8.0.1
 
 ### Public key tweaking

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -276,19 +276,28 @@ Then:
    --failed` reruns the cell alone and it passes the second time
 1. check the GitHub release the workflow created once PyPI had accepted
    the upload — and check that it exists at all before reading anything
-   in it: `github-release` (`needs: [publish-pypi, attest]`, both of which
-   can be green) was left `skipped` rather than run on 0.8.0, at the same
-   time `published`'s cell above was failing and the Actions API was
-   answering this run's own `.../jobs` endpoint with intermittent `502`s
-   for a while after — evidence of a platform-side hiccup on this
-   particular run rather than a condition in the workflow, but not a
-   citation for one, and worth treating as an open question rather than a
-   settled one. `gh run rerun --failed` does not reach it either way: that
-   flag reruns jobs whose conclusion is `failure` and their dependents,
-   and `skipped` is neither, so a rerun scoped to `published`'s failing
-   cell leaves `github-release` exactly where it was. Recreate it by hand
-   from the run's own artifacts, which is the same thing that step would
-   have done:
+   in it: `github-release` was left `skipped` on both 0.8.0 and 0.8.0.1,
+   despite `publish-pypi` and `attest` succeeding both times. The cause
+   was `attest`'s own `if: always() && (...)`, needed so it can run past
+   a skipped sibling — `publish-testpypi` is always skipped on a real
+   tag, `publish-pypi` on a dispatch. `github-release`'s implicit default
+   `if`, called with no arguments, does not stop at its own direct
+   `needs`; it looks at the whole graph reachable through them, and a
+   skipped job found two hops back through an `always()`-guarded edge is
+   treated the same as a failed direct one — which skipped this job on
+   every real release regardless of what `publish-pypi` and `attest`
+   themselves did. Fixed now: `github-release`'s `if` is explicit,
+   `needs.publish-pypi.result == 'success' && needs.attest.result ==
+   'success'`, asking only the two questions this job has a reason to
+   ask. A release cut after this fix should not need what follows here;
+   keep it for a release that predates the fix, or for a failure of
+   `github-release` itself rather than a skip, which `gh run rerun
+   --failed` reaches directly — a skip, unlike a failure, is not what
+   that flag reruns, so before the fix a rerun scoped to some other job's
+   failing cell always left `github-release` exactly where it was.
+
+   Recreate a skipped release by hand from the run's own artifacts, which
+   is the same thing that step would have done:
 
    ```shell
    run=<run id>; tag=v0.8.0; repo=btclib-org/btclib-secp256k1


### PR DESCRIPTION
`github-release` (needs: [publish-pypi, attest]) has no explicit `if` of its own today, which means its condition is the implicit default: `success()` with no arguments, which does not stop at a job's own `needs` — it looks at the whole dependency graph reachable through them.

`attest`'s own `if` is `always() && (needs.publish-pypi.result == 'success' || needs.publish-testpypi.result == 'success')`, needed so it can run when its sibling `publish-testpypi` is skipped (every real tag) or when `publish-pypi` is skipped (every rehearsal dispatch). The implicit default treats a skipped job found two hops back through that `always()`-guarded edge the same as a failed direct need — so `github-release` was skipped on every real tag regardless of whether `publish-pypi` and `attest` themselves succeeded.

They did, twice: v0.8.0 (https://github.com/btclib-org/btclib-secp256k1/releases/tag/v0.8.0) and v0.8.0.1 (https://github.com/btclib-org/btclib-secp256k1/releases/tag/v0.8.0.1) both published clean and both left no GitHub release, discovered only because the release page was empty rather than because any job reported failure — `gh run rerun --failed` does not reach a `skipped` job either, so both had to be recreated by hand from the run's own `sdist` and `attestation` artifacts.

The fix makes the condition explicit: `needs.publish-pypi.result == 'success' && needs.attest.result == 'success'`, asking only about its own two direct needs and nothing further up the graph. Verified with `actionlint`/`zizmor` (both clean) and by re-reading the rehearsal path: on a `workflow_dispatch`, `publish-pypi` is skipped, so the new condition still correctly keeps `github-release` from running there, unchanged from before. The one thing this PR cannot verify locally is the fixed condition actually letting the job run on a real tag — that needs the next real release to confirm.

RELEASING.md and CHANGELOG.md are updated with what was actually found, replacing an earlier RELEASING.md note (from the 0.8.0 cycle, #137) that treated the first occurrence as a possible platform hiccup — it was not; it is deterministic and this is why.

## Summary by Sourcery

Ensure GitHub releases are only gated on the success of their direct dependency jobs and document the previous release-skipping issue and its recovery steps.

Enhancements:
- Make the `github-release` workflow job condition explicit, depending only on `publish-pypi` and `attest` results to prevent unintended skips on successful real releases.

Documentation:
- Update RELEASING.md to describe the deterministic cause of skipped GitHub releases and to document how to recover releases for runs predating the fix.
- Add CHANGELOG entry under v0.8.0.2 explaining the CI fix for the `github-release` job and the impact on past releases.