### PR TITLE
Tweak the point the caller already parsed, not its x again

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1533
+        "line_number": 1564
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T09:19:59Z"
+  "generated_at": "2026-08-15T13:29:37Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,37 @@ release-notes length in the first place, and are still in
   used to name the message. Each on its own is refused as before, and
   every wipe that happened still happens
 
+### The parsed public key
+
+- **`xonly.tweak_add_` tweaks the point, where `tweak_add` tweaks its
+  x.** BIP341's output key is an internal key plus the TapTweak hash
+  times the generator, and the caller reaching it holds a public key it
+  has just validated — which is a `keys.parse`, and for a compressed key
+  a field square root. `tweak_add` takes the 32-byte x-only form and
+  parses that, so such a caller lifted one x twice:
+  `secp256k1_xonly_pubkey_from_pubkey` is a conversion and not a lift,
+  and reading the y it is given costs what the square root did not.
+  Measured as the entry above, on an Apple M5, macOS 26.6, arm64, CPython
+  3.14.6, and by the median of seven alternating rounds of 20 000 calls,
+  microseconds per call: `tweak_add` 5.92, `tweak_add_` 3.79, with a
+  `mult.mult_` control that moved by 0.06 across the rounds. btclib's
+  `script.taproot.output_pubkey` is the caller: it validates the internal
+  key through `pub_keyinfo_from_key` and then hands the x-only octets to
+  `tweak_add`.
+- **It takes a full public key, and that is the module's rule rather than
+  an exception to it.** The bytes entry points take the 32-byte form so
+  that a y coordinate is never discarded inside an argument check; a call
+  taking what `keys.parse` returns and answering 32 bytes discards it in
+  plain sight. An odd-y point is tweaked as its negation, BIP341's
+  internal key being x-only, and answers the output key `tweak_add`
+  answers for the same x — `from_pubkey_` is where that parity is read,
+  and takes the same object.
+- **`tests/test_parsed_keys.py` pairs it outside the parametrized
+  table**, as it pairs `ssa.verify_`: the equality is
+  `tweak_add_(keys.parse(sec))` against `tweak_add(from_pubkey(sec)[0])`,
+  held over both serializations and over the negated key, so the
+  odd-y case is not left to the reading of a docstring.
+
 ### CI
 
 - **`github-release` needed `always()` too, not just an explicit `if`.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,9 @@ a tag is generated from.
 
 ## v0.8.0.3 (work in progress, not released yet)
 
-Non-breaking, and one addition for a caller that signs more than once
-under one key.
+Non-breaking, and two additions: one for a caller that signs more than
+once under one key, one for a caller computing a taproot output key from
+a public key it has validated.
 
 `ssa.Signer` is new: it builds the BIP340 keypair once and signs with it
 as often as asked, where `ssa.sign` and `ssa.sign_custom` build one per
@@ -26,6 +27,15 @@ the way out whether the block ended in a signature or in an exception.
 to sign rather than signing with what the wipe left. The private key
 handed to the constructor is a python `bytes` or `int` and is no more
 zeroizable than before: SECURITY.md's limits are unchanged.
+
+`xonly.tweak_add_` is the inner half of `xonly.tweak_add`: it takes the
+parsed point `keys.parse` returns, rather than the 32-byte x-only form,
+and so tweaks a key that is already lifted instead of lifting its x a
+second time. The x-only conversion in front of the tweak is
+`secp256k1_xonly_pubkey_from_pubkey`, which reads the y it is given; the
+result is the output key and parity `tweak_add` answers with, the
+negation of an odd-y point included, and `tweak_add` itself is unchanged
+in behaviour and cost.
 
 ## v0.8.0.2
 

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -12,11 +12,13 @@ An x-only public key is the 32-byte x coordinate of the point with even
 y; the parity returned along a tweaked key is the one of the tweaked
 point, to be committed to by the taproot output.
 
