### PR TITLE
Ask for fifty-one jobs a commit, not seventy-three

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,22 +41,28 @@ name: codeql
 # the repository
 
 on:
-  pull_request:
-    # no path filter, unlike the sentinels here: the aggregate below is a
-    # required check on main, and a required check that produces no run at
-    # all blocks the merge instead of passing it -- so a documentation-only
-    # pull request has to run this too.
-    # ready_for_review, so a pull request marked ready gets the run the
-    # draft condition below withheld while it was a draft: the default
-    # types do not include it, and without it a readied pull request would
-    # wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+  # main and the schedule below, and no pull_request trigger: this analysis
+  # is the one gate that was worth trading for the slots it held. GitHub
+  # Free gives an organization twenty concurrent jobs, shared across every
+  # repository in it, and this workflow's three of them were held while a
+  # pull request waited -- so the analysis lands on the merge commit rather
+  # than before it, and the aggregate below is no longer a required check
+  # on main. REPOSITORY.md is where that rule is written down, and dropping
+  # the context there is a token operation that had to come first.
+  # What still reads a branch before it merges is lint.yml: zizmor is a
+  # pre-commit hook and reads exactly these files for an injected
+  # expression, which is the finding this workflow would otherwise be alone
+  # in making. What a merge defers is the rest -- the python and actions
+  # queries -- for the time between that merge and the next run, which for
+  # main is the merge itself.
+  # No path filter either, and now for a plainer reason than the one that
+  # used to be here: nothing waits on the answer, so nothing is bought by
+  # withholding it
   push:
-    # main only, for the reason lint.yml gives at the same key -- but with a
-    # second one this workflow does not share with the other gates: an
-    # analysis of the default branch is what an alert is measured against,
-    # so the branch every pull request is compared to has to be scanned
-    # itself, and a merge creates a commit no pull request tested
+    # main only, and with a second reason this workflow does not share with
+    # the other gates: an analysis of the default branch is what an alert is
+    # measured against, so the branch every pull request is compared to has
+    # to be scanned itself, and a merge creates a commit nothing else tested
     branches: [main]
   schedule:
     # Tuesday 04:33 UTC. Weekly, which is what default setup ran, and it
@@ -69,12 +75,14 @@ on:
     # with no other cron here, nor with btclib's or bitcoin-core-rpc's --
     # `grep -rn 'cron:' .github/workflows/*.yml` in each is what re-derives
     # that, and the other days are Monday (links), Wednesday (macos,
-    # latest), Sunday (mutation) and the 1st (published, vendored vectors).
+    # latest), Saturday (windows), Sunday (mutation) and the 1st
+    # (published, vendored vectors).
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "33 4 * * 2"
-  # the escape hatch: a scan on demand for a branch whose pull request is
-  # not open yet
+  # the escape hatch, and with no pull_request trigger above it is the only
+  # way to scan a branch before it is merged: worth reaching for on one that
+  # touches a workflow, which is what the actions queries read
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job can read
@@ -192,7 +200,7 @@ jobs:
     # satisfied. The gate has to run to be able to fail -- and it carries
     # the draft condition every job above carries, so a draft skips
     # uniformly rather than tripping the skip check below
