### PR TITLE
Add ssa.Signer, so BIP340 signing builds the keypair once (#153)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1491
+        "line_number": 1533
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -221,240 +221,240 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 925
+        "line_number": 934
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 926
+        "line_number": 935
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 927
+        "line_number": 936
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 932
+        "line_number": 941
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 933
+        "line_number": 942
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 934
+        "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 937
+        "line_number": 946
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 939
+        "line_number": 948
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 940
+        "line_number": 949
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 941
+        "line_number": 950
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 946
+        "line_number": 955
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 947
+        "line_number": 956
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 948
+        "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 956
+        "line_number": 965
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 957
+        "line_number": 966
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 958
+        "line_number": 967
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 966
+        "line_number": 975
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 967
+        "line_number": 976
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 968
+        "line_number": 977
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 971
+        "line_number": 980
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 976
+        "line_number": 985
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 977
+        "line_number": 986
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 978
+        "line_number": 987
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 1017
+        "line_number": 1026
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 1020
+        "line_number": 1029
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 1021
+        "line_number": 1030
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 1028
+        "line_number": 1037
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 1029
+        "line_number": 1038
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 1062
+        "line_number": 1071
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 1063
+        "line_number": 1072
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 1087
+        "line_number": 1096
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 1088
+        "line_number": 1097
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 1104
+        "line_number": 1113
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 1105
+        "line_number": 1114
       }
     ]
   },