-`from_pubkey` is the conversion from a full public key, and the only
-conversion here taking one -- `from_pubkey_` being itself, on the parsed
-point rather than the bytes: everything else takes the 32-byte form, so
-that discarding a y coordinate happens where the caller can see it and
-not inside an argument check.
+`from_pubkey` is the conversion from a full public key, and the only one
+taking its bytes: every other entry point taking bytes takes the 32-byte
+form, so that discarding a y coordinate happens where the caller can see
+it and not inside an argument check. `from_pubkey_` and `tweak_add_` take
+a full public key too, and are that same rule rather than an exception to
+it -- a caller holding what `keys.parse` returns is holding the point,
+and a call that takes it and answers 32 bytes drops the y in plain sight.
 """
 
 from __future__ import annotations
@@ -25,6 +27,50 @@ from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import octets, scalar
 from ._secret import take, wipe
 from .context import ctx
+
+
+def _from_pubkey(pubkey: CData) -> tuple[CData, int]:
+    """Convert a parsed public key into a parsed x-only key and the parity.
+
+    The conversion itself, which is where the y is dropped, without the
+    serialization that follows it in `from_pubkey_`: `tweak_add_` wants
+    the object and not the 32 bytes, having a tweak to add to it.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+
+    Returns:
+        The libsecp256k1 x-only public key object, and the parity of the
+        y that was dropped: 0 for even, 1 for odd.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to convert it, which no valid
+            key can make it do.
+    """
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    parity = ffi.new("int *")
+    if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
+        raise RuntimeError("x-only public key conversion failed")
+    return xonly_pubkey, parity[0]
+
+
+def _serialize(xonly_pubkey: CData) -> bytes:
+    """Return the 32 bytes of a parsed x-only public key.
+
+    Args:
+        xonly_pubkey: the x-only public key object, as `parse` returns.
+
+    Returns:
+        The 32-byte x coordinate.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to serialize it, which no
+            valid key can make it do.
+    """
+    output = ffi.new("char[32]")
+    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
+        raise RuntimeError("x-only public key serialization failed")
+    return ffi.unpack(output, ffi.sizeof(output))
 
 
 def from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
@@ -45,15 +91,8 @@ def from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    parity = ffi.new("int *")
-    if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
-        raise RuntimeError("x-only public key conversion failed")
-
-    output = ffi.new("char[32]")
-    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
-        raise RuntimeError("x-only public key serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output)), parity[0]
+    xonly_pubkey, parity = _from_pubkey(pubkey)
+    return _serialize(xonly_pubkey), parity
 
 
 def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
@@ -98,7 +137,61 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             result, which no valid input can make it do.
     """