-    if: ${{ always() && !github.event.pull_request.draft }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,11 @@
 ---
 name: macos
 
-# the platform the merge gate does not wait for. test.yml runs the suite on
-# four operating systems on every pull request and this one runs the two
-# macOS images, weekly and before a release, because macOS is where the wait
-# came from: the numbers, and the command that re-derives them, are in
+# one of the two platforms the merge gate does not wait for -- windows.yml
+# is the other, and its header carries the number that moved it. test.yml
+# runs the suite on the two ubuntu images on every pull request and this one
+# runs the two macOS images, weekly and before a release, because macOS is
+# where the wait came from: the numbers, and the command that re-derives them, are in
 # test.yml's own header, next to the matrices these cells left.
 #
 # What runs here is not what left, and the difference is the point. The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,13 @@ jobs:
       # see the lint job above
       concurrency-suffix: "-release"
 
+  windows:
+    name: Run the windows workflow
+    uses: ./.github/workflows/windows.yml
+    with:
+      # see the lint job above
+      concurrency-suffix: "-release"
+
   # what a version cannot survive being wrong about, checked before
   # anything is built and long before anything is uploaded: a version is
   # consumed by the upload that carries it, and can then only be yanked.
@@ -291,7 +298,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, macos]
+    needs: [test, lint, docs, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -325,7 +332,7 @@ jobs:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, macos]
+    needs: [test, lint, docs, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,13 @@
 name: test
 
 # the merge gate: everything this package ships, built and then tested on
-# the platforms it claims, minus the one platform a reviewer would wait for.
+# the platforms it claims, minus the two platforms a reviewer would wait
+# for. Their suite cells are macos.yml's and windows.yml's, and each file
+# carries the measurement that moved it; the wheel builds for all six stay
+# here, because the release publishes the artifacts of this run.
 #
-# macOS is that platform, and the split is a measurement rather than a
-# preference. Over six pull request runs of this workflow, ninety-eight jobs
+# macOS was the first of the two, and the split is a measurement rather than
+# a preference. Over six pull request runs of this workflow, ninety-eight jobs
 # each, thirty-five of them on the two macOS images: a macOS job waited 20.8
 # and 19.0 minutes on average for a runner, against 2.1 to 2.6 elsewhere,
 # and the wait grows with the number of cells asking at once -- in the
@@ -17,6 +20,13 @@ name: test
 #     id=$(gh run list --workflow=test.yml --limit 1 \
 #         --json databaseId --jq '.[0].databaseId')
 #     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# The Windows cells were the second, and a different number moved them:
+# GitHub Free gives an organization twenty concurrent jobs, shared across
+# every repository in it, and this workflow set asked for seventy-three on
+# every commit. The twenty-one Windows suite cells were 27.3 of the 112.9
+# runner-minutes, the largest family of jobs in the run and ahead of every
+# wheel build. windows.yml has the rest of that measurement.
 #
 # So the macOS *suite* cells moved to macos.yml, which runs them weekly and
 # before a release. The macOS *wheel builds* stay here, and the same
@@ -561,11 +571,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # the two macOS images are macos.yml's; see the header
+        # the macOS images are macos.yml's and the Windows ones are
+        # windows.yml's; see the header
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - windows-latest
         # 3.14t, the free-threaded interpreter, matters here in particular:
         # the dynamic wheel is tagged py3-none, so it is what a
         # free-threaded interpreter installs, and unlike the static wheels
@@ -631,34 +641,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # the two macOS images are macos.yml's; see the header. What is
-        # given up here is narrower than elsewhere, and cibuildwheel is
-        # why: it runs the suite against every wheel it builds, on the
-        # runner that built it, so the macOS wheels this workflow ships are
-        # still tested by the job that produces them. What moves is pip's
-        # selection among them
+        # the macOS images are macos.yml's and the Windows ones are
+        # windows.yml's; see the header. What is given up there is narrower
+        # than elsewhere, and cibuildwheel is why: it runs the suite against
+        # every wheel it builds, on the runner that built it, so the macOS
+        # and Windows wheels this workflow ships are still tested by the job
+        # that produces them. What moves is pip's selection among them.
+        # With both Windows rows gone so are the three exclusions they
+        # carried, each of them a wheel that is not built rather than a
+        # platform not worth running: no PyPy wheel on Windows on either
+        # architecture, and no CPython before 3.11 on windows arm64
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - windows-latest
-          - windows-11-arm
         python-version:
           ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
         # cibuildwheel already runs the suite against every wheel it
         # builds, cp314t included: what this job adds is that pip, given a
         # directory holding all of them, selects the right one, which for
-        # the free-threaded interpreter nothing checked.
-        # PyPy wheels are not built on Windows, on either architecture.
-        # CPython has no Windows arm64 build before 3.11, so there is no
-        # interpreter to test a win_arm64 wheel against and cibuildwheel
-        # does not produce one
-        exclude:
-          - os: windows-latest
-            python-version: "pypy-3.11"
-          - os: windows-11-arm
-            python-version: "pypy-3.11"
-          - os: windows-11-arm
-            python-version: "3.10"
+        # the free-threaded interpreter nothing checked
     needs: build-cibuildwheel
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,154 @@
+---
+name: windows
+
+# the second platform the merge gate does not wait for, and the whole of
+# this file is macos.yml's argument applied to the rows beside those.
+#
+# The constraint is a ceiling rather than a wall clock, which is what makes
+# it worth re-deciding a split that was already made once: GitHub Free gives
+# an organization twenty concurrent jobs, shared across every repository in
+# it, and this workflow set asked for seventy-three of them on every commit
+# while btclib asked for thirty-nine and bitcoin-core-rpc for forty-four. On
+# one pull request run the twenty-one Windows suite cells were 27.3 of the
+# 112.9 runner-minutes and the largest single family of jobs in it, ahead of
+# every wheel build; the run's critical path was 1713 seconds, of which the
+# median cell spent 694 queueing. The command that re-derives it:
+#
+#     id=$(gh run list --workflow=test.yml --limit 1 \
+#         --json databaseId --jq '.[0].databaseId')
+#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# **The Windows wheel builds stay in test.yml**, and that is the same line
+# macos.yml's header draws: the release publishes the artifacts of that run,
+# so a win_amd64 or win_arm64 wheel not built there is a wheel not on PyPI.
+# Those two jobs are not what stretched the run either -- what did was
+# twenty-one cells contending for slots behind them.
+#
+# What is given up is therefore narrower than twenty-one jobs suggests, and
+# cibuildwheel is why: `test-command` in pyproject.toml runs the whole suite
+# against every wheel it builds, on the runner that built it, so the Windows
+# wheels this package ships are still tested before a merge by the job that
+# produces them. What moves to Saturday is pip's *selection* among them --
+# the question suite-static exists to ask, and the one nothing else covers.
+#
+# What runs here is not what left, for the reason macos.yml gives at the
+# same point: the cells that moved installed a wheel built earlier in the
+# same run, and rebuilding those here would mean cibuildwheel per image and
+# artifact names the release must not confuse with test.yml's. This builds
+# from the tree instead, twice per cell -- the static extension a CPython
+# wheel carries, then the dynamic one, which is the choice
+# `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
+# of `_load_lib`. Two steps of one job rather than two jobs, because the
+# queue is the cost being managed and a second job pays it again.
+#
+# It gates no commit and no merge -- a Windows regression sits on main for
+# at most a week -- but release.yml calls it, so one cannot be published
+
+on:
+  schedule:
+    # Saturday, the day nothing else here asks for -- the mutation session
+    # Sunday, links Monday, codeql Tuesday, macos and latest Wednesday,
+    # Dependabot Thursday -- so a failure notification still names the
+    # workflow by the day it arrived. A minute that is not the hour, as
+    # every cron here, for the reason links.yml gives, and minute 17 is
+    # shared with none of them (07, 11, 23, 29, 37, 49).
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "17 4 * * 6"
+  # lets release.yml gate a publication on this platform too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
+  # the escape hatch: the platform on demand, for a branch that touches the
+  # build, the loader or anything a toolchain decides
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies, build scripts) can read the token, so it must not
+# be able to write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than through github.workflow, which in
+# a called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other. The suffix is the second half of the same problem,
+# github.ref inside a called workflow being the caller's ref: see lint.yml
+concurrency:
+  group: windows-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  cancel-in-progress: true
+
+jobs:
+  suite-windows:
+    name: Run the suite on ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # every cell to the end: which interpreter fails on which image is the
+      # whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # the two images test.yml's suite matrices no longer carry. Both,
+        # because what differs between them is the architecture the
+        # interpreter and the compiled extension target
+        os:
+          - windows-latest
+          - windows-11-arm
+        # the interpreter set the matrices ran, and the exclusions those
+        # carried are gone with the wheels that caused them: nothing here
+        # installs a published wheel, so there is no PyPy-on-Windows wheel
+        # to be missing. What remains is what an interpreter cannot do --
+        # CPython has no Windows arm64 build before 3.11, so 3.10 has no
+        # interpreter to run on that image
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy-3.10"
+          - "pypy-3.11"
+        exclude:
+          - os: windows-11-arm
+            python-version: "3.10"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the vendored library is what gets compiled here
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # the wheels of the test group, not the extension, which is built
+          # from the tree twice below whatever the cache holds
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      # the command CONTRIBUTING.md gives a developer, and the one the
+      # coverage job of test.yml runs on ubuntu: a static build, where
+      # `_load_lib` returns the extension's own `lib`
+      - name: Run pytest against a static build
+        run: uv run --locked --no-default-groups --group test pytest
+
+      # the other branch of `_load_lib`: cffi in ABI mode, dlopening the
+      # shared object beside the module.
+      # --reinstall-package with --no-cache because the extension already
+      # installed by the step above is the other linkage, and neither the
+      # environment nor the build cache is keyed on the variable that
+      # chooses between them
+      - name: Run pytest against a dynamic build
+        env:
+          BTCLIB_LIBSECP256K1_DYNAMIC: "true"
+        run: >
+          uv run --locked --no-default-groups --group test
+          --reinstall-package btclib_secp256k1 --no-cache pytest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1333
+        "line_number": 1361
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T19:45:12Z"
+  "generated_at": "2026-08-13T22:41:06Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,34 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **A pull request asks for fifty-one jobs instead of seventy-three**, and
+  the number that decided it is a ceiling rather than a wall clock: GitHub
+  Free gives an organization twenty concurrent jobs, shared across every
+  repository in it, so a commit here, one in btclib and one in
+  bitcoin-core-rpc compete for the same twenty. Measured on one pull
+  request run, this workflow set asked for seventy-three jobs and 112.9
+  runner-minutes, its critical path 1713 seconds of which the median cell
+  spent 694 queueing. Two changes, each moving an answer off the review
+  path rather than dropping it:
+    - the twenty-one Windows suite cells become `windows.yml`, weekly on
+    Saturday and called by `release.yml`, exactly as `macos.yml` already
+    holds the macOS ones and built the same way -- from the tree, in both
+    linkages, two steps of one job rather than a wheel rebuilt per image.
+    They were 27.3 of the 112.9 runner-minutes, the largest family of jobs
+    in the run and ahead of every wheel build. **The Windows wheel builds
+    stay in `test.yml`**, for the reason its header gives of macOS: the
+    release publishes the artifacts of that run, and `cibuildwheel` runs
+    the suite against every wheel as it builds it, so what moves to
+    Saturday is pip's *selection* among them. With both Windows rows gone
+    so are the three exclusions `suite-static` carried, each of them a
+    wheel that is not built rather than a platform not worth running.
+    - `codeql.yml` loses its `pull_request` trigger and keeps `main` and its
+    Tuesday schedule, so `codeql: every job passed` is no longer one of
+    main's required checks -- three now, and REPOSITORY.md carries the rule
+    and the `PATCH` that dropped the context. `zizmor` is a `pre-commit`
+    hook, so `lint.yml` still audits these workflows for an injected
+    expression on every pull request.
+
 - **`github-release` no longer risks a skip on a release that actually
   succeeded.** Its `if` used to be the implicit default, and that default
   has no arguments: it does not stop at this job's own `needs`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,38 +186,54 @@ read by every checkout of this repository.
 
 | workflow | when | what it varies |
 | --- | --- | --- |
