### PR TITLE
Let the underscore mean the parsed key on the way out too

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1564
+        "line_number": 1640
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T13:29:37Z"
+  "generated_at": "2026-08-15T14:12:43Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,82 @@ release-notes length in the first place, and are still in
   `tweak_add_(keys.parse(sec))` against `tweak_add(from_pubkey(sec)[0])`,
   held over both serializations and over the negated key, so the
   odd-y case is not left to the reading of a docstring.
+- **The underscore now means the same thing on the producing side**
+  (#159). It meant "takes the parsed key in place of the bytes", which
+  covers every wrapper whose *first* act is a parse and none of those
+  whose *last* act is a serialization — so a caller composing two of them
+  paid, between the two, for a serialization of a point that was already
+  in hand and a parse of what had just been serialized. The convention
+  reads the same in both directions now, the outer half being the inner
+  one with a `parse` in front of it or a `serialize` behind it, and
+  `keys.parse` states both. `keys.pubkey_from_prvkey_`,
+  `keys.pubkey_combine_`, `keys.pubkey_sort_`, `recovery.recover_`,
+  `ellswift.decode_` and `silentpayments.label_` answer with the object;
+  `ellswift.encode_` and `silentpayments.labeled_spend_pubkey_` take one,
+  the second taking two. Every outer half is unchanged in behaviour and
+  cost, and is now written as its inner half with the missing step around
+  it, so neither can drift into a second spelling of the same call.
+- **Which composition pays what.** Measured as the entries above, on an
+  Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 10 rounds of
+  20 000 calls, microseconds per call. The unit is one round trip of a
+  compressed key: `keys.serialize` 0.35 and `keys.parse` 2.28, against
+  0.24 for the uncompressed form, the difference being the field square
+  root. So: aggregating five keys the BIP67 way, `pubkey_combine(
+  pubkey_sort(keys))` 28.23 against 14.84 for the two inner halves over
+  keys parsed once — it is per key, which is why this one is half the
+  total; a labeled Silent Payments address, 14.28 against 9.25;
+  `xonly.from_pubkey(ellswift.decode(ell))` 7.44 against 4.69; and
+  recovering a key to verify with it, 29.57 against 26.75, the
+  verification being most of that number either way.
+- **`keys.pubkey_combine_` and `keys.pubkey_sort_` were the two v0.8.0.2
+  left out**, on the grounds that their inner halves would take lists of
+  cffi objects and no caller had asked. The caller is their own
+  composition: sorting is what BIP67 and MuSig2 key aggregation do
+  *before* adding, and between the outer halves every key is serialized
+  and parsed again. `pubkey_sort_` hands back the caller's own objects,
+  found by the address each reordered pointer holds — an element of the
+  array libsecp256k1 sorted owns nothing, and would dangle the moment the
+  caller dropped the sequence it points into. `tests/test_keys.py`
+  asserts that identity rather than the value, which is the part a
+  serialization comparison would not catch.
+- **`xonly.from_prvkey` and `ssa.Signer.pubkey` are two shortcuts rather
+  than two halves.** The x-only public key of a private key was
+  `xonly.from_pubkey(keys.pubkey_from_prvkey(k))` — 10.49, of which 2.63
+  is a round trip of the compressed key nobody wanted — and BIP340 and
+  BIP341 want that key and not the point, so the composition is the
+  common case and not an exotic one: `from_prvkey` is 7.90. A signer
+  already holds the keypair, and reading the key off it is
+  `secp256k1_keypair_xonly_pub`: `Signer.pubkey()` is 0.43 against the
+  10.49 of deriving it a second time, and `tests/test_signer.py` holds it
+  to `xonly.from_prvkey` and to the key its own signatures verify
+  against, parity included.
+- **`xonly.from_keypair` is the second wrapper taking a libsecp256k1
+  object rather than bytes**, `keys.serialize` having been the only one.
+  A MuSig2 session driven through `lib` holds a keypair, which is the
+  caller beyond `Signer.pubkey`. There is nothing to check about such an
+  argument before the call, so a violated precondition is reachable
+  through it: like `keys.serialize` it calls `context.check()`, which
+  raises what libsecp256k1 reported *and* takes it off the thread, where
+  it would otherwise surface out of the next `check` a MuSig2 caller
+  makes. A wiped keypair is the reachable mistake and is reported as the
+  zero it holds where the x of a point should be; `tests/
+  test_callbacks.py` drives both it and the NULL pointer.
+- **`silentpayments` had no inner halves at all**, and its round trip is
+  a label: those 33 bytes are a compressed point, so a recipient
+  publishing a labeled address paid a square root between `label` and
+  `labeled_spend_pubkey`. `label_` answers with the object, `parse_label`
+  and `serialize_label` are `keys.parse` and `keys.serialize` for it —
+  public now, having been private — and the 33 bytes are still what a
+  scan cache is keyed on, so `label` is unchanged and is still what a
+  recipient keeping labels as bytes wants.
+- **The tables that hold the convention were widened, not trusted.**
+  `tests/test_parsed_keys.py` gains a `PRODUCERS` table whose equality is
+  `outer(...) == serialize(inner(...))`, and its pairing check now reads
+  `ellswift`, `recovery` and `silentpayments` as well, so a producing
+  half added and left unpaired fails there; `tests/test_bytes_like.py`
+  sweeps the new entry points that take bytes, through a serializing
+  wrapper where what they answer is a cffi object, and excuses the rest
+  by name.
 
 ### CI
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,11 @@ a tag is generated from.
 
 ## v0.8.0.3 (work in progress, not released yet)
 
-Non-breaking, and two additions: one for a caller that signs more than
+Non-breaking, and additions only: one for a caller that signs more than
 once under one key, one for a caller computing a taproot output key from
-a public key it has validated.
+a public key it has validated, and a set for a caller composing two of
+these calls where the second used to parse what the first had just
+serialized.
 
 `ssa.Signer` is new: it builds the BIP340 keypair once and signs with it
 as often as asked, where `ssa.sign` and `ssa.sign_custom` build one per
@@ -36,6 +38,41 @@ second time. The x-only conversion in front of the tweak is
 result is the output key and parity `tweak_add` answers with, the
 negation of an odd-y point included, and `tweak_add` itself is unchanged
 in behaviour and cost.
+
+**The trailing underscore now means the same thing on the producing side
+of the boundary.** It has meant "takes the parsed key in place of the
+bytes" since 0.8.0.2; a wrapper that *answers* with a key had no such
+half, so a caller composing two of them — sorting keys and then adding
+them together, recovering a key and then verifying with it, decoding an
+ElligatorSwift encoding and then tweaking what came out — serialized a
+point libsecp256k1 had just handed over and parsed it straight back,
+which for the compressed form is a field square root. `pubkey_combine_`,
+`pubkey_sort_` and `pubkey_from_prvkey_` in `keys`, `recovery.recover_`,
+`ellswift.decode_` and `encode_`, and `silentpayments.label_`,
+`labeled_spend_pubkey_`, `parse_label` and `serialize_label` are those
+halves. Every outer half is unchanged in behaviour and cost, and is now
+written as its inner half with a `serialize` behind it.
+
+What that saves is the round trip and nothing else, so it is worth what
+the two calls around it are not: aggregating five public keys the BIP67
+way is 28.2 microseconds through `pubkey_combine(pubkey_sort(...))` and
+14.8 through the two inner halves on keys parsed once, and a labeled
+Silent Payments address is 14.3 against 9.3. CHANGELOG.md states the
+machine and the method.
+
+**`xonly.from_prvkey` and `ssa.Signer.pubkey` are the two shortcuts
+where the round trip was not worth making at all.** The first is the
+x-only public key of a private key — `keys.pubkey_from_prvkey` and
+`xonly.from_pubkey` with neither the serialization nor the parse between
+them, 7.9 microseconds against 10.5 — and it is the BIP340 and BIP341
+form of a key derivation this package made every caller spell in two
+steps. The second reads that same key off the keypair a signer already
+holds, which is a read rather than a multiplication: 0.4 microseconds,
+where deriving it again is 10.5. `xonly.from_keypair` is that read for a
+caller holding a keypair of its own, a MuSig2 session through `lib`
+being one, and it is the second wrapper of these bindings taking a
+libsecp256k1 object rather than bytes: like `keys.serialize`, it raises
+what libsecp256k1 reported rather than leaving it on the thread.
 
 ## v0.8.0.2
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,38 @@ against a single key. `xonly.parse` is the same thing for the 32-byte
 x-only key BIP340 verifies against, and `keys.serialize` is how a parsed
 key becomes bytes again.
 
+The other side of the boundary is spelled the same way. A wrapper that
+*produces* a key — recovering it from a signature, decoding it,
+deriving it, adding keys together — serializes what libsecp256k1 handed
+it already parsed, and its inner half answers with the object instead:
+
+```python
+>>> from btclib_secp256k1 import recovery
+>>> sig, recid = recovery.sign(msg, prvkey)
+>>> recovered = recovery.recover_(msg, sig, recid)  # the point, not its bytes
+>>> dsa.verify_(msg, recovered, ecdsa_sig)          # used as it stands
+True
+
+```
+
+So the underscore means one thing in both directions: the half that
+speaks in parsed keys, where the outer half speaks in bytes. What it
+buys is what composing two wrappers otherwise pays between them — a
+serialization of a point that was already in hand, and a parse of what
+was just serialized, which for the compressed form is that square root
+again. `keys.pubkey_from_prvkey_`, `keys.pubkey_combine_`,
+`keys.pubkey_sort_`, `recovery.recover_`, `ellswift.decode_` and
+`silentpayments.label_` are the producing halves; sorting keys and then
+adding them together is the composition that pays it per key, and
+`silentpayments.parse_label` is `keys.parse` for the 33 bytes of a
+label, which are a point like any other.
+
+Two shortcuts exist because the round trip is not worth making at all.
+`xonly.from_prvkey` is the x-only public key of a private key, which is
+`keys.pubkey_from_prvkey` and `xonly.from_pubkey` without the bytes in
+the middle; and `ssa.Signer.pubkey` reads that same key off the keypair
+the signer already holds, which is a read rather than a multiplication.
+
 ## Building the keypair once
 
 Signing has the same shape and a different object. `ssa.sign` builds a
@@ -344,8 +376,10 @@ combination, arbitrary point multiplication) underlying BIP32 key
 derivation, plus the lexicographic ordering of public keys (`pubkey_cmp`,
 `pubkey_sort`) that BIP67 and MuSig2 key aggregation call for; `xonly`
 provides the BIP341 taproot tweaking of x-only public keys and of their
