### PR TITLE
Take a public key in any of its three serializations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1675
+        "line_number": 1685
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T14:29:59Z"
+  "generated_at": "2026-08-15T14:45:02Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,23 +188,33 @@ release-notes length in the first place, and are still in
   the root once and leaves every later call at the price of reading it.
   Measured as the entries above, median of seven alternating rounds of
   20 000 calls, `mult.mult_` control within 0.04.
-- **`xonly.tweak_add_from_pubkey` is the outer half `tweak_add_` was
-  merged without.** The rule stated right above — the outer half is the
-  inner one with a `parse` in front of it — is what says it was missing:
-  `tweak_add` is not it, taking the 32-byte x-only form and lifting it.
-  From the uncompressed form the whole call is **4.11 us against 5.92**,
-  the x-only conversion reading the y it is given where 32 octets are a
-  square root. The discard is in the name and not in an argument check,
-  which is this module's rule: `ssa.verify` refuses a full public key for
-  the same reason, and there is no BIP340 spelling of this one — BIP341's
-  internal key is x-only by definition, a BIP340 verification against the
-  wrong point is not.
+- **Every entry point taking a public key takes any of its three
+  serializations**, and `xonly.parse` is where that is written: 32, 33 or
+  65 octets, all of them the same BIP340 key. `02 || x`, `03 || x` and
+  `04 || x || y` name one point as far as BIP340 and BIP341 are
+  concerned — `lift_x` is the even-y point whatever form the x arrived
+  in, and a signer whose point has odd y signs with `n - d` for exactly
+  that reason — so the parity is a property of the serialization and not
+  of the key. `ssa.verify` and `xonly.tweak_add` used to refuse the 33-
+  and 65-byte forms, on the reasoning that a key with odd y "verifies as
+  the point that is not the one passed": it is not another point, it is
+  the same key, and what the refusal cost was a lift. Which form to hand
+  in is now a question of cost alone — the uncompressed one is read
+  rather than lifted, so `tweak_add` on it is **4.11 us against the 5.92**
+  of the 32-byte form, whose parse is a field square root like the
+  compressed one's.
 
-  These two are what
-  <https://github.com/btclib-org/btclib-secp256k1/issues/161> proposes to
-  build on: with them a caller validates, converts and operates in
-  octets, and the parsed key stops being something an API has to hand
-  around.
+  `xonly.from_pubkey` answers the parity for a caller that wants to know
+  which form it held, and 0 for one that arrived x-only. Nothing about
+  the arithmetic moves: `tests/test_parsed_keys.py` holds all four
+  spellings of one key — x-only, compressed, uncompressed, negated — to
+  the same answer from `from_pubkey`, `tweak_add`, `tweak_add_check` and
+  `ssa.verify`.
+
+  This is what <https://github.com/btclib-org/btclib-secp256k1/issues/161>
+  builds on, with `keys.reserialize` above: a caller validates, converts
+  and operates in octets, and the parsed key stops being something an API
+  has to hand around.
 
 ### CI
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,8 @@ Non-breaking, and additions only: one for a caller that signs more than
 once under one key, one for a caller computing a taproot output key from
 a public key it has validated, a set for a caller composing two of these
 calls where the second used to parse what the first had just serialized,
-and two for a caller that would rather hold octets than a parsed key.
+and one for a caller that would rather hold octets than a parsed key at
+all.
 
 `ssa.Signer` is new: it builds the BIP340 keypair once and signs with it
 as often as asked, where `ssa.sign` and `ssa.sign_custom` build one per
@@ -60,8 +61,8 @@ way is 28.2 microseconds through `pubkey_combine(pubkey_sort(...))` and
 Silent Payments address is 14.3 against 9.3. CHANGELOG.md states the
 machine and the method.
 
-**`keys.reserialize` and `xonly.tweak_add_from_pubkey` are for the caller
-who wants none of that.** A parsed key is an optimization of a parse, and
+**`keys.reserialize` is for the caller who wants none of that.** A
+parsed key is an optimization of a parse, and
 a parse of the *uncompressed* serialization is 0.256 microseconds against
 2.343 for the compressed one — both coordinates are there to read, where
 a compressed key is a field square root. So 65 octets are a parsed key