-| `test` | pull request, push | every platform but macOS, every interpreter |
+| `test` | pull request, push | the wheels, and ubuntu × every interpreter |
 | `lint`, `docs` | pull request, push | — |
-| `codeql` | pull request, push, Tuesday | the two scanned languages |
 | `vendored-vectors` | monthly, a change to itself | — |
+| `codeql` | push to main, Tuesday | the two scanned languages |
 | `macos` | Wednesday, a release | both macOS images, both linkages |
+| `windows` | Saturday, a release | both Windows images, both linkages |
 | `latest` | Wednesday | the dependencies, at their newest |
 | `links`, `mutation` | weekly | — |
 | `published` | monthly, a release | what PyPI serves |
-| `release` | a tag | calls the gates, `macos` and `published` |
+| `release` | a tag | calls the gates, `macos`, `windows`, `published` |
 
-The first three rows are what a merge waits for. macOS is not among them on
-purpose, and the numbers are in `test.yml`'s header: it is the one platform
-whose runners queue for tens of minutes rather than for two, so it answers
-weekly, and before a release, rather than before a review. The wheels it
-ships are still built on every pull request, `cibuildwheel` running the
-suite against each one as it builds it — what waits a week is pip's
-selection among them and the dynamic build. Everything but the first two
-rows also takes `workflow_dispatch`.
+The first two rows are what a merge waits for.
 
