### PR TITLE
Fix github-release skipping every real release, this time for real

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,31 +443,34 @@ jobs:
   # rehearsal too, so naming it by itself would make this job cut a
   # release from a dispatch, where publish-pypi is skipped and a skipped
   # need is what keeps this to the tag.
-  # The `if` is explicit and checks only these two `.result`s, which is
-  # not the same thing as leaving it to the implicit default -- this job
-  # used to, and that was a bug, not a simplification. attest's own `if`
-  # above is `always()`, so the implicit default here does not stop at
-  # this job's direct needs: with no arguments it looks at the whole
-  # dependency graph, and publish-testpypi -- two hops back, through
-  # attest's always()-guarded edge -- is *always* skipped on a real tag,
-  # only running on a dispatch. The implicit default treats a skipped
-  # job found that way the same as a failed direct need, so this job was
-  # skipped on every real release regardless of whether publish-pypi and
-  # attest themselves succeeded. They did, twice: v0.8.0 and v0.8.0.1
-  # both published clean and both left no GitHub release, which is how
-  # this was found. `needs.attest.result == 'success'` asks the one
-  # question that matters -- did the job actually succeed -- without
-  # asking the implicit default's much larger question about a job this
-  # one has no reason to care about.
-  # A failure in either named job still leaves the version published and
-  # no release cut, which `gh run rerun --failed` finishes without
-  # rebuilding anything, same as before this fix; what is different is
-  # that a *success* on both no longer risks a skip
+  # `always()` is required here too, and an explicit `if` without it is
+  # not enough to say so -- measured the hard way, twice. The first fix
+  # added the two `.result` checks below and reasoned that was the whole
+  # story: the implicit default asks a bigger question than this job has
+  # reason to ask, so asking only about its own direct needs should have
+  # been enough. v0.8.0.2 shipped with exactly that and was skipped all
+  # the same, `publish-pypi` and `attest` both green. What actually
+  # happens is structural, not a property of which question the `if`
+  # asks: a job with a skipped job anywhere in its ancestry is
+  # force-skipped regardless of its own condition, unless that condition
+  # starts with `always()` (or `success()`/`failure()`) -- and that
+  # override does not clear the taint for whoever depends on *it*.
+  # attest's `always()` keeps attest itself from being skipped when
+  # publish-testpypi is; github-release, needing attest, still sits
+  # behind that same skipped ancestor and is force-skipped in turn unless
+  # it also opts out on its own. Every job that crosses a skip has to say
+  # `always()` for itself; the first fix said it for neither of the two
+  # that needed it and the second still said it for only one.
+  # v0.8.0, v0.8.0.1 and v0.8.0.2 all published clean and none produced a
+  # GitHub release: recreated by hand from the run's own `sdist` and
+  # `attestation` artifacts each time, which `gh run rerun --failed` does
+  # not reach either way -- that flag reruns `failure`, and a structural
+  # skip is neither a failure nor within its blast radius
   github-release:
     name: Attach the files to the GitHub release
     needs: [publish-pypi, attest]
     if: >-
-      needs.publish-pypi.result == 'success' &&
+      always() && needs.publish-pypi.result == 'success' &&
       needs.attest.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1467