@@ -70,10 +71,13 @@ that costs nothing to open, and nothing has to own their lifetime.
 call, which is at once the validation a library does at its own boundary
 and the conversion between the two serializations, which nothing here
 offered — `compressed` is a filter on the form everywhere else, not a
-conversion to it. `xonly.tweak_add_from_pubkey` is `tweak_add_` with that
-parse in front of it, the outer half it was published without: 4.11
-microseconds against `tweak_add`'s 5.92, the difference being again the
-square root a 32-byte x-only key costs and 65 octets do not.
+conversion to it. And every entry point taking a public key now
+takes any of its three serializations: `02 || x`, `03 || x` and
+`04 || x || y` are one BIP340 key, `lift_x` being the even-y point
+whatever form the x arrived in, so `ssa.verify`, `xonly.tweak_add` and
+`xonly.tweak_add_check` no longer refuse the 33- and 65-byte forms — what
+that refusal cost was a lift, and a tweak from the uncompressed form is
+4.11 microseconds against the 5.92 of the 32-byte one.
 
 **`xonly.from_prvkey` and `ssa.Signer.pubkey` are the two shortcuts
 where the round trip was not worth making at all.** The first is the

--- a/README.md
+++ b/README.md
@@ -216,13 +216,17 @@ and decides nothing else.
 - **nothing is normalized into validity.** An argument of the wrong size
   raises, and is never padded: the 32 bytes of nonce entropy (`ndata`,
   `aux_rand32`, `rnd32`) are 32 bytes or omitted, a shorter value being a
