### PR TITLE
Answer whether octets are a public key, and keep nothing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1691
+        "line_number": 1707
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T14:56:09Z"
+  "generated_at": "2026-08-15T15:27:50Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,22 @@ release-notes length in the first place, and are still in
   the root once and leaves every later call at the price of reading it.
   Measured as the entries above, median of seven alternating rounds of
   20 000 calls, `mult.mult_` control within 0.04.
+- **`keys.pubkey_verify` is the validation with nothing kept**, and the
+  public-key twin of `prvkey_verify`, which has been there since the
+  beginning. A library proving a key at its own boundary has
+  `secp256k1_ec_pubkey_parse` and no use for what it produces: `parse`
+  hands back an object whose lifetime becomes the caller's, and
+  `reserialize` hands back the octets it was given — 0.37 us of
+  serialization for an answer that was in the argument. btclib's
+  `to_pub_key.pub_keyinfo_from_pub_key` is the caller, and that
+  serialization is what it was paying.
+
+  A verdict rather than an exception, as `prvkey_verify` answers one:
+  what is wrong with the octets is the caller's to phrase. False for a
+  length no serialization has, too, where every other entry point taking
+  a key raises — a caller asking whether it holds a public key has asked
+  about the length as well.
+
 - **Every entry point taking a public key takes any of its three
   serializations**, and `xonly.parse` is where that is written: 32, 33 or
   65 octets, all of them the same BIP340 key. `02 || x`, `03 || x` and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -61,15 +61,20 @@ way is 28.2 microseconds through `pubkey_combine(pubkey_sort(...))` and
 Silent Payments address is 14.3 against 9.3. CHANGELOG.md states the
 machine and the method.
 
-**`keys.reserialize` is for the caller who wants none of that.** A
-parsed key is an optimization of a parse, and
-a parse of the *uncompressed* serialization is 0.256 microseconds against
-2.343 for the compressed one — both coordinates are there to read, where
-a compressed key is a field square root. So 65 octets are a parsed key
-that costs nothing to open, and nothing has to own their lifetime.
-`keys.reserialize` is what produces them: `serialize(parse(key))` in one
-call, which is at once the validation a library does at its own boundary
-and the conversion between the two serializations, which nothing here
+**`keys.pubkey_verify` and `keys.reserialize` are for the caller who
+wants none of that.** The first is the public-key twin of
+`prvkey_verify`: the validation a library makes at its own boundary, with
+nothing kept — where `parse` hands back an object to hold and
+`reserialize` the octets the caller already had.
+
+The second is for the caller that wants the *other* serialization. A
+parsed key is an optimization of a parse, and a parse of the
+*uncompressed* form is 0.256 microseconds against 2.343 for the
+compressed one — both coordinates are there to read, where a compressed
+key is a field square root. So 65 octets are a parsed key that costs
+nothing to open, and nothing has to own their lifetime.
+`keys.reserialize` is `serialize(parse(key))` in one call, and it is also
+the conversion between the two serializations, which nothing here
 offered — `compressed` is a filter on the form everywhere else, not a
 conversion to it. And every entry point taking a public key now
 takes any of its three serializations: `02 || x`, `03 || x` and

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -47,6 +47,37 @@ def prvkey_verify(prvkey: BytesLike | int) -> bool:
     return bool(lib.secp256k1_ec_seckey_verify(ctx, prvkey_bytes))
 
 