-`codeql` is the one gate with no local command: reproducing it means the
-CodeQL CLI, a bundle GitHub distributes rather than a dependency `uv.lock`
-can pin, so what answers a finding is the run itself and the Security tab
-beside it. What it scans, with which queries and on what schedule is in the
-file, `.github/workflows/codeql.yml`; the branch rule that names its
-aggregate is in REPOSITORY.md.
+What the rows below them have in common is one number: GitHub Free gives an
+organization twenty concurrent jobs, shared across every repository in it.
+A commit here asked for seventy-three, one in btclib for thirty-nine and one
+in bitcoin-core-rpc for forty-four, so a pull request in any of the three
+spent its wall clock waiting for a slot. A platform therefore earns a place
+before a review only if it is cheap to wait for, and neither of these is:
+macOS runners queue for tens of minutes rather than for two, and the
+twenty-one Windows suite cells were 27.3 of a run's 112.9 runner-minutes,
+the largest family of jobs in it and ahead of every wheel build. The numbers
+are in `test.yml`'s header and in each of the two files.
+
+**The wheels for both are still built on every pull request**, which is the
+half that does not move: `cibuildwheel` runs the suite against each wheel as
+it builds it, and the release publishes the artifacts of that run. What
+waits a week is pip's *selection* among them, and the dynamic build.
+Everything but the first two rows also takes `workflow_dispatch`, which for
+`codeql` and the two platform workflows is the only way to ask about a
+branch at all.
+
+`codeql` runs on `main` and on its Tuesday schedule and not on a pull
+request, which is the same arithmetic as the rows above: three slots held
+while a review waits. What still reads a branch before it merges is
+`zizmor`, a `pre-commit` hook and therefore part of `lint`, which audits
+these workflows for an injected expression; REPOSITORY.md has the trade in
+full. It is also the one workflow with no local command: reproducing it
+means the CodeQL CLI, a bundle GitHub distributes rather than a dependency
+`uv.lock` can pin, so what answers a finding is the run itself and the
+Security tab beside it.
 
 ### Running what CI runs
 
 Each job of the `lint`, `docs` and `test` workflows, and the local command
 that reproduces it. Two of them cannot be reproduced on a machine that is