-private keys; `hashes` provides the BIP340 tagged hash, the domain
-separation the taproot tags are built on.
+private keys, and the x-only public key itself, from a full public key
+(`from_pubkey`) or straight from a private key (`from_prvkey`);
+`hashes` provides the BIP340 tagged hash, the domain separation the
+taproot tags are built on.
 
 `ssa.sign` signs a 32-byte message hash, as bitcoin does; `ssa.sign_custom`
 signs a message of any length, which BIP340 allows and which a protocol

--- a/btclib_secp256k1/context.py
+++ b/btclib_secp256k1/context.py
@@ -121,11 +121,12 @@ def check() -> None:
     after the call whose return value you are explaining.
 
     The bindings check their arguments before calling, so a violated
-    precondition is unreachable through all but one of them:
-    `keys.serialize` takes a libsecp256k1 object rather than bytes, and
-    there is nothing to check about one before handing it over. It calls
-    this itself, which is what keeps its own failure from being left on
-    the thread for the next caller to find.
+    precondition is unreachable through all but two of them:
+    `keys.serialize` takes a libsecp256k1 public key and
+    `xonly.from_keypair` a libsecp256k1 keypair, rather than bytes, and
+    there is nothing to check about either before handing it over. Both
+    call this themselves, which is what keeps their own failure from
+    being left on the thread for the next caller to find.
 
     What was recorded is cleared, so a second call reports nothing and
     a later one cannot inherit this call's message.

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -57,7 +57,10 @@ def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
     passing through python objects; and it would buy nothing, the point
     being available as keys.pubkey_tweak_mul(pubkey_bytes, prvkey),
     itself constant time. A protocol needing another derivation applies
-    it to that: SHA256 of it is what this function returns.
+    it to that: SHA256 of it is what this function returns. Wanting both
+    of them is where the inner halves earn their keep -- one
+    `keys.parse`, then `shared_secret_` and `keys.pubkey_tweak_mul_` of
+    it -- the two outer halves parsing the same key twice.
 
     Args:
         pubkey_bytes: the other party's public key, 33 or 65 bytes.

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 
 import secrets
 
-from . import BytesLike, ffi, lib
+from . import BytesLike, CData, ffi, lib
 from ._scalar import octets, scalar
 from ._secret import take
 from .context import ctx
-from .keys import serialize
+from .keys import parse, serialize
 
 
 def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> bytes:
@@ -54,6 +54,37 @@ def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> byte
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
+def encode_(pubkey: CData, rnd32: BytesLike | None = None) -> bytes:
+    """Encode an already-parsed public key as 64 ElligatorSwift bytes.
+
+    The inner half of `encode`, for a caller who already holds the parsed
+    point -- one encoding a key it has just decoded, or one encoding the
+    same key more than once, which BIP324 does with fresh randomness at
+    every connection: see `keys.parse` for what the underscore means
+    throughout.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+        rnd32: the 32 bytes deciding which of the encodings of that key
+            is produced, or None for fresh randomness.
+
+    Returns:
+        The 64-byte ElligatorSwift encoding.
+
+    Raises:
+        ValueError: if rnd32 is given and is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to encode, which no valid
+            input can make it do.
+    """
+    # 32 bytes of entropy, or nothing: see the comment in create
+    rnd32 = secrets.token_bytes(32) if rnd32 is None else octets(rnd32, "rnd32", 32)
+
+    ell_bytes = ffi.new("char[64]")
+    if not lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, rnd32):
+        raise RuntimeError("ElligatorSwift encoding failed")
+    return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
+
+
 def encode(pubkey_bytes: BytesLike, rnd32: BytesLike | None = None) -> bytes:
     """Encode a public key as 64 ElligatorSwift bytes.
 
@@ -75,18 +106,38 @@ def encode(pubkey_bytes: BytesLike, rnd32: BytesLike | None = None) -> bytes:
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
-    pubkey_bytes = octets(pubkey_bytes, "public key")
+    return encode_(parse(pubkey_bytes), rnd32)
+
+
+def decode_(ell_bytes: BytesLike) -> CData:
+    """Decode a 64-byte ElligatorSwift public key into a parsed key.
+
+    The inner half of `decode`, and the one that answers with the point
+    rather than with its serialization: see `keys.parse` for what the
+    underscore means throughout. A decoded key that is about to be
+    tweaked, verified against or encoded again is what this is for --
+    libsecp256k1 hands the point over already lifted, and serializing it
+    only to lift it back is a field square root nothing asked for.
+
+    Args:
+        ell_bytes: the 64-byte encoding.
+
+    Returns:
+        The libsecp256k1 public key object. Every 64 bytes decode to a
+        point, which is what makes the encoding indistinguishable from
+        random: there is nothing to reject.
+
+    Raises:
+        ValueError: if the input is not 64 bytes.
+        RuntimeError: if libsecp256k1 fails to decode, which no 64 bytes
+            can make it do.
+    """
+    ell_bytes = octets(ell_bytes, "ElligatorSwift public key", 64)
+
     pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError("invalid public key")
-
-    # 32 bytes of entropy, or nothing: see the comment in create
-    rnd32 = secrets.token_bytes(32) if rnd32 is None else octets(rnd32, "rnd32", 32)
-
-    ell_bytes = ffi.new("char[64]")
-    if not lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, rnd32):
-        raise RuntimeError("ElligatorSwift encoding failed")
-    return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
+    if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
+        raise RuntimeError("ElligatorSwift decoding failed")
+    return pubkey
 
 
 def decode(ell_bytes: BytesLike, compressed: bool = True) -> bytes:
@@ -106,12 +157,7 @@ def decode(ell_bytes: BytesLike, compressed: bool = True) -> bytes:
         RuntimeError: if libsecp256k1 fails to decode or serialize,
             which no 64 bytes can make it do.
     """