+def pubkey_verify(pubkey_bytes: BytesLike) -> bool:
+    """Return True if the octets are a public key libsecp256k1 accepts.
+
+    The public-key twin of `prvkey_verify`, and the call for a library
+    validating a key at its own boundary: `secp256k1_ec_pubkey_parse` is
+    the proof, and this is that proof with nothing kept. `parse` hands
+    back an object whose lifetime becomes the caller's, and `reserialize`
+    hands back octets it already had -- 0.37 us of serialization for an
+    answer that was in the argument.
+
+    A verdict and not an exception, as `prvkey_verify` is: what the octets
+    are wrong about is the caller's to phrase, and a library validating an
+    input has its own word for it.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+
+    Returns:
+        True if it is a point of the curve in either serialization; False
+        for octets of any other length too, which is a verdict here where
+        every other entry point taking a key raises: there is nothing to
+        do with such a key either way, and a caller asking whether it has
+        one has asked about the length as well.
+    """
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey = ffi.new("secp256k1_pubkey *")
+    return bool(
+        lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes))
+    )
+
+
 def prvkey_negate(prvkey: BytesLike | int) -> bytes:
     """Negate a private key.
 

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -167,6 +167,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     # function above which serializes what it built, so what the sweep
     # compares is the bytes its outer half would have answered
     ("keys.pubkey_from_prvkey_", created, (PRVKEY,), {}),
+    ("keys.pubkey_verify", keys.pubkey_verify, (PUBKEY,), {}),
     ("keys.pubkey_negate", keys.pubkey_negate, (PUBKEY,), {}),
     ("keys.pubkey_tweak_add", keys.pubkey_tweak_add, (PUBKEY, TWEAK), {}),
     ("keys.pubkey_tweak_mul", keys.pubkey_tweak_mul, (PUBKEY, TWEAK), {}),

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -551,3 +551,37 @@ def test_size_checks_refuse_both_sides() -> None:
     # and the tweaked key of the commitment check, one octet too many
     with pytest.raises(ValueError, match="tweaked x-only public key"):
         xonly.tweak_add_check(xonly_bytes + b"\x01", parity, xonly_bytes, b"\x01" * 32)
+
+
+def test_pubkey_verify_is_the_parse_with_nothing_kept() -> None:
+    """`keys.pubkey_verify` answers what `keys.parse` proves.
+
+    True for exactly what parses, in either serialization, and False for
+    everything else -- a point of no curve, and octets of a length no
+    public key has, which every other entry point taking a key raises
+    over. A verdict is what a library validating its own input wants:
+    `parse` would hand it an object to hold and `reserialize` the octets
+    it already had.
+    """
+    prvkey = 11
+    compressed = keys.pubkey_from_prvkey(prvkey)
+    uncompressed = mult.mult_(prvkey)
+
+    for form in (compressed, uncompressed):
+        assert keys.pubkey_verify(form)
+        assert keys.serialize(keys.parse(form)) == compressed
+
+    # what does not parse, in the two ways it can fail
+    for refused in (b"\x02" + bytes(32), b"\x04" + b"\xff" * 64):
+        assert not keys.pubkey_verify(refused)
+        with pytest.raises(ValueError, match="invalid public key"):
+            keys.parse(refused)
+
+    # and a length no serialization has, which is a verdict here and an
+    # exception everywhere else
+    for wrong_size in (b"", compressed[:-1], compressed + b"\x00"):
+        assert not keys.pubkey_verify(wrong_size)
+
+    # the type check is not relaxed with it: a str is no octets
+    with pytest.raises(TypeError, match="public key"):
+        keys.pubkey_verify("02" + "00" * 32)  # type: ignore[arg-type]


### PR DESCRIPTION
`keys.prvkey_verify` has been here since the beginning; the public key
had no twin, so a library validating one at its own boundary had to keep
something it did not want:

- `keys.parse` hands back an object whose lifetime becomes the caller's —
  which is what btclib carried in four modules until
  [btclib#915](https://github.com/btclib-org/btclib/pull/915) took it out;
- `keys.reserialize` hands back the octets it was given, and charges
  **0.37 us of serialization for an answer that was in the argument**.

That second one is measurable and was being paid. btclib's
`pub_keyinfo_from_pub_key` proves a key and answers the octets it was
handed, and profiling a verification on either side of #915 shows the
parse count unchanged and 40 000 serializations added over 40 000 calls —
the whole of that PR's regression on two of its rows.

`keys.pubkey_verify` is the parse with nothing kept. A verdict rather
than an exception, as `prvkey_verify` answers one: what is wrong with the
octets is the caller's to phrase, and False covers a length no
serialization has as well, where every other entry point taking a key
raises — a caller asking whether it holds a public key has asked about
the length too.

`tests/test_keys.py` holds it to `keys.parse` in both directions: true
for exactly what parses, in either serialization, false for a point of no
curve and for every wrong length, and the type check unrelaxed.

`pytest --cov` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a public-key verification helper that validates secp256k1 public keys without retaining parsing artifacts and document its role alongside existing key utilities.

New Features:
- Add keys.pubkey_verify to check whether given octets represent a valid secp256k1 public key in either supported serialization.

Enhancements:
- Describe keys.pubkey_verify and its relationship to keys.reserialize and prvkey_verify in HISTORY and CHANGELOG to clarify public-key validation semantics.

Tests:
- Add tests ensuring keys.pubkey_verify aligns with keys.parse behavior, returning True for valid compressed and uncompressed keys, False for malformed or wrong-length inputs, and preserving strict type checking.
- Include keys.pubkey_verify in bytes-like labeling tests to verify correct handling of public key inputs.

Chores:
- Update secrets baseline metadata file without functional impact.