-  "generated_at": "2026-08-14T19:45:47Z"
+  "generated_at": "2026-08-15T09:19:59Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,48 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### Signing under one key
+
+- **`ssa.Signer` builds the BIP340 keypair once** (#153). `ssa.sign` and
+  `ssa.sign_custom` build a `secp256k1_keypair` from the private key and
+  wipe it in a `finally`, so a caller signing several messages under one
+  key pays for it once per signature — and it is about half of what a
+  signature costs, being the point multiplication of the public key.
+  Measured on this tree, on an Apple M5, macOS 26.6, arm64, CPython
+  3.14.6, minimum of 10 rounds of 20 000 calls, microseconds per call:
+  `ssa.sign` 15.7, `Signer.sign` 8.2, `secp256k1_keypair_create` alone
+  7.3 — the saving is the keypair and nothing else, and it puts one
+  signature at the cost the C call itself has. `sign_custom` is the same
+  pair, 16.0 and 8.4. What holds the new path to the old one is not that
+  agreement: `tests/test_vectors.py` signs every BIP340 vector through a
+  signer as well, so both are held against bitcoin/bips' published value
+- **and it hands the caller a lifetime, which is the trade it makes.**
+  A keypair is the private key in libsecp256k1's layout, in memory this
+  package owns and can overwrite, so a signer holds a secret across
+  calls where the two functions hold one for the length of one. The
+  `with` block is what makes the wipe deliberate rather than forgotten:
+  `__exit__` overwrites the keypair whether the block ended in a
+  signature or in an exception, `wipe()` is the same instruction by
+  hand, wiping twice is not an error, and a wiped signer raises rather
+  than signing with the zeros — it cannot be revived, the private key
+  being kept nowhere else here. This is the case #87 declined and the
+  reason it declined it does not cover: that issue asked whether an
+  opaque secret handle buys *assurance*, and the answer was no, the
+  python-side copies at import and export being what they are — an
+  answer this does not disturb, SECURITY.md's limits being unchanged and
+  the constructor still taking a `bytes` or an `int` nothing can zeroize.
+  What is new is a measured cost, and it is paid by every caller signing
+  more than once under one key. BIP340 only: `secp256k1_ecdsa_sign`
+  takes the private key directly, so `dsa.sign` has no keypair to hoist
+- **the two functions are now the signer's two calls with the keypair
+  built and wiped around them**, `_sign32` and `_sign_custom` being the
+  shared body, so neither side can drift into a second spelling of the
+  same checks. One consequence is visible: those checks now happen after
+  the private key is turned into a keypair rather than before, so a call
+  with *both* a bad private key and a bad message names the key where it
+  used to name the message. Each on its own is refused as before, and
+  every wipe that happened still happens
+
 ### CI
 
 - **`github-release` needed `always()` too, not just an explicit `if`.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,26 @@ a tag is generated from.
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+Non-breaking, and one addition for a caller that signs more than once
+under one key.
+
+`ssa.Signer` is new: it builds the BIP340 keypair once and signs with it
+as often as asked, where `ssa.sign` and `ssa.sign_custom` build one per
+call and wipe it before returning. That keypair is about half of what a
+signature costs — 15.7 microseconds a signature through `ssa.sign`
+against 8.2 through a signer, on the machine and with the method
+CHANGELOG.md states — so a caller signing a batch under one key roughly
+halves it. Both functions are unchanged in behaviour and cost, and are
+still the right call for a single signature.
+
+What a signer holds is a secret, and it is the caller's for as long as
+they hold it: use it in a `with` block, which overwrites the keypair on
+the way out whether the block ended in a signature or in an exception.
+`signer.wipe()` says the same thing by hand, and a wiped signer refuses
+to sign rather than signing with what the wipe left. The private key
+handed to the constructor is a python `bytes` or `int` and is no more
+zeroizable than before: SECURITY.md's limits are unchanged.
+
 ## v0.8.0.2
 
 Non-breaking, and two additions for a caller that verifies signatures it

--- a/README.md
+++ b/README.md
@@ -287,6 +287,40 @@ against a single key. `xonly.parse` is the same thing for the 32-byte
 x-only key BIP340 verifies against, and `keys.serialize` is how a parsed
 key becomes bytes again.
 
+## Building the keypair once
+
+Signing has the same shape and a different object. `ssa.sign` builds a
+`secp256k1_keypair` from the private key, signs with it and overwrites it
+before returning, so a caller signing a second message under the same key
+builds it again — and that keypair is about half of what a BIP340
+signature costs here, being the point multiplication of the public key.
+`ssa.Signer` holds one across signatures:
+
+```python
+>>> messages = [hashlib.sha256(bytes([index])).digest() for index in range(3)]
+>>> with ssa.Signer(prvkey) as signer:
+...     signatures = [signer.sign(each) for each in messages]
+>>> [ssa.verify(m, xonly_pubkey, s) for m, s in zip(messages, signatures)]
+[True, True, True]
+
+```
+
+Where a parsed public key is a public value a caller may hold for as long
+as they like, a keypair is the private key in libsecp256k1's own layout,
+so this hands the caller a lifetime and not only a saving. That is what
+the `with` block is for: on the way out of it the keypair is overwritten,
+whether the block ended in a signature or in an exception, and a wiped
+signer refuses to sign rather than signing with the zeros left behind.
+`signer.wipe()` is the same instruction spelled by hand, for a caller who
+is done before the block is. What none of it changes is the python side:
+the `bytes` or `int` the constructor is handed is a python object like
+any other, and
+[SECURITY.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/SECURITY.md)
+records why that copy cannot be taken back.
+
+ECDSA has no counterpart and needs none: `secp256k1_ecdsa_sign` takes the
+private key itself, so `dsa.sign` has no object to build once.
+
 ## Wrapped modules
 
 All the optional libsecp256k1 modules are compiled in and their
@@ -409,6 +443,13 @@ the buffers it writes to.
 This matters on a free-threaded interpreter, for which a wheel is built
 (`cp314t`), where those calls are no longer serialized;
 `tests/test_concurrency.py` exercises it.
+
+`ssa.Signer` is the one thing here holding a buffer across calls, and it
+does not cost that guarantee: libsecp256k1 takes a keypair const, so
+several threads may sign through one signer. What is theirs to order is
+the wipe, which overwrites the very memory a concurrent signature is
+reading — the same shape of race as re-randomizing the context below,
+and the reason the `with` block ends where the threads have joined.
 
 The one way to lose that guarantee is to re-randomize the shared context
 while it is in use. `context._randomize(context.ctx)` is there for a

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -12,6 +12,7 @@ https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 from __future__ import annotations
 
 import secrets
+from types import TracebackType
 
 from . import BytesLike, CData, ffi, lib, xonly
 from ._scalar import octets, scalar
@@ -27,6 +28,11 @@ def sign(
     msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
 ) -> bytes:
     """Create a Schnorr signature of a 32-byte message hash.
+
+    The keypair this needs is built from the private key and wiped
+    before returning, which is the right cost for one signature and
+    half the cost of each of several: signing more than once under one
+    key is `Signer`, which builds it once.
 
     Args:
         msg_bytes: the 32-byte message hash.
@@ -55,22 +61,14 @@ def sign(
         >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
         True
     """
-    msg_bytes = octets(msg_bytes, "message hash", 32)
     keypair = _keypair(prvkey)
-
-    sig = ffi.new("char[64]")
     try:
-        signed = lib.secp256k1_schnorrsig_sign32(
-            ctx, sig, msg_bytes, keypair, _aux_rand32(aux_rand32)
-        )
+        return _sign32(msg_bytes, keypair, aux_rand32)
     finally:
         # a keypair carries the private key: overwrite it whether the
-        # signature was made, refused, or never attempted, _aux_rand32
-        # being able to raise between the two
+        # signature was made, refused, or never attempted, the argument
+        # checks inside being able to raise between the two
         wipe(keypair)
-    if signed:
-        return ffi.unpack(sig, ffi.sizeof(sig))
-    raise RuntimeError("schnorr signing failed")
 
 
 def sign_custom(
@@ -83,7 +81,8 @@ def sign_custom(
     hand says otherwise, hash the message with a tag of its own
     (hashes.tagged_sha256) and sign that instead, so that a signature
     cannot be read as one of a different protocol. For a 32-byte message
-    the signature is the one sign returns.
+    the signature is the one sign returns. Signing more than one message
+    under one key is `Signer.sign_custom`, for the reason given there.
 
     Args:
         msg_bytes: the message, of any length.
@@ -101,28 +100,177 @@ def sign_custom(
         RuntimeError: if libsecp256k1 fails to sign, which no input can
             make it do.
     """
-    msg_bytes = octets(msg_bytes, "message")
     keypair = _keypair(prvkey)
-
-    sig = ffi.new("char[64]")
     try:
-        ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
-        extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
-        extraparams.magic = EXTRAPARAMS_MAGIC
-        extraparams.noncefp = ffi.NULL
-        # ndata has to stay referenced until the call is over: cffi keeps
-        # alive what a variable points to, not what a struct field does
-        extraparams.ndata = ndata
-
-        signed = lib.secp256k1_schnorrsig_sign_custom(
-            ctx, sig, msg_bytes, len(msg_bytes), keypair, extraparams
-        )
+        return _sign_custom(msg_bytes, keypair, aux_rand32)
     finally:
         # the keypair carries the private key: see sign
         wipe(keypair)
-    if signed:
-        return ffi.unpack(sig, ffi.sizeof(sig))
-    raise RuntimeError("schnorr signing failed")
+
+
+class Signer:
+    """Sign under one private key repeatedly, building the keypair once.
+
+    `sign` builds a `secp256k1_keypair` and wipes it before returning, so
+    a caller signing a second message under the same key builds it again
+    -- and that keypair is about half of what a BIP340 signature costs
+    here, being the point multiplication of the public key. This holds
+    one across calls instead, so the first signature is the only one
+    paying for it, and `sign` and `sign_custom` are the same signatures
+    over it.
+
+    What that hands the caller is the lifetime of a secret, and it is the
+    trade this makes deliberately. A keypair is the private key in
+    libsecp256k1's own layout, in memory this package owns and can
+    overwrite; the two functions own one for the length of a call and
+    wipe it in a `finally`, while a signer holds it until it is told to
+    let go. `wipe` is that instruction, and the `with` statement is how
+    to give it without having to remember: on the way out of the block
+    the keypair is overwritten, whether the block ended in a signature or
+    in an exception. A wiped signer refuses to sign rather than signing
+    with the zeros, and it cannot be revived -- the private key is kept
+    nowhere else here, which is the point -- so signing again means
+    building another one.
+
+    What it does not change is the python side: the `bytes` or `int`
+    handed in here is a python object like any other, and SECURITY.md
+    records why that copy cannot be taken back.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256. Every
+            signature is of its x-only public key, so the key is negated
+            first where its y is odd, as BIP340 prescribes -- once here,
+            rather than once per signature.
+
+    Raises:
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1].
+
+    Example:
+        >>> from btclib_secp256k1 import ssa, xonly, mult
+        >>> msg, prvkey = bytes(32), 1
+        >>> pubkey, _ = xonly.from_pubkey(mult.mult_(prvkey))
+        >>> with ssa.Signer(prvkey) as signer:
+        ...     sig = signer.sign(msg, bytes(32))
+        >>> sig == ssa.sign(msg, prvkey, bytes(32))
+        True
+        >>> ssa.verify(msg, pubkey, sig)
+        True
+    """
+
+    # pydoclint (DOC301) asks that this carry no docstring of its own,
+    # the class docstring above being where the constructor is documented
+    def __init__(self, prvkey: BytesLike | int) -> None:  # noqa: D107
+        # None once wiped, which is what tells the two states apart: a
+        # wiped keypair is 96 zero octets and looks like any other
+        self._keypair: CData | None = _keypair(prvkey)
+
+    def sign(self, msg_bytes: BytesLike, aux_rand32: BytesLike | None = None) -> bytes:
+        """Create a Schnorr signature of a 32-byte message hash.
+
+        The signature `ssa.sign` makes of the same arguments, over the
+        keypair built when this signer was.
+
+        Args:
+            msg_bytes: the 32-byte message hash.
+            aux_rand32: the 32 bytes of auxiliary randomness BIP340
+                defines, or None for fresh randomness.
+
+        Returns:
+            The 64-byte signature.
+
+        Raises:
+            ValueError: if the message hash is not 32 bytes, if
+                aux_rand32 is given and is not 32 bytes, or if this
+                signer has been wiped.
+            RuntimeError: if libsecp256k1 fails to sign, which no input
+                can make it do.
+        """
+        return _sign32(msg_bytes, self._held(), aux_rand32)
+
+    def sign_custom(
+        self, msg_bytes: BytesLike, aux_rand32: BytesLike | None = None
+    ) -> bytes:
+        """Create a Schnorr signature of a message of any length.
+
+        The signature `ssa.sign_custom` makes of the same arguments, and
+        what that function says about hashing a message first holds here
+        too.
+
+        Args:
+            msg_bytes: the message, of any length.
+            aux_rand32: the 32 bytes of auxiliary randomness, or None
+                for fresh randomness.
+
+        Returns:
+            The 64-byte signature.
+
+        Raises:
+            ValueError: if aux_rand32 is given and is not 32 bytes, or
+                if this signer has been wiped.
+            RuntimeError: if libsecp256k1 fails to sign, which no input
+                can make it do.
+        """
+        return _sign_custom(msg_bytes, self._held(), aux_rand32)
+
+    def wipe(self) -> None:
+        """Overwrite the keypair, ending what this signer can do.
+
+        The deliberate half of the trade above, and what `__exit__`
+        calls. Signing afterwards raises rather than signing with the
+        zeros left behind, and wiping twice is not an error: a signer
+        used as a context manager and wiped inside the block is the case
+        that makes it one.
+        """
+        if self._keypair is not None:
+            wipe(self._keypair)
+            self._keypair = None
+
+    # PYI034 asks for `typing.Self` here, and that is 3.11 while this
+    # package supports 3.10. The class itself says the same thing of a
+    # class nothing subclasses, and `typing_extensions` is a dependency
+    # this package does not have and would not add for one annotation
+    def __enter__(self) -> Signer:  # noqa: PYI034
+        """Return this signer, for the `with` block that wipes it.
+
+        Returns:
+            The signer itself, nothing being built here that the
+            constructor did not already build.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Wipe the keypair, whatever ended the block.
+
+        Nothing is suppressed: returning None lets an exception raised
+        inside the block go on being raised, the wipe having happened
+        first.
+
+        Args:
+            exc_type: the class of the exception ending the block, if
+                one is.
+            exc_value: that exception.
+            traceback: its traceback.
+        """
+        self.wipe()
+
+    def _held(self) -> CData:
+        """Return the keypair, or refuse if it has been wiped.
+
+        Returns:
+            The libsecp256k1 keypair this signer holds.
+
+        Raises:
+            ValueError: if `wipe` has already overwritten it.
+        """
+        if self._keypair is None:
+            raise ValueError("this signer has been wiped")
+        return self._keypair
 
 
 def verify_(
@@ -186,6 +334,83 @@ def verify(
             not an exception.
     """
     return verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
+
+
+def _sign32(
+    msg_bytes: BytesLike, keypair: CData, aux_rand32: BytesLike | None
+) -> bytes:
+    """Sign a 32-byte message hash with a keypair somebody else owns.
+
+    The whole of `sign` and of `Signer.sign` except for the keypair:
+    where it comes from and who overwrites it is the only difference
+    between the two, so every argument check is here rather than at each
+    of the two call sites, where a second spelling could drift from this
+    one. Named after the libsecp256k1 call it is.
+
+    Args:
+        msg_bytes: the 32-byte message hash.
+        keypair: the libsecp256k1 keypair to sign with, wiped by
+            whoever built it and not here.
+        aux_rand32: the 32 bytes of auxiliary randomness, or None for
+            fresh randomness.
+
+    Returns:
+        The 64-byte signature.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, or if
+            aux_rand32 is given and is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to sign, which no input can
+            make it do.
+    """
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+
+    sig = ffi.new("char[64]")
+    if not lib.secp256k1_schnorrsig_sign32(
+        ctx, sig, msg_bytes, keypair, _aux_rand32(aux_rand32)
+    ):
+        raise RuntimeError("schnorr signing failed")
+    return ffi.unpack(sig, ffi.sizeof(sig))
+
+
+def _sign_custom(
+    msg_bytes: BytesLike, keypair: CData, aux_rand32: BytesLike | None
+) -> bytes:
+    """Sign a message of any length with a keypair somebody else owns.
+
+    What `_sign32` is to `sign`, this is to `sign_custom`.
+
+    Args:
+        msg_bytes: the message, of any length.
+        keypair: the libsecp256k1 keypair to sign with, wiped by
+            whoever built it and not here.
+        aux_rand32: the 32 bytes of auxiliary randomness, or None for
+            fresh randomness.
+
+    Returns:
+        The 64-byte signature.
+
+    Raises:
+        ValueError: if aux_rand32 is given and is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to sign, which no input can
+            make it do.
+    """
+    msg_bytes = octets(msg_bytes, "message")
+
+    sig = ffi.new("char[64]")
+    ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
+    extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
+    extraparams.magic = EXTRAPARAMS_MAGIC
+    extraparams.noncefp = ffi.NULL
+    # ndata has to stay referenced until the call is over: cffi keeps
+    # alive what a variable points to, not what a struct field does
+    extraparams.ndata = ndata
+
+    if not lib.secp256k1_schnorrsig_sign_custom(
+        ctx, sig, msg_bytes, len(msg_bytes), keypair, extraparams
+    ):
+        raise RuntimeError("schnorr signing failed")
+    return ffi.unpack(sig, ffi.sizeof(sig))
 
 
 def _keypair(prvkey: BytesLike | int) -> CData:

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -70,6 +70,37 @@ SP_OUTPUTS = silentpayments.create_outputs(
 SP_SUMMARY = silentpayments.prevouts_summary(OUTPOINT, pubkeys=[PUBKEY])
 SP_LABEL, SP_LABEL_TWEAK = silentpayments.label(SCAN_PRVKEY, 0)
 
+
+def signed(prvkey: Any, msg_bytes: Any, aux_rand32: Any) -> bytes:
+    """Sign a 32-byte message hash through a signer, and wipe it.
+
+    Args:
+        prvkey: the private key to build the signer from.
+        msg_bytes: the 32-byte message hash.
+        aux_rand32: the 32 bytes of auxiliary randomness.
+
+    Returns:
+        The 64-byte signature.
+    """
+    with ssa.Signer(prvkey) as signer:
+        return signer.sign(msg_bytes, aux_rand32)
+
+
+def signed_custom(prvkey: Any, msg_bytes: Any, aux_rand32: Any) -> bytes:
+    """Sign a message of any length through a signer, and wipe it.
+
+    Args:
+        prvkey: the private key to build the signer from.
+        msg_bytes: the message.
+        aux_rand32: the 32 bytes of auxiliary randomness.
+
+    Returns:
+        The 64-byte signature.
+    """
+    with ssa.Signer(prvkey) as signer:
+        return signer.sign_custom(msg_bytes, aux_rand32)
+
+
 # every entry point taking an argument that crosses as a bare pointer,
 # with the arguments it takes: the bytes ones are retyped below
 CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
@@ -96,6 +127,13 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("dsa.to_der", dsa.to_der, (COMPACT,), {}),
     ("ssa.sign", ssa.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("ssa.sign_custom", ssa.sign_custom, (b"a message", PRVKEY, bytes(32)), {}),
+    # the signer's own two, which is where its three bytes-like arguments
+    # are: the private key the constructor takes, and the message and aux
+    # of each signature. Driven through the two functions below, so that
+    # what is compared is a signature rather than the object holding the
+    # keypair -- and so that the keypair is wiped, as it is anywhere else
+    ("ssa.Signer.sign", signed, (PRVKEY, MSG, bytes(32)), {}),
+    ("ssa.Signer.sign_custom", signed_custom, (PRVKEY, b"a message", bytes(32)), {}),
     ("ssa.verify", ssa.verify, (MSG, XONLY, SSA_SIG), {}),
     ("ssa.verify_", ssa.verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
@@ -176,7 +214,10 @@ MODULES = {
 # theirs straight in: what they answer with is the parsed key they
 # mutated, and two calls of it are never equal. `PubkeyTweakChain` is the
 # same, calling `parse` on construction and reaching `scalar` through
-# `pubkey_tweak_add_` on every `tweak_add`
+# `pubkey_tweak_add_` on every `tweak_add`. `ssa.Signer` is a class too
+# and its private key does cross as a bare pointer, but it is swept: the
+# two entries above build one and sign through it, which is every
+# argument of the constructor and of both methods
 NOT_SWEPT = {
     "keys.serialize",
     "keys.parse",
@@ -185,6 +226,7 @@ NOT_SWEPT = {
     "keys.pubkey_tweak_mul_",
     "keys.pubkey_cmp_",
     "keys.PubkeyTweakChain",
+    "ssa.Signer",
     "xonly.parse",
     "xonly.from_pubkey_",
 }

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -16,6 +16,11 @@ interpreter lock.
 Every operation exercised here is deterministic, ECDSA by RFC6979 and
 BIP340 by a fixed aux_rand32, so a result that differs between threads
 is a shared buffer, not a legitimate difference.
+
+`ssa.Signer` is the one thing that does hold a buffer across calls, and
+the second test is the half of the reasoning that does not follow from
+the paragraph above: what makes a shared signer safe is that
+libsecp256k1 takes a keypair const.
 """
 
 from concurrent.futures import ThreadPoolExecutor
@@ -62,3 +67,26 @@ def test_concurrent_round_trips() -> None:
         # map is lazy: the results have to be consumed for an assertion
         # failing in a worker to be raised here
         list(pool.map(round_trip, range(WORKERS * ROUNDS)))
+
+
+def test_one_signer_signs_from_every_thread() -> None:
+    """Eight threads share one keypair and reach the one signature.
+
+    The keypair a signer holds is the one buffer these bindings keep
+    across calls, so it is the one place the module docstring's reasoning
+    does not reach: what makes this safe is that libsecp256k1 takes a
+    keypair const, and signing does not write to it. What is not safe is
+    wiping it while a thread is inside `sign`, which is why the wipe here
+    is after the pool has joined -- the ordering the `with` block gives a
+    caller for free.
+    """
+    expected = ssa.sign(msg, prvkey, aux_rand32)
+    signer = ssa.Signer(prvkey)
+
+    def sign_through(_: int) -> None:
+        assert signer.sign(msg, aux_rand32) == expected
+
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        list(pool.map(sign_through, range(WORKERS * ROUNDS)))
+
+    signer.wipe()

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,0 +1,195 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A signer signs what the module functions sign, and then wipes.
+
+`ssa.Signer` is one of the two module functions with the keypair hoisted
+out of it, so what has to hold is an equality -- signature for signature,
+message length for message length -- and that equality is what the
+published BIP340 vectors already pin on the other side: tests/
+test_vectors.py signs each vector through a signer as well as through
+`ssa.sign_custom`, so the value both are held against comes from
+bitcoin/bips rather than from this package agreeing with itself.
+
+What is left for this file is the half a vector cannot state: the
+lifetime the signer hands the caller. The keypair is the private key in
+libsecp256k1's layout, in memory this package owns, so what is asserted
+here is that it is still there while the signer is usable, that `wipe`
+and the `with` block each overwrite it, and that a wiped signer refuses
+to sign instead of signing with the zeros.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from btclib_secp256k1 import ffi, keys, ssa, xonly
+
+PRVKEY = (7).to_bytes(32, "big")
+AUX = bytes(32)
+MSG = hashlib.sha256(b"btclib_secp256k1").digest()
+XONLY, PARITY = xonly.from_pubkey(keys.pubkey_from_prvkey(PRVKEY))
+
+
+def keypair_memory(signer: ssa.Signer) -> bytes:
+    """Return the octets of the keypair a signer holds.
+
+    Reaching into the object is the only way to ask: nothing a signer
+    answers with says whether the secret is still in there, which is the
+    property under test.
+
+    Args:
+        signer: the signer to look inside.
+
+    Returns:
+        The 96 octets of the `secp256k1_keypair`, or an empty bytes once
+        the signer has dropped it.
+    """
+    keypair = signer._keypair
+    return b"" if keypair is None else bytes(ffi.buffer(keypair))
+
+
+def test_a_signer_signs_what_the_function_signs() -> None:
+    """Both signatures, over both message lengths, for the same aux.
+
+    The aux is fixed, so a BIP340 signature is a value rather than a
+    distribution and the two sides are comparable at all. A message of
+    any other length is `sign_custom`'s, and a 32-byte one is signed the
+    same way by both, which is what makes the four assertions two pairs
+    rather than four values.
+    """
+    long_msg = b"a message longer than a hash, and of no particular length"
+
+    with ssa.Signer(PRVKEY) as signer:
+        assert signer.sign(MSG, AUX) == ssa.sign(MSG, PRVKEY, AUX)
+        assert signer.sign_custom(MSG, AUX) == ssa.sign_custom(MSG, PRVKEY, AUX)
+        assert signer.sign_custom(long_msg, AUX) == ssa.sign_custom(
+            long_msg, PRVKEY, AUX
+        )
+        # and the signatures verify against the x-only key of the private
+        # key the signer was built from, which is what they are for
+        assert ssa.verify(MSG, XONLY, signer.sign(MSG))
+        assert ssa.verify(long_msg, XONLY, signer.sign_custom(long_msg))
+
+
+def test_a_signer_signs_more_than_once() -> None:
+    """The motivating case: one keypair, several signatures.
+
+    Signing does not consume or change the keypair -- the C call takes it
+    const -- so a caller signing a batch under one key builds it once.
+    Checked by signing three messages through one signer and verifying
+    each, and then asserting the keypair is still the one the signer was
+    built with rather than something the signatures left behind.
+    """
+    signer = ssa.Signer(PRVKEY)
+    before = keypair_memory(signer)
+    for index in range(3):
+        msg = hashlib.sha256(index.to_bytes(4, "big")).digest()
+        assert ssa.verify(msg, XONLY, signer.sign(msg))
+    assert keypair_memory(signer) == before
+    signer.wipe()
+
+
+def test_an_int_private_key_is_the_same_signer() -> None:
+    """The constructor takes what `sign` takes, the int scalar included."""
+    with ssa.Signer(7) as by_int, ssa.Signer(PRVKEY) as by_bytes:
+        assert by_int.sign(MSG, AUX) == by_bytes.sign(MSG, AUX)
+
+
+@pytest.mark.parametrize("prvkey", [0, b"\x01" * 31, bytes(32)], ids=str)
+def test_a_private_key_is_refused_where_sign_refuses_it(prvkey: bytes | int) -> None:
+    """What `sign` refuses, the constructor refuses, and at construction.
+
+    Zero and the 32 zero octets are not scalars in [1, n-1], and 31
+    octets are not a private key at all: the signer is the same check as
+    `sign`'s, made once instead of once per signature.
+
+    Args:
+        prvkey: the value no signer can be built from.
+    """
+    with pytest.raises(ValueError, match="private key"):
+        ssa.Signer(prvkey)
+    with pytest.raises(ValueError, match="private key"):
+        ssa.sign(MSG, prvkey, AUX)
+
+
+def test_a_signer_checks_every_other_argument_too() -> None:
+    """What the keypair was hoisted out of, the rest of the call still is.
+
+    A message hash that is not 32 octets, and an aux that is not 32:
+    both refused by the signer exactly as by the function, a bare
+    pointer's length being what no C return code can report.
+    """
+    with ssa.Signer(PRVKEY) as signer:
+        with pytest.raises(ValueError, match="message hash"):
+            signer.sign(MSG[1:])
+        with pytest.raises(ValueError, match="aux_rand32"):
+            signer.sign(MSG, b"\x01" * 31)
+        with pytest.raises(ValueError, match="aux_rand32"):
+            signer.sign_custom(b"any length at all", b"\x01" * 33)
+
+
+def test_wipe_overwrites_the_keypair() -> None:
+    """The private key is in there until `wipe`, and gone after it.
+
+    The keypair holds the 32 octets of the key, so the assertion is that
+    they are found in the memory the signer holds and are not found
+    afterwards -- which is the same thing tests/test_secret.py asserts of
+    the buffer a call owns, over the one a caller owns.
+    """
+    signer = ssa.Signer(PRVKEY)
+    assert PRVKEY in keypair_memory(signer)
+
+    signer.wipe()
+    assert keypair_memory(signer) == b""
+
+
+def test_the_with_block_wipes_whatever_ended_it() -> None:
+    """A signature, and an exception, leave the same zeroed keypair.
+
+    The second is the case the `finally` in `sign` covers for a call, and
+    the one a caller holding a keypair across calls would otherwise have
+    to write for themselves.
+    """
+    with ssa.Signer(PRVKEY) as signer:
+        signer.sign(MSG, AUX)
+    assert keypair_memory(signer) == b""
+
+    raising = ssa.Signer(PRVKEY)
+    with pytest.raises(ValueError, match="what the block raised"), raising:
+        raise ValueError("what the block raised")
+    assert keypair_memory(raising) == b""
+
+
+def test_wiping_twice_is_not_an_error() -> None:
+    """Wiping inside the block is the case that makes it one.
+
+    A caller that ends with the secret rather than with the block writes
+    `signer.wipe()` and then leaves the `with`, so `__exit__` finds a
+    signer already wiped: that is a signer with nothing left to do, not
+    a mistake to report.
+    """
+    with ssa.Signer(PRVKEY) as signer:
+        signer.wipe()
+    signer.wipe()
+    assert keypair_memory(signer) == b""
+
+
+def test_a_wiped_signer_refuses_to_sign() -> None:
+    """Rather than signing with the zeros the wipe left.
+
+    Both entry points refuse, and the refusal is the one a caller can
+    act on: the key is kept nowhere else here, so the answer is another
+    signer rather than a way back.
+    """
+    signer = ssa.Signer(PRVKEY)
+    signer.wipe()
+
+    with pytest.raises(ValueError, match="wiped"):
+        signer.sign(MSG, AUX)
+    with pytest.raises(ValueError, match="wiped"):
+        signer.sign_custom(MSG, AUX)

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -154,9 +154,11 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
     the length of the message: `ssa.sign` is BIP340's 32-byte signing, and
     `ssa.sign_custom` is the arbitrary-length one, so the four vectors
     added in 2022 -- messages of 0, 1, 17 and 100 octets -- are the only
-    published values `sign_custom` can be held against. A structurally
-    invalid input raises where the vector says false, so the exception is
-    read as that verdict rather than as an error.
+    published values `sign_custom` can be held against. `ssa.Signer` is
+    those same two calls with the keypair hoisted out of them, so it is
+    signed here as well, against the vector rather than against them. A
+    structurally invalid input raises where the vector says false, so
+    the exception is read as that verdict rather than as an error.
     """
     msg = bytes.fromhex(vector["message"])
     pubkey = bytes.fromhex(vector["public key"])
@@ -174,6 +176,13 @@ def test_bip340_vector(vector: dict[str, str]) -> None:
         # returns, which is what makes the two comparable at all
         if len(msg) == 32:
             assert ssa.sign(msg, seckey, aux_rand) == sig
+        # and a signer is those same two calls with the keypair built
+        # once, so the published value is what holds it too rather than
+        # an agreement between two functions of this package
+        with ssa.Signer(seckey) as signer:
+            assert signer.sign_custom(msg, aux_rand) == sig
+            if len(msg) == 32:
+                assert signer.sign(msg, aux_rand) == sig
 
     try:
         result = bool(ssa.verify(msg, pubkey, sig))


### PR DESCRIPTION
Closes #153.

## What was measured, and what it is

`ssa.sign` and `ssa.sign_custom` build a `secp256k1_keypair` from the
private key, sign with it, and wipe it in a `finally`. That keypair is
the point multiplication of the public key, and it is about half of what
a BIP340 signature costs here — so a caller signing several messages
under one key pays for it once per signature.

On an Apple M5, macOS 26.6, arm64, CPython 3.14.6, on this branch,
minimum of 10 rounds of 20 000 calls, microseconds per call:

| | µs/call |
| --- | ---: |
| `ssa.sign`, keypair per call | 15.7 |
| `ssa.Signer.sign`, keypair held | 8.2 |
| `secp256k1_keypair_create` alone | 7.3 |
| `ssa.sign_custom`, keypair per call | 16.0 |
| `ssa.Signer.sign_custom`, keypair held | 8.4 |

The saving is the keypair and nothing else, and the rows still sum the
way #153's own decomposition did (15.5 / 7.3 / 8.0 there). It puts one
signature at the cost of the C call, which is the 7.7 the issue quotes
for secp256k1-py — whose `PrivateKey` constructor builds the keypair
once for the same reason.

## The shape

`ssa.Signer(prvkey)`, with `sign` and `sign_custom` taking exactly what
the module functions take minus the private key:

```python
with ssa.Signer(prvkey) as signer:
    signatures = [signer.sign(msg) for msg in messages]
```

Not a bare `keypair()` plus `sign_` inner halves, though that is the
spelling #147/#149 set for the parsed public key. A parsed key is a
public value a caller may hold as long as they like; a keypair is the
private key in libsecp256k1's layout, so what the inner half would hand
back is a lifetime — and handing it back as a bare `CData` would need a
public `wipe` beside it and a caller who remembers to call it. The
class is that lifetime named: `__exit__` wipes whether the block ended
in a signature or in an exception, `wipe()` is the same instruction by
hand, wiping twice is not an error, and a wiped signer raises rather
than signing with the zeros left behind. It cannot be revived, the key
being kept nowhere else here.

## Against #87

#87 declined an opaque secret handle, and that answer stands: it asked
whether one buys *assurance*, and the analysis was that the python-side
copies at import and export are what they are. Nothing here disturbs
that — SECURITY.md's limits are unchanged and the constructor still
takes a `bytes` or an `int` nothing can zeroize. What is new is a
measured cost paid by every caller signing more than once under one key,
which that issue never weighed. The trade is named in the class
docstring, in the README and in CHANGELOG.md rather than left implicit.

BIP340 only, as #153 says: `secp256k1_ecdsa_sign` takes the private key
directly, so `dsa.sign` has no keypair to hoist.

## One consequence to know about

The two functions are now the signer's two calls with the keypair built
and wiped around them — `_sign32` and `_sign_custom` are the shared
body, so the argument checks cannot drift into two spellings. They
therefore run after the keypair is built rather than before, so a call
with *both* a bad private key and a bad message names the key where it
used to name the message. Each on its own is refused as before, and
every wipe that happened still happens.

## Tests

- `tests/test_vectors.py` signs every BIP340 vector through a signer as
  well, so the new path is held against bitcoin/bips' published value
  rather than against the two functions agreeing with it
- `tests/test_signer.py` is the half a vector cannot state: it reaches
  into the object to assert the private key is in the keypair while the
  signer is usable and gone after `wipe`, after the `with` block, and
  after a block an exception ended; that wiping twice is not an error;
  and that both entry points refuse afterwards
- `tests/test_concurrency.py` shares one signer across eight threads —
  libsecp256k1 takes a keypair const, which is what makes that safe and
  what the README's Thread safety section now says, wiping being the
  part a caller has to order
- `tests/test_bytes_like.py` sweeps the constructor and both methods
  with `bytearray` and `memoryview`

## Gate

`uvx pre-commit run --all-files` clean; `pytest --cov` 475 passed at
100.00%; the suite passes on 3.10 as well as on 3.14 (`uv run --python
3.10 --no-cache`); `sphinx-build -W --keep-going`, `uv build --sdist`,
`twine check --strict` and `pyroma --min 10` all pass locally. The
README's new example is executed by `tests/test_examples.py` like every
other.

## Summary by Sourcery

Introduce a reusable BIP340 Schnorr signer that hoists keypair creation out of individual signing calls while preserving existing function behavior.

New Features:
- Add ssa.Signer class to sign multiple BIP340 messages under one private key using a single libsecp256k1 keypair.
- Provide context-manager and explicit wipe APIs on Signer to control keypair lifetime and zeroization.

Enhancements:
- Refactor BIP340 signing into shared helpers (_sign32 and _sign_custom) used by both module-level functions and Signer to keep argument validation consistent.
- Clarify documentation and release notes around BIP340 signing performance, keypair lifetime semantics, and thread safety when sharing a Signer.

Tests:
- Add dedicated signer tests covering equivalence with existing signing functions, keypair wiping behavior, invalid input handling, and repeated use.
- Extend bytes-like, concurrency, and BIP340 vector tests to exercise Signer, including multi-threaded signing via a shared keypair.