-not the runner, and that is worth knowing before trying; the fourth gate,
-`codeql`, has no command at all, for the reason above.
+not the runner, and that is worth knowing before trying; `codeql` has no
+command at all, for the reason above, and no longer gates.
 
 - `Lint and type-check`
 
@@ -312,7 +328,7 @@ The sentinels beside it gate nothing, so a red one is read in the Actions
 tab rather than fixed on a branch. Each is dispatchable, and all but `links`
 run locally.
 
-- `macos`, which is the suite on the two macOS images and reproducible only
+- `macos` and `windows`, which are the suite on those images and reproducible only
   on a Mac. Both linkages, the commands being the pair given above under
   the suite job
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -35,7 +35,23 @@ gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
 | `test: every job passed` | `test.yml`, aggregate over the matrix |
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
-| `codeql: every job passed` | `codeql.yml`, aggregate over the languages |
+
+`codeql: every job passed` is not among them, and that is the one place a
+check was traded for the slots it held. GitHub Free gives an organization
+twenty concurrent jobs, shared across every repository in it: this one asked
+for seventy-three on every commit, btclib for thirty-nine and
+bitcoin-core-rpc for forty-four, so a pull request in any of the three
+waited for a slot rather than for the work. `codeql.yml` now runs on `main`
+and on its Tuesday schedule, the analysis landing on the merge commit rather
+than ahead of it, and it still produces that aggregate — the name is
+available, so requiring it again is a patch to the rule and nothing in the
+tree.
+
+What still reads a branch before it merges is the workflow half of the same
+question: `zizmor` is a `pre-commit` hook, so `lint.yml` audits these very
+files for an injected expression on every pull request, and that check is
+required. What a merge defers is the rest of the analysis, for the time
+between that merge and the next run — which for `main` is the merge itself.
 
 `Build the documentation` is named on its own on purpose: a rule naming
 `Lint and type-check` alone would leave a red documentation build outside