-    internal_pubkey = parse(pubkey_bytes)
+    return _tweak_add(parse(pubkey_bytes), tweak)
+
+
+def tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
+    """Add the generator multiplied by the tweak, to an already-parsed key.
+
+    The inner half of `tweak_add`, for a caller who already holds the
+    parsed point: see `keys.parse` for what the underscore means
+    throughout. The parsed point is a full public key, and the x-only
+    form of it is `secp256k1_xonly_pubkey_from_pubkey`, which lifts
+    nothing; reaching `tweak_add` from there instead means serializing the
+    x and parsing it back, and that parse is a field square root -- of an
+    x whose y the caller is holding.
+
+    The point is taken as BIP341 takes an internal key, x-only: an odd-y
+    key is tweaked as its negation, and answers the output key
+    `tweak_add` answers for the same 32 bytes. `from_pubkey_` is where
+    that parity is read, and takes the same object.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked x-only key, and the parity of its y.
+
+    Raises:
+        ValueError: if the tweak is not 32 bytes or does not fit in them,
+            or if the tweak or the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            result, which no valid input can make it do.
+    """
+    return _tweak_add(_from_pubkey(pubkey)[0], tweak)
+
+
+def _tweak_add(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
+    """Add the generator multiplied by the tweak to a parsed x-only key.
+
+    What the two halves above share, once each has reached the x-only key
+    its own way: `parse` from the 32 bytes, or `_from_pubkey` from the
+    point.
+
+    Args:
+        internal_pubkey: the x-only public key object.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked x-only key, and the parity of its y.
+
+    Raises:
+        ValueError: if the tweak is not 32 bytes or does not fit in them,
+            or if the tweak or the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            result, which no valid input can make it do.
+    """
     tweak_bytes = scalar(tweak, "tweak")
 
     tweaked_pubkey = ffi.new("secp256k1_pubkey *")

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -138,6 +138,9 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("ssa.verify_", ssa.verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
+    # the parsed key is not retyped, being no bytes; the tweak beside it
+    # is, and what comes back is 32 bytes and a parity, which compare
+    ("xonly.tweak_add_", xonly.tweak_add_, (PARSED, TWEAK), {}),
     (
         "xonly.tweak_add_check",
         xonly.tweak_add_check,

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -124,6 +124,27 @@ def test_the_schnorr_pair_parses_the_x_only_key() -> None:
     assert not ssa.verify_(MSG, xonly.parse(XONLY), tampered)
 
 
+def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
+    """`xonly.tweak_add_` is `xonly.tweak_add` of the key's own x.
+
+    The other pair whose parsed key is not the one its outer half makes:
+    `tweak_add` takes 32 bytes and lifts them, `tweak_add_` takes the
+    point those bytes are the x of, which is what a caller that validated
+    a full public key is already holding.
+
+    The odd-y key is the case worth writing down: BIP341's internal key
+    is x-only, so the point is tweaked as its negation and answers the
+    output key of the x it shares with it -- which is the same 32 bytes
+    the even-y key gives, and the assertion below is that equality.
+    """
+    for pubkey_bytes in (PUBKEY, PUBKEY_LONG, keys.pubkey_negate(PUBKEY)):
+        x_only, _ = xonly.from_pubkey(pubkey_bytes)
+        assert x_only == XONLY
+        assert xonly.tweak_add_(keys.parse(pubkey_bytes), TWEAK) == xonly.tweak_add(
+            x_only, TWEAK
+        )
+
+
 def test_a_parsed_key_verifies_more_than_once() -> None:
     """The motivating case: one parse, several signatures.
 
@@ -165,6 +186,8 @@ def test_an_inner_half_still_checks_everything_but_the_key() -> None:
         keys.pubkey_tweak_add_(pubkey, b"\x01" * 31)
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
         keys.pubkey_tweak_mul_(pubkey, b"\x01" * 33)
+    with pytest.raises(ValueError, match="tweak must be 32 bytes"):
+        xonly.tweak_add_(pubkey, b"\x01" * 31)
 
     # and the two verdicts libsecp256k1 gives on a tweak, through the
     # inner halves: the sum that is the point at infinity, and the zero
@@ -184,6 +207,12 @@ def test_every_inner_half_is_paired() -> None:
     exception and is named as one: its underscore is older and means the
     other thing, the serialized point against the pair of coordinates
     `mult` answers with, and there is no key to hand it already parsed.
+
+    `ssa.verify_` and `xonly.tweak_add_` are paired in tests of their own
+    rather than in the table: the parsed key of the first is
+    `xonly.parse`'s and not `keys.parse`'s, and the second takes the point
+    whose x its outer half is given, so neither equality is the one
+    parametrized above.
     """
     modules = {
         "dsa": dsa,
@@ -193,7 +222,7 @@ def test_every_inner_half_is_paired() -> None:
         "ssa": ssa,
         "xonly": xonly,
     }
-    paired = {f"{name}_" for name, *_ in PAIRS} | {"ssa.verify_"}
+    paired = {f"{name}_" for name, *_ in PAIRS} | {"ssa.verify_", "xonly.tweak_add_"}
     inner_halves = {
         f"{module_name}.{name}"
         for module_name, module in modules.items()


### PR DESCRIPTION
`xonly.tweak_add` takes the 32-byte x-only key and parses it, and that
parse is a field square root. The caller computing a BIP341 output key
reaches it holding a public key it has just validated — and validating a
key is parsing it — so the same x was lifted twice.

btclib is the caller: `script.taproot.output_pubkey` validates the
internal key through `pub_keyinfo_from_key`, drops the parsed key that
validation built, and hands the x-only octets to `tweak_add`.

`xonly.tweak_add_` is the inner half: the same tweak from the parsed
point, **3.79 us against 5.92** — median of seven alternating rounds of
20000 calls, with a `mult.mult_` control that moved by 0.06 us across
them. `secp256k1_xonly_pubkey_from_pubkey` reads the y it is given
instead of lifting one.

It takes a full public key, where every other entry point of the module
taking bytes takes the 32-byte form. That is the module's own rule rather
than an exception to it: the rule exists so a y coordinate is never
discarded inside an argument check, and a call that takes what
`keys.parse` returns and answers 32 bytes discards it in plain sight. An
odd-y point is tweaked as its negation, BIP341's internal key being
x-only, and answers the output key `tweak_add` answers for the same x.

`tests/test_parsed_keys.py` pairs it outside the parametrized table, as
it pairs `ssa.verify_`: the equality is `tweak_add_(keys.parse(sec))`
against `tweak_add(from_pubkey(sec)[0])`, held over both serializations
and over the negated key, so the odd-y case is asserted rather than only
documented. `tests/test_bytes_like.py` sweeps it like any other entry
point taking a tweak.

Gates run locally: `pytest --cov` at 100.00%, `pre-commit run
--all-files` clean, and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an inner x-only taproot tweak API that operates on already-parsed public keys and refactor shared x-only conversion/tweak logic.

New Features:
- Add xonly.tweak_add_ to tweak taproot output keys starting from an already-parsed full public key.

Enhancements:
- Refactor x-only public key conversion and serialization into reusable helpers to share logic between from_pubkey and tweak_add paths.

Documentation:
- Update CHANGELOG and HISTORY to document the new xonly.tweak_add_ helper and its taproot use case.

Tests:
- Extend parsed-key tests to cover xonly.tweak_add_ behaviour, including odd-y taproot cases, inner-half pairing, and bytes-like handling.