### PR TITLE
0.8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
-## v0.8.0.2 (work in progress, not released yet)
+## v0.8.0.2
 
 ### The parsed public key
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.8.0.2 (work in progress, not released yet)
+## v0.8.0.2
 
 Non-breaking, and two additions for a caller that verifies signatures it
 did not make.


### PR DESCRIPTION
Non-breaking, and two additions for a caller that verifies signatures it did not make: verification takes the parsed public key now (#147), and `dsa.verify`/`dsa.verify_` take a `normalize` flag (#148). The benchmark moved out to [btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks). Full detail in the closed sections of [HISTORY.md](../blob/main/HISTORY.md) and [CHANGELOG.md](../blob/main/CHANGELOG.md).

This cycle also carries the `release.yml` fix from #141 (`github-release` no longer risks a skip on a real release) — untested on the real-tag path until this release's own tag, since a rehearsal does not exercise it.

No TestPyPI rehearsal for this one, by explicit choice rather than by RELEASING.md's own criterion (which would have leaned toward one, `release.yml` having changed) — `actionlint`/`zizmor` already validated the workflow file statically.

`latest` was dispatched on `main` before this PR: [run 31828803126](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31828803126), red again (it gates nothing either way; check the run for what moved).

Everything merged since v0.8.0.1:

```
0bb41ff Fix github-release skipping every real release (#141)
87254e2 Open 0.8.0.2 (#140)
```

## Summary by Sourcery

Documentation:
- Mark v0.8.0.2 as a released version in CHANGELOG and HISTORY instead of work-in-progress.