### PR TITLE
Switch off the analysis nobody could read

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1361
+        "line_number": 1374
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T22:41:06Z"
+  "generated_at": "2026-08-13T22:54:30Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **The generated Code Quality analysis is off.** `Analyze (python)` ran
+  on every pull request and every push to `main` from a
+  `dynamic/github-code-scanning/codeql` workflow no file in this tree
+  declares -- some 52 seconds of a slot each time, out of twenty shared
+  with every other repository in the organization, where the same setting
+  was on. What it produced cannot be read from outside a browser: there is
+  no `code-quality/alerts` endpoint and no `code-quality/analyses`, both
+  404, the alert list is empty and every analysis carries `codeql.yml`'s
+  own category. REPOSITORY.md gains the section and the endpoint that
+  reports and sets it, `code-quality/setup`: not
+  `code-scanning/default-setup`, and not the Actions API, which answers
+  422 for a workflow this repository does not own.
+
 - **A pull request asks for fifty-one jobs instead of seventy-three**, and
   the number that decided it is a ceiling rather than a wall clock: GitHub
   Free gives an organization twenty concurrent jobs, shared across every

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -165,7 +165,8 @@ comes from this tree: GitHub keeps a generated
 `dynamic/github-code-scanning/codeql` workflow, which uploads *code
 quality* results rather than security ones — `python.quality.sarif` in its
 log, where the security analysis produced `python.sarif`. That is a
-separate setting, and the endpoint above does not report it:
+separate setting with an endpoint of its own, the "Code quality" section
+below, and the endpoint above reports nothing about it:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1/actions/workflows \
@@ -225,6 +226,47 @@ the name the rule now wants; `enforce_admins` being off is what makes the
 window survivable rather than a lock. Every open pull request that predates
 the rename is blocked until it is rebased, which is the reason to do it
 with none open but the one doing the renaming.
+
+## Code quality
+
+The analysis the generated workflow above was left running, and it is off.
+Its setting is not `code-scanning/default-setup`, and the Actions API is
+not the way in either: a generated workflow is not one this repository
+owns, and `actions/workflows/<id>/disable` answers 422. The endpoint that
+reports the setting is the one that sets it:
+
+```shell
+gh api repos/btclib-org/btclib-secp256k1/code-quality/setup
+# {"state":"not-configured","languages":["python"], ...}
+
+gh api -X PATCH repos/btclib-org/btclib-secp256k1/code-quality/setup \
+  -F state=not-configured
+```
+
+What decided it is the ceiling the section above already trades against,
+not the queries. `Analyze (python)` ran on every pull request and every
+push to `main` — `Code Quality: PR #N` in the run list — for some 52
+seconds of a slot each time, and the twenty concurrent jobs are shared
+with every other repository in the organization, where the same setting
+was on.
+
+What it produced in exchange cannot be read from outside a browser. There
+is no `code-quality/alerts` and no `code-quality/analyses`, both 404, and
+a quality upload appears in neither endpoint that does answer: the alert
+list is empty, and every analysis carries `codeql.yml`'s own category.
+
+```shell
+gh api "repos/btclib-org/btclib-secp256k1/code-scanning/alerts?per_page=100" \
+  --jq length
+gh api "repos/btclib-org/btclib-secp256k1/code-scanning/analyses?per_page=100" \
+  --jq '[.[] | .category] | unique'
+```
+
+`state=configured` is the way back, and the argument for it is that these
+queries are a class of finding nothing else here makes: ruff, mypy and the
+spell checkers are the cover, and they are not the same questions. What
+refuses them is the ceiling, so a fleet not waiting for slots is what
+would change the answer.
 
 ## Branch protection
 


### PR DESCRIPTION
The same rationalization as
https://github.com/btclib-org/btclib/pull/798, whose issue is
https://github.com/btclib-org/btclib/issues/788: the setting was
`configured` on all three of the organization's active repositories, and
this is the python-only half of it.

**One command has to be run before this merges.** The setting is neither
`code-scanning/default-setup` nor anything the Actions API will disable —
422, `Unable to disable this workflow`, a generated workflow not being one
this repository owns:

```shell
gh api -X PATCH repos/btclib-org/btclib-secp256k1/code-quality/setup \
  -F state=not-configured
```

I could not run it from here — writes to that endpoint are refused by this
session's permission classifier — so `REPOSITORY.md` describing the
setting as off becomes true when you run it. `gh api
repos/btclib-org/btclib-secp256k1/code-quality/setup` is the check, and
`state=configured` is the way back.

## What the decision rests on

- **Cost**: `Analyze (python)`, some 52 seconds of a slot on every pull
  request and every push to `main`, out of the twenty concurrent jobs
  shared with btclib and bitcoin-core-rpc — the ceiling this repository
  already went from seventy-three jobs to fifty-one for.
- **Output, read as far as an API can read it**: `code-quality/alerts` and
  `code-quality/analyses` are both 404. The alert list is empty and every
  analysis is `codeql.yml`'s own, `/language:python` and
  `/language:actions`. The Code quality tab in a browser is the whole of
  the audience, which is most of the reason nobody has been in it.

The argument for keeping it is in the new section rather than dropped:
these queries are a class of finding ruff, mypy and the spell checkers do
not make, and what refuses them is the ceiling.

`.secrets.baseline` moves with the CHANGELOG insertion, its line numbers
being what it records.

Gates: `uv run pre-commit run --all-files` exit 0. Prose only.

## Summary by Sourcery

Document disabling the generated Code Quality analysis and its impact on CI resource usage.

Enhancements:
- Clarify repository behaviour around the generated Code Quality workflow and its configuration endpoint.
- Record in the changelog that the Code Quality analysis has been turned off to reduce shared CI slot consumption.

Documentation:
- Add a dedicated "Code quality" section to REPOSITORY.md explaining the generated analysis, its status, and how to view or change the configuration state.

Chores:
- Update the secrets baseline to reflect shifted line numbers after documentation changes.