-    ell_bytes = octets(ell_bytes, "ElligatorSwift public key", 64)
-
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
-        raise RuntimeError("ElligatorSwift decoding failed")
-    return serialize(pubkey, compressed)
+    return serialize(decode_(ell_bytes), compressed)
 
 
 def xdh(

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -113,6 +113,31 @@ def prvkey_tweak_mul(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     return take(prvkey_buffer)
 
 
+def pubkey_from_prvkey_(prvkey: BytesLike | int) -> CData:
+    """Return the public key of a private key, as the parsed point.
+
+    The inner half of `pubkey_from_prvkey`, for a caller who is about to
+    hand the point to another wrapper rather than to hold its bytes:
+    `xonly.from_prvkey` is the one this package makes, and a caller
+    aggregating or tweaking a key it has just derived is the other. See
+    `parse` for what the underscore means throughout.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The libsecp256k1 public key object of the point kG.
+
+    Raises:
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1].
+    """
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_create(ctx, pubkey, scalar(prvkey, "private key")):
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return pubkey
+
+
 def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> bytes:
     """Return the public key of a private key, i.e. the point kG.
 
@@ -141,10 +166,7 @@ def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> byte
         >>> keys.pubkey_from_prvkey(1).hex()[:10]
         '0279be667e'
     """
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_create(ctx, pubkey, scalar(prvkey, "private key")):
-        raise ValueError("invalid private key: not in [1, n-1]")
-    return serialize(pubkey, compressed)
+    return serialize(pubkey_from_prvkey_(prvkey), compressed)
 
 
 def pubkey_negate_(pubkey: CData) -> CData:
@@ -353,6 +375,39 @@ def pubkey_tweak_mul(
     return serialize(pubkey_tweak_mul_(parse(pubkey_bytes), tweak), compressed)
 
 
+def pubkey_combine_(pubkeys: Sequence[CData]) -> CData:
+    """Add already-parsed public keys together.
+
+    The inner half of `pubkey_combine`, and the one that answers with the
+    sum rather than with its serialization: see `parse` for what the
+    underscore means throughout. `pubkey_sort_` is what hands the keys
+    over in the order BIP67 and MuSig2 ask for, and the two together are
+    an aggregation that parses each key once and serializes once, where
+    the outer halves serialize every sorted key only to parse it back.
+
+    Args:
+        pubkeys: the already-parsed public keys, as `parse` returns. At
+            least one is required.
+
+    Returns:
+        The libsecp256k1 public key object of the sum.
+
+    Raises:
+        ValueError: if the sequence is empty, or if the sum is the point
+            at infinity, which is no public key.
+    """
+    pubkeys = list(pubkeys)
+    if not pubkeys:
+        raise ValueError("at least one public key is required")
+
+    combined = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_combine(
+        ctx, combined, ffi.new("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
+    ):
+        raise ValueError("invalid public key sum")
+    return combined
+
+
 def pubkey_combine(
     pubkeys_bytes: Sequence[BytesLike], compressed: bool = True
 ) -> bytes:
@@ -373,16 +428,10 @@ def pubkey_combine(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    if not pubkeys_bytes:
-        raise ValueError("at least one public key is required")
-
-    pubkeys = [parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]
-    combined = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_combine(
-        ctx, combined, ffi.new("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
-    ):
-        raise ValueError("invalid public key sum")
-    return serialize(combined, compressed)
+    return serialize(
+        pubkey_combine_([parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]),
+        compressed,
+    )
 
 
 def pubkey_cmp_(pubkey1: CData, pubkey2: CData) -> int:
@@ -427,6 +476,40 @@ def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
     return pubkey_cmp_(parse(pubkey1_bytes), parse(pubkey2_bytes))
 
 
+def pubkey_sort_(pubkeys: Sequence[CData]) -> list[CData]:
+    """Sort already-parsed public keys, in compressed-form order.
+
+    The inner half of `pubkey_sort`, and the one that answers with the
+    keys rather than with their serializations: see `parse` for what the
+    underscore means throughout. Sorting in order to aggregate is this
+    and `pubkey_combine_`, which takes what this returns.
+
+    Args:
+        pubkeys: the already-parsed public keys, as `parse` returns. An
+            empty sequence sorts to an empty list.
+
+    Returns:
+        The same objects that were passed in, in ascending order.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to sort them, which no valid
+            key can make it do.
+    """
+    pubkeys = list(pubkeys)
+    # the array holds borrowed pointers, and is what gets reordered: the
+    # list above is what keeps the keys it points to alive
+    array = ffi.new("secp256k1_pubkey *[]", pubkeys)
+    if not lib.secp256k1_ec_pubkey_sort(ctx, array, len(pubkeys)):
+        raise RuntimeError("public key sorting failed")
+    # what comes back are the caller's own objects, found by the address
+    # each reordered pointer holds -- a cffi pointer hashes and compares
+    # as that address. Handing back the array's own elements instead
+    # would hand back pointers that own nothing, and that dangle the
+    # moment the caller drops the sequence they point into
+    owners = {pubkey: pubkey for pubkey in pubkeys}
+    return [owners[pointer] for pointer in array]
+
+
 def pubkey_sort(
     pubkeys_bytes: Sequence[BytesLike], compressed: bool = True
 ) -> list[bytes]:
@@ -449,13 +532,12 @@ def pubkey_sort(
         RuntimeError: if libsecp256k1 fails to sort or serialize, which
             no valid input can make it do.
     """
-    pubkeys = [parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]
-    # the array holds borrowed pointers, and is what gets reordered: the
-    # list above is what keeps the keys it points to alive
-    array = ffi.new("secp256k1_pubkey *[]", pubkeys)
-    if not lib.secp256k1_ec_pubkey_sort(ctx, array, len(pubkeys)):
-        raise RuntimeError("public key sorting failed")
-    return [serialize(pubkey, compressed) for pubkey in array]
+    return [
+        serialize(pubkey, compressed)
+        for pubkey in pubkey_sort_([
+            parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes
+        ])
+    ]
 
 
 def parse(pubkey_bytes: BytesLike) -> CData:
@@ -477,6 +559,20 @@ def parse(pubkey_bytes: BytesLike) -> CData:
     buy it twice. Nothing else about the two halves differs: the
     remaining arguments are checked exactly as the outer half checks
     them, a bare pointer's length being what no C return code can report.
+
+    The other side of the boundary is spelled the same way. A wrapper
+    whose last act is to serialize a key libsecp256k1 built for it also
+    has an inner half -- `pubkey_combine_` here, `recovery.recover_` and
+    `ellswift.decode_` elsewhere -- answering with the object where the
+    outer half answers with the bytes, and the outer half is that inner
+    half with a `serialize` behind it. So the underscore means one thing
+    in both directions: the half that speaks in parsed keys, where the
+    outer half speaks in bytes. What it buys is what a composition of two
+    wrappers would otherwise pay between them -- recovering a key and
+    verifying with it, sorting keys and adding them together, decoding an
+    ElligatorSwift encoding and tweaking what came out -- a serialization
+    of a point that was already in hand, and a parse of what was just
+    serialized.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -60,6 +60,43 @@ def sign(
     return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes)), recid[0]
 
 
+def recover_(msg_bytes: BytesLike, signature_bytes: BytesLike, recid: int) -> CData:
+    """Recover the public key of a recoverable signature, as a parsed key.
+
+    The inner half of `recover`, and the one that answers with the point
+    rather than with its serialization: see `keys.parse` for what the
+    underscore means throughout. Recovery is how a caller gets a key it
+    did not have, so what usually follows is a use of it -- verifying the
+    signature against it, comparing it with an expected key, deriving an
+    address -- and libsecp256k1 hands it over already lifted.
+
+    Args:
+        msg_bytes: the 32-byte hash the signature was made over.
+        signature_bytes: the 64-byte compact signature.
+        recid: the recovery id, 0 to 3.
+
+    Returns:
+        The libsecp256k1 public key object of the recovered key.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if the
+            signature is not 64 bytes or has r or s at or above the
+            group order, if recid is outside 0 to 3, or if no key can be
+            recovered.
+    """
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    signature_bytes = octets(signature_bytes, "signature", 64)
+    if recid not in (0, 1, 2, 3):
+        raise ValueError("the recovery id must be 0, 1, 2, or 3")
+
+    signature = _parse(signature_bytes, recid)
+
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ecdsa_recover(ctx, pubkey, signature, msg_bytes):
+        raise ValueError("public key recovery failed")
+    return pubkey
+
+
 def recover(
     msg_bytes: BytesLike,
     signature_bytes: BytesLike,
@@ -87,17 +124,7 @@ def recover(
         RuntimeError: if libsecp256k1 fails to serialize the key, which
             no input can make it do.
     """
-    msg_bytes = octets(msg_bytes, "message hash", 32)
-    signature_bytes = octets(signature_bytes, "signature", 64)
-    if recid not in (0, 1, 2, 3):
-        raise ValueError("the recovery id must be 0, 1, 2, or 3")
-
-    signature = _parse(signature_bytes, recid)
-
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ecdsa_recover(ctx, pubkey, signature, msg_bytes):
-        raise ValueError("public key recovery failed")
-    return serialize(pubkey, compressed)
+    return serialize(recover_(msg_bytes, signature_bytes, recid), compressed)
 
 
 def to_der(signature_bytes: BytesLike, recid: int) -> bytes:

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -141,6 +141,49 @@ def create_outputs(
     return [_serialize_xonly(output) for output in outputs]
 
 
+def label_(scan_prvkey: BytesLike | int, m: int) -> tuple[CData, bytes]:
+    """Create the m-th label of a scan key as a parsed label, and its tweak.
+
+    The inner half of `label`, and the one that answers with the label
+    object rather than with its 33 bytes: see `keys.parse` for what the
+    underscore means throughout. A label is a point, so parsing those 33
+    bytes back is a field square root -- which is what a recipient
+    publishing a labeled address pays between `label` and
+    `labeled_spend_pubkey`, and what this and `labeled_spend_pubkey_`
+    are for. The 33 bytes are still wanted, being what `scan_outputs` is
+    keyed on: `serialize_label` is where they come from.
+
+    Args:
+        scan_prvkey: the recipient's scan private key, 32 bytes or an
+            int below 2**256.
+        m: which label, an int below 2**32. Zero is BIP352's change
+            label.
+
+    Returns:
+        The libsecp256k1 label object, and the 32-byte tweak that spends
+        what was paid to it.
+
+    Raises:
+        ValueError: if m is out of range, or if the scan key is not 32
+            bytes, does not fit in them, or is not in [1, n-1].
+    """
+    scan_prvkey_bytes = scalar(scan_prvkey, "scan private key")
+    # uint32_t: cffi would answer an out of range m with OverflowError,
+    # which is not how this package reports an argument out of domain
+    if not 0 <= m < 2**32:
+        raise ValueError("the label m must fit in 4 bytes")
+
+    label_obj = ffi.new("secp256k1_silentpayments_label *")
+    tweak = ffi.new("char[32]")
+    if not lib.secp256k1_silentpayments_recipient_label_create(
+        ctx, label_obj, tweak, scan_prvkey_bytes, m
+    ):
+        # the hash landing outside [1, n-1] is the other way this fails,
+        # and it has never been reached: it is negligible per evaluation
+        raise ValueError("invalid scan private key")
+    return label_obj, take(tweak)
+
+
 def label(scan_prvkey: BytesLike | int, m: int) -> tuple[bytes, bytes]:
     """Create the m-th label of a scan key, and its tweak.
 
@@ -174,21 +217,40 @@ def label(scan_prvkey: BytesLike | int, m: int) -> tuple[bytes, bytes]:
         >>> len(label), len(tweak)
         (33, 32)
     """
-    scan_prvkey_bytes = scalar(scan_prvkey, "scan private key")
-    # uint32_t: cffi would answer an out of range m with OverflowError,
-    # which is not how this package reports an argument out of domain
-    if not 0 <= m < 2**32:
-        raise ValueError("the label m must fit in 4 bytes")
+    label_obj, tweak = label_(scan_prvkey, m)
+    return serialize_label(label_obj), tweak
 
-    label_obj = ffi.new("secp256k1_silentpayments_label *")
-    tweak = ffi.new("char[32]")
-    if not lib.secp256k1_silentpayments_recipient_label_create(
-        ctx, label_obj, tweak, scan_prvkey_bytes, m
+
+def labeled_spend_pubkey_(spend_pubkey: CData, label_obj: CData) -> CData:
+    """Add an already-parsed label to an already-parsed spend public key.
+
+    The inner half of `labeled_spend_pubkey`, taking both parsed objects
+    and answering with a third: see `keys.parse` for what the underscore
+    means throughout. A recipient publishing a labeled address holds
+    both of them already -- the label from `label_`, the spend key from
+    `keys.parse` -- so this is the pair of C calls BIP352 asks for with
+    no serialization between them, and `keys.serialize` is how what comes
+    out becomes an address.
+
+    Args:
+        spend_pubkey: the recipient's already-parsed unlabeled spend
+            public key, as `keys.parse` returns.
+        label_obj: the parsed label, as `label_` returns and as
+            `parse_label` reads back.
+
+    Returns:
+        The libsecp256k1 public key object of the labeled spend key.
+
+    Raises:
+        ValueError: if the two sum to the point at infinity, which has no
+            serialization and which a label BIP352 made cannot produce.
+    """
+    labeled = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_silentpayments_recipient_create_labeled_spend_pubkey(
+        ctx, labeled, spend_pubkey, label_obj
     ):
-        # the hash landing outside [1, n-1] is the other way this fails,
-        # and it has never been reached: it is negligible per evaluation
-        raise ValueError("invalid scan private key")
-    return _serialize_label(label_obj), take(tweak)
+        raise ValueError("invalid labeled spend public key")
+    return labeled
 
 
 def labeled_spend_pubkey(
@@ -225,15 +287,12 @@ def labeled_spend_pubkey(
         >>> len(silentpayments.labeled_spend_pubkey(spend_pubkey, label))
         33
     """
-    spend_pubkey = _pubkey(spend_pubkey_bytes, "spend public key")
-    label_obj = _parse_label(label_bytes)
-
-    labeled = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_silentpayments_recipient_create_labeled_spend_pubkey(
-        ctx, labeled, spend_pubkey, label_obj
-    ):
-        raise ValueError("invalid labeled spend public key")
-    return serialize(labeled, compressed)
+    return serialize(
+        labeled_spend_pubkey_(
+            _pubkey(spend_pubkey_bytes, "spend public key"), parse_label(label_bytes)
+        ),
+        compressed,
+    )
 
 
 def prevouts_summary(
@@ -503,7 +562,7 @@ def _found_output(found: CData) -> tuple[bytes, bytes, bytes | None]:
     tweak = bytes(ffi.buffer(found.tweak))
     if not found.found_with_label:
         return pubkey, tweak, None
-    return pubkey, tweak, _serialize_label(ffi.addressof(found, "label"))
+    return pubkey, tweak, serialize_label(ffi.addressof(found, "label"))
 
 
 def _array(cdecl: str, items: list[CData]) -> CData:
@@ -619,8 +678,15 @@ def _serialize_xonly(xonly_pubkey: CData) -> bytes:
     return ffi.unpack(output, ffi.sizeof(output))
 
 
-def _parse_label(label_bytes: BytesLike) -> CData:
-    """Parse a 33-byte label.
+def parse_label(label_bytes: BytesLike) -> CData:
+    """Parse a 33-byte label into its internal representation.
+
+    What `keys.parse` is to a public key, this is to a label, and for the
+    same reason: those 33 bytes are a compressed point, so reading them
+    back is a field square root. A recipient that keeps its labels as
+    bytes -- the cache `scan_outputs` takes is exactly that -- parses one
+    here and hands it to `labeled_spend_pubkey_`, rather than through the
+    outer half which parses it again at every address.
 
     Args:
         label_bytes: the label, as `label` returned it.
@@ -640,11 +706,14 @@ def _parse_label(label_bytes: BytesLike) -> CData:
     return label_obj
 
 
-def _serialize_label(label_obj: CData) -> bytes:
+def serialize_label(label_obj: CData) -> bytes:
     """Serialize a label libsecp256k1 produced.
 
+    What `keys.serialize` is to a public key: the 33 bytes are what a
+    recipient keys its label cache on, and what `label` answers with.
+
     Args:
-        label_obj: the libsecp256k1 label object.
+        label_obj: the libsecp256k1 label object, as `label_` returns.
 
     Returns:
         Its 33 bytes, which are the compressed point it is.

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -117,7 +117,9 @@ class Signer:
     here, being the point multiplication of the public key. This holds
     one across calls instead, so the first signature is the only one
     paying for it, and `sign` and `sign_custom` are the same signatures
-    over it.
+    over it. `pubkey()` is the x-only key those signatures verify
+    against, read off that same keypair rather than derived a second
+    time.
 
     What that hands the caller is the lifetime of a secret, and it is the
     trade this makes deliberately. A keypair is the private key in
@@ -212,6 +214,28 @@ class Signer:
                 can make it do.
         """
         return _sign_custom(msg_bytes, self._held(), aux_rand32)
+
+    def pubkey(self) -> tuple[bytes, int]:
+        """Return the x-only public key this signer signs under.
+
+        The keypair already holds the point, so this is a read of it and
+        not a multiplication: `xonly.from_prvkey` is the same answer
+        derived from the private key, and costs the point multiplication
+        this signer has already paid for.
+
+        Returns:
+            The 32-byte x coordinate BIP340 verifies against, and the
+            parity of the y of the private key's own point: 0 for even,
+            1 for odd. A signature made here verifies against the 32
+            bytes whichever the parity is, which is what the negation
+            BIP340 prescribes is for.
+
+        Raises:
+            ValueError: if this signer has been wiped.
+            RuntimeError: if libsecp256k1 fails to convert or serialize
+                the key, which a keypair it built cannot make it do.
+        """
+        return xonly.from_keypair(self._held())
 
     def wipe(self) -> None:
         """Overwrite the keypair, ending what this signer can do.

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import octets, scalar
 from ._secret import take, wipe
-from .context import ctx
+from .context import check, ctx
 
 
 def _from_pubkey(pubkey: CData) -> tuple[CData, int]:
@@ -113,6 +113,80 @@ def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
             which no valid key can make it do.
     """
     return from_pubkey_(keys.parse(pubkey_bytes))
+
+
+def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
+    """Return the x-only public key of a private key, and the y parity.
+
+    The BIP340 and BIP341 form of `keys.pubkey_from_prvkey`, and the one
+    to reach for when the 32 bytes are what is wanted: it is that call
+    and `from_pubkey` with neither the serialization nor the parse
+    between them, the point going straight from the multiplication into
+    the conversion that drops its y.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte x coordinate of kG, and the parity of its y: 0 for
+        even, 1 for odd. That parity is what BIP340 signing negates the
+        key for, so a signer wanting only the key it signs under can
+        ignore it.
+
+    Raises:
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            point, which no valid key can make it do.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, xonly
+        >>> pubkey = keys.pubkey_from_prvkey(1)
+        >>> xonly.from_prvkey(1) == xonly.from_pubkey(pubkey)
+        True
+    """
+    return from_pubkey_(keys.pubkey_from_prvkey_(prvkey))
+
+
+def from_keypair(keypair: CData) -> tuple[bytes, int]:
+    """Return the x-only public key of a keypair, and the y parity.
+
+    The keypair already holds the point, so this is a read of it rather
+    than a multiplication: `ssa.Signer.pubkey` is this call on the
+    keypair a signer holds, and a MuSig2 session driven through `lib`
+    holds another. `from_prvkey` is the same answer for a caller holding
+    the private key and no keypair.
+
+    Args:
+        keypair: the libsecp256k1 keypair object, as `ssa.Signer` holds
+            and as `secp256k1_keypair_create` writes.
+
+    Returns:
+        The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
+        odd. The parity is of the point the private key gives, the
+        keypair being the negated key where that y is odd.
+
+    Raises:
+        ValueError: if the object is not a keypair libsecp256k1 will read
+            -- a NULL pointer, or one that has been wiped. This and
+            `keys.serialize` are the two arguments of these bindings that
+            are libsecp256k1 objects rather than bytes, and so the two
+            that cannot be checked before the call.
+        RuntimeError: if libsecp256k1 fails for any other reason, or
+            fails to serialize the result, which a keypair it built
+            cannot make it do.
+    """
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    parity = ffi.new("int *")
+    if not lib.secp256k1_keypair_xonly_pub(ctx, xonly_pubkey, parity, keypair):
+        # the keypair is the caller's object, so a violated precondition
+        # is reachable here as it is in `keys.serialize`, which says why
+        # raising it is also what takes it off the thread. A wiped
+        # keypair is the reachable way in, and what it is reported as is
+        # the zero it holds where the x of a point should be
+        check()
+        raise RuntimeError("x-only public key conversion failed")
+    return _serialize(xonly_pubkey), parity[0]
 
 
 def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, int]:

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -101,6 +101,59 @@ def signed_custom(prvkey: Any, msg_bytes: Any, aux_rand32: Any) -> bytes:
         return signer.sign_custom(msg_bytes, aux_rand32)
 
 
+def created(prvkey: Any) -> bytes:
+    """Derive a public key through the inner half, and serialize it.
+
+    Args:
+        prvkey: the private key.
+
+    Returns:
+        The compressed public key, which is what the outer half answers.
+    """
+    return keys.serialize(keys.pubkey_from_prvkey_(prvkey))
+
+
+def decoded(ell_bytes: Any) -> bytes:
+    """Decode an ElligatorSwift key through the inner half, and serialize.
+
+    Args:
+        ell_bytes: the 64-byte encoding.
+
+    Returns:
+        The compressed public key.
+    """
+    return keys.serialize(ellswift.decode_(ell_bytes))
+
+
+def recovered(msg_bytes: Any, signature_bytes: Any, recid: int) -> bytes:
+    """Recover a public key through the inner half, and serialize it.
+
+    Args:
+        msg_bytes: the 32-byte message hash.
+        signature_bytes: the 64-byte compact signature.
+        recid: the recovery id.
+
+    Returns:
+        The compressed recovered public key.
+    """
+    return keys.serialize(recovery.recover_(msg_bytes, signature_bytes, recid))
+
+
+def labeled(scan_prvkey: Any, m: int) -> tuple[bytes, bytes]:
+    """Create a label through the inner half, and serialize it.
+
+    Args:
+        scan_prvkey: the recipient's scan private key.
+        m: which label.
+
+    Returns:
+        The 33-byte label and its 32-byte tweak, which is what the outer
+        half answers.
+    """
+    label_obj, tweak = silentpayments.label_(scan_prvkey, m)
+    return silentpayments.serialize_label(label_obj), tweak
+
+
 # every entry point taking an argument that crosses as a bare pointer,
 # with the arguments it takes: the bytes ones are retyped below
 CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
@@ -109,6 +162,11 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.prvkey_tweak_add", keys.prvkey_tweak_add, (PRVKEY, TWEAK), {}),
     ("keys.prvkey_tweak_mul", keys.prvkey_tweak_mul, (PRVKEY, TWEAK), {}),
     ("keys.pubkey_from_prvkey", keys.pubkey_from_prvkey, (PRVKEY,), {}),
+    # the producing inner halves answer with a cffi object, and two of
+    # those are equal to nothing at all: each is driven through a
+    # function above which serializes what it built, so what the sweep
+    # compares is the bytes its outer half would have answered
+    ("keys.pubkey_from_prvkey_", created, (PRVKEY,), {}),
     ("keys.pubkey_negate", keys.pubkey_negate, (PUBKEY,), {}),
     ("keys.pubkey_tweak_add", keys.pubkey_tweak_add, (PUBKEY, TWEAK), {}),
     ("keys.pubkey_tweak_mul", keys.pubkey_tweak_mul, (PUBKEY, TWEAK), {}),
@@ -137,6 +195,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("ssa.verify", ssa.verify, (MSG, XONLY, SSA_SIG), {}),
     ("ssa.verify_", ssa.verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
+    ("xonly.from_prvkey", xonly.from_prvkey, (PRVKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
     # the parsed key is not retyped, being no bytes; the tweak beside it
     # is, and what comes back is 32 bytes and a parity, which compare
@@ -150,12 +209,17 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("xonly.prvkey_tweak_add", xonly.prvkey_tweak_add, (PRVKEY, TWEAK), {}),
     ("recovery.sign", recovery.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("recovery.recover", recovery.recover, (MSG, RECOVERABLE, RECID), {}),
+    ("recovery.recover_", recovered, (MSG, RECOVERABLE, RECID), {}),
     ("recovery.to_der", recovery.to_der, (RECOVERABLE, RECID), {}),
     ("ecdh.shared_secret", ecdh.shared_secret, (PUBKEY, PRVKEY), {}),
     ("ecdh.shared_secret_", ecdh.shared_secret_, (PARSED, PRVKEY), {}),
     ("ellswift.create", ellswift.create, (PRVKEY, bytes(32)), {}),
     ("ellswift.encode", ellswift.encode, (PUBKEY, bytes(32)), {}),
+    # the parsed key is not retyped, being no bytes; the randomness
+    # beside it is, and pinning it is what makes two encodings comparable
+    ("ellswift.encode_", ellswift.encode_, (PARSED, bytes(32)), {}),
     ("ellswift.decode", ellswift.decode, (ELL_A,), {}),
+    ("ellswift.decode_", decoded, (ELL_A,), {}),
     ("ellswift.xdh", ellswift.xdh, (ELL_A, ELL_B, PRVKEY, 0), {}),
     # the silentpayments arguments are passed positionally, keyword
     # defaults though they are: what is retyped below is `args`, so a
@@ -168,6 +232,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
         {},
     ),
     ("silentpayments.label", silentpayments.label, (SCAN_PRVKEY, 0), {}),
+    ("silentpayments.label_", labeled, (SCAN_PRVKEY, 0), {}),
     (
         "silentpayments.labeled_spend_pubkey",
         silentpayments.labeled_spend_pubkey,
@@ -208,10 +273,14 @@ MODULES = {
 }
 
 # the ones that take no argument crossing as a bare pointer, or nothing
-# this sweep has not already exercised. Both `parse` functions take one
-# and are covered through every wrapper above; `serialize`,
-# `pubkey_negate_`, `pubkey_cmp_` and `from_pubkey_` take the
-# libsecp256k1 object a `parse` hands back and no bytes at all. The two
+# this sweep has not already exercised. All three `parse` functions take
+# one and are covered through every wrapper above, `parse_label` through
+# `silentpayments.labeled_spend_pubkey`; `serialize`, `serialize_label`,
+# `pubkey_negate_`, `pubkey_cmp_`, `from_pubkey_`, `from_keypair` and
+# `labeled_spend_pubkey_` take the libsecp256k1 objects a `parse`, a
+# producing inner half or `ssa.Signer` hands back, and no bytes at all --
+# as do `pubkey_combine_` and `pubkey_sort_`, whose sequences hold those
+# same objects and no bytes to retype. The two
 # tweaking inner halves do take a tweak, and it is the retyped one of
 # `keys.pubkey_tweak_add` and `keys.pubkey_tweak_mul` above, which pass
 # theirs straight in: what they answer with is the parsed key they
@@ -228,10 +297,16 @@ NOT_SWEPT = {
     "keys.pubkey_tweak_add_",
     "keys.pubkey_tweak_mul_",
     "keys.pubkey_cmp_",
+    "keys.pubkey_combine_",
+    "keys.pubkey_sort_",
     "keys.PubkeyTweakChain",
     "ssa.Signer",
     "xonly.parse",
     "xonly.from_pubkey_",
+    "xonly.from_keypair",
+    "silentpayments.parse_label",
+    "silentpayments.serialize_label",
+    "silentpayments.labeled_spend_pubkey_",
 }
 
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,9 +5,10 @@
 
 """Tests of what libsecp256k1 reports through the callbacks of the context.
 
-An illegal argument is reachable through `lib`, and through the one
-wrapper that takes a libsecp256k1 object rather than bytes; both are
-driven here. An internal error is not: libsecp256k1 reports through that
+An illegal argument is reachable through `lib`, and through the two
+wrappers that take a libsecp256k1 object rather than bytes -- a public
+key for `keys.serialize`, a keypair for `xonly.from_keypair`; all three
+are driven here. An internal error is not: libsecp256k1 reports through that
 callback what it holds to be unreachable, so the recording function is
 called directly, the way test_extension.py drives the branch of the
 loader that the build it runs on does not have.
@@ -19,7 +20,7 @@ import threading
 
 import pytest
 
-from btclib_secp256k1 import context, ffi, keys, lib
+from btclib_secp256k1 import context, ffi, keys, lib, ssa, xonly
 from btclib_secp256k1.context import ctx
 
 # a public key libsecp256k1 is asked to parse into nowhere: the bindings
@@ -36,9 +37,10 @@ def test_check_with_nothing_reported() -> None:
 def test_illegal_argument() -> None:
     """An illegal argument reaches the caller as ValueError, with its text.
 
-    Driven through `lib`, which all but one of the bindings' wrappers
+    Driven through `lib`, which all but two of the bindings' wrappers
     cannot do: they give libsecp256k1 bytes they have already checked.
-    `keys.serialize` is the exception, and has a test of its own below.
+    `keys.serialize` and `xonly.from_keypair` are the exceptions, and
+    have tests of their own below.
     """
     assert not lib.secp256k1_ec_pubkey_parse(ctx, *NOWHERE_ARGS)
     with pytest.raises(ValueError, match="illegal argument: pubkey != NULL"):
@@ -84,6 +86,27 @@ def test_serialize_leaves_nothing_on_the_thread() -> None:
     with pytest.raises(ValueError, match="illegal argument"):
         keys.serialize(ffi.new("secp256k1_pubkey *"))
     # raising it took it off the thread: this reports nothing
+    context.check()
+
+
+def test_from_keypair_raises_what_was_reported() -> None:
+    """`xonly.from_keypair` raises the message, as `keys.serialize` does.
+
+    It takes the keypair the caller holds, so the precondition is
+    libsecp256k1's to violate here too. A NULL pointer names itself; a
+    wiped keypair is the reachable mistake, and what libsecp256k1 reports
+    of it is the zero it finds where the x of a point should be. Neither
+    is left on the thread: the `check` after each reports nothing.
+    """
+    with pytest.raises(ValueError, match="illegal argument: keypair != NULL"):
+        xonly.from_keypair(ffi.NULL)
+    context.check()
+
+    signer = ssa.Signer(7)
+    keypair = signer._keypair
+    signer.wipe()
+    with pytest.raises(ValueError, match="illegal argument: !secp256k1_fe_is_zero"):
+        xonly.from_keypair(keypair)
     context.check()
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -222,6 +222,69 @@ def test_pubkey_order() -> None:
         keys.pubkey_cmp(compressed[0], b"")
 
 
+def test_sorting_and_adding_the_same_parsed_keys() -> None:
+    """The aggregation the producing halves are for: parse once, sort, add.
+
+    `pubkey_sort` serializes every key it ordered and `pubkey_combine`
+    parses every key it is given, so the two composed pay a serialization
+    and a field square root per key for nothing. The inner halves hand
+    the objects along instead, and the answer is the outer halves' own.
+
+    What `pubkey_sort_` returns is the caller's own objects, and that is
+    asserted by identity rather than by value: an array element would
+    compare equal to one and dangle the moment the list it points into
+    was dropped.
+    """
+    pubkeys_bytes = [mult.mult_(k) for k in (5, 2, 9, 1)]
+    parsed = [keys.parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]
+
+    ordered = keys.pubkey_sort_(parsed)
+    assert [keys.serialize(pubkey) for pubkey in ordered] == keys.pubkey_sort(
+        pubkeys_bytes
+    )
+    # the objects handed back are the ones handed in, and all of them
+    assert sorted(id(pubkey) for pubkey in ordered) == sorted(
+        id(pubkey) for pubkey in parsed
+    )
+
+    assert keys.serialize(keys.pubkey_combine_(ordered)) == keys.pubkey_combine(
+        keys.pubkey_sort(pubkeys_bytes)
+    )
+    # sorting no key at all is no key at all here too
+    assert keys.pubkey_sort_([]) == []
+    # and what the outer half refuses, this refuses: an empty sum, and
+    # one that lands on the point at infinity
+    with pytest.raises(ValueError, match="at least one public key"):
+        keys.pubkey_combine_([])
+    with pytest.raises(ValueError, match="invalid public key sum"):
+        keys.pubkey_combine_([
+            keys.parse(mult.mult_(7)),
+            keys.parse(keys.pubkey_negate(mult.mult_(7))),
+        ])
+
+
+def test_xonly_from_prvkey() -> None:
+    """The x-only key of a private key, without the point in between.
+
+    `from_prvkey` is `from_pubkey` of `keys.pubkey_from_prvkey`, and the
+    equality is asserted over an even-y key and an odd-y one, the parity
+    being what the two have to agree on and not only the 32 bytes. The
+    private key is bounded exactly as everywhere else.
+    """
+    for prvkey in (7, 11):
+        assert xonly.from_prvkey(prvkey) == xonly.from_pubkey(
+            keys.pubkey_from_prvkey(prvkey)
+        )
+    # the two keys above are one of each parity, which is what makes the
+    # agreement above worth asserting
+    assert {xonly.from_prvkey(7)[1], xonly.from_prvkey(11)[1]} == {0, 1}
+
+    with pytest.raises(ValueError, match="private key"):
+        xonly.from_prvkey(0)
+    with pytest.raises(ValueError, match="private key must be 32 bytes"):
+        xonly.from_prvkey(b"\x01" * 31)
+
+
 def test_keys_invalid_inputs() -> None:
     """Every argument the keys module bounds is refused out of range.
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -552,8 +552,8 @@ def test_the_prevouts_summary_carries_no_secret() -> None:
 def test_a_label_is_a_point_and_round_trips_through_its_33_bytes() -> None:
     """The 33 bytes of a label parse back into the label they came from.
 
-    `labeled_spend_pubkey` is the only entry point taking one, so the
-    parse is exercised through it: the same 33 bytes have to give the
+    `labeled_spend_pubkey` and `parse_label` are what take one, and the
+    parse is exercised through both: the same 33 bytes have to give the
     same labeled key, and a label is a point rather than an opaque blob
     -- the sum below is what says so.
     """
@@ -565,6 +565,18 @@ def test_a_label_is_a_point_and_round_trips_through_its_33_bytes() -> None:
     assert silentpayments.labeled_spend_pubkey(
         SP_SPEND_PUBKEY, label, compressed=False
     ) == keys.pubkey_combine([SP_SPEND_PUBKEY, label], compressed=False)
+
+    # and the 33 bytes parse back into the label the recipient made,
+    # which is what lets a cache of them be used without going round
+    # through the serialization at every address
+    assert (
+        keys.serialize(
+            silentpayments.labeled_spend_pubkey_(
+                keys.parse(SP_SPEND_PUBKEY), silentpayments.parse_label(label)
+            )
+        )
+        == labeled
+    )
 
 
 def test_a_label_of_a_scan_key_is_the_scan_key_and_m() -> None:

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -25,14 +25,28 @@ from typing import Any
 
 import pytest
 
-from btclib_secp256k1 import dsa, ecdh, keys, mult, ssa, xonly
+from btclib_secp256k1 import (
+    dsa,
+    ecdh,
+    ellswift,
+    keys,
+    mult,
+    recovery,
+    silentpayments,
+    ssa,
+    xonly,
+)
 
 # secp256k1 group order
 N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 PRVKEY = 7
 TWEAK = 11
+SCAN_PRVKEY = 13
 MSG = hashlib.sha256(b"btclib_secp256k1").digest()
+# the randomness of an ElligatorSwift encoding, pinned: fresh randomness
+# is what the encoding takes by default, and two of those never agree
+RND32 = bytes(32)
 
 PUBKEY_LONG = mult.mult_(PRVKEY)
 PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
@@ -40,6 +54,21 @@ OTHER = keys.pubkey_from_prvkey(3)
 XONLY, PARITY = xonly.from_pubkey(PUBKEY)
 DER = dsa.sign(MSG, PRVKEY)
 SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
+RECOVERABLE, RECID = recovery.sign(MSG, PRVKEY)
+ELL = ellswift.create(PRVKEY, RND32)
+LABEL, LABEL_TWEAK = silentpayments.label(SCAN_PRVKEY, 0)
+
+
+def label_through_the_inner_half() -> tuple[bytes, bytes]:
+    """Create a label through `label_`, and serialize what it answered.
+
+    Returns:
+        The 33-byte label and its 32-byte tweak, which is the pair
+        `silentpayments.label` answers with.
+    """
+    label_obj, tweak = silentpayments.label_(SCAN_PRVKEY, 0)
+    return silentpayments.serialize_label(label_obj), tweak
+
 
 # every pair of the convention: the name of the outer half, that half as
 # a call of the serialized key alone, and the inner half as a call of the
@@ -80,6 +109,64 @@ PAIRS: list[tuple[str, Callable[[bytes], Any], Callable[[Any], Any]]] = [
         lambda pubkey_bytes: dsa.verify(MSG, pubkey_bytes, DER),
         lambda pubkey: dsa.verify_(MSG, pubkey, DER),
     ),
+    (
+        "ellswift.encode",
+        lambda pubkey_bytes: ellswift.encode(pubkey_bytes, RND32),
+        lambda pubkey: ellswift.encode_(pubkey, RND32),
+    ),
+]
+
+# and the halves on the other side of the boundary: the ones that answer
+# with the key instead of with its bytes, whose outer half is the same
+# call with a `serialize` behind it rather than a `parse` in front. Each
+# is written as the pair of calls it is, the key being what they produce
+# rather than what they take -- so there are no two serializations of an
+# argument to drive them with, and the equality is over the answer alone
+PRODUCERS: list[tuple[str, Callable[[], Any], Callable[[], Any]]] = [
+    (
+        "keys.pubkey_from_prvkey",
+        lambda: keys.pubkey_from_prvkey(PRVKEY),
+        lambda: keys.serialize(keys.pubkey_from_prvkey_(PRVKEY)),
+    ),
+    (
+        "keys.pubkey_combine",
+        lambda: keys.pubkey_combine([PUBKEY, OTHER]),
+        lambda: keys.serialize(
+            keys.pubkey_combine_([keys.parse(PUBKEY), keys.parse(OTHER)])
+        ),
+    ),
+    (
+        "keys.pubkey_sort",
+        lambda: keys.pubkey_sort([PUBKEY, OTHER]),
+        lambda: [
+            keys.serialize(pubkey)
+            for pubkey in keys.pubkey_sort_([keys.parse(PUBKEY), keys.parse(OTHER)])
+        ],
+    ),
+    (
+        "recovery.recover",
+        lambda: recovery.recover(MSG, RECOVERABLE, RECID),
+        lambda: keys.serialize(recovery.recover_(MSG, RECOVERABLE, RECID)),
+    ),
+    (
+        "ellswift.decode",
+        lambda: ellswift.decode(ELL),
+        lambda: keys.serialize(ellswift.decode_(ELL)),
+    ),
+    (
+        "silentpayments.label",
+        lambda: silentpayments.label(SCAN_PRVKEY, 0),
+        label_through_the_inner_half,
+    ),
+    (
+        "silentpayments.labeled_spend_pubkey",
+        lambda: silentpayments.labeled_spend_pubkey(PUBKEY, LABEL),
+        lambda: keys.serialize(
+            silentpayments.labeled_spend_pubkey_(
+                keys.parse(PUBKEY), silentpayments.parse_label(LABEL)
+            )
+        ),
+    ),
 ]
 
 
@@ -105,6 +192,28 @@ def test_the_inner_half_is_the_outer_one_without_the_parse(
         pubkey_bytes: the key, compressed or not.
     """
     assert outer(pubkey_bytes) == inner(keys.parse(pubkey_bytes))
+
+
+@pytest.mark.parametrize(
+    "name,outer,inner", PRODUCERS, ids=[producer[0] for producer in PRODUCERS]
+)
+def test_the_producing_half_is_the_outer_one_without_the_serialize(
+    name: str, outer: Callable[[], Any], inner: Callable[[], Any]
+) -> None:
+    """`outer(...)` is `serialize(inner(...))`, key for key.
+
+    The same equality read the other way round: where the halves above
+    take the key, these produce it, so what the outer half adds is the
+    serialization behind the call rather than the parse in front of it.
+    A caller who hands the key straight to another wrapper -- which is
+    what these are for -- never pays for either.
+
+    Args:
+        name: the outer half, for the test id.
+        outer: it, as a call of its own arguments.
+        inner: the inner half, with what serializes its answer.
+    """
+    assert outer() == inner()
 
 
 def test_the_schnorr_pair_parses_the_x_only_key() -> None:
@@ -217,12 +326,19 @@ def test_every_inner_half_is_paired() -> None:
     modules = {
         "dsa": dsa,
         "ecdh": ecdh,
+        "ellswift": ellswift,
         "keys": keys,
         "mult": mult,
+        "recovery": recovery,
+        "silentpayments": silentpayments,
         "ssa": ssa,
         "xonly": xonly,
     }
-    paired = {f"{name}_" for name, *_ in PAIRS} | {"ssa.verify_", "xonly.tweak_add_"}
+    paired = (
+        {f"{name}_" for name, *_ in PAIRS}
+        | {f"{name}_" for name, *_ in PRODUCERS}
+        | {"ssa.verify_", "xonly.tweak_add_"}
+    )
     inner_halves = {
         f"{module_name}.{name}"
         for module_name, module in modules.items()

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -94,6 +94,29 @@ def test_a_signer_signs_more_than_once() -> None:
     signer.wipe()
 
 
+def test_a_signer_answers_the_key_it_signs_under() -> None:
+    """`pubkey()` is the x-only key of the private key, read off the keypair.
+
+    The keypair already holds the point, so this is the derivation the
+    caller would otherwise make a second time -- and it is asserted
+    against both of the ways of making it, `xonly.from_prvkey` and the
+    serialized public key of the same private key. The parity comes with
+    it, and is the one of the point before BIP340's negation, so a
+    signature made here verifies against the 32 bytes whichever it is.
+    """
+    with ssa.Signer(PRVKEY) as signer:
+        assert signer.pubkey() == (XONLY, PARITY)
+        assert signer.pubkey() == xonly.from_prvkey(PRVKEY)
+        assert ssa.verify(MSG, signer.pubkey()[0], signer.sign(MSG))
+
+    # and a wiped signer has no key to answer with, as it has none to
+    # sign with: the keypair is gone, and this refuses before reaching it
+    signer = ssa.Signer(PRVKEY)
+    signer.wipe()
+    with pytest.raises(ValueError, match="wiped"):
+        signer.pubkey()
+
+
 def test_an_int_private_key_is_the_same_signer() -> None:
     """The constructor takes what `sign` takes, the int scalar included."""
     with ssa.Signer(7) as by_int, ssa.Signer(PRVKEY) as by_bytes:


### PR DESCRIPTION
`dsa.verify_` and the other inner halves take a parsed key, so a caller
that already holds one does not pay for a second parse. Nothing said the
same thing on the way *out*: a wrapper that produces a key serializes
what libsecp256k1 handed it already parsed, so composing two of them
pays a serialization of a point that was in hand and a parse of what was
just serialized — a field square root, for the compressed form.

This makes the convention read the same in both directions: the outer
half is the inner one with a `parse` in front of it or a `serialize`
behind it, and `keys.parse` states both.

## What is new

- **producing halves**: `keys.pubkey_from_prvkey_`, `keys.pubkey_combine_`,
  `keys.pubkey_sort_`, `recovery.recover_`, `ellswift.decode_`,
  `silentpayments.label_`
- **consuming halves** where there were none: `ellswift.encode_`,
  `silentpayments.labeled_spend_pubkey_`, plus `silentpayments.parse_label`
  and `serialize_label`, which are `keys.parse` and `keys.serialize` for the
  33 bytes of a label
- **two shortcuts** where the round trip was not worth making at all:
  `xonly.from_prvkey`, and `ssa.Signer.pubkey` — with `xonly.from_keypair`
  behind it, for a MuSig2 session that holds a keypair through `lib`
- **documentation**: the convention in `keys.parse`, the README section, and
  the ECDH note for a caller that wants both the secret and the shared point

Every outer half is unchanged in behaviour and cost, and is now written as
its inner half with the missing step around it.

## What it costs

Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 10 rounds of 20 000
calls, microseconds per call. The unit is `keys.serialize` 0.35 plus
`keys.parse` 2.28, against 0.24 for the uncompressed form.

| composition | as it was | through the halves |
| --- | --- | --- |
| aggregate five keys, BIP67 order | 28.23 | 14.84 |
| labeled Silent Payments address | 14.28 | 9.25 |
| `xonly.from_pubkey(ellswift.decode(ell))` | 7.44 | 4.69 |
| recover a key and verify with it | 29.57 | 26.75 |
| x-only public key of a private key | 10.49 | 7.90 |
| the same, off a signer's keypair | 10.49 | 0.43 |

## What holds it

`tests/test_parsed_keys.py` gains a `PRODUCERS` table whose equality is
`outer(...) == serialize(inner(...))`, and its pairing check now reads
`ellswift`, `recovery` and `silentpayments`, so a producing half left
unpaired fails there rather than going untested. `pubkey_sort_` hands back
the caller's own objects — an element of the array libsecp256k1 sorted owns
nothing — and `tests/test_keys.py` asserts that by identity.
`tests/test_callbacks.py` drives `xonly.from_keypair` with a NULL and with a
wiped keypair: like `keys.serialize` it raises what libsecp256k1 reported
and takes it off the thread. Coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align underscore naming convention for key-wrapping helpers so it consistently denotes functions operating on parsed key objects, and introduce inner/outer halves for key-producing wrappers to avoid redundant parse/serialize roundtrips.

New Features:
- Add inner-half helpers that return parsed key objects for public key derivation, aggregation, sorting, recovery, ElligatorSwift decoding, and Silent Payments label creation.
- Add inner-half helpers that consume parsed key objects for ElligatorSwift encoding and Silent Payments labeled spend key derivation, plus dedicated parse/serialize helpers for Silent Payments labels.
- Expose x-only public key derivation directly from a private key and from an existing keypair, and surface a signer helper to read the x-only public key it signs under.

Enhancements:
- Refactor existing outer wrapper functions to delegate to their new inner halves, maintaining behaviour and cost while standardising the parse/serialize boundary.
- Clarify documentation and history around the underscore convention, parsed key handling, and performance impact of avoiding redundant round trips.
- Extend ECDH documentation to describe efficient access to both shared secret and shared point via inner halves.

Documentation:
- Update README, CHANGELOG, and HISTORY to document the bidirectional underscore convention, new inner-half helpers, performance characteristics of compositions, and new x-only key derivation APIs.

Tests:
- Expand parsed key convention tests to cover producing halves, ensure every inner-half helper is paired with its outer counterpart, and verify identity semantics for pubkey sorting.
- Broaden bytes-like sweeps and module tests to cover new inner-half entry points, label parse/serialize behaviour, and Silent Payments label round trips.
- Add tests for x-only key derivation from private keys and keypairs, including callback handling for invalid keypair inputs and signer.pubkey behaviour.