### PR TITLE
Give the caller octets to hold, where it held a parsed key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1640
+        "line_number": 1675
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T14:12:43Z"
+  "generated_at": "2026-08-15T14:29:59Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,41 @@ release-notes length in the first place, and are still in
   sweeps the new entry points that take bytes, through a serializing
   wrapper where what they answer is a cffi object, and excuses the rest
   by name.
+- **`keys.reserialize` is the validation a caller wants, and the
+  conversion nothing here offered.** `serialize(parse(key))` in one call:
+  a library proving a public key at its own boundary has `parse` and
+  nothing to do with what `parse` returns, and now answers octets instead
+  of owning an object's lifetime; a caller holding one serialization and
+  needing the other — an uncompressed key to hash compressed, a
+  compressed key about to be used several times — had no call to make at
+  all, `compressed` being a filter on the form everywhere else rather
+  than a conversion to it.
+
+  What makes it worth a name rather than two calls is which form it is
+  asked for. `parse` is **0.256 us on 65 bytes against 2.343 on 33**:
+  both coordinates are there to read, where a compressed key is a field
+  square root. So the uncompressed serialization is a parsed key that
+  costs nothing to open, and `reserialize(key, compressed=False)` pays
+  the root once and leaves every later call at the price of reading it.
+  Measured as the entries above, median of seven alternating rounds of
+  20 000 calls, `mult.mult_` control within 0.04.
+- **`xonly.tweak_add_from_pubkey` is the outer half `tweak_add_` was
+  merged without.** The rule stated right above — the outer half is the
+  inner one with a `parse` in front of it — is what says it was missing:
+  `tweak_add` is not it, taking the 32-byte x-only form and lifting it.
+  From the uncompressed form the whole call is **4.11 us against 5.92**,
+  the x-only conversion reading the y it is given where 32 octets are a
+  square root. The discard is in the name and not in an argument check,
+  which is this module's rule: `ssa.verify` refuses a full public key for
+  the same reason, and there is no BIP340 spelling of this one — BIP341's
+  internal key is x-only by definition, a BIP340 verification against the
+  wrong point is not.
+
+  These two are what
+  <https://github.com/btclib-org/btclib-secp256k1/issues/161> proposes to
+  build on: with them a caller validates, converts and operates in
+  octets, and the parsed key stops being something an API has to hand
+  around.
 
 ### CI
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,9 +9,9 @@ a tag is generated from.
 
 Non-breaking, and additions only: one for a caller that signs more than
 once under one key, one for a caller computing a taproot output key from
-a public key it has validated, and a set for a caller composing two of
-these calls where the second used to parse what the first had just
-serialized.
+a public key it has validated, a set for a caller composing two of these
+calls where the second used to parse what the first had just serialized,
+and two for a caller that would rather hold octets than a parsed key.
 
 `ssa.Signer` is new: it builds the BIP340 keypair once and signs with it
 as often as asked, where `ssa.sign` and `ssa.sign_custom` build one per
@@ -59,6 +59,21 @@ way is 28.2 microseconds through `pubkey_combine(pubkey_sort(...))` and
 14.8 through the two inner halves on keys parsed once, and a labeled
 Silent Payments address is 14.3 against 9.3. CHANGELOG.md states the
 machine and the method.
+
+**`keys.reserialize` and `xonly.tweak_add_from_pubkey` are for the caller
+who wants none of that.** A parsed key is an optimization of a parse, and
+a parse of the *uncompressed* serialization is 0.256 microseconds against
+2.343 for the compressed one — both coordinates are there to read, where
+a compressed key is a field square root. So 65 octets are a parsed key
+that costs nothing to open, and nothing has to own their lifetime.
+`keys.reserialize` is what produces them: `serialize(parse(key))` in one
+call, which is at once the validation a library does at its own boundary
+and the conversion between the two serializations, which nothing here
+offered — `compressed` is a filter on the form everywhere else, not a
+conversion to it. `xonly.tweak_add_from_pubkey` is `tweak_add_` with that
+parse in front of it, the outer half it was published without: 4.11
+microseconds against `tweak_add`'s 5.92, the difference being again the
+square root a 32-byte x-only key costs and 65 octets do not.
 
 **`xonly.from_prvkey` and `ssa.Signer.pubkey` are the two shortcuts
 where the round trip was not worth making at all.** The first is the

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -591,6 +591,51 @@ def parse(pubkey_bytes: BytesLike) -> CData:
     return pubkey
 
 
