### PR TITLE
Say what the two new entry points save, and what they do not

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1685
+        "line_number": 1691
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T14:45:02Z"
+  "generated_at": "2026-08-15T14:56:09Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,10 +137,16 @@ release-notes length in the first place, and are still in
   `xonly.from_pubkey(keys.pubkey_from_prvkey(k))` — 10.49, of which 2.63
   is a round trip of the compressed key nobody wanted — and BIP340 and
   BIP341 want that key and not the point, so the composition is the
-  common case and not an exotic one: `from_prvkey` is 7.90. A signer
-  already holds the keypair, and reading the key off it is
-  `secp256k1_keypair_xonly_pub`: `Signer.pubkey()` is 0.43 against the
-  10.49 of deriving it a second time, and `tests/test_signer.py` holds it
+  common case and not an exotic one: `from_prvkey` is 7.90. It buys no
+  microsecond the halves had not already bought —
+  `from_pubkey_(pubkey_from_prvkey_(k))` is 7.87, and `from_prvkey` is
+  written as exactly that — which is the whole claim: it is a name for a
+  composition whose intermediate nothing here asked for, and the number
+  beside it is the round trip, not a third algorithm. `Signer.pubkey()`
+  is the one that saves what no pair of halves could: a signer already
+  holds the keypair, and the point with it, so reading the key off it is
+  `secp256k1_keypair_xonly_pub` and not a multiplication — 0.43 against
+  the 10.49 of deriving it a second time. `tests/test_signer.py` holds it
   to `xonly.from_prvkey` and to the key its own signatures verify
   against, parity included.
 - **`xonly.from_keypair` is the second wrapper taking a libsecp256k1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -79,19 +79,21 @@ whatever form the x arrived in, so `ssa.verify`, `xonly.tweak_add` and
 that refusal cost was a lift, and a tweak from the uncompressed form is
 4.11 microseconds against the 5.92 of the 32-byte one.
 
-**`xonly.from_prvkey` and `ssa.Signer.pubkey` are the two shortcuts
-where the round trip was not worth making at all.** The first is the
-x-only public key of a private key — `keys.pubkey_from_prvkey` and
-`xonly.from_pubkey` with neither the serialization nor the parse between
-them, 7.9 microseconds against 10.5 — and it is the BIP340 and BIP341
-form of a key derivation this package made every caller spell in two
-steps. The second reads that same key off the keypair a signer already
-holds, which is a read rather than a multiplication: 0.4 microseconds,
-where deriving it again is 10.5. `xonly.from_keypair` is that read for a
-caller holding a keypair of its own, a MuSig2 session through `lib`
-being one, and it is the second wrapper of these bindings taking a
-libsecp256k1 object rather than bytes: like `keys.serialize`, it raises
-what libsecp256k1 reported rather than leaving it on the thread.
+**`xonly.from_prvkey` and `ssa.Signer.pubkey` are two entry points
+rather than two halves**, and they save different things. The first is
+the x-only public key of a private key: it is `pubkey_from_prvkey_` and
+`from_pubkey_` composed, so the halves above are where its 7.9
+microseconds against 10.5 come from, and what it adds is a name for a
+composition BIP340 and BIP341 make the common case — the full public
+key in the middle being an intermediate step nothing here asked for.
+The second saves what no pair of halves could: a signer holds the
+keypair, and the point with it, so reading the key off it is a read and
+not a multiplication — 0.4 microseconds, where deriving it again is
+10.5. `xonly.from_keypair` is that read for a caller holding a keypair
+of its own, a MuSig2 session through `lib` being one, and it is the
+second wrapper of these bindings taking a libsecp256k1 object rather
+than bytes: like `keys.serialize`, it raises what libsecp256k1 reported
+rather than leaving it on the thread.
 
 ## v0.8.0.2
 

--- a/README.md
+++ b/README.md
@@ -317,11 +317,13 @@ adding them together is the composition that pays it per key, and
 `silentpayments.parse_label` is `keys.parse` for the 33 bytes of a
 label, which are a point like any other.
 
-Two shortcuts exist because the round trip is not worth making at all.
-`xonly.from_prvkey` is the x-only public key of a private key, which is
-`keys.pubkey_from_prvkey` and `xonly.from_pubkey` without the bytes in
-the middle; and `ssa.Signer.pubkey` reads that same key off the keypair
-the signer already holds, which is a read rather than a multiplication.
+Two entry points are there instead of two halves. `xonly.from_prvkey` is
+the x-only public key of a private key — the two halves above composed,
+which is what BIP340 and BIP341 ask for and what this package used to
+make every caller spell in two steps, with a full public key in the
+middle that nothing wanted. `ssa.Signer.pubkey` reads that same key off
+the keypair the signer already holds, which is a read rather than a
+multiplication, and so is cheaper than any composition could be.
 
 ## Building the keypair once
 


### PR DESCRIPTION
#159 called `xonly.from_prvkey` and `ssa.Signer.pubkey` "two shortcuts where
the round trip was not worth making at all". That is one sentence over two
different facts, and it is wrong about the second.

- **`from_prvkey` saves exactly the round trip**: 10.49 against 7.90, of
  which 2.62 is `keys.serialize` 0.35 plus `keys.parse` 2.28. And it buys no
  microsecond the producing halves of that same commit had not already
  bought — `from_pubkey_(pubkey_from_prvkey_(k))` is 7.87, and `from_prvkey`
  is written as exactly that. What it adds is a *name* for a composition
  BIP340 and BIP341 make the common case, the full public key in the middle
  being an intermediate nothing here asked for.
- **`Signer.pubkey` saves what no pair of halves could**: the keypair holds
  the point, so `secp256k1_keypair_xonly_pub` reads the key instead of
  deriving it — 0.43 against 10.49. Calling that a round trip avoided names
  the smaller half of what it does.

Prose only — HISTORY.md, CHANGELOG.md and the README's "Parsing the key
once" section. No call changes shape or cost, and every number was already
measured for #159. The gate passes and coverage is unchanged at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the role and benefits of the x-only public key entry points `xonly.from_prvkey` and `ssa.Signer.pubkey`, emphasizing what each saves and what they do not change in terms of behavior or performance characteristics beyond already-measured components.

Documentation:
- Update HISTORY.md to distinguish `xonly.from_prvkey` and `ssa.Signer.pubkey` as entry points rather than shortcuts and explain their respective performance implications.
- Refine CHANGELOG.md wording to make clear that `xonly.from_prvkey` is a named composition of existing operations while `ssa.Signer.pubkey` avoids recomputation by reading from the keypair.
- Revise the README description of the two entry points to better describe their purpose, the common BIP340/341 use case, and why they are cheaper than composing lower-level operations.