### PR TITLE
Say what the DER buffer is now, not what it was before #71

### DIFF
--- a/.github/mutation/bindings.toml
+++ b/.github/mutation/bindings.toml
@@ -28,8 +28,10 @@
 #   written as a second copy of the buffer's own size. Six of the 13.
 #   `ffi.sizeof` now derives the capacity from the buffer and the buffer is
 #   what is unpacked, so a wrong size reaches the caller instead of being
-#   absorbed -- and the DER buffer, sized 73 for a serialization that
-#   cannot exceed 72, has a test for the octet that decides it
+#   absorbed. The DER buffer went with them: 73 was slack over a
+#   serialization that cannot exceed 72, so shrinking it was a mutant no
+#   test could distinguish, and at the 72 it is now
+#   `test_der_reaches_all_72_octets` reaches the last octet and 71 dies
 #
 #   secrets.token_bytes(32) -> 31 or 33, randomness this package generates
 #   rather than accepts: a BIP340 aux, an ellswift encoding, the context


### PR DESCRIPTION
`.github/mutation/bindings.toml` recounts what #71 fixed -- an output
buffer whose size was written twice, six of that session's thirteen
survivors -- and then, in the same sentence, describes the DER buffer at
the size #71 took it away from:

> and the DER buffer, sized 73 for a serialization that cannot exceed 72,
> has a test for the octet that decides it

`dsa.py` and `recovery.py` have carried `char[72]` since that commit, and
[dsa.py's own comment](https://github.com/btclib-org/btclib_secp256k1/blob/main/btclib_secp256k1/dsa.py#L289-L295)
says 72 is reached rather than approached -- `to_der` serializes a high-s
signature and lands on it, which `test_der_reaches_all_72_octets` asserts.

Which is the paragraph's own point, told backwards. At 73 the slack was
real, so `73 -> 72` was a mutant nothing could distinguish; at 72 the
boundary *is* the value, and shrinking it dies.

## Verified rather than argued

The claim the new wording makes is that 71 is killed, so it was measured,
`PYTHONDONTWRITEBYTECODE=1` throughout for the stale-bytecode trap:

| step | result |
| --- | --- |
| baseline | `459 passed` |
| `char[72]` -> `char[71]` in `dsa.py` | `1 failed` -- `test_der_reaches_all_72_octets`, `RuntimeError: signature serialization failed` |
| restored, control run | `459 passed` |

No code changes: the comment is the whole diff. Every other checkable
claim in the file still holds -- the only ` | ` in the package is
`BytesLike`, there is no bitwise operator of any kind, `2**256` is still
in `_scalar.py`, and no unpack length is written by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update bindings documentation to describe the current 72-byte DER buffer behavior and how `test_der_reaches_all_72_octets` exercises the boundary.