+def reserialize(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
+    """Prove octets a public key, and answer them in the form asked for.
+
+    `serialize(parse(key))` as one call, which is two things a caller
+    wants separately and always together.
+
+    It is the **validation**: a library proving a key at its own boundary
+    has `parse` and nothing to do with what `parse` returns, and this
+    answers octets instead of an object whose lifetime is the caller's.
+
+    And it is the **conversion**, which nothing else here offers: a caller
+    holding an uncompressed key and needing the compressed one to hash has
+    no other call to make, and one holding a compressed key and about to
+    make several more calls with it has a reason to ask for the other
+    form. The uncompressed serialization is the cheap one to open --
+    `parse` is 0.256 us on 65 bytes against 2.343 on 33, both coordinates
+    being there to read where a compressed key is a field square root --
+    so `reserialize(key, compressed=False)` pays that root once and leaves
+    every later call at the price of reading it.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The same point, serialized as asked.
+
+    Raises:
+        ValueError: if the bytes are not a valid point in either
+            serialization.
+        RuntimeError: if libsecp256k1 fails to serialize it, which no
+            valid key can make it do.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, mult
+        >>> compressed = keys.pubkey_from_prvkey(1)
+        >>> uncompressed = keys.reserialize(compressed, compressed=False)
+        >>> uncompressed == mult.mult_(1)
+        True
+        >>> keys.reserialize(uncompressed) == compressed
+        True
+    """
+    return serialize(parse(pubkey_bytes), compressed)
+
+
 def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     """Serialize an internal public key, in compressed form by default.
 

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -246,6 +246,44 @@ def tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
     return _tweak_add(_from_pubkey(pubkey)[0], tweak)
 
 
+def tweak_add_from_pubkey(
+    pubkey_bytes: BytesLike, tweak: BytesLike | int
+) -> tuple[bytes, int]:
+    """Add the generator multiplied by the tweak, to a full public key.
+
+    The outer half of `tweak_add_`: that call with a `keys.parse` in front
+    of it, which is what the underscore means throughout (see
+    `keys.parse`). `tweak_add` is not it -- that one takes the 32-byte
+    x-only form -- and the two differ in what they cost as well as in what
+    they take: 33 or 65 octets are parsed as a point, and the x-only
+    conversion that follows reads the y it is given, where 32 octets are a
+    field square root. From the uncompressed form the whole call is 4.11
+    us against `tweak_add`'s 5.92.
+
+    The y is discarded, as BIP341 discards it: the internal key of a
+    taproot output is x-only, so an odd-y key is tweaked as its negation
+    and answers the output key `tweak_add` answers for the same x. That is
+    in the name rather than in the argument check, which is this module's
+    rule -- `ssa.verify` refuses a full public key for the same reason,
+    and there is no BIP340 spelling of this one.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked x-only key, and the parity of its y.
+
+    Raises:
+        ValueError: if the public key is not a valid point, if the tweak
+            is not 32 bytes or does not fit in them, or if the tweak or
+            the resulting key is invalid.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            result, which no valid input can make it do.
+    """
+    return tweak_add_(keys.parse(pubkey_bytes), tweak)
+
+
 def _tweak_add(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
     """Add the generator multiplied by the tweak to a parsed x-only key.
 

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -171,6 +171,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.pubkey_tweak_add", keys.pubkey_tweak_add, (PUBKEY, TWEAK), {}),
     ("keys.pubkey_tweak_mul", keys.pubkey_tweak_mul, (PUBKEY, TWEAK), {}),
     ("keys.pubkey_combine", keys.pubkey_combine, ([PUBKEY, PUBKEY_LONG],), {}),
+    ("keys.reserialize", keys.reserialize, (PUBKEY,), {}),
     ("keys.pubkey_cmp", keys.pubkey_cmp, (PUBKEY, PUBKEY_LONG), {}),
     ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
     ("mult.mult_", mult.mult_, (PRVKEY,), {}),
@@ -197,6 +198,12 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
     ("xonly.from_prvkey", xonly.from_prvkey, (PRVKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
+    (
+        "xonly.tweak_add_from_pubkey",
+        xonly.tweak_add_from_pubkey,
+        (PUBKEY, TWEAK),
+        {},
+    ),
     # the parsed key is not retyped, being no bytes; the tweak beside it
     # is, and what comes back is 32 bytes and a parity, which compare
     ("xonly.tweak_add_", xonly.tweak_add_, (PARSED, TWEAK), {}),

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -254,6 +254,45 @@ def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
         )
 
 
+def test_the_taproot_outer_half_is_the_inner_one_behind_a_parse() -> None:
+    """`xonly.tweak_add_from_pubkey` is `tweak_add_` with a `keys.parse`.
+
+    The pair the convention describes, over both serializations: the
+    outer half takes the octets, the inner one the point they parse to,
+    and neither is `tweak_add`, which takes the 32-byte x-only form and
+    lifts it.
+    """
+    for pubkey_bytes in (PUBKEY, PUBKEY_LONG):
+        assert xonly.tweak_add_from_pubkey(pubkey_bytes, TWEAK) == xonly.tweak_add_(
+            keys.parse(pubkey_bytes), TWEAK
+        )
+    # and the y it discards is BIP341's to discard: the negated key is the
+    # same internal key, and answers the same output key
+    negated = keys.pubkey_negate(PUBKEY)
+    assert xonly.tweak_add_from_pubkey(negated, TWEAK) == xonly.tweak_add(XONLY, TWEAK)
+
+
+def test_reserialize_is_the_two_calls_it_replaces() -> None:
+    """`keys.reserialize` is `serialize(parse(key))`, both forms both ways.
+
+    And the refusal is `parse`'s, which is what makes it a validation: a
+    caller proving a key at its own boundary has this and nothing to do
+    with a parsed object.
+    """
+    for pubkey_bytes in (PUBKEY, PUBKEY_LONG):
+        for compressed in (True, False):
+            assert keys.reserialize(pubkey_bytes, compressed) == keys.serialize(
+                keys.parse(pubkey_bytes), compressed
+            )
+    # the round trip in both directions, which is the conversion nothing
+    # else here offers
+    assert keys.reserialize(PUBKEY, compressed=False) == PUBKEY_LONG
+    assert keys.reserialize(PUBKEY_LONG) == PUBKEY
+
+    with pytest.raises(ValueError, match="invalid public key"):
+        keys.reserialize(b"\x02" + bytes(32))
+
+
 def test_a_parsed_key_verifies_more_than_once() -> None:
     """The motivating case: one parse, several signatures.
 


### PR DESCRIPTION
Step one of https://github.com/btclib-org/btclib-secp256k1/issues/161,
and the only additive one.

A parsed key is an optimization of a parse, and `keys.parse` is **0.256
us on 65 bytes against 2.343 on 33** — both coordinates are there to
read, where a compressed key is a field square root. So the uncompressed
serialization *is* a parsed key: it costs nothing to open and nothing has
to own its lifetime.

### `keys.reserialize(pubkey_bytes, compressed=True)`

`serialize(parse(key))` as one call, which is two things a caller wants
separately and always together:

- the **validation** a library makes at its own boundary, which has
  `parse` and nothing to do with what `parse` returns;
- the **conversion** between the two serializations, which no entry point
  offered — `compressed` is a filter on the form everywhere else, not a
  conversion to it. A caller holding an uncompressed key and needing the
  compressed one to hash had no call to make.

Asked for the uncompressed form it pays the square root once and leaves
every later call at 0.256.

### `xonly.tweak_add_from_pubkey(pubkey_bytes, tweak)`

The outer half `xonly.tweak_add_` (#158) was published without. The rule
#159 states — the outer half is the inner one with a `parse` in front of
it — is what says it was missing; `tweak_add` is not it, taking the
32-byte x-only form and lifting it. From the uncompressed form the whole
call is **4.11 us against 5.92**.

The y it discards is in the name and not in an argument check, which is
this module's rule: `ssa.verify` refuses a full public key for the same
reason, and there is deliberately no BIP340 spelling of this one —
BIP341's internal key is x-only by definition, a BIP340 verification
against the wrong point is not.

### Tests

`tests/test_parsed_keys.py` pairs both: `tweak_add_from_pubkey(sec)`
against `tweak_add_(keys.parse(sec))` over both serializations and over
the negated key, and `reserialize(key, compressed)` against
`serialize(parse(key), compressed)` in both directions, with `parse`'s
own refusal. `tests/test_bytes_like.py` sweeps them.

`pytest --cov` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build.

### What follows

btclib then drops `CData`, `keys.parse`, `keys.serialize` and
`xonly.parse` entirely — its currency for a validated public key becomes
the uncompressed SEC — and the inner halves nothing calls any more can be
retired here. `xonly.parse` and `ssa.verify_` survive that: an x-only key
has no cheap serialization, its 32 bytes being a lift to open, so there
the object is the only way to verify twice against one key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce helper APIs that let callers validate and operate on public keys using raw octets instead of parsed key objects.

New Features:
- Add keys.reserialize to validate a public key and convert between compressed and uncompressed SEC encodings in a single call.
- Add xonly.tweak_add_from_pubkey to compute a tweaked x-only taproot internal key directly from a full SEC-encoded public key.

Enhancements:
- Document the new octet-focused public-key APIs in CHANGELOG and HISTORY, including their performance characteristics and intended usage.

Tests:
- Extend parsed key tests to cover keys.reserialize behavior, round-trip conversions, invalid input handling, and xonly.tweak_add_from_pubkey equivalence to the inner tweak_add_ API.
- Update bytes-like parameter sweep tests to include the new keys.reserialize and xonly.tweak_add_from_pubkey entry points.