### PR TITLE
Let verification take the parsed key, and normalize while verifying

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1398
+        "line_number": 1467
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T11:43:30Z"
+  "generated_at": "2026-08-14T16:35:37Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,75 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.2 (work in progress, not released yet)
 
+### The parsed public key
+
+- **Verification takes the parsed key a caller already holds** (#147).
+  `keys.parse` was public and `keys.serialize` took what it returned, and
+  `pubkey_tweak_add_` consumed one — but `dsa.verify`, `ssa.verify` and
+  `ecdh.shared_secret` took bytes and parsed them, so a caller holding a
+  parsed key had nowhere to put it. Two callers pay for that twice: one
+  that validates a key before verifying with it, which is
+  <https://github.com/btclib-org/btclib/issues/887> and the other half of
+  this pair, and one checking several signatures against one key, which
+  is the case `PubkeyTweakChain` exists to stop for tweaks. For a
+  compressed key the parse is a field square root, so it is not a
+  rounding error next to the verification it precedes. `dsa.verify_`,
+  `ssa.verify_`, `ecdh.shared_secret_`, `keys.pubkey_negate_`,
+  `keys.pubkey_tweak_mul_`, `keys.pubkey_cmp_` and `xonly.from_pubkey_`
+  are the inner halves, and `xonly.parse` is public beside `keys.parse`
+  because BIP340 verifies against the x-only key and that is the object
+  `ssa.verify_` takes.
+- **The convention is one sentence, and it is in `keys.parse`**: the
+  inner half takes the parsed key in place of the bytes, and the outer
+  half is that inner half with a `parse` in front of it. Nothing else
+  differs — every remaining argument is checked exactly as before, a bare
+  pointer's length being what no C return code can report, which is why
+  these are not quite the "already validated, nothing left to redo" shape
+  `pubkey_tweak_add_` was documented as. That one is brought to the same
+  rule here: it takes `BytesLike | int` and validates the tweak itself,
+  where it took 32 bytes on trust and would have read past the end of a
+  shorter value. `PubkeyTweakChain` is unchanged in behaviour, its
+  `scalar` call now happening one frame further in.
+- **`tests/test_parsed_keys.py` holds every pair to that equality**, over
+  both serializations of the key, and holds the table of pairs to what
+  the modules export: an inner half added and left unpaired fails there
+  rather than going untested. `mult.mult_` is named in it as the one
+  trailing underscore that means the older thing — the serialized point
+  against `mult`'s pair of coordinates — and has no key to be handed
+  already parsed.
+- **What is deliberately not there**: `keys.pubkey_combine` and
+  `keys.pubkey_sort` take sequences, so their inner halves would take
+  lists of cffi objects, and no caller has asked; and there is no
+  `xonly.serialize` beside `xonly.parse`, nothing here handing back a
+  parsed x-only key for one to take.
+
+### ECDSA signature normalization
+
+- **`dsa.verify` and `dsa.verify_` take a `normalize` flag** (#148),
+  false by default. `verify` does not accept a signature outside the
+  lower-s form, and which of the two forms a signature carries was the
+  signer's choice, so a caller checking signatures it did not make always
+  normalizes first — and `normalize` takes DER and returns DER, so that
+  is a parse, a normalization, a serialization, and then `verify` parsing
+  what came out. libsecp256k1 documents `sigout == sigin` for
+  `secp256k1_ecdsa_signature_normalize`, so neither the serialization nor
+  the second parse is the normalization's own need: with the flag, the
+  normalization happens on the signature `verify` has already parsed.
+  <https://github.com/btclib-org/btclib/issues/889> is the caller.
+- **A flag rather than a public parsed-signature form**, which is the
+  other answer #148 offered and the one that would have followed #147
+  exactly. The parsed *key* is a thing a caller holds for its own reasons
+  — `keys.parse` is how a key is validated — while a parsed DER signature
+  is an intermediate nothing here produces or consumes, so publishing it
+  would have meant a `parse` and a `serialize` for signatures and inner
+  halves of `normalize`, `is_low_s` and `to_compact` besides, for one
+  caller that wants none of them. The flag is the whole of what that
+  caller needs, and the default keeps today's refusal for the caller
+  enforcing the lower-s form of its own signatures. It is not the
+  leniency the README's "nothing is normalized into validity" refuses,
+  either: that bullet is about a boundary guessing what the caller meant,
+  and this is the caller saying it.
+
 ### The benchmark
 
 - **`scripts/benchmark.py` moves to

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,28 @@ a tag is generated from.
 
 ## v0.8.0.2 (work in progress, not released yet)
 
+Non-breaking, and two additions for a caller that verifies signatures it
+did not make.
+
+Verification takes the parsed public key now, where it took only the
+bytes: `dsa.verify_`, `ssa.verify_` and `ecdh.shared_secret_` are the
+inner halves of the three, taking what `keys.parse` and `xonly.parse`
+return, and `keys.pubkey_negate_`, `keys.pubkey_tweak_mul_`,
+`keys.pubkey_cmp_` and `xonly.from_pubkey_` complete the convention
+`keys.pubkey_tweak_add_` had started. A caller that validated a key
+before verifying with it, or that checks several signatures against one
+key, parses it once instead of once per call — and for a compressed key
+that parse is a field square root, a measurable part of a verification
+rather than a rounding error. Every outer half is unchanged in behaviour
+and cost.
+
+`dsa.verify` and `dsa.verify_` take a `normalize` flag, off by default:
+with it on, a signature outside the lower-s form is normalized and
+verified rather than rejected, which is what a caller checking other
+people's signatures wants. `dsa.verify(msg, key, dsa.normalize(sig))`
+still says the same thing and costs a DER serialization and a second
+parse more. What the default refuses, it still refuses.
+
 The benchmark is no longer in this repository: it lives in
 [btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks) as
 `scripts/libsecp256k1_wrappers.py`. `uv sync --group bench` resolves

--- a/README.md
+++ b/README.md
@@ -222,7 +222,13 @@ and decides nothing else.
   full public key with odd y would be verified or tweaked as a point the
   caller did not pass, so `xonly.from_pubkey` is where a y coordinate
   gets dropped, in the caller's own code. A leniency is a guess at what
-  the caller meant, and that decision is theirs to make
+  the caller meant, and that decision is theirs to make.
+  `dsa.verify(..., normalize=True)` is that decision made, rather than an
+  exception to it: ECDSA signatures are malleable, which of the two forms
+  one carries was the signer's choice, and a caller checking signatures
+  it did not make says so in the call instead of round-tripping the
+  signature through `dsa.normalize` and back into DER. Off, which is the
+  default, a signature outside the lower-s form is refused as before
 - **the one convenience is the int scalar,** and it widens nothing. A
   private key or a tweak may be given as an `int`, checked against
   `0 <= num < 2**256` and serialized big endian. This is not the padding
@@ -253,6 +259,33 @@ And there is a way past all of it: `lib` and `ffi` are exported, and a
 call made through them has no python in front of it whatsoever. That is
 how MuSig2 is reachable, and it is the path for a caller who wants the
 library and nothing added to it.
+
+## Parsing the key once
+
+A public key crosses this boundary as bytes, and every wrapper taking one
+begins by parsing it — for a compressed key that is a field square root,
+which is a measurable part of the verification that follows it. A caller
+that has already paid for that parse can hand it on instead of paying
+again: `keys.parse` returns the libsecp256k1 object, and every wrapper
+whose first act is to build one has an inner half, spelled with a
+trailing underscore, taking that object in place of the bytes.
+
+```python
+>>> ecdsa_sig = dsa.sign(msg, prvkey)
+>>> parsed = keys.parse(pubkey)          # a valid point: proved once
+>>> dsa.verify_(msg, parsed, ecdsa_sig)  # and used, rather than proved again
+True
+
+```
+
+The outer half is the inner half with a `parse` in front of it, and
+nothing else about the two differs: the remaining arguments are checked
+exactly as before, a bare pointer's length being what no C return code
+can report. The two callers this is for are the one that validates a key
+and then verifies with it, and the one checking several signatures
+against a single key. `xonly.parse` is the same thing for the 32-byte
+x-only key BIP340 verifies against, and `keys.serialize` is how a parsed
+key becomes bytes again.
 
 ## Wrapped modules
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, lib
+from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import octets, scalar
 from .context import ctx
 
@@ -70,18 +70,71 @@ def sign(
     return _serialize_der(sig)
 
 
+def verify_(
+    msg_bytes: BytesLike,
+    pubkey: CData,
+    signature_bytes: BytesLike,
+    normalize: bool = False,
+) -> bool:
+    """Verify an ECDSA signature against an already-parsed public key.
+
+    The inner half of `verify`, for a caller who already holds the parsed
+    key -- one that validated it before verifying with it, or one
+    checking several signatures against the same key: see `keys.parse`
+    for what the underscore means throughout. For a compressed key that
+    parse is a field square root, which is a measurable part of the
+    verification it precedes rather than a rounding error.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+        signature_bytes: the signature in DER encoding.
+        normalize: whether to verify the lower-s form of the signature
+            rather than reject a signature that is not in it.
+
+    Returns:
+        True if the signature is valid for that key and message.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, or if the DER
+            signature is malformed. A well-formed signature that simply
+            does not verify is False, not an exception.
+    """
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    signature = _parse_der(signature_bytes)
+    if normalize:
+        # libsecp256k1 takes the same object as input and output here,
+        # documenting sigout == sigin, so this is the normalization
+        # alone: `verify(msg, key, normalize(sig))` is the same answer
+        # through a DER serialization and a second parse of it. The
+        # return value says whether anything was changed, which is what
+        # `is_low_s` asks and this does not
+        lib.secp256k1_ecdsa_signature_normalize(ctx, signature, signature)
+    return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
+
+
 def verify(
-    msg_bytes: BytesLike, pubkey_bytes: BytesLike, signature_bytes: BytesLike
+    msg_bytes: BytesLike,
+    pubkey_bytes: BytesLike,
+    signature_bytes: BytesLike,
+    normalize: bool = False,
 ) -> bool:
     """Verify a ECDSA signature.
 
-    A signature which is not in the normalized lower-s form is rejected;
-    normalize it first if it comes from a system not enforcing it.
+    A signature which is not in the normalized lower-s form is rejected,
+    unless `normalize` is set: which of the two forms a signature carries
+    was the signer's choice, so a caller checking signatures it did not
+    make normalizes rather than refuses, and says so here rather than
+    round-tripping the signature through `normalize` and back into DER.
+    The default is the refusal, that being what a caller enforcing the
+    lower-s form of its own signatures wants.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
         pubkey_bytes: the public key, 33 or 65 bytes.
         signature_bytes: the signature in DER encoding.
+        normalize: whether to verify the lower-s form of the signature
+            rather than reject a signature that is not in it.
 
     Returns:
         True if the signature is valid for that key and message.
@@ -99,20 +152,17 @@ def verify(
         >>> dsa.verify(msg, mult.mult_(1), dsa.sign(msg, 1))
         True
     """
-    msg_bytes = octets(msg_bytes, "message hash", 32)
-
-    signature = _parse_der(signature_bytes)
-
-    pubkey_bytes = octets(pubkey_bytes, "public key")
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError("invalid public key")
-
-    return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
+    return verify_(msg_bytes, keys.parse(pubkey_bytes), signature_bytes, normalize)
 
 
 def normalize(signature_bytes: BytesLike) -> bytes:
     """Convert a DER signature to its normalized lower-s form.
+
+    This is for a caller that needs the normalized bytes -- storing them,
+    forwarding them, comparing them. Normalizing in order to verify is
+    `verify(..., normalize=True)` instead, which is the same
+    normalization without the serialization and the second parse between
+    it and the verification.
 
     Args:
         signature_bytes: the signature in DER encoding.

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -7,10 +7,42 @@
 
 from __future__ import annotations
 
-from . import BytesLike, ffi, lib
-from ._scalar import octets, scalar
+from . import BytesLike, CData, ffi, keys, lib
+from ._scalar import scalar
 from ._secret import take
 from .context import ctx
+
+
+def shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
+    """Compute the ECDH shared secret from an already-parsed public key.
+
+    The inner half of `shared_secret`, for a caller who already holds the
+    other party's parsed key -- one exchanging with the same counterparty
+    more than once, or one that validated the key on receipt: see
+    `keys.parse` for what the underscore means throughout.
+
+    Args:
+        pubkey: the other party's already-parsed public key, as
+            `keys.parse` returns.
+        prvkey: this party's private key, 32 bytes or an int below
+            2**256.
+
+    Returns:
+        The 32-byte shared secret, the SHA256 of the compressed shared
+        point as `shared_secret` documents it.
+
+    Raises:
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not a valid scalar.
+    """
+    prvkey_bytes = scalar(prvkey, "private key")
+
+    output = ffi.new("char[32]")
+    # a NULL hash function selects secp256k1_ecdh_hash_function_sha256,
+    # which writes 32 bytes to output
+    if not lib.secp256k1_ecdh(ctx, output, pubkey, prvkey_bytes, ffi.NULL, ffi.NULL):
+        raise ValueError("invalid private key")
+    return take(output)
 
 
 def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
@@ -40,16 +72,4 @@ def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
             private key is not 32 bytes or does not fit in them, or if
             it is not a valid scalar.
     """
-    prvkey_bytes = scalar(prvkey, "private key")
-    pubkey_bytes = octets(pubkey_bytes, "public key")
-
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError("invalid public key")
-
-    output = ffi.new("char[32]")
-    # a NULL hash function selects secp256k1_ecdh_hash_function_sha256,
-    # which writes 32 bytes to output
-    if not lib.secp256k1_ecdh(ctx, output, pubkey, prvkey_bytes, ffi.NULL, ffi.NULL):
-        raise ValueError("invalid private key")
-    return take(output)
+    return shared_secret_(keys.parse(pubkey_bytes), prvkey)

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -147,6 +147,28 @@ def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> byte
     return serialize(pubkey, compressed)
 
 
+def pubkey_negate_(pubkey: CData) -> CData:
+    """Negate an already-parsed public key.
+
+    The inner half of `pubkey_negate`, for a caller who already holds the
+    parsed point: see `parse` for what the underscore means throughout.
+
+    Args:
+        pubkey: the already-parsed public key, as `parse` returns.
+            Mutated in place.
+
+    Returns:
+        The same object passed in, negated.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to negate it, which no valid
+            key can make it do.
+    """
+    if not lib.secp256k1_ec_pubkey_negate(ctx, pubkey):
+        raise RuntimeError("public key negation failed")
+    return pubkey
+
+
 def pubkey_negate(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
     """Negate a public key.
 
@@ -162,33 +184,31 @@ def pubkey_negate(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
         RuntimeError: if libsecp256k1 fails to negate or serialize it,
             which no valid key can make it do.
     """
-    pubkey = parse(pubkey_bytes)
-    if not lib.secp256k1_ec_pubkey_negate(ctx, pubkey):
-        raise RuntimeError("public key negation failed")
-    return serialize(pubkey, compressed)
+    return serialize(pubkey_negate_(parse(pubkey_bytes)), compressed)
 
 
-def pubkey_tweak_add_(pubkey: CData, tweak_bytes: bytes) -> CData:
+def pubkey_tweak_add_(pubkey: CData, tweak: BytesLike | int) -> CData:
     """Add the generator multiplied by the tweak, to an already-parsed key.
 
     The inner half of `pubkey_tweak_add`, for a caller who already holds
-    both a parsed key and a validated tweak and so has no validation left
-    to redo: `PubkeyTweakChain` is the one, walking a BIP32 path one
-    tweak at a time without parsing the point back out of its own
-    serialization at every step.
+    the parsed point and so has no parse left to redo: `PubkeyTweakChain`
+    is the one, walking a BIP32 path one tweak at a time without parsing
+    the point back out of its own serialization at every step. See
+    `parse` for what the underscore means throughout.
 
     Args:
         pubkey: the already-parsed public key, as `parse` returns.
             Mutated in place.
-        tweak_bytes: the tweak, already 32 bytes, as `scalar` returns.
+        tweak: the tweak, 32 bytes or an int below 2**256.
 
     Returns:
         The same object passed in, tweaked.
 
     Raises:
-        ValueError: if the tweak or the resulting public key is invalid.
+        ValueError: if the tweak is not 32 bytes or does not fit in them,
+            or if the tweak or the resulting public key is invalid.
     """
-    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, tweak_bytes):
+    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, scalar(tweak, "tweak")):
         raise ValueError("invalid tweak or resulting public key")
     return pubkey
 
@@ -218,10 +238,7 @@ def pubkey_tweak_add(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    pubkey = parse(pubkey_bytes)
-    tweak_bytes = scalar(tweak, "tweak")
-    pubkey_tweak_add_(pubkey, tweak_bytes)
-    return serialize(pubkey, compressed)
+    return serialize(pubkey_tweak_add_(parse(pubkey_bytes), tweak), compressed)
 
 
 class PubkeyTweakChain:
@@ -278,9 +295,33 @@ class PubkeyTweakChain:
             RuntimeError: if libsecp256k1 fails to serialize the result,
                 which no valid input can make it do.
         """
-        tweak_bytes = scalar(tweak, "tweak")
-        pubkey_tweak_add_(self._pubkey, tweak_bytes)
-        return serialize(self._pubkey, compressed)
+        return serialize(pubkey_tweak_add_(self._pubkey, tweak), compressed)
+
+
+def pubkey_tweak_mul_(pubkey: CData, tweak: BytesLike | int) -> CData:
+    """Multiply an already-parsed public key by a tweak.
+
+    The inner half of `pubkey_tweak_mul`, for a caller who already holds
+    the parsed point: see `parse` for what the underscore means
+    throughout. This is the shared point of an ECDH exchange, and
+    `ecdh.shared_secret_` is the hash of it from the same parsed key.
+
+    Args:
+        pubkey: the already-parsed public key, as `parse` returns.
+            Mutated in place.
+        tweak: the scalar to multiply by, 32 bytes or an int below
+            2**256.
+
+    Returns:
+        The same object passed in, multiplied.
+
+    Raises:
+        ValueError: if the tweak is not 32 bytes or does not fit in them,
+            or if it is zero or at or above the group order.
+    """
+    if not lib.secp256k1_ec_pubkey_tweak_mul(ctx, pubkey, scalar(tweak, "tweak")):
+        raise ValueError("invalid tweak")
+    return pubkey
 
 
 def pubkey_tweak_mul(
@@ -309,11 +350,7 @@ def pubkey_tweak_mul(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    pubkey = parse(pubkey_bytes)
-    tweak_bytes = scalar(tweak, "tweak")
-    if not lib.secp256k1_ec_pubkey_tweak_mul(ctx, pubkey, tweak_bytes):
-        raise ValueError("invalid tweak")
-    return serialize(pubkey, compressed)
+    return serialize(pubkey_tweak_mul_(parse(pubkey_bytes), tweak), compressed)
 
 
 def pubkey_combine(
@@ -348,6 +385,27 @@ def pubkey_combine(
     return serialize(combined, compressed)
 
 
+def pubkey_cmp_(pubkey1: CData, pubkey2: CData) -> int:
+    """Compare two already-parsed public keys, in compressed-form order.
+
+    The inner half of `pubkey_cmp`, for a caller who already holds both
+    parsed points -- sorting keys it has parsed for another reason, where
+    every comparison of a sort would otherwise parse both of its
+    arguments again. See `parse` for what the underscore means
+    throughout.
+
+    Args:
+        pubkey1: the first already-parsed public key, as `parse` returns.
+        pubkey2: the second one.
+
+    Returns:
+        A negative number, zero, or a positive number, according to
+        whether the first key sorts before, equal to, or after the
+        second.
+    """
+    return int(lib.secp256k1_ec_pubkey_cmp(ctx, pubkey1, pubkey2))
+
+
 def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
     """Compare two public keys, in lexicographic order of compressed form.
 
@@ -366,9 +424,7 @@ def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
     Raises:
         ValueError: if either key is not a valid point.
     """
-    return int(
-        lib.secp256k1_ec_pubkey_cmp(ctx, parse(pubkey1_bytes), parse(pubkey2_bytes))
-    )
+    return pubkey_cmp_(parse(pubkey1_bytes), parse(pubkey2_bytes))
 
 
 def pubkey_sort(
@@ -408,6 +464,19 @@ def parse(pubkey_bytes: BytesLike) -> CData:
     The internal form is what the raw `lib` calls take, and what
     `serialize` turns back into bytes: `serialize(parse(key))` is the
     compressed form of a key given in either form.
+
+    It is also what a trailing underscore means across these bindings.
+    Every wrapper whose first act is to parse a public key has an inner
+    half spelled with one -- `pubkey_tweak_add_` here, `dsa.verify_`
+    elsewhere -- taking the object this returns in place of the bytes,
+    and the outer half is that inner half with a `parse` in front of it,
+    which is the equality `tests/test_parsed_keys.py` holds every pair
+    to. For a compressed key that parse is a field square root, so a
+    caller who has already paid for one -- having validated the key, or
+    being about to use the same key again -- can hand it on rather than
+    buy it twice. Nothing else about the two halves differs: the
+    remaining arguments are checked exactly as the outer half checks
+    them, a bare pointer's length being what no C return code can report.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import secrets
 
-from . import BytesLike, CData, ffi, lib
+from . import BytesLike, CData, ffi, lib, xonly
 from ._scalar import octets, scalar
 from ._secret import wipe
 from .context import ctx
@@ -125,6 +125,41 @@ def sign_custom(
     raise RuntimeError("schnorr signing failed")
 
 
+def verify_(
+    msg_bytes: BytesLike, xonly_pubkey: CData, signature_bytes: BytesLike
+) -> bool:
+    """Verify a Schnorr signature against an already-parsed x-only key.
+
+    The inner half of `verify`, for a caller who already holds the parsed
+    key -- one that proved 32 bytes to be the x coordinate of a point,
+    which is what `xonly.parse` answers and what this verification would
+    ask again, or one checking several signatures against the same key:
+    see `keys.parse` for what the underscore means throughout.
+
+    Args:
+        msg_bytes: the message, of any length.
+        xonly_pubkey: the already-parsed x-only public key, as
+            `xonly.parse` returns.
+        signature_bytes: the 64-byte signature.
+
+    Returns:
+        True if the signature is valid for that key and message.
+
+    Raises:
+        ValueError: if the signature is not 64 bytes. A well-formed
+            signature that simply does not verify is False, not an
+            exception.
+    """
+    msg_bytes = octets(msg_bytes, "message")
+    signature_bytes = octets(signature_bytes, "signature", 64)
+
+    return bool(
+        lib.secp256k1_schnorrsig_verify(
+            ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
+        )
+    )
+
+
 def verify(
     msg_bytes: BytesLike, pubkey_bytes: BytesLike, signature_bytes: BytesLike
 ) -> bool:
@@ -150,20 +185,7 @@ def verify(
             well-formed signature that simply does not verify is False,
             not an exception.
     """
-    msg_bytes = octets(msg_bytes, "message")
-    signature_bytes = octets(signature_bytes, "signature", 64)
-    # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    pubkey_bytes = octets(pubkey_bytes, "x-only public key", 32)
-
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
-        raise ValueError("invalid x-only public key")
-
-    return bool(
-        lib.secp256k1_schnorrsig_verify(
-            ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
-        )
-    )
+    return verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
 
 
 def _keypair(prvkey: BytesLike | int) -> CData:

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -13,17 +13,47 @@ y; the parity returned along a tweaked key is the one of the tweaked
 point, to be committed to by the taproot output.
 
 `from_pubkey` is the conversion from a full public key, and the only
-function here taking one: everything else takes the 32-byte form, so
+conversion here taking one -- `from_pubkey_` being itself, on the parsed
+point rather than the bytes: everything else takes the 32-byte form, so
 that discarding a y coordinate happens where the caller can see it and
 not inside an argument check.
 """
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, lib
+from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import octets, scalar
 from ._secret import take, wipe
 from .context import ctx
+
+
+def from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
+    """Convert an already-parsed public key into its x-only form and parity.
+
+    The inner half of `from_pubkey`, for a caller who already holds the
+    parsed point: see `keys.parse` for what the underscore means
+    throughout.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+
+    Returns:
+        The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
+        odd.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to convert or serialize it,
+            which no valid key can make it do.
+    """
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    parity = ffi.new("int *")
+    if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
+        raise RuntimeError("x-only public key conversion failed")
+
+    output = ffi.new("char[32]")
+    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
+        raise RuntimeError("x-only public key serialization failed")
+    return ffi.unpack(output, ffi.sizeof(output)), parity[0]
 
 
 def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
@@ -43,11 +73,7 @@ def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
-    pubkey_bytes = octets(pubkey_bytes, "public key")
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError("invalid public key")
-    return _to_xonly(pubkey)
+    return from_pubkey_(keys.parse(pubkey_bytes))
 
 
 def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, int]:
@@ -72,7 +98,7 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             result, which no valid input can make it do.
     """
-    internal_pubkey = _parse(pubkey_bytes)
+    internal_pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
 
     tweaked_pubkey = ffi.new("secp256k1_pubkey *")
@@ -80,7 +106,7 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         ctx, tweaked_pubkey, internal_pubkey, tweak_bytes
     ):
         raise ValueError("invalid tweak or resulting public key")
-    return _to_xonly(tweaked_pubkey)
+    return from_pubkey_(tweaked_pubkey)
 
 
 def tweak_add_check(
@@ -119,7 +145,7 @@ def tweak_add_check(
     if tweaked_parity not in (0, 1):
         raise ValueError("the parity must be 0 or 1")
 
-    internal_pubkey = _parse(pubkey_bytes)
+    internal_pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
 
     return bool(
@@ -169,8 +195,17 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
         wipe(keypair)
 
 
-def _parse(pubkey_bytes: BytesLike) -> CData:
+def parse(pubkey_bytes: BytesLike) -> CData:
     """Parse a 32-byte x-only public key.
+
+    The x-only counterpart of `keys.parse`, and the argument of
+    `ssa.verify_`: a caller that has proved 32 bytes to be the x
+    coordinate of a point has made the call BIP340 verification makes
+    anyway, and can hand the result on rather than make it twice.
+
+    There is no `serialize` beside it, and that is not an omission:
+    nothing here hands back a parsed x-only key except this, `from_pubkey`
+    and `tweak_add` answering with the 32 bytes and the parity instead.
 
     Args:
         pubkey_bytes: the 32-byte x coordinate.
@@ -188,30 +223,6 @@ def _parse(pubkey_bytes: BytesLike) -> CData:
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
         raise ValueError("invalid x-only public key")
     return xonly_pubkey
-
-
-def _to_xonly(pubkey: CData) -> tuple[bytes, int]:
-    """Serialize a public key as its x-only form and y parity.
-
-    Args:
-        pubkey: the libsecp256k1 public key object.
-
-    Returns:
-        Its 32-byte x coordinate, and the parity of y.
-
-    Raises:
-        RuntimeError: if libsecp256k1 fails to convert or serialize it,
-            which no valid key can make it do.
-    """
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    parity = ffi.new("int *")
-    if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
-        raise RuntimeError("x-only public key conversion failed")
-
-    output = ffi.new("char[32]")
-    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
-        raise RuntimeError("x-only public key serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output)), parity[0]
 
 
 def _keypair(prvkey: BytesLike | int) -> CData:

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -44,6 +44,10 @@ MSG = b"\x01" * 32
 PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
 PUBKEY_LONG = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
 XONLY, PARITY = xonly.from_pubkey(PUBKEY)
+# the parsed forms the inner halves take, which are what those entry
+# points have in place of the bytes rather than an argument to retype
+PARSED = keys.parse(PUBKEY)
+PARSED_XONLY = xonly.parse(XONLY)
 DER = dsa.sign(MSG, PRVKEY)
 COMPACT = dsa.to_compact(DER)
 SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
@@ -85,6 +89,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),
     ("dsa.sign", dsa.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("dsa.verify", dsa.verify, (MSG, PUBKEY, DER), {}),
+    ("dsa.verify_", dsa.verify_, (MSG, PARSED, DER), {}),
     ("dsa.normalize", dsa.normalize, (DER,), {}),
     ("dsa.is_low_s", dsa.is_low_s, (DER,), {}),
     ("dsa.to_compact", dsa.to_compact, (DER,), {}),
@@ -92,6 +97,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("ssa.sign", ssa.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("ssa.sign_custom", ssa.sign_custom, (b"a message", PRVKEY, bytes(32)), {}),
     ("ssa.verify", ssa.verify, (MSG, XONLY, SSA_SIG), {}),
+    ("ssa.verify_", ssa.verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
     (
@@ -105,6 +111,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("recovery.recover", recovery.recover, (MSG, RECOVERABLE, RECID), {}),
     ("recovery.to_der", recovery.to_der, (RECOVERABLE, RECID), {}),
     ("ecdh.shared_secret", ecdh.shared_secret, (PUBKEY, PRVKEY), {}),
+    ("ecdh.shared_secret_", ecdh.shared_secret_, (PARSED, PRVKEY), {}),
     ("ellswift.create", ellswift.create, (PRVKEY, bytes(32)), {}),
     ("ellswift.encode", ellswift.encode, (PUBKEY, bytes(32)), {}),
     ("ellswift.decode", ellswift.decode, (ELL_A,), {}),
@@ -160,20 +167,26 @@ MODULES = {
 }
 
 # the ones that take no argument crossing as a bare pointer, or nothing
-# this sweep has not already exercised: `parse` takes one and is covered
-# through every wrapper above, `serialize` takes the libsecp256k1 object
-# `parse` hands back and no bytes at all. `pubkey_tweak_add_` is the same
-# shape as `serialize`, an already-parsed key and the already-32-byte
-# output of `scalar`, neither retyped here. `PubkeyTweakChain` calls
-# `parse` on construction and `scalar` on every `tweak_add`, so its own
-# bytes-like handling is `keys.pubkey_tweak_add`'s above, not a call this
-# sweep can equality-check across instances that are never equal to begin
-# with
+# this sweep has not already exercised. Both `parse` functions take one
+# and are covered through every wrapper above; `serialize`,
+# `pubkey_negate_`, `pubkey_cmp_` and `from_pubkey_` take the
+# libsecp256k1 object a `parse` hands back and no bytes at all. The two
+# tweaking inner halves do take a tweak, and it is the retyped one of
+# `keys.pubkey_tweak_add` and `keys.pubkey_tweak_mul` above, which pass
+# theirs straight in: what they answer with is the parsed key they
+# mutated, and two calls of it are never equal. `PubkeyTweakChain` is the
+# same, calling `parse` on construction and reaching `scalar` through
+# `pubkey_tweak_add_` on every `tweak_add`
 NOT_SWEPT = {
     "keys.serialize",
     "keys.parse",
+    "keys.pubkey_negate_",
     "keys.pubkey_tweak_add_",
+    "keys.pubkey_tweak_mul_",
+    "keys.pubkey_cmp_",
     "keys.PubkeyTweakChain",
+    "xonly.parse",
+    "xonly.from_pubkey_",
 }
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -431,6 +431,45 @@ def test_dsa_low_s() -> None:
     assert dsa.verify(msg, pubkey_bytes, dsa.normalize(malleated_bytes))
 
 
+def test_dsa_verify_normalizes_when_it_is_told_to() -> None:
+    """`normalize=True` is that round trip, without the round trip.
+
+    The same verdict as verifying `normalize(sig)`, on the malleated
+    signature and on the one that was already low-s, and through both
+    halves of `verify`. What it does not do is make anything else
+    verify: the wrong message is still False with it on, so the answer
+    is a normalization and not a leniency. The default is unchanged and
+    is asserted here too, that being the promise the keyword is behind.
+    """
+    prvkey = 7
+    pubkey_bytes = compress(mult.mult_(prvkey))
+    pubkey = keys.parse(pubkey_bytes)
+    der_bytes = dsa.sign(msg, prvkey)
+
+    compact_bytes = dsa.to_compact(der_bytes)
+    s = int.from_bytes(compact_bytes[32:], "big")
+    malleated_bytes = dsa.to_der(compact_bytes[:32] + (N - s).to_bytes(32, "big"))
+
+    # the same answer the round trip through DER gives, and the outer and
+    # inner halves agree on it
+    assert dsa.verify(msg, pubkey_bytes, malleated_bytes, True)
+    assert dsa.verify_(msg, pubkey, malleated_bytes, True)
+    # a signature already low-s is normalized to itself, so nothing about
+    # the ordinary case changes
+    assert dsa.verify(msg, pubkey_bytes, der_bytes, True)
+    assert dsa.verify_(msg, pubkey, der_bytes, True)
+
+    # and the default is still the refusal, through both halves
+    assert not dsa.verify(msg, pubkey_bytes, malleated_bytes)
+    assert not dsa.verify_(msg, pubkey, malleated_bytes)
+
+    # normalizing s says nothing about the message: a signature of
+    # another one is False either way
+    other_msg = hashlib.sha256(b"another message").digest()
+    assert not dsa.verify(other_msg, pubkey_bytes, malleated_bytes, True)
+    assert not dsa.verify(other_msg, pubkey_bytes, der_bytes, True)
+
+
 def test_size_checks_refuse_both_sides() -> None:
     """Both x-only size checks refuse a value too short as well as too long.
 
@@ -441,7 +480,7 @@ def test_size_checks_refuse_both_sides() -> None:
     """
     xonly_bytes, parity = xonly.from_pubkey(mult.mult_(11))
 
-    # _parse, reached through both entry points
+    # parse, reached through both entry points
     with pytest.raises(ValueError, match="x-only public key must be 32 bytes"):
         xonly.tweak_add(xonly_bytes[:-1], b"\x01" * 32)
 

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -1,0 +1,210 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Every inner half answers what its outer half answers.
+
+A trailing underscore means one thing across these bindings, and
+`keys.parse` states it: the wrapper takes the parsed public key in place
+of the bytes, and the outer half is that same call with a `parse` in
+front of it. That is an equality, so it is written as one here, pair by
+pair and over both serializations of the key -- which is what keeps the
+two halves from drifting into two implementations of the same thing.
+
+`test_every_inner_half_is_paired` holds the table to the modules' own
+contents, so an inner half added and not paired here is visible as an
+absence rather than as a test nobody wrote.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from btclib_secp256k1 import dsa, ecdh, keys, mult, ssa, xonly
+
+# secp256k1 group order
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+PRVKEY = 7
+TWEAK = 11
+MSG = hashlib.sha256(b"btclib_secp256k1").digest()
+
+PUBKEY_LONG = mult.mult_(PRVKEY)
+PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
+OTHER = keys.pubkey_from_prvkey(3)
+XONLY, PARITY = xonly.from_pubkey(PUBKEY)
+DER = dsa.sign(MSG, PRVKEY)
+SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
+
+# every pair of the convention: the name of the outer half, that half as
+# a call of the serialized key alone, and the inner half as a call of the
+# parsed one. The arguments that are not the key are closed over, being
+# the same on both sides by construction. Two of the inner halves answer
+# with the key they mutated, and a cffi object is equal to no other, so
+# those are compared through `keys.serialize` -- which is what their
+# outer halves do with the same object
+PAIRS: list[tuple[str, Callable[[bytes], Any], Callable[[Any], Any]]] = [
+    (
+        "keys.pubkey_negate",
+        keys.pubkey_negate,
+        lambda pubkey: keys.serialize(keys.pubkey_negate_(pubkey)),
+    ),
+    (
+        "keys.pubkey_tweak_add",
+        lambda pubkey_bytes: keys.pubkey_tweak_add(pubkey_bytes, TWEAK),
+        lambda pubkey: keys.serialize(keys.pubkey_tweak_add_(pubkey, TWEAK)),
+    ),
+    (
+        "keys.pubkey_tweak_mul",
+        lambda pubkey_bytes: keys.pubkey_tweak_mul(pubkey_bytes, TWEAK),
+        lambda pubkey: keys.serialize(keys.pubkey_tweak_mul_(pubkey, TWEAK)),
+    ),
+    (
+        "keys.pubkey_cmp",
+        lambda pubkey_bytes: keys.pubkey_cmp(pubkey_bytes, OTHER),
+        lambda pubkey: keys.pubkey_cmp_(pubkey, keys.parse(OTHER)),
+    ),
+    ("xonly.from_pubkey", xonly.from_pubkey, xonly.from_pubkey_),
+    (
+        "ecdh.shared_secret",
+        lambda pubkey_bytes: ecdh.shared_secret(pubkey_bytes, PRVKEY),
+        lambda pubkey: ecdh.shared_secret_(pubkey, PRVKEY),
+    ),
+    (
+        "dsa.verify",
+        lambda pubkey_bytes: dsa.verify(MSG, pubkey_bytes, DER),
+        lambda pubkey: dsa.verify_(MSG, pubkey, DER),
+    ),
+]
+
+
+@pytest.mark.parametrize("pubkey_bytes", [PUBKEY, PUBKEY_LONG], ids=["33", "65"])
+@pytest.mark.parametrize("name,outer,inner", PAIRS, ids=[pair[0] for pair in PAIRS])
+def test_the_inner_half_is_the_outer_one_without_the_parse(
+    name: str,
+    outer: Callable[[bytes], Any],
+    inner: Callable[[Any], Any],
+    pubkey_bytes: bytes,
+) -> None:
+    """`outer(key_bytes)` is `inner(parse(key_bytes))`, in both forms.
+
+    Both serializations, because the parse is what tells them apart: the
+    compressed one costs a field square root the uncompressed one does
+    not, which is the whole reason for the pair, and the parsed key it
+    ends at is the same point either way.
+
+    Args:
+        name: the outer half, for the test id.
+        outer: it, as a call of the serialized key.
+        inner: the inner half, as a call of the parsed key.
+        pubkey_bytes: the key, compressed or not.
+    """
+    assert outer(pubkey_bytes) == inner(keys.parse(pubkey_bytes))
+
+
+def test_the_schnorr_pair_parses_the_x_only_key() -> None:
+    """`ssa.verify` is `ssa.verify_` behind `xonly.parse`.
+
+    The one pair whose parsed key is not `keys.parse`'s: BIP340 verifies
+    against the 32-byte x-only key, so what a caller holds is what
+    `xonly.parse` returns, and proving those 32 bytes to be the x
+    coordinate of a point is the call the verification would make again.
+    """
+    assert ssa.verify(MSG, XONLY, SSA_SIG)
+    assert ssa.verify_(MSG, xonly.parse(XONLY), SSA_SIG)
+    # and a signature that does not verify is False through both, rather
+    # than an equality that holds because everything is True
+    tampered = bytes([SSA_SIG[0] ^ 1]) + SSA_SIG[1:]
+    assert not ssa.verify(MSG, XONLY, tampered)
+    assert not ssa.verify_(MSG, xonly.parse(XONLY), tampered)
+
+
+def test_a_parsed_key_verifies_more_than_once() -> None:
+    """The motivating case: one parse, several signatures.
+
+    Verification does not consume or change the key it is given -- the
+    C call takes it const -- so a caller checking a batch of signatures
+    against one key pays for the parse once. Checked by verifying three
+    signatures of three messages through the same parsed key, and then
+    asserting the key still serializes to the bytes it was parsed from.
+    """
+    pubkey = keys.parse(PUBKEY)
+    for index in range(3):
+        msg = hashlib.sha256(index.to_bytes(4, "big")).digest()
+        assert dsa.verify_(msg, pubkey, dsa.sign(msg, PRVKEY))
+        assert not dsa.verify_(msg, pubkey, DER)
+    assert keys.serialize(pubkey) == PUBKEY
+
+
+def test_an_inner_half_still_checks_everything_but_the_key() -> None:
+    """What the underscore drops is the parse, and nothing else.
+
+    Each remaining argument is refused exactly as the outer half refuses
+    it: a message hash that is not 32 octets, a DER signature that is
+    malformed, a signature that is not 64, a private key that is not a
+    scalar, a tweak that is not 32 octets. A bare pointer's length is
+    what no C return code can report, so an inner half that skipped these
+    would be reading past the end of a short value.
+    """
+    pubkey = keys.parse(PUBKEY)
+
+    with pytest.raises(ValueError, match="message hash"):
+        dsa.verify_(MSG[1:], pubkey, DER)
+    with pytest.raises(ValueError, match="DER"):
+        dsa.verify_(MSG, pubkey, b"\x00" * 10)
+    with pytest.raises(ValueError, match="signature must be 64 bytes"):
+        ssa.verify_(MSG, xonly.parse(XONLY), SSA_SIG[1:])
+    with pytest.raises(ValueError, match="private key"):
+        ecdh.shared_secret_(pubkey, 0)
+    with pytest.raises(ValueError, match="tweak must be 32 bytes"):
+        keys.pubkey_tweak_add_(pubkey, b"\x01" * 31)
+    with pytest.raises(ValueError, match="tweak must be 32 bytes"):
+        keys.pubkey_tweak_mul_(pubkey, b"\x01" * 33)
+
+    # and the two verdicts libsecp256k1 gives on a tweak, through the
+    # inner halves: the sum that is the point at infinity, and the zero
+    # multiplier
+    with pytest.raises(ValueError, match="tweak or resulting public key"):
+        keys.pubkey_tweak_add_(keys.parse(mult.mult_(7)), N - 7)
+    with pytest.raises(ValueError, match="invalid tweak"):
+        keys.pubkey_tweak_mul_(pubkey, 0)
+
+
+def test_every_inner_half_is_paired() -> None:
+    """Every trailing underscore of the boundary is in the table above.
+
+    The convention is a claim about every function spelled that way, so
+    the table is checked against what the modules export rather than
+    trusted to have been kept up to date. `mult.mult_` is the one
+    exception and is named as one: its underscore is older and means the
+    other thing, the serialized point against the pair of coordinates
+    `mult` answers with, and there is no key to hand it already parsed.
+    """
+    modules = {
+        "dsa": dsa,
+        "ecdh": ecdh,
+        "keys": keys,
+        "mult": mult,
+        "ssa": ssa,
+        "xonly": xonly,
+    }
+    paired = {f"{name}_" for name, *_ in PAIRS} | {"ssa.verify_"}
+    inner_halves = {
+        f"{module_name}.{name}"
+        for module_name, module in modules.items()
+        for name in dir(module)
+        if name.endswith("_")
+        and not name.startswith("_")
+        and callable(getattr(module, name))
+        and getattr(getattr(module, name), "__module__", "")
+        == f"btclib_secp256k1.{module_name}"
+    }
+
+    assert inner_halves - paired == {"mult.mult_"}
+    # and the table names nothing the modules do not have
+    assert paired - inner_halves == set()


### PR DESCRIPTION
Closes #147 and #148. They are one design question — #148 says so itself
("if that one is answered by making the parsed form part of the API, this
follows it") — and the caller behind both,
btclib-org/btclib#887 / btclib-org/btclib#889, pays the two costs in the
same function, so `dsa.verify_` has to be introduced once with its final
signature rather than twice.

## The parsed public key (#147)

`keys.parse` was public, `keys.serialize` took what it returned, and
`pubkey_tweak_add_` consumed one — but `dsa.verify`, `ssa.verify` and
`ecdh.shared_secret` took bytes and parsed them, so a caller already
holding a parsed key had nowhere to put it. New:

| inner half | outer half |
| --- | --- |
| `dsa.verify_` | `dsa.verify` |
| `ssa.verify_` | `ssa.verify` |
| `ecdh.shared_secret_` | `ecdh.shared_secret` |
| `keys.pubkey_negate_` | `keys.pubkey_negate` |
| `keys.pubkey_tweak_mul_` | `keys.pubkey_tweak_mul` |
| `keys.pubkey_cmp_` | `keys.pubkey_cmp` |
| `xonly.from_pubkey_` | `xonly.from_pubkey` |

plus `xonly.parse`, public beside `keys.parse` because BIP340 verifies
against the x-only key and that is what `ssa.verify_` takes.

The convention is stated once, in `keys.parse`, and it is narrower than
`pubkey_tweak_add_`'s docstring was: **the inner half takes the parsed key
in place of the bytes, and the outer half is that inner half with a
`parse` in front of it.** Nothing else differs — every remaining argument
is checked exactly as before, a bare pointer's length being what no C
return code can report. That is why `pubkey_tweak_add_` is brought to the
same rule here: it now takes `BytesLike | int` and validates the tweak
itself, where it took 32 bytes on trust and would have read past the end
of a shorter one. `PubkeyTweakChain` is unchanged in behaviour, its
`scalar` call happening one frame further in.

`tests/test_parsed_keys.py` holds every pair to that equality, over both
serializations of the key, and holds the table of pairs to what the
modules export — an inner half added and left unpaired fails there.
`mult.mult_` is named in it as the one trailing underscore that means the
older thing.

## Normalizing while verifying (#148)

`dsa.verify` and `dsa.verify_` take a `normalize` flag, false by default.
libsecp256k1 documents `sigout == sigin` for
`secp256k1_ecdsa_signature_normalize`, so with the flag the normalization
happens on the signature `verify` has already parsed, where
`verify(msg, key, normalize(sig))` costs a DER serialization and a second
parse besides.

A flag rather than the public parsed-signature form #148 also offered: a
parsed *key* is something a caller holds for its own reasons, while a
parsed DER signature is an intermediate nothing here produces or consumes,
so publishing it would have meant a `parse`, a `serialize` and inner
halves of `normalize`, `is_low_s` and `to_compact` for one caller that
wants none of them. CHANGELOG.md records both decisions.

## Gate

`uvx pre-commit run --all-files` clean; `pytest --cov` 459 passed at
100.00%; the docs build (`sphinx-build -W --keep-going`), `uv build
--sdist`, `twine check --strict` and `pyroma --min 10` all pass locally.
The README's new example is executed by `tests/test_examples.py` like
every other.

## Summary by Sourcery

Introduce inner-underscore APIs that accept already-parsed public or x-only keys, and add an optional normalization path to ECDSA verification.

New Features:
- Add inner variants for key operations and verification (`dsa.verify_`, `ssa.verify_`, `ecdh.shared_secret_`, `keys.pubkey_negate_`, `keys.pubkey_tweak_mul_`, `keys.pubkey_cmp_`, `xonly.from_pubkey_`) that operate on already-parsed keys to avoid redundant parsing.
- Expose `xonly.parse` as the x-only counterpart to `keys.parse` for BIP340 key handling.
- Add a `normalize` flag to `dsa.verify`/`dsa.verify_` to optionally normalize ECDSA signatures to lower-s form during verification.

Enhancements:
- Refine `keys.pubkey_tweak_add_` and related APIs to validate tweaks internally and share scalar-handling logic.
- Document and enforce a consistent convention for trailing-underscore inner functions via `keys.parse` and new README/CHANGELOG/HISTORY entries.
- Refactor x-only key parsing and conversion logic to reuse shared helpers and align with the new parsed-key convention.

Tests:
- Add `tests/test_parsed_keys.py` to verify inner/outer function equivalence and coverage of all trailing-underscore APIs.
- Extend tests to cover ECDSA verification with and without in-place normalization and ensure non-lenient behavior.
- Update bytes-like tests to exercise new inner functions and parsed-key entry points.