@@ -60,17 +76,19 @@ rule names, `Lint and type-check`, checks the submodule out with
 developer's own commit. Re-read that skip list before adding to it: an
 entry may join for a reason of that kind and no other.
 
-Neither `macos.yml`, `latest.yml`, `links.yml`, `mutation.yml`,
-`published.yml` nor `vendored-vectors.yml` appears in the rule, and none of
-them must: each is expected to go red for a reason no pull request
-introduced. `macos.yml` is the one worth naming twice, because it does run
-the suite: what a merge no longer waits for is the platform whose runners
-queue for tens of minutes, measured in `test.yml`'s header, and
-`release.yml` calls it so that a publication still does.
+Neither `macos.yml`, `windows.yml`, `latest.yml`, `links.yml`,
+`mutation.yml`, `published.yml` nor `vendored-vectors.yml` appears in the
+rule, and none of them must: each is expected to go red for a reason no pull
+request introduced. `macos.yml` and `windows.yml` are the two worth naming
+twice, because they do run the suite: what a merge no longer waits for is
+the platform whose runners queue for tens of minutes and the one whose cells
+were the largest family of jobs in a run, both measured in `test.yml`'s
+header and theirs, and `release.yml` calls both so that a publication still
+does.
 
 A check can be bound to the app that produces it — `checks` with an
 `app_id` rather than the bare `contexts` list — so that nothing else can
-satisfy it, and 15368 is Actions, which produces them all. All four carry
+satisfy it, and 15368 is Actions, which produces them all. All three carry
 that binding, and the two that did not are why it is worth stating: an
 unbound context reads `app_id: null` and is satisfied by *any* app
 reporting a check run of that name, so anything installed on the
@@ -135,9 +153,12 @@ merge path open, where any other order closes it on a context nothing
 reports. `enforce_admins` being off is what makes that window survivable
 rather than a lock.
 
-That exchange has been made: the endpoint above answers `not-configured`,
-and the rule names `codeql: every job passed`. The order is kept here
-because the setting can be configured again.
+That exchange has been made: the endpoint above answers `not-configured`.
+What the rule does *not* name any more is `codeql: every job passed`, for
+the reason the section above gives — so the last step of that order was
+undone afterwards, deliberately, and the order is kept here because the
+setting can be configured again and because requiring the context again is
+the same `PATCH` with one entry more.
 
 A `CodeQL` check and an `Analyze (python)` job outlive it, and neither
 comes from this tree: GitHub keeps a generated
@@ -181,9 +202,7 @@ sub=branches/main/protection/required_status_checks
 gh api "repos/{owner}/{repo}/$sub" -X PATCH -F strict=true \
   -F 'checks[][context]=test: every job passed' -F 'checks[][app_id]=15368' \
   -F 'checks[][context]=Lint and type-check' -F 'checks[][app_id]=15368' \