-  caller mistake rather than a small number. BIP340 verification
-  (`ssa.verify`) and taproot tweaking (`xonly.tweak_add`,
-  `xonly.tweak_add_check`) take the 32-byte x-only key and only it: a
-  full public key with odd y would be verified or tweaked as a point the
-  caller did not pass, so `xonly.from_pubkey` is where a y coordinate
-  gets dropped, in the caller's own code. A leniency is a guess at what
-  the caller meant, and that decision is theirs to make.
+  caller mistake rather than a small number. Taking a public key in any
+  of its three serializations is not a leniency of that kind and is worth
+  the distinction: BIP340 verification (`ssa.verify`) and taproot
+  tweaking (`xonly.tweak_add`, `xonly.tweak_add_check`) take 32, 33 or 65
+  octets because `02 || x`, `03 || x` and `04 || x || y` are one key —
+  `lift_x` is the even-y point whatever form the x arrived in, and a
+  signer whose point has odd y signs with `n - d` for that reason. The y
+  is not consulted rather than guessed at, and `xonly.from_pubkey`
+  answers which form was handed in for a caller that wants to know. A
+  leniency is a guess at what the caller meant, and that decision is
+  theirs to make.
   `dsa.verify(..., normalize=True)` is that decision made, rather than an
   exception to it: ECDSA signatures are malleable, which of the two forms
   one carries was the signer's choice, and a caller checking signatures

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -335,26 +335,28 @@ def verify_(
 def verify(
     msg_bytes: BytesLike, pubkey_bytes: BytesLike, signature_bytes: BytesLike
 ) -> bool:
-    """Verify a Schnorr signature against a 32-byte x-only public key.
+    """Verify a Schnorr signature against a public key, in any of its forms.
 
-    The public key is the x-only one BIP340 verifies against, and only
-    that: dropping the y coordinate of a full public key is a decision
-    of the caller, `xonly.from_pubkey` being the conversion, because a
-    key with odd y verifies as the point that is not the one passed.
+    BIP340 verifies against an x coordinate, so `02 || x`, `03 || x` and
+    `04 || x || y` are one key and any of the three is accepted: the y is
+    not consulted, a signer whose point has odd y having signed with
+    `n - d` for exactly that reason. Which form to hand in is a question
+    of cost -- the uncompressed one is read rather than lifted, see
+    `xonly.parse`.
 
     Args:
         msg_bytes: the message, of any length. It is the 32-byte hash
             for a signature made by `sign`.
-        pubkey_bytes: the 32-byte x-only public key, and only that.
+        pubkey_bytes: the public key, 32, 33 or 65 bytes.
         signature_bytes: the 64-byte signature.
 
     Returns:
         True if the signature is valid for that key and message.
 
     Raises:
-        ValueError: if the signature is not 64 bytes, if the public key
-            is not 32 bytes, or if it is not a valid x coordinate. A
-            well-formed signature that simply does not verify is False,
+        ValueError: if the signature is not 64 bytes, or if the public
+            key is not a valid point in one of the three serializations.
+            A well-formed signature that simply does not verify is False,
             not an exception.
     """
     return verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -12,13 +12,20 @@ An x-only public key is the 32-byte x coordinate of the point with even
 y; the parity returned along a tweaked key is the one of the tweaked
 point, to be committed to by the taproot output.
 
-`from_pubkey` is the conversion from a full public key, and the only one
-taking its bytes: every other entry point taking bytes takes the 32-byte
-form, so that discarding a y coordinate happens where the caller can see
-it and not inside an argument check. `from_pubkey_` and `tweak_add_` take
-a full public key too, and are that same rule rather than an exception to
-it -- a caller holding what `keys.parse` returns is holding the point,
-and a call that takes it and answers 32 bytes drops the y in plain sight.
+**A public key here is an x coordinate, and `02 || x`, `03 || x` and
+`04 || x || y` all name it.** Every entry point taking a key takes any of
+the three, and none of them consults the y: `lift_x` is the even-y point
+whatever serialization the x arrived in, and a signer whose key is the
+odd-y one signs with `n - d` for exactly that reason. So the parity is a
+property of the serialization and not of the key, and there is no
+discarding for an argument check to make visible -- `from_pubkey` returns
+it because a caller converting a key it holds may want to know which of
+the two forms it was handed, not because the two are different keys.
+
+Which serialization to hand in is a question of cost and not of meaning:
+`keys.parse` reads the uncompressed form for 0.256 us, both coordinates
+being there, where the compressed form and the 32-byte one are a field
+square root at 2.343.
 """
 
 from __future__ import annotations
@@ -27,6 +34,10 @@ from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import octets, scalar
 from ._secret import take, wipe
 from .context import check, ctx
+
+# the x-only serialization, which is the whole of the key: the other
+# two lengths this module takes are a full public key, whose x it is
+_XONLY_SIZE = 32
 
 
 def _from_pubkey(pubkey: CData) -> tuple[CData, int]:
@@ -99,19 +110,25 @@ def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
     """Convert a public key into its x-only form and y parity.
 
     Args:
-        pubkey_bytes: the public key, 33 or 65 bytes.
+        pubkey_bytes: the public key, 32, 33 or 65 bytes.
 
     Returns:
-        The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
-        odd. The parity is returned rather than dropped because the
-        x-only key of an odd-y point is the key of its negation, which
-        the caller may need to know.
+        The 32-byte x coordinate, and the parity of the y it was handed:
+        0 for even, 1 for odd, and 0 for a key that arrived x-only, an
+        x naming the even-y point. The parity is answered rather than
+        dropped because a caller may want to know which serialization it
+        held, not because the two are different keys.
 
     Raises:
-        ValueError: if the public key is not a valid point.
+        ValueError: if the public key is not a valid point, or is not 32,
+            33 or 65 bytes.
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    if len(pubkey_bytes) == _XONLY_SIZE:
+        # already the x, and the conversion is the proof that it is one
+        return _serialize(parse(pubkey_bytes)), 0
     return from_pubkey_(keys.parse(pubkey_bytes))
 
 
@@ -196,7 +213,8 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
     the TapTweak hash.
 
     Args:
-        pubkey_bytes: the 32-byte x-only internal key.
+        pubkey_bytes: the internal key, 32, 33 or 65 bytes. The
+            uncompressed form is the cheap one to hand in: see `parse`.
         tweak: the tweak, 32 bytes or an int below 2**256.
 
     Returns:
@@ -205,8 +223,8 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         `tweak_add_check` is given back.
 
     Raises:
-        ValueError: if the key is not 32 bytes or not a valid x
-            coordinate, if the tweak is not 32 bytes or does not fit in
+        ValueError: if the key is not a valid point, or is not 32, 33 or
+            65 bytes, if the tweak is not 32 bytes or does not fit in
             them, or if the tweak or the resulting key is invalid.
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             result, which no valid input can make it do.
@@ -244,44 +262,6 @@ def tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
             result, which no valid input can make it do.
     """
     return _tweak_add(_from_pubkey(pubkey)[0], tweak)
-
-
-def tweak_add_from_pubkey(
-    pubkey_bytes: BytesLike, tweak: BytesLike | int
-) -> tuple[bytes, int]:
-    """Add the generator multiplied by the tweak, to a full public key.
-
-    The outer half of `tweak_add_`: that call with a `keys.parse` in front
-    of it, which is what the underscore means throughout (see
-    `keys.parse`). `tweak_add` is not it -- that one takes the 32-byte
-    x-only form -- and the two differ in what they cost as well as in what
-    they take: 33 or 65 octets are parsed as a point, and the x-only
-    conversion that follows reads the y it is given, where 32 octets are a
-    field square root. From the uncompressed form the whole call is 4.11
-    us against `tweak_add`'s 5.92.
-
-    The y is discarded, as BIP341 discards it: the internal key of a
-    taproot output is x-only, so an odd-y key is tweaked as its negation
-    and answers the output key `tweak_add` answers for the same x. That is
-    in the name rather than in the argument check, which is this module's
-    rule -- `ssa.verify` refuses a full public key for the same reason,
-    and there is no BIP340 spelling of this one.
-
-    Args:
-        pubkey_bytes: the public key, 33 or 65 bytes.
-        tweak: the tweak, 32 bytes or an int below 2**256.
-
-    Returns:
-        The 32-byte tweaked x-only key, and the parity of its y.
-
-    Raises:
-        ValueError: if the public key is not a valid point, if the tweak
-            is not 32 bytes or does not fit in them, or if the tweak or
-            the resulting key is invalid.
-        RuntimeError: if libsecp256k1 fails to convert or serialize the
-            result, which no valid input can make it do.
-    """
-    return tweak_add_(keys.parse(pubkey_bytes), tweak)
 
 
 def _tweak_add(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
@@ -329,7 +309,7 @@ def tweak_add_check(
         tweaked_pubkey_bytes: the 32-byte x-only key to check.
         tweaked_parity: the parity of its y, 0 or 1, as `tweak_add`
             returned it.
-        pubkey_bytes: the 32-byte x-only internal key.
+        pubkey_bytes: the internal key, 32, 33 or 65 bytes.
         tweak: the tweak, 32 bytes or an int below 2**256.
 
     Returns:
@@ -401,28 +381,39 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
 
 
 def parse(pubkey_bytes: BytesLike) -> CData:
-    """Parse a 32-byte x-only public key.
+    """Parse a public key, in any of its serializations, into its x.
 
     The x-only counterpart of `keys.parse`, and the argument of
-    `ssa.verify_`: a caller that has proved 32 bytes to be the x
-    coordinate of a point has made the call BIP340 verification makes
-    anyway, and can hand the result on rather than make it twice.
+    `ssa.verify_`: a caller that has proved octets a public key has made
+    the call BIP340 verification makes anyway, and can hand the result on
+    rather than make it twice.
+
+    Every entry point of this module that takes a public key reaches it,
+    which is what makes them all take any of the three serializations.
+    Which one costs what: the 32-byte form is `secp256k1_xonly_pubkey_parse`,
+    a field square root at 2.343 us, and so is the compressed form; the
+    uncompressed form is 0.256, both coordinates being there to read, and
+    the x-only conversion that follows it reads the y rather than lifting
+    one.
 
     There is no `serialize` beside it, and that is not an omission:
     nothing here hands back a parsed x-only key except this, `from_pubkey`
     and `tweak_add` answering with the 32 bytes and the parity instead.
 
     Args:
-        pubkey_bytes: the 32-byte x coordinate.
+        pubkey_bytes: the public key, 32, 33 or 65 bytes.
 
     Returns:
         The libsecp256k1 x-only public key object.
 
     Raises:
-        ValueError: if it is not 32 bytes, or not a valid x coordinate.
+        ValueError: if it is not a valid point, or is not 32, 33 or 65
+            bytes.
     """
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    pubkey_bytes = octets(pubkey_bytes, "x-only public key", 32)
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    if len(pubkey_bytes) != _XONLY_SIZE:
+        return _from_pubkey(keys.parse(pubkey_bytes))[0]
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -198,12 +198,6 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
     ("xonly.from_prvkey", xonly.from_prvkey, (PRVKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
-    (
-        "xonly.tweak_add_from_pubkey",
-        xonly.tweak_add_from_pubkey,
-        (PUBKEY, TWEAK),
-        {},
-    ),
     # the parsed key is not retyped, being no bytes; the tweak beside it
     # is, and what comes back is 32 bytes and a parity, which compare
     ("xonly.tweak_add_", xonly.tweak_add_, (PARSED, TWEAK), {}),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,11 +63,12 @@ def test_sign_and_verify() -> None:
         dsa.sign(msg, prvkey, b"\x01")
 
     ssa_sig = ssa.sign(msg, prvkey)
-    # BIP340 verification takes the x-only public key, and only it: a
-    # full public key is converted by the caller, through xonly
+    # BIP340 verifies against an x coordinate, so every serialization of
+    # the point names the same key -- the public key of this scalar has
+    # odd y, and verifies as itself
     assert ssa.verify(msg, xonly_bytes, ssa_sig)
-    with pytest.raises(ValueError, match="x-only public key must be 32 bytes"):
-        ssa.verify(msg, pubkey_bytes, ssa_sig)
+    assert ssa.verify(msg, pubkey_bytes, ssa_sig)
+    assert ssa.verify(msg, keys.reserialize(pubkey_bytes), ssa_sig)
 
 
 def test_ssa_sign_custom() -> None:
@@ -341,8 +342,9 @@ def test_size_checks_refuse_both_sides() -> None:
     with pytest.raises(ValueError, match="signature"):
         ssa.verify(msg, xonly_bytes, ssa_sig + b"\x01")
 
-    # and one too few, where they pass one too many
-    with pytest.raises(ValueError, match="x-only public key"):
+    # and one too few, where they pass one too many: 31 octets are none
+    # of the three serializations a public key has here
+    with pytest.raises(ValueError, match="invalid public key"):
         ssa.verify(msg, xonly_bytes[:-1], ssa_sig)
 
     # past the top of the scalar range, which 2**256 cannot reach: both

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -356,13 +356,12 @@ def test_xonly_tweak_add() -> None:
     lifted = keys.pubkey_tweak_add(b"\x02" + xonly_bytes, tweak)
     assert (tweaked_bytes, parity) == xonly.from_pubkey(lifted)
 
-    # a full public key is not accepted: the public key of 11 has odd y,
-    # so tweaking it would tweak a point the caller did not pass, and
-    # from_pubkey is where that lift is asked for
+    # a full public key is accepted and names the same key: the public
+    # key of 11 has odd y, and BIP340 reads it as the x it shares with
+    # its negation rather than as another point
     assert mult.mult_(prvkey)[64] & 1
     for form in (mult.mult_(prvkey), compress(mult.mult_(prvkey))):
-        with pytest.raises(ValueError, match="x-only public key must be 32 bytes"):
-            xonly.tweak_add(form, tweak)
+        assert xonly.tweak_add(form, tweak) == (tweaked_bytes, parity)
 
     # the commitment can be checked without recomputing it
     assert xonly.tweak_add_check(tweaked_bytes, parity, xonly_bytes, tweak)
@@ -412,7 +411,8 @@ def test_xonly_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="invalid x-only public key"):
         # 32 bytes which are not a valid x coordinate
         xonly.tweak_add(b"\xff" * 32, b"\x01" * 32)
-    with pytest.raises(ValueError, match="x-only public key must be 32 bytes"):
+    with pytest.raises(ValueError, match="invalid public key"):
+        # 33 octets which are no point either
         xonly.tweak_add(b"\x02" + b"\x00" * 32, b"\x01" * 32)
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
         xonly.tweak_add(xonly_bytes, b"\x01" * 31)
@@ -543,8 +543,9 @@ def test_size_checks_refuse_both_sides() -> None:
     """
     xonly_bytes, parity = xonly.from_pubkey(mult.mult_(11))
 
-    # parse, reached through both entry points
-    with pytest.raises(ValueError, match="x-only public key must be 32 bytes"):
+    # parse, reached through both entry points: 31 octets are none of the
+    # three serializations, and libsecp256k1 is never handed them
+    with pytest.raises(ValueError, match="invalid public key"):
         xonly.tweak_add(xonly_bytes[:-1], b"\x01" * 32)
 
     # and the tweaked key of the commitment check, one octet too many

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -54,6 +54,7 @@ OTHER = keys.pubkey_from_prvkey(3)
 XONLY, PARITY = xonly.from_pubkey(PUBKEY)
 DER = dsa.sign(MSG, PRVKEY)
 SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
+TWEAKED, TWEAKED_PARITY = xonly.tweak_add(XONLY, TWEAK)
 RECOVERABLE, RECID = recovery.sign(MSG, PRVKEY)
 ELL = ellswift.create(PRVKEY, RND32)
 LABEL, LABEL_TWEAK = silentpayments.label(SCAN_PRVKEY, 0)
@@ -254,22 +255,27 @@ def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
         )
 
 
-def test_the_taproot_outer_half_is_the_inner_one_behind_a_parse() -> None:
-    """`xonly.tweak_add_from_pubkey` is `tweak_add_` with a `keys.parse`.
+def test_every_serialization_of_a_key_is_the_same_x_only_key() -> None:
+    """32, 33 and 65 octets are one BIP340 key, and answer alike.
 
-    The pair the convention describes, over both serializations: the
-    outer half takes the octets, the inner one the point they parse to,
-    and neither is `tweak_add`, which takes the 32-byte x-only form and
-    lifts it.
+    The parity is a property of the serialization and not of the key:
+    `lift_x` is the even-y point whatever form the x arrived in, and a
+    signer whose point has odd y signs with n - d for that reason. So the
+    negated key is not another key, and every entry point that takes one
+    has to answer for all four spellings the same way.
     """
-    for pubkey_bytes in (PUBKEY, PUBKEY_LONG):
-        assert xonly.tweak_add_from_pubkey(pubkey_bytes, TWEAK) == xonly.tweak_add_(
-            keys.parse(pubkey_bytes), TWEAK
-        )
-    # and the y it discards is BIP341's to discard: the negated key is the
-    # same internal key, and answers the same output key
     negated = keys.pubkey_negate(PUBKEY)
-    assert xonly.tweak_add_from_pubkey(negated, TWEAK) == xonly.tweak_add(XONLY, TWEAK)
+    forms = (XONLY, PUBKEY, PUBKEY_LONG, negated, keys.pubkey_negate(PUBKEY, False))
+    for pubkey_bytes in forms:
+        assert xonly.from_pubkey(pubkey_bytes)[0] == XONLY
+        assert xonly.tweak_add(pubkey_bytes, TWEAK) == xonly.tweak_add(XONLY, TWEAK)
+        assert ssa.verify(MSG, pubkey_bytes, SSA_SIG)
+        assert xonly.tweak_add_check(TWEAKED, TWEAKED_PARITY, pubkey_bytes, TWEAK)
+
+    # and the parity is answered for what it is: which form was handed in
+    assert xonly.from_pubkey(XONLY)[1] == 0
+    assert xonly.from_pubkey(PUBKEY)[1] == 0
+    assert xonly.from_pubkey(negated)[1] == 1
 
 
 def test_reserialize_is_the_two_calls_it_replaces() -> None:


### PR DESCRIPTION
A BIP340 public key **is** an x coordinate: `02 || x`, `03 || x` and
`04 || x || y` all name it. `lift_x` is the even-y point whatever form
the x arrived in, and a signer whose point has odd y signs with `n - d`
for exactly that reason — so the parity is a property of the
serialization, not of the key.

`ssa.verify`, `xonly.tweak_add` and `xonly.tweak_add_check` refused the
33- and 65-byte forms, on the reasoning recorded in `ssa.verify`'s
docstring: a full public key with odd y "verifies as the point that is
not the one passed". It is not another point, it is the same key. What
the refusal cost the caller was a lift — from the uncompressed form a
tweak is **4.11 us against the 5.92** of the 32-byte one, whose parse is
a field square root like the compressed one's.

`xonly.parse` is where the rule is written now, every entry point of the
module reaching it and `ssa.verify` through it. `xonly.from_pubkey`
answers the parity for a caller that wants to know which form it held,
and 0 for one that arrived x-only.

`xonly.tweak_add_from_pubkey` goes with the refusal it worked around: it
was `tweak_add` for a full public key, which `tweak_add` now is. It never
shipped — 0.8.0.3 is unreleased — so no release carries the name.

This is not the leniency `README.md` refuses two bullets earlier, and the
distinction is now stated there: a short value padded into a number
nobody wrote is a guess at what the caller meant; three lengths that are
one key spelled three ways are not.

### Tests

`tests/test_parsed_keys.py` holds all four spellings of one key — x-only,
compressed, uncompressed, and the negated compressed and uncompressed —
to the same answer from `from_pubkey`, `tweak_add`, `tweak_add_check` and
`ssa.verify`, and asserts the parity each form reports. The three tests
that encoded the refusal now assert what replaces it; a 31-octet key is
still refused, by `keys.parse`, and libsecp256k1 is never handed it.

`pytest --cov` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build.

Part of https://github.com/btclib-org/btclib-secp256k1/issues/161, whose
plan this simplifies: with any serialization accepted there is no
BIP340-shaped exception left, so btclib holds uncompressed octets for
every key and no parsed one for any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Accept BIP340 public keys in any of their standard serializations and unify x-only handling across verification and taproot tweaking APIs.

New Features:
- Allow `xonly.from_pubkey`, `xonly.tweak_add`, `xonly.tweak_add_check`, and `ssa.verify` to accept public keys in 32-, 33-, or 65-byte form, treating compressed, uncompressed, and x-only encodings as the same key.

Enhancements:
- Centralize public key parsing and serialization handling in `xonly.parse`, with parity reported as a property of the incoming serialization rather than a distinct key.
- Adjust error messages and validation so invalid-length or non-point inputs are rejected as invalid public keys rather than x-only specific errors.
- Update README, HISTORY, and CHANGELOG docs to describe the unified key serialization behavior and its performance implications, clarifying that multi-length acceptance is not a leniency but a precise interpretation of BIP340 keys.

Tests:
- Expand tests to assert that all supported serializations (x-only, compressed, uncompressed, and negated forms) produce consistent results across `from_pubkey`, `tweak_add`, `tweak_add_check`, and `ssa.verify`.
- Update existing tests to reflect the new acceptance of full public keys, revised error messages for invalid inputs, and removal of the `xonly.tweak_add_from_pubkey` helper from the public API.

Chores:
- Remove the unused `xonly.tweak_add_from_pubkey` function and its references from tests and helper listings, simplifying the x-only API surface.