+        "line_number": 1491
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T16:35:37Z"
+  "generated_at": "2026-08-14T19:45:47Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
+## v0.8.0.3 (work in progress, not released yet)
+
+### CI
+
+- **`github-release` needed `always()` too, not just an explicit `if`.**
+  The previous fix (v0.8.0.2's own CHANGELOG entry, right below) added
+  `needs.publish-pypi.result == 'success' && needs.attest.result ==
+  'success'` and reasoned that asking only about direct needs would be
+  enough — it was not: v0.8.0.2 published clean and was *still* skipped
+  with both of those green. GitHub's needs-based skip is structural, not
+  a property of which question a job's own `if` asks: a job with a
+  skipped job anywhere in its ancestry is force-skipped regardless of its
+  condition unless that condition itself starts with `always()`, and the
+  override does not clear the taint for whoever depends on the job that
+  used it. `attest`'s `always()` keeps attest itself from being skipped
+  when `publish-testpypi` is (always, on a real tag); `github-release`,
+  needing `attest`, still sat behind that same skipped ancestor and was
+  force-skipped in turn until it opted out on its own. `if: always() &&
+  needs.publish-pypi.result == 'success' && needs.attest.result ==
+  'success'` is what actually breaks the chain. v0.8.0, v0.8.0.1 and
+  v0.8.0.2 all published clean and none produced a GitHub release,
+  recreated by hand from each run's own `sdist` and `attestation`
+  artifacts every time
+
 ## v0.8.0.2
 
 ### The parsed public key

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
+## v0.8.0.3 (work in progress, not released yet)
+
 ## v0.8.0.2
 
 Non-breaking, and two additions for a caller that verifies signatures it

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -276,25 +276,32 @@ Then:
    --failed` reruns the cell alone and it passes the second time
 1. check the GitHub release the workflow created once PyPI had accepted
    the upload — and check that it exists at all before reading anything
-   in it: `github-release` was left `skipped` on both 0.8.0 and 0.8.0.1,
-   despite `publish-pypi` and `attest` succeeding both times. The cause
-   was `attest`'s own `if: always() && (...)`, needed so it can run past
-   a skipped sibling — `publish-testpypi` is always skipped on a real
-   tag, `publish-pypi` on a dispatch. `github-release`'s implicit default
-   `if`, called with no arguments, does not stop at its own direct
-   `needs`; it looks at the whole graph reachable through them, and a
-   skipped job found two hops back through an `always()`-guarded edge is
-   treated the same as a failed direct one — which skipped this job on
-   every real release regardless of what `publish-pypi` and `attest`
-   themselves did. Fixed now: `github-release`'s `if` is explicit,
-   `needs.publish-pypi.result == 'success' && needs.attest.result ==
-   'success'`, asking only the two questions this job has a reason to
-   ask. A release cut after this fix should not need what follows here;
-   keep it for a release that predates the fix, or for a failure of
-   `github-release` itself rather than a skip, which `gh run rerun
-   --failed` reaches directly — a skip, unlike a failure, is not what
-   that flag reruns, so before the fix a rerun scoped to some other job's
-   failing cell always left `github-release` exactly where it was.
+   in it: `github-release` was left `skipped` on 0.8.0, 0.8.0.1 and
+   0.8.0.2, despite `publish-pypi` and `attest` succeeding every time.
+   The cause is `attest`'s own `if: always() && (...)`, needed so it can
+   run past a skipped sibling — `publish-testpypi` is always skipped on a
+   real tag, `publish-pypi` on a dispatch. GitHub's needs-based skip is
+   structural, not a property of which question a job's own `if` asks: a
+   job with a skipped job anywhere in its ancestry is force-skipped
+   regardless of its condition, unless that condition itself starts with
+   `always()` — and the override does not clear the taint for whoever
+   depends on the job that used it. That is what the 0.8.0 fix got wrong:
+   it gave `github-release` an explicit `if:
+   needs.publish-pypi.result == 'success' && needs.attest.result ==
+   'success'`, reasoning that asking only about direct needs would be
+   enough, and 0.8.0.2 shipped with exactly that and was skipped all the
+   same — `attest`'s `always()` keeps attest itself from being skipped
+   when `publish-testpypi` is, but `github-release`, needing attest,
+   still sat behind that same skipped ancestor and was force-skipped in
+   turn. `github-release`'s `if` needs its own `always()` too: `if:
+   always() && needs.publish-pypi.result == 'success' &&
+   needs.attest.result == 'success'`. A release cut after this second fix
+   should not need what follows here; keep it for a release that
+   predates it, or for a failure of `github-release` itself rather than a
+   skip, which `gh run rerun --failed` reaches directly — a skip, unlike
+   a failure, is not what that flag reruns, so before this fix a rerun
+   scoped to some other job's failing cell always left `github-release`
+   exactly where it was.
 
    Recreate a skipped release by hand from the run's own artifacts, which
    is the same thing that step would have done:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btclib_secp256k1"
-version = "0.8.0.2"
+version = "0.8.0.3"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "btclib-secp256k1"
-version = "0.8.0.2"
+version = "0.8.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
The #141 fix was incomplete, discovered when v0.8.0.2 published clean and `github-release` was skipped all the same, `publish-pypi` and `attest` both green — exactly what #141 was supposed to have already fixed.

The real mechanism: GitHub's needs-based skip is structural, not a property of which question a job's own `if` asks. A job with a skipped job anywhere in its ancestry is force-skipped regardless of its own condition, unless that condition starts with `always()` — and the override does not clear the taint for whoever depends on the job that used it. `attest`'s `always()` keeps attest itself from being skipped when `publish-testpypi` is (always, on a real tag); `github-release`, needing attest, still sat behind that same skipped ancestor and was force-skipped in turn, `#141`'s explicit `.result` checks notwithstanding.

The fix adds `always()` to `github-release`'s own condition too: `if: always() && needs.publish-pypi.result == 'success' && needs.attest.result == 'success'`. Verified with `actionlint`/`zizmor` (clean) and by reasoning through the rehearsal path again (`publish-pypi` skipped there keeps `github-release` skipped, unchanged). I cannot verify the positive branch locally or in a rehearsal — same limitation as #141 — only the next real tag proves it, and given #141 already looked sufficient and wasn't, that limitation is worth taking seriously this time rather than repeating the same confidence.

v0.8.0.2's GitHub release was recreated by hand from its run's own `sdist` and `attestation` artifacts (hash verified against PyPI, attestation verified) — third time this has happened, after v0.8.0 and v0.8.0.1.

Opens 0.8.0.3 alongside (step 10 of RELEASING.md), carrying this fix's CHANGELOG entry since nothing had landed yet to open it for otherwise.

## Summary by Sourcery

Ensure the GitHub release workflow job runs for successful real releases and open v0.8.0.3 to carry the fix.

Bug Fixes:
- Prevent the github-release workflow job from being structurally skipped on real tags despite successful publish-pypi and attest runs.

CI:
- Update the github-release job condition in the release workflow to include always() alongside explicit needs result checks so it can run past skipped ancestors.

Documentation:
- Refresh RELEASING.md, CHANGELOG.md and HISTORY.md to document the GitHub release skip behaviour and the v0.8.0.3 work-in-progress release carrying this CI fix.

Chores:
- Bump project version from 0.8.0.2 to 0.8.0.3 to open the next release for this fix.