-  -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368' \
-  -F 'checks[][context]=codeql: every job passed' \
-  -F 'checks[][app_id]=15368'
+  -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368'
 ```
 
 `checks[][…]` repeated is how one array of objects is written: `-F` pairs


### PR DESCRIPTION
The same rationalisation btclib had in
https://github.com/btclib-org/btclib/pull/777 and bitcoin-core-rpc in
https://github.com/btclib-org/bitcoin-core-rpc/pull/119, measured on this
repository — where it is worth the most, this being the workflow set that
asks for the most.

The constraint is a ceiling, not a wall clock: **GitHub Free gives an
organization twenty concurrent jobs, shared across every repository in it**.
A commit here asked for seventy-three, one in btclib for thirty-nine and one
in bitcoin-core-rpc for forty-four, so the three competed for the same
twenty and a pull request in any of them spent its wall clock waiting.

Measured on one pull request run:

| | jobs | runner-minutes | critical path | median queue |
| --- | --- | --- | --- | --- |
| before | 73 | 112.9 | 1713 s | 694 s |
| after | 51 | ~85 | — | — |

Peak concurrency in that run was **7**, against seventy-three jobs asked
for — which is what a shared ceiling looks like from inside one repository.

## The two changes

**The twenty-one Windows suite cells become `windows.yml`**, weekly on
Saturday and called by `release.yml`, exactly as `macos.yml` already holds
the macOS ones — and built the same way, from the tree in both linkages, two
steps of one job rather than a wheel rebuilt per image. They were 27.3 of
the 112.9 runner-minutes: the largest single family of jobs in the run, ahead
of every wheel build.

**The Windows wheel builds stay in `test.yml`**, which is the line
`macos.yml`'s header already draws: the release publishes the artifacts of
that run, so a `win_amd64` or `win_arm64` wheel not built there is a wheel
not on PyPI. And what is given up is narrower than twenty-one jobs suggests,
because `[tool.cibuildwheel]`'s `test-command` runs the whole suite against
every wheel as it builds it, on the runner that built it — so the Windows
wheels this package ships are still tested before a merge by the job that
produces them. What moves to Saturday is pip's *selection* among them, which
is the question `suite-static` exists to ask.

With both Windows rows gone, so are the three exclusions `suite-static`
carried: each of them named a wheel that is not built (no PyPy on Windows on
either architecture, no CPython before 3.11 on win arm64) rather than a
platform not worth running, and nothing here installs a published wheel.

**`codeql.yml` loses its `pull_request` trigger** and keeps `main` and its
Tuesday schedule. What still reads a branch before it merges is `zizmor`, a
`pre-commit` hook and therefore part of `Lint and type-check`, which audits
these very workflows for an injected expression.

## This needs the branch rule patched first

`codeql: every job passed` is a required check on `main`, and this branch
stops producing it — so nothing merges until the rule drops that context.
That half cannot be made in a pull request. REPOSITORY.md carries the table
and the command, now three checks:

```shell
sub=branches/main/protection/required_status_checks
gh api "repos/btclib-org/btclib-secp256k1/$sub" -X PATCH -F strict=true \
  -F 'checks[][context]=test: every job passed' -F 'checks[][app_id]=15368' \
  -F 'checks[][context]=Lint and type-check' -F 'checks[][app_id]=15368' \
  -F 'checks[][context]=Build the documentation' -F 'checks[][app_id]=15368'
```

`windows.yml` also reaches `main` having never run — `schedule`,
`workflow_call` and `workflow_dispatch` only, so GitHub cannot dispatch it
until its file is on the default branch. A dispatch right after the merge is
what confirms the matrix, and it is worth doing here more than elsewhere:
these cells compile the vendored library rather than install a wheel.

Local gates, all exit 0: `uv run pre-commit run --all-files` (with the
submodule initialised, which `submodule-pin` needs), the sphinx build with
`-W`, and `uv run pytest` at 434 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce CI concurrency by moving Windows test suite jobs out of the main merge gate and removing CodeQL from pull-request gating, while ensuring releases still run full platform coverage.

New Features:
- Introduce a dedicated `windows` workflow that runs the test suite on Windows images on a weekly schedule and during releases.

Enhancements:
- Adjust the `test` workflow matrices so Windows suite cells no longer run on every pull request, keeping only wheel-build coverage for Windows within the merge gate.
- Update the `release` workflow to call the new `windows` workflow and require it alongside existing gates before publishing to PyPI.
- Refine CI concurrency configuration and documentation to reflect the reduced job count per commit and shared GitHub Free concurrency limits.
- Change CodeQL analysis to run only on pushes to `main`, its weekly schedule, or manual dispatch, removing it from pull request-triggered gating while keeping security scanning via `zizmor` in lint.

CI:
- Add `.github/workflows/windows.yml` for scheduled and release-triggered Windows suite runs.
- Modify `.github/workflows/test.yml`, `.github/workflows/macos.yml`, `.github/workflows/codeql.yml`, and `.github/workflows/release.yml` to align with the new Windows workflow and CodeQL gating strategy.

Documentation:
- Revise CONTRIBUTING.md and REPOSITORY.md to document the new workflow triggers, merge requirements, and the removal of CodeQL as a required status check.
- Add CHANGELOG notes describing the CI restructuring and reduced per-commit job count.