### PR TITLE
Hide the half that speaks in objects, and answer for a wrong one

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1707
+        "line_number": 1835
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -221,240 +221,240 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 934
+        "line_number": 936
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 935
+        "line_number": 937
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 936
+        "line_number": 938
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 941
+        "line_number": 943
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 942
+        "line_number": 944
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 943
+        "line_number": 945
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 946
+        "line_number": 948
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 948
+        "line_number": 950
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 949
+        "line_number": 951
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 950
+        "line_number": 952
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 955
+        "line_number": 957
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 956
+        "line_number": 958
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 957
+        "line_number": 959
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 965
+        "line_number": 967
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 966
+        "line_number": 968
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 967
+        "line_number": 969
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 975
+        "line_number": 977
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 976
+        "line_number": 978
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 977
+        "line_number": 979
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 980
+        "line_number": 982
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 985
+        "line_number": 987
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 988
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 987
+        "line_number": 989
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 1026
+        "line_number": 1028
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 1029
+        "line_number": 1031
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 1030
+        "line_number": 1032
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1039
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 1038
+        "line_number": 1040
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 1071
+        "line_number": 1073
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 1072
+        "line_number": 1074
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 1096
+        "line_number": 1098
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 1097
+        "line_number": 1099
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 1113
+        "line_number": 1115
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 1114
+        "line_number": 1116
       }
     ]
   },
-  "generated_at": "2026-08-15T15:27:50Z"
+  "generated_at": "2026-08-15T15:36:34Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,134 @@ release-notes length in the first place, and are still in
   and operates in octets, and the parsed key stops being something an API
   has to hand around.
 
+### The half that speaks in objects is private, and is spelled `_foo_`
+
+- **`foo_` is now `_foo_`, everywhere, and the API break is the point.**
+  The trailing underscore said "takes the parsed object in place of the
+  octets"; what it did not say is that such a call is past the boundary
+  that proves anything. An object is a promise no argument check can hold
+  a caller to — `ffi.NULL`, a `secp256k1_pubkey` nothing wrote to, a
+  keypair already wiped are all the same to a bare pointer — so these
+  belong with the leading underscore that says so. The trailing one stays
+  and now says which kind of private: `_verify_` takes a parsed object
+  where `_parse_der` is an ordinary helper, and
+  `tests/test_parsed_keys.py` reads the modules for names spelled that
+  way and fails on one no table pairs. The renamed are
+  `keys._pubkey_from_prvkey_`, `_pubkey_negate_`, `_pubkey_tweak_add_`,
+  `_pubkey_tweak_mul_`, `_pubkey_combine_`, `_pubkey_cmp_`,
+  `_pubkey_sort_`, `xonly._from_pubkey_`, `_tweak_add_`, `dsa._verify_`,
+  `ssa._verify_`, `ecdh._shared_secret_`, `recovery._recover_`,
+  `ellswift._encode_`, `_decode_`, `silentpayments._label_` and
+  `_labeled_spend_pubkey_`
+- **`mult.mult_` is `mult.mult_bytes`**, for the same underscore and
+  nothing it does: it is a public function answering octets, and it was
+  the one name in the package whose trailing underscore meant something
+  else — the serialized point against the pair of coordinates `mult`
+  answers with. `_bytes` is what the rest of this package calls the
+  octets of a thing
+- **the convention is stated once, in the package docstring**, where a
+  rule about every module belongs; `keys.parse` used to carry it and now
+  points at it
+- **every kind of object has a public `parse`/`serialize` pair now**, so
+  the private halves have something to take and something to hand back:
+  `dsa.parse_der`, `dsa.parse_compact`, `dsa.serialize_der`,
+  `dsa.serialize_compact`, `recovery.parse_compact`,
+  `recovery.serialize_compact` and `xonly.serialize` join `keys.parse`,
+  `keys.serialize`, `xonly.parse`, `silentpayments.parse_label` and
+  `silentpayments.serialize_label`. `dsa.to_der` and `dsa.to_compact` are
+  now the compositions they always were, and `xonly.parse`'s "there is no
+  `serialize` beside it, and that is not an omission" is gone with the
+  omission it excused — `silentpayments` had copied that serialization
+  rather than call it
+- **and every wrapper with a parse or a serialize to save has a private
+  half**, which is what "symmetric" means here: `dsa._sign_`,
+  `_normalize_`, `_is_low_s_`, `recovery._sign_`, `_to_der_`,
+  `silentpayments._create_outputs_`, `_prevouts_summary_` and
+  `_scan_outputs_` are new. The Silent Payments three are the ones that
+  pay: a wallet scanning block after block parses its own spend key once
+  rather than once per transaction, and `_prevouts_summary_` hands
+  `_scan_outputs_` the summary object where the public halves write those
+  octets out of one struct and back into another. `dsa._verify_` takes
+  the parsed signature too, so asking `_is_low_s_` and then verifying is
+  one parse rather than two
+- **`keys.PubkeyTweakChain` hands out the point it holds**, `pubkey()` in
+  octets and `_pubkey_()` as the object: a caller reaching the end of a
+  BIP32 path had no way to ask the chain what it had arrived at except by
+  the last `tweak_add`, and none at all to hand the point on
+
+### What answers for an argument that cannot be checked
+
+- **`context.guarded` is that answer, and it is now every such call's.**
+  Three docstrings and a test claimed a violated precondition was
+  reachable through "two" wrappers, `keys.serialize` and
+  `xonly.from_keypair`. It was reachable through every private half, and
+  what came back was measured rather than reasoned about: through
+  `keys._pubkey_negate_` a bare `RuntimeError` with libsecp256k1's reason
+  left on the thread, through `dsa._verify_` a plain `False`, through
+  `keys._pubkey_cmp_` a `0` that reads as "equal", and through
+  `ecdh._shared_secret_` a success and 32 bytes that are a shared secret
+  with nobody. The message left behind is the misattribution the
+  `check()` in `keys.serialize` already existed to prevent: the next
+  `check()` — a MuSig2 caller's, about a call of their own — inherited it
+- **so the guard clears the thread before the call and checks after it,
+  whatever the call answered.** Both halves are needed and either alone
+  is a bug: without the clearing an older message is raised out of this
+  call, without the check a refusal that shows in no return value is
+  believed. It is a context manager because the pair has to be
+  inseparable, which is the argument `_secret.take` makes for its own
+  pair. The eight failures above are eight `ValueError`s now, each
+  carrying libsecp256k1's own text, and `tests/test_callbacks.py` no
+  longer counts the exceptions to a rule that has none
+- **and it costs 0.48 microseconds a call**, which is worth writing down
+  because on the cheapest call it is most of the call. Measured on an
+  Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 5 rounds of
+  300 000 calls: `secp256k1_ec_pubkey_cmp` through `lib` is 0.087
+  microseconds and `keys._pubkey_cmp_` is 0.57, where a verification is
+  12.1 against 12.9 — the same 0.5 on a call that does real work. Two
+  cheaper spellings were measured and not taken: the pair written out at
+  each call site is 0.23 and a hand-written context manager class 0.30,
+  and what the second buys over `@contextmanager` is 0.27 microseconds
+  against three methods and their docstrings. The clearing and the check
+  are one thing, and the generator is the shortest way to say so; a
+  caller counting microseconds on a comparison has `lib`, which is
+  exported for exactly that
+
+### One statement of each thing
+
+- **the duplications are gone**, each of them two spellings of one
+  call that could drift apart. `_secret.keypair` is the
+  `secp256k1_keypair_create` that `ssa`, `xonly` and `silentpayments`
+  each carried verbatim, and it lives beside the `wipe` its caller owes
+  it. `xonly.serialize` is the x-only serialization `silentpayments` had
+  copied. `keys.parse` and `xonly.parse` take the name the exception
+  should use, which is what `silentpayments._pubkey` and `_xonly_pubkey`
+  existed for. `dsa.serialize_der` is the DER writer `recovery.to_der`
+  had inlined, comment pointing at the original included.
+  `_scalar.entropy` and `_scalar.optional_entropy` are the "32 bytes or
+  none" of `ssa`, `ellswift.create`, `ellswift.encode`, `dsa.sign` and
+  `recovery.sign`. `_scalar.in_range` is the small-int check of a
+  recovery id, a parity, an ElligatorSwift party and a label index — and
+  it refuses a `float`, which `recid not in (0, 1, 2, 3)` accepted as
+  `0.0`. `_cdata.array` is the borrowed-pointer array `keys` built inline
+  and `silentpayments` had a helper for
+- **the entropy argument is `aux_rand32` in all five**, BIP340's name for
+  what libsecp256k1 spells `ndata` in one place and `rnd32` in another.
+  What omitting it means still differs, and the difference is what the
+  two helpers are named for
+- **the octets of a thing end in `_bytes`**: `hashes.tagged_sha256` takes
+  `tag_bytes` and `msg_bytes`, and `silentpayments` takes
+  `recipients_bytes`, `taproot_pubkeys_bytes`, `pubkeys_bytes` and
+  `tx_outputs_bytes` where its private halves take the parsed objects
+  under the same names without the suffix
+- **`ffi.unpack` is not `bytes(ffi.buffer(...))`, and the vectors said
+  so**: unifying the two idioms turned the `unsigned char[32]` tweak of a
+  found Silent Payments output into a list of 32 ints, which
+  `tests/test_vectors.py` caught in every BIP352 receiving case. The
+  reason it is the exception is now written where it is made
+- **the messages of a refusal are one shape**: "invalid private key: not
+  in [1, n-1]" wherever that is the whole of what was wrong, and "the
+  {name} must be in [0, {upper}]" for the four small numbers
+
 ### CI
 
 - **`github-release` needed `always()` too, not just an explicit `if`.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,45 @@ a tag is generated from.
 
 ## v0.8.0.3 (work in progress, not released yet)
 
-Non-breaking, and additions only: one for a caller that signs more than
+**Breaking, and every break is a rename.** The public surface of these
+bindings speaks in octets; the half of each call that speaks in
+libsecp256k1 objects is now private, and spelled `_foo_` where it was
+`foo_`. Nothing was removed and no behaviour changed with the names, so
+a caller using the octets API has nothing to do; a caller holding parsed
+keys renames what it calls.
+
+| module | was | is |
+| --- | --- | --- |
+| `keys` | `pubkey_from_prvkey_` | `_pubkey_from_prvkey_` |
+| `keys` | `pubkey_negate_` | `_pubkey_negate_` |
+| `keys` | `pubkey_tweak_add_` | `_pubkey_tweak_add_` |
+| `keys` | `pubkey_tweak_mul_` | `_pubkey_tweak_mul_` |
+| `keys` | `pubkey_combine_` | `_pubkey_combine_` |
+| `keys` | `pubkey_cmp_` | `_pubkey_cmp_` |
+| `keys` | `pubkey_sort_` | `_pubkey_sort_` |
+| `xonly` | `from_pubkey_` | `_from_pubkey_` |
+| `xonly` | `tweak_add_` | `_tweak_add_` |
+| `dsa` | `verify_` | `_verify_` |
+| `ssa` | `verify_` | `_verify_` |
+| `ecdh` | `shared_secret_` | `_shared_secret_` |
+| `recovery` | `recover_` | `_recover_` |
+| `ellswift` | `encode_`, `decode_` | `_encode_`, `_decode_` |
+| `silentpayments` | `label_` | `_label_` |
+| `silentpayments` | `labeled_spend_pubkey_` | `_labeled_spend_pubkey_` |
+| `mult` | `mult_` | `mult_bytes` |
+
+Three of them take a different argument as well, the object having
+replaced the octets there too: `dsa._verify_` takes the parsed signature
+`dsa.parse_der` returns, and `recovery._recover_` the parsed pair
+`recovery.parse_compact` returns, in place of a signature and a recovery
+id. And four argument names changed: the 32 bytes of nonce entropy are
+`aux_rand32` everywhere, where `dsa.sign` and `recovery.sign` called
+them `ndata` and `ellswift.encode` called them `rnd32`, and
+`silentpayments.prevouts_summary` takes `taproot_pubkeys_bytes` and
+`pubkeys_bytes`. All four are keyword names; a positional call is
+unaffected.
+
+What the rest of the release adds: one for a caller that signs more than
 once under one key, one for a caller computing a taproot output key from
 a public key it has validated, a set for a caller composing two of these
 calls where the second used to parse what the first had just serialized,
@@ -31,28 +69,38 @@ to sign rather than signing with what the wipe left. The private key
 handed to the constructor is a python `bytes` or `int` and is no more
 zeroizable than before: SECURITY.md's limits are unchanged.
 
-`xonly.tweak_add_` is the inner half of `xonly.tweak_add`: it takes the
-parsed point `keys.parse` returns, rather than the 32-byte x-only form,
-and so tweaks a key that is already lifted instead of lifting its x a
-second time. The x-only conversion in front of the tweak is
+`xonly._tweak_add_` is the private half of `xonly.tweak_add`: it takes
+the parsed point `keys.parse` returns, rather than the x-only form, and
+so tweaks a key that is already lifted instead of lifting its x a second
+time. The x-only conversion in front of the tweak is
 `secp256k1_xonly_pubkey_from_pubkey`, which reads the y it is given; the
 result is the output key and parity `tweak_add` answers with, the
 negation of an odd-y point included, and `tweak_add` itself is unchanged
 in behaviour and cost.
 
-**The trailing underscore now means the same thing on the producing side
-of the boundary.** It has meant "takes the parsed key in place of the
-bytes" since 0.8.0.2; a wrapper that *answers* with a key had no such
-half, so a caller composing two of them — sorting keys and then adding
-them together, recovering a key and then verifying with it, decoding an
+**The convention now runs in both directions, and over every kind of
+object.** It has meant "takes the parsed key in place of the bytes"
+since 0.8.0.2; a wrapper that *answers* with a key had no such half, so
+a caller composing two of them — sorting keys and then adding them
+together, recovering a key and then verifying with it, decoding an
 ElligatorSwift encoding and then tweaking what came out — serialized a
 point libsecp256k1 had just handed over and parsed it straight back,
-which for the compressed form is a field square root. `pubkey_combine_`,
-`pubkey_sort_` and `pubkey_from_prvkey_` in `keys`, `recovery.recover_`,
-`ellswift.decode_` and `encode_`, and `silentpayments.label_`,
-`labeled_spend_pubkey_`, `parse_label` and `serialize_label` are those
-halves. Every outer half is unchanged in behaviour and cost, and is now
-written as its inner half with a `serialize` behind it.
+which for the compressed form is a field square root. And a signature, a
+label or the summary of a transaction's inputs is an object like a key:
+`dsa.parse_der`, `dsa.parse_compact`, `recovery.parse_compact` and
+`xonly.serialize` join the `parse`/`serialize` pairs, so `dsa._sign_`,
+`_normalize_`, `_is_low_s_`, `recovery._sign_`, `_to_der_` and the three
+of `silentpayments` — `_create_outputs_`, `_prevouts_summary_`,
+`_scan_outputs_` — have something to take and something to hand back.
+Every public half is unchanged in behaviour and cost, and is now written
+as its private half with a `parse` in front of it, a `serialize` behind
+it, or both.
+
+The Silent Payments three are the ones a wallet feels: scanning block
+after block, `scan_outputs` parses the spend key and every transaction
+output at every transaction, where `_scan_outputs_` takes them parsed
+once and takes the summary object `_prevouts_summary_` built rather than
+octets to be written back into a struct.
 
 What that saves is the round trip and nothing else, so it is worth what
 the two calls around it are not: aggregating five public keys the BIP67
@@ -86,8 +134,8 @@ that refusal cost was a lift, and a tweak from the uncompressed form is
 
 **`xonly.from_prvkey` and `ssa.Signer.pubkey` are two entry points
 rather than two halves**, and they save different things. The first is
-the x-only public key of a private key: it is `pubkey_from_prvkey_` and
-`from_pubkey_` composed, so the halves above are where its 7.9
+the x-only public key of a private key: it is `_pubkey_from_prvkey_` and
+`_from_pubkey_` composed, so the halves above are where its 7.9
 microseconds against 10.5 come from, and what it adds is a name for a
 composition BIP340 and BIP341 make the common case — the full public
 key in the middle being an intermediate step nothing here asked for.
@@ -95,10 +143,24 @@ The second saves what no pair of halves could: a signer holds the
 keypair, and the point with it, so reading the key off it is a read and
 not a multiplication — 0.4 microseconds, where deriving it again is
 10.5. `xonly.from_keypair` is that read for a caller holding a keypair
-of its own, a MuSig2 session through `lib` being one, and it is the
-second wrapper of these bindings taking a libsecp256k1 object rather
-than bytes: like `keys.serialize`, it raises what libsecp256k1 reported
-rather than leaving it on the thread.
+of its own, a MuSig2 session through `lib` being one.
+
+**And a wrong object is now told to the caller, wherever one is taken.**
+`keys.serialize` and `xonly.from_keypair` raised what libsecp256k1
+reported of an argument no python check can prove; every other call
+taking such an object did not, which was measured rather than assumed:
+a wiped or unwritten key made `dsa._verify_` answer `False`,
+`keys._pubkey_cmp_` answer `0` — the answer for two equal keys — and
+`ecdh._shared_secret_` answer success and 32 bytes that are a shared
+secret with nobody, each leaving libsecp256k1's reason on the thread for
+the next `context.check()` to raise about a call that did not produce
+it, a MuSig2 caller's own being the one that would. All of them raise a
+`ValueError` carrying that reason now. A caller passing the objects
+these calls are meant to take sees no difference in what it gets back,
+and 0.48 microseconds a call in what it costs: nothing on a
+verification, which is 12.9 microseconds against 12.1, and most of the
+call on `keys._pubkey_cmp_`, which is 0.57 against a C comparison of
+0.087. `lib` is exported for a caller who counts that.
 
 ## v0.8.0.2
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,13 @@ and decides nothing else.
   the function applying it; the `ValueError` names what the library
   refused. No wrapper here knows the curve order
 - **nothing is normalized into validity.** An argument of the wrong size
-  raises, and is never padded: the 32 bytes of nonce entropy (`ndata`,
-  `aux_rand32`, `rnd32`) are 32 bytes or omitted, a shorter value being a
-  caller mistake rather than a small number. Taking a public key in any
+  raises, and is never padded: the 32 bytes of nonce entropy are 32 bytes
+  or omitted, a shorter value being a caller mistake rather than a small
+  number. They are `aux_rand32` in every module that takes them, BIP340's
+  own name for the pair libsecp256k1 spells `ndata` here and `rnd32`
+  there, and what omitting them means is the one thing that differs:
+  fresh randomness where BIP340 and BIP324 ask for it, and the RFC6979
+  nonce alone where ECDSA leaves it deterministic. Taking a public key in any
   of its three serializations is not a leniency of that kind and is worth
   the distinction: BIP340 verification (`ssa.verify`) and taproot
   tweaking (`xonly.tweak_add`, `xonly.tweak_add_check`) take 32, 33 or 65
@@ -266,56 +270,68 @@ library and nothing added to it.
 
 ## Parsing the key once
 
-A public key crosses this boundary as bytes, and every wrapper taking one
-begins by parsing it — for a compressed key that is a field square root,
-which is a measurable part of the verification that follows it. A caller
-that has already paid for that parse can hand it on instead of paying
-again: `keys.parse` returns the libsecp256k1 object, and every wrapper
-whose first act is to build one has an inner half, spelled with a
-trailing underscore, taking that object in place of the bytes.
+A public key crosses this boundary as octets, and every wrapper taking
+one begins by parsing it — for a compressed key that is a field square
+root, which is a measurable part of the verification that follows it. A
+caller that has already paid for that parse can hand it on instead of
+paying again: `keys.parse` returns the libsecp256k1 object, and every
+wrapper whose first act is to build one has a half that takes it in
+place of the octets.
+
+That half is spelled `_foo_`, and both underscores are load-bearing. The
+leading one says private, and means it: an object is a promise no
+argument check can hold a caller to, so what answers for a wrong one is
+libsecp256k1's own illegal-argument callback, and a caller reaching for
+these is past the boundary that proves things. The trailing one says
+which kind of private — `_verify_` takes a parsed key where `_parse_der`
+is an ordinary helper.
 
 ```python
 >>> ecdsa_sig = dsa.sign(msg, prvkey)
->>> parsed = keys.parse(pubkey)          # a valid point: proved once
->>> dsa.verify_(msg, parsed, ecdsa_sig)  # and used, rather than proved again
+>>> parsed = keys.parse(pubkey)           # a valid point: proved once
+>>> parsed_sig = dsa.parse_der(ecdsa_sig)
+>>> dsa._verify_(msg, parsed, parsed_sig)  # used, rather than proved again
 True
 
 ```
 
-The outer half is the inner half with a `parse` in front of it, and
+The public half is the private one with a `parse` in front of it, and
 nothing else about the two differs: the remaining arguments are checked
 exactly as before, a bare pointer's length being what no C return code
-can report. The two callers this is for are the one that validates a key
-and then verifies with it, and the one checking several signatures
-against a single key. `xonly.parse` is the same thing for the 32-byte
-x-only key BIP340 verifies against, and `keys.serialize` is how a parsed
-key becomes bytes again.
+can report. The callers this is for are the one that validates a key and
+then verifies with it, the one checking several signatures against a
+single key, and the one asking `is_low_s` about a signature it is about
+to verify. `xonly.parse` is the same thing for the x coordinate BIP340
+verifies against, `dsa.parse_der` and `dsa.parse_compact` for the two
+serializations of a signature, and every one of them has a `serialize`
+beside it turning the object back into octets.
 
 The other side of the boundary is spelled the same way. A wrapper that
-*produces* a key — recovering it from a signature, decoding it,
-deriving it, adding keys together — serializes what libsecp256k1 handed
-it already parsed, and its inner half answers with the object instead:
+*produces* an object — recovering a key from a signature, decoding it,
+deriving it, adding keys together, signing — serializes what
+libsecp256k1 handed it already made, and its private half answers with
+the object instead:
 
 ```python
 >>> from btclib_secp256k1 import recovery
 >>> sig, recid = recovery.sign(msg, prvkey)
->>> recovered = recovery.recover_(msg, sig, recid)  # the point, not its bytes
->>> dsa.verify_(msg, recovered, ecdsa_sig)          # used as it stands
+>>> parsed_recoverable = recovery.parse_compact(sig, recid)
+>>> recovered = recovery._recover_(msg, parsed_recoverable)  # the point
+>>> dsa._verify_(msg, recovered, parsed_sig)                 # as it stands
 True
 
 ```
 
-So the underscore means one thing in both directions: the half that
-speaks in parsed keys, where the outer half speaks in bytes. What it
+So `_foo_` means one thing in both directions: the half that speaks in
+libsecp256k1 objects, where the public half speaks in octets. What it
 buys is what composing two wrappers otherwise pays between them — a
 serialization of a point that was already in hand, and a parse of what
 was just serialized, which for the compressed form is that square root
-again. `keys.pubkey_from_prvkey_`, `keys.pubkey_combine_`,
-`keys.pubkey_sort_`, `recovery.recover_`, `ellswift.decode_` and
-`silentpayments.label_` are the producing halves; sorting keys and then
-adding them together is the composition that pays it per key, and
-`silentpayments.parse_label` is `keys.parse` for the 33 bytes of a
-label, which are a point like any other.
+again. Sorting keys and then adding them together is the composition
+that pays it per key; scanning block after block for a silent payment
+pays it per transaction, which is why `silentpayments` has a private
+half for each of its three entry points, the summary of a transaction's
+inputs included.
 
 Two entry points are there instead of two halves. `xonly.from_prvkey` is
 the x-only public key of a private key — the two halves above composed,
@@ -376,7 +392,7 @@ declarations are available through the `lib` and `ffi` cffi objects:
 | `silentpayments`    | `silentpayments` (BIP352)                 |
 
 `keys` provides the public key of a private key (`pubkey_from_prvkey`,
-compressed by default, of which `mult.mult_` is the uncompressed
+compressed by default, of which `mult.mult_bytes` is the uncompressed
 spelling) and the scalar and point algebra (tweaking, negation,
 combination, arbitrary point multiplication) underlying BIP32 key
 derivation, plus the lexicographic ordering of public keys (`pubkey_cmp`,

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -3,7 +3,30 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Pure python cffi bindings to libsecp256k1: https://github.com/bitcoin-core/secp256k1."""
+"""Pure python cffi bindings to libsecp256k1: https://github.com/bitcoin-core/secp256k1.
+
+Every entry point of these bindings takes octets and answers octets. A
+libsecp256k1 object crosses the boundary only where a caller already
+holds one: `keys.parse` and `keys.serialize`, and the pairs beside them
+in `xonly`, `dsa`, `recovery` and `silentpayments`, are that bridge, and
+a MuSig2 session driven through the raw `lib` is who is on the other
+side of it.
+
+Under each of those entry points is the half of it that speaks in those
+objects, spelled `_foo_`. The leading underscore says private, because
+an object is a promise no argument check can hold a caller to: what can
+be proved of a bare pointer's contents is nothing, and what answers for
+it is libsecp256k1 itself, through the illegal callback `context.guarded`
+turns back into an exception. The trailing one says which kind of
+private, `_verify_` taking a parsed key where `_parse_der` is an
+ordinary helper. `foo` is `_foo_` with a parse in front of it, a
+serialize behind it, or both, which is the equality
+`tests/test_parsed_keys.py` holds every pair to; what the private half
+saves is what composing two public ones pays between them, a
+serialization of a point that was already in hand and a parse of what
+was just serialized -- and for a compressed key that parse is a field
+square root.
+"""
 
 import pathlib
 from importlib.metadata import version

--- a/btclib_secp256k1/_cdata.py
+++ b/btclib_secp256k1/_cdata.py
@@ -1,0 +1,37 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The arrays of borrowed pointers libsecp256k1 takes several objects in."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import CData, ffi
+
+
+def array(cdecl: str, items: Sequence[CData]) -> CData:
+    """Build the array of pointers libsecp256k1 reads a sequence through.
+
+    The array holds borrowed pointers: what keeps the objects alive is
+    the sequence the caller passes, which has to outlive the call, and
+    what libsecp256k1 reorders where it sorts is this array rather than
+    the objects it points at.
+
+    An empty sequence answers NULL, which is what libsecp256k1 requires
+    rather than merely accepts: it reads the count against the pointer,
+    and a non-NULL one with a count of zero fails an ARG_CHECK --
+    `n_xonly_pubkeys > 0` in the Silent Payments summary, reported
+    through the illegal callback. cffi would hand over an array of
+    length zero quite happily, so it is this call that has to say NULL.
+
+    Args:
+        cdecl: the cffi declaration of the array type.
+        items: the objects to point at, which the caller keeps alive.
+
+    Returns:
+        The array, or NULL where there is nothing to point at.
+    """
+    return ffi.new(cdecl, list(items)) if items else ffi.NULL

--- a/btclib_secp256k1/_scalar.py
+++ b/btclib_secp256k1/_scalar.py
@@ -7,7 +7,9 @@
 
 from __future__ import annotations
 
-from . import BytesLike
+import secrets
+
+from . import BytesLike, CData, ffi
 
 
 def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
@@ -129,3 +131,95 @@ def scalar(num: BytesLike | int, name: str) -> bytes:
     if not isinstance(num, (bytes, bytearray, memoryview)):
         raise TypeError(f"the {name} must be bytes or an int, not {type(num).__name__}")
     return octets(num, name, 32)
+
+
+def entropy(aux_rand32: BytesLike | None, name: str = "aux_rand32") -> bytes:
+    """Normalize 32 bytes of entropy, generating them where none was given.
+
+    Entropy is not a serialization: a shorter value is a caller mistake
+    rather than a small number, and padding it here would turn one into a
+    valid argument. Omitting it altogether is not that mistake, and is
+    what every caller with no entropy of its own should do -- BIP340
+    recommends fresh randomness at every signature, and the
+    ElligatorSwift encoding requires randomness that is not a function of
+    the key it encodes.
+
+    Args:
+        aux_rand32: the 32 bytes given by the caller, or None.
+        name: what the entropy is, as the exception should call it.
+
+    Returns:
+        Those 32 bytes, or 32 freshly generated ones.
+
+    Raises:
+        TypeError: if a value is given and is not bytes.
+        ValueError: if a value is given and is not 32 bytes.
+    """
+    if aux_rand32 is None:
+        return secrets.token_bytes(32)
+    return octets(aux_rand32, name, 32)
+
+
+def optional_entropy(
+    aux_rand32: BytesLike | None, name: str = "aux_rand32"
+) -> bytes | CData:
+    """Normalize 32 bytes of entropy, or the NULL that asks for none.
+
+    What `entropy` is where omitting the argument means fresh randomness,
+    this is where it means none at all: the RFC6979 nonce is a function
+    of the message and the key, and the extra entropy libsecp256k1 mixes
+    into it is what a NULL pointer declines. Generating it here instead
+    would take determinism away from a caller who asked for it by saying
+    nothing.
+
+    Args:
+        aux_rand32: the 32 bytes given by the caller, or None.
+        name: what the entropy is, as the exception should call it.
+
+    Returns:
+        Those 32 bytes, or NULL.
+
+    Raises:
+        TypeError: if a value is given and is not bytes.
+        ValueError: if a value is given and is not 32 bytes.
+    """
+    if aux_rand32 is None:
+        return ffi.NULL
+    return octets(aux_rand32, name, 32)
+
+
+def in_range(value: int, name: str, upper: int) -> int:
+    """Normalize an int the caller chose from a small closed set.
+
+    A recovery id, a y parity, an ElligatorSwift party, a label index:
+    each is a small number libsecp256k1 takes as a C int, and each is out
+    of domain in the same way. Refused here rather than at the boundary,
+    where cffi answers an out of range value with OverflowError and a
+    float with a TypeError about a ctype, neither of which names the
+    argument.
+
+    A bool passes, where `scalar` refuses one, and the two are the same
+    rule rather than opposite ones: there a `True` would be the scalar 1
+    and the answer to a question nobody asked, indistinguishable from
+    the answer to the one that was meant, while here the value *is* the
+    number, and `bool(recid)` of a recovery id that is 0 or 1 says
+    exactly what it says. What is refused is what is not a number at
+    all: `0.0` passes an `in (0, 1)` test and reaches cffi as a float.
+
+    Args:
+        value: the number, as the caller passed it.
+        name: what the number is, as the exception should call it.
+        upper: the largest value the set holds, the smallest being zero.
+
+    Returns:
+        The value itself, that being what it already is.
+
+    Raises:
+        TypeError: if it is not an int.
+        ValueError: if it is outside [0, upper].
+    """
+    if not isinstance(value, int):
+        raise TypeError(f"the {name} must be an int, not {type(value).__name__}")
+    if not 0 <= value <= upper:
+        raise ValueError(f"the {name} must be in [0, {upper}]")
+    return value

--- a/btclib_secp256k1/_secret.py
+++ b/btclib_secp256k1/_secret.py
@@ -17,11 +17,17 @@ than a limit.
 It buys one copy, not safety: the `bytes` returned to the caller holds
 the same secret and cannot be overwritten. Scalar work that must not
 leave a trace belongs where that can be promised.
+
+The one such buffer this package builds rather than fills is the
+keypair, and `keypair` below is where it is built, so that the module
+holding the obligation to wipe one is the module that hands one out.
 """
 
 from __future__ import annotations
 
-from . import CData, ffi
+from . import BytesLike, CData, ffi, lib
+from ._scalar import scalar
+from .context import ctx
 
 
 def wipe(buffer: CData) -> None:
@@ -56,3 +62,32 @@ def take(buffer: CData) -> bytes:
     secret = bytes(ffi.buffer(buffer))
     wipe(buffer)
     return secret
+
+
+def keypair(prvkey: BytesLike | int) -> CData:
+    """Build the libsecp256k1 keypair of a private key.
+
+    Three modules need one -- `ssa` to sign, `xonly` to tweak a taproot
+    private key, `silentpayments` to spend a taproot input -- and each
+    wipes it on the way out, `wipe` above being how. That is why the
+    building of it lives here beside the wiping rather than in `keys`:
+    what a keypair holds is the private key in libsecp256k1's own
+    layout, so a caller of this owes the buffer a `wipe`, and the two
+    halves of that obligation are better read together than looked up in
+    two places.
+
+    Args:
+        prvkey: the private key, 32 bytes or an int below 2**256.
+
+    Returns:
+        The libsecp256k1 keypair object, which the caller wipes.
+
+    Raises:
+        TypeError: if the key is neither an int nor bytes.
+        ValueError: if it is not 32 bytes, does not fit in them, or is
+            not in [1, n-1].
+    """
+    buffer = ffi.new("secp256k1_keypair *")
+    if not lib.secp256k1_keypair_create(ctx, buffer, scalar(prvkey, "private key")):
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return buffer

--- a/btclib_secp256k1/context.py
+++ b/btclib_secp256k1/context.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import secrets
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from . import CData, ffi, lib
 
@@ -120,13 +122,13 @@ def check() -> None:
     session is, and it reports what was last recorded: call it right
     after the call whose return value you are explaining.
 
-    The bindings check their arguments before calling, so a violated
-    precondition is unreachable through all but two of them:
-    `keys.serialize` takes a libsecp256k1 public key and
-    `xonly.from_keypair` a libsecp256k1 keypair, rather than bytes, and
-    there is nothing to check about either before handing it over. Both
-    call this themselves, which is what keeps their own failure from
-    being left on the thread for the next caller to find.
+    The wrappers do not need it where they hand libsecp256k1 bytes,
+    having proved those bytes first; where they hand it an object the
+    caller built, they cannot prove anything and run the call inside
+    `guarded` below, which is what calls this. So a violated
+    precondition raised through a wrapper is this message, and no
+    wrapper leaves one on the thread for the next caller to be blamed
+    for.
 
     What was recorded is cleared, so a second call reports nothing and
     a later one cannot inherit this call's message.
@@ -142,3 +144,51 @@ def check() -> None:
         raise RuntimeError(f"libsecp256k1 internal error: {error}")
     if illegal is not None:
         raise ValueError(f"libsecp256k1 illegal argument: {illegal}")
+
+
+@contextmanager
+def guarded() -> Iterator[None]:
+    """Run a libsecp256k1 call whose argument could not be checked first.
+
+    Every argument these bindings pass as bytes is proved before the
+    call, a bare pointer's length being what no C return code can
+    report. An argument that is a libsecp256k1 object is the case that
+    cannot be: `keys.serialize` takes a public key, `xonly.from_keypair`
+    a keypair, and every private half takes what a `parse` returned, and
+    of none of them is there anything to ask before handing it over. So
+    what answers for those is libsecp256k1 itself, through the illegal
+    callback, and this is how what it says reaches the caller.
+
+    Both halves are here because either alone is a bug. The clearing is
+    what makes the message this call's own: recorded and left by an
+    earlier call, one would be raised out of this one, which is the
+    misattribution `check` exists to prevent. The `check` is what makes
+    the failure speak: `secp256k1_ec_pubkey_negate` of a pointer to
+    nothing returns 0 like any other refusal, and the reason it returns
+    0 is on the thread and nowhere else.
+
+    And it is called whatever the call answered, not only on a failure,
+    because a violated precondition does not always show in the return
+    value: `secp256k1_ecdsa_verify` of an unreadable key answers False,
+    which is a verdict a caller would believe, and
+    `secp256k1_ecdh` of one answers success and 32 bytes that are a
+    shared secret with nobody.
+
+    Yields:
+        None: nothing, the block being what this is for. It should hold
+        that call and nothing else -- an exception raised inside it
+        passes through with the thread left as libsecp256k1 set it.
+
+    Raises:
+        ValueError: if libsecp256k1 reported a violated precondition.
+        RuntimeError: if it reported an internal error.
+
+    Example:
+        >>> from btclib_secp256k1 import ffi, keys
+        >>> keys.serialize(ffi.NULL)
+        Traceback (most recent call last):
+        ValueError: libsecp256k1 illegal argument: pubkey != NULL
+    """
+    _reported.illegal = _reported.error = None
+    yield
+    check()

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -3,37 +3,98 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Elliptic Curve Digital Signature Algorithm (ECDSA)."""
+"""Elliptic Curve Digital Signature Algorithm (ECDSA).
+
+A signature crosses this boundary in one of its two serializations, DER
+or the 64-byte compact form, and `parse_der`, `parse_compact`,
+`serialize_der` and `serialize_compact` are what open and close each of
+them. They are here for the reason `keys.parse` is: a caller doing more
+than one thing with one signature -- asking whether it is low-s and then
+verifying it, verifying it against several keys, storing it in the other
+form -- parses it once and hands the object to the private halves, where
+`normalize`, `is_low_s`, `to_der` and `to_compact` each parse and
+serialize one of their own.
+"""
 
 from __future__ import annotations
 
 from . import BytesLike, CData, ffi, keys, lib
-from ._scalar import octets, scalar
-from .context import ctx
+from ._scalar import octets, optional_entropy, scalar
+from .context import ctx, guarded
 
 
-def sign(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, ndata: BytesLike | None = None
-) -> bytes:
-    """Create an ECDSA signature.
+def _sign_(
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+) -> CData:
+    """Create an ECDSA signature, as the parsed signature.
 
-    The nonce is the deterministic RFC6979 one, so the signature is a
-    function of the message and the key alone unless ndata is given.
+    The private half of `sign`, and the one that answers with the object
+    rather than with its DER encoding: see the package docstring for what
+    the two underscores mean throughout. A signer wanting the compact
+    form is this and `serialize_compact`, where `sign` and `to_compact`
+    are a DER serialization and a parse of what was just serialized.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
-        ndata: 32 bytes of extra entropy mixed into the nonce, or None
-            for the RFC6979 nonce alone. Never a shorter value: entropy
-            is not a serialization, and padding one would make a caller
-            mistake a valid argument.
+        aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
+            None for the RFC6979 nonce alone.
+
+    Returns:
+        The libsecp256k1 signature object, in the lower-s form
+        libsecp256k1 always produces.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if aux_rand32 is
+            given and is not 32 bytes, or if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1].
+    """
+    prvkey_bytes = scalar(prvkey, "private key")
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+
+    signature = ffi.new("secp256k1_ecdsa_signature *")
+
+    # secp256k1_ecdsa_sign takes the nonce function and its data: NULL
+    # for the first selects the RFC6979 default, and it is the only one
+    # these bindings pass -- a python nonce function would be called from
+    # inside the signature, with the secret passing through a python
+    # object on every call. The contribution beside it is 32 bytes of
+    # entropy, and `optional_entropy` says what omitting it means here
+    noncefp = ffi.NULL
+    if not lib.secp256k1_ecdsa_sign(
+        ctx,
+        signature,
+        msg_bytes,
+        prvkey_bytes,
+        noncefp,
+        optional_entropy(aux_rand32),
+    ):
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return signature
+
+
+def sign(
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+) -> bytes:
+    """Create an ECDSA signature.
+
+    The nonce is the deterministic RFC6979 one, so the signature is a
+    function of the message and the key alone unless aux_rand32 is given.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
+            None for the RFC6979 nonce alone. Never a shorter value:
+            entropy is not a serialization, and padding one would make a
+            caller mistake a valid argument.
 
     Returns:
         The signature in DER encoding, in the lower-s form libsecp256k1
         always produces.
 
     Raises:
-        ValueError: if the message hash is not 32 bytes, if ndata is
+        ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, or if the private key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to serialize the signature,
@@ -46,49 +107,31 @@ def sign(
         >>> dsa.is_low_s(dsa.sign(msg, 1))
         True
     """
-    prvkey_bytes = scalar(prvkey, "private key")
-    msg_bytes = octets(msg_bytes, "message hash", 32)
-
-    sig = ffi.new("secp256k1_ecdsa_signature *")
-
-    # secp256k1_ecdsa_sign takes the nonce function and its data: NULL
-    # for the first selects the RFC6979 default, and it is the only one
-    # these bindings pass -- a python nonce function would be called from
-    # inside the signature, with the secret passing through a python
-    # object on every call.
-    #
-    # The contribution beside it is 32 bytes of entropy, not a
-    # serialization: a shorter value is a caller mistake rather than a
-    # small number, and padding it here would turn one into a valid
-    # argument. Omitted, the nonce is the RFC6979 one alone
-    noncefp = ffi.NULL
-    ndata_ptr = ffi.NULL if ndata is None else octets(ndata, "ndata", 32)
-    if not lib.secp256k1_ecdsa_sign(
-        ctx, sig, msg_bytes, prvkey_bytes, noncefp, ndata_ptr
-    ):
-        raise ValueError("invalid private key")
-    return _serialize_der(sig)
+    return serialize_der(_sign_(msg_bytes, prvkey, aux_rand32))
 
 
-def verify_(
+def _verify_(
     msg_bytes: BytesLike,
     pubkey: CData,
-    signature_bytes: BytesLike,
+    signature: CData,
     normalize: bool = False,
 ) -> bool:
-    """Verify an ECDSA signature against an already-parsed public key.
+    """Verify an ECDSA signature against an already-parsed key and signature.
 
-    The inner half of `verify`, for a caller who already holds the parsed
-    key -- one that validated it before verifying with it, or one
-    checking several signatures against the same key: see `keys.parse`
-    for what the underscore means throughout. For a compressed key that
-    parse is a field square root, which is a measurable part of the
+    The private half of `verify`, for a caller who already holds both --
+    one that validated the key before verifying with it, one checking
+    several signatures against the same key, or one that has just asked
+    `_is_low_s_` about the signature: see the package docstring for what
+    the two underscores mean throughout. For a compressed key that parse
+    is a field square root, which is a measurable part of the
     verification it precedes rather than a rounding error.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
         pubkey: the already-parsed public key, as `keys.parse` returns.
-        signature_bytes: the signature in DER encoding.
+        signature: the already-parsed signature, as `parse_der` and
+            `parse_compact` return. Mutated in place where `normalize`
+            asks for it.
         normalize: whether to verify the lower-s form of the signature
             rather than reject a signature that is not in it.
 
@@ -96,21 +139,17 @@ def verify_(
         True if the signature is valid for that key and message.
 
     Raises:
-        ValueError: if the message hash is not 32 bytes, or if the DER
-            signature is malformed. A well-formed signature that simply
-            does not verify is False, not an exception.
+        ValueError: if the message hash is not 32 bytes, or if either
+            object is not one libsecp256k1 will read; see
+            `context.guarded`, without which an unreadable key would
+            answer False, which is a verdict a caller would believe.
     """
     msg_bytes = octets(msg_bytes, "message hash", 32)
-    signature = _parse_der(signature_bytes)
     if normalize:
-        # libsecp256k1 takes the same object as input and output here,
-        # documenting sigout == sigin, so this is the normalization
-        # alone: `verify(msg, key, normalize(sig))` is the same answer
-        # through a DER serialization and a second parse of it. The
-        # return value says whether anything was changed, which is what
-        # `is_low_s` asks and this does not
-        lib.secp256k1_ecdsa_signature_normalize(ctx, signature, signature)
-    return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
+        _normalize_(signature)
+    with guarded():
+        verified = lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey)
+    return bool(verified)
 
 
 def verify(
@@ -149,10 +188,42 @@ def verify(
         >>> import hashlib
         >>> from btclib_secp256k1 import dsa, mult
         >>> msg = hashlib.sha256(b"hello").digest()
-        >>> dsa.verify(msg, mult.mult_(1), dsa.sign(msg, 1))
+        >>> dsa.verify(msg, mult.mult_bytes(1), dsa.sign(msg, 1))
         True
     """
-    return verify_(msg_bytes, keys.parse(pubkey_bytes), signature_bytes, normalize)
+    return _verify_(
+        msg_bytes, keys.parse(pubkey_bytes), parse_der(signature_bytes), normalize
+    )
+
+
+def _normalize_(signature: CData) -> CData:
+    """Convert an already-parsed signature to its lower-s form.
+
+    The private half of `normalize`, for a caller who already holds the
+    parsed signature: see the package docstring for what the two
+    underscores mean throughout. Normalizing in order to verify is
+    `_verify_(..., normalize=True)`, which is this call inside that one.
+
+    Args:
+        signature: the already-parsed signature, as `parse_der` and
+            `parse_compact` return. Mutated in place.
+
+    Returns:
+        The same object passed in, with s replaced by n - s where s was
+        the higher of the two. A signature already normalized is left as
+        it is.
+
+    Raises:
+        ValueError: if the object is not a signature libsecp256k1 will
+            read; see `context.guarded`.
+    """
+    # libsecp256k1 takes the same object as input and output here,
+    # documenting sigout == sigin. The return value says whether
+    # anything was changed, which is what `_is_low_s_` asks and this
+    # does not
+    with guarded():
+        lib.secp256k1_ecdsa_signature_normalize(ctx, signature, signature)
+    return signature
 
 
 def normalize(signature_bytes: BytesLike) -> bytes:
@@ -177,10 +248,33 @@ def normalize(signature_bytes: BytesLike) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no input can make it do.
     """
-    signature = _parse_der(signature_bytes)
-    normalized = ffi.new("secp256k1_ecdsa_signature *")
-    lib.secp256k1_ecdsa_signature_normalize(ctx, normalized, signature)
-    return _serialize_der(normalized)
+    return serialize_der(_normalize_(parse_der(signature_bytes)))
+
+
+def _is_low_s_(signature: CData) -> bool:
+    """Return True if an already-parsed signature is in the lower-s form.
+
+    The private half of `is_low_s`, for a caller who already holds the
+    parsed signature -- one about to verify it, `_verify_` taking the
+    same object: see the package docstring for what the two underscores
+    mean throughout.
+
+    Args:
+        signature: the already-parsed signature, as `parse_der` and
+            `parse_compact` return. Not mutated: this asks.
+
+    Returns:
+        True if s is the lower of the two.
+
+    Raises:
+        ValueError: if the object is not a signature libsecp256k1 will
+            read; see `context.guarded`.
+    """
+    # a NULL output only checks the input, which is reported as
+    # not normalized by a return value of 1
+    with guarded():
+        changed = lib.secp256k1_ecdsa_signature_normalize(ctx, ffi.NULL, signature)
+    return not changed
 
 
 def is_low_s(signature_bytes: BytesLike) -> bool:
@@ -200,10 +294,7 @@ def is_low_s(signature_bytes: BytesLike) -> bool:
     Raises:
         ValueError: if the DER signature is malformed.
     """
-    signature = _parse_der(signature_bytes)
-    # a NULL output only checks the input, which is reported as
-    # not normalized by a return value of 1
-    return not lib.secp256k1_ecdsa_signature_normalize(ctx, ffi.NULL, signature)
+    return _is_low_s_(parse_der(signature_bytes))
 
 
 def to_compact(signature_bytes: BytesLike) -> bytes:
@@ -220,11 +311,7 @@ def to_compact(signature_bytes: BytesLike) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize it, which no
             input can make it do.
     """
-    signature = _parse_der(signature_bytes)
-    sig_bytes = ffi.new("char[64]")
-    if not lib.secp256k1_ecdsa_signature_serialize_compact(ctx, sig_bytes, signature):
-        raise RuntimeError("signature serialization failed")
-    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes))
+    return serialize_compact(parse_der(signature_bytes))
 
 
 def to_der(signature_bytes: BytesLike) -> bytes:
@@ -244,16 +331,16 @@ def to_der(signature_bytes: BytesLike) -> bytes:
         RuntimeError: if libsecp256k1 fails to serialize it, which no
             input can make it do.
     """
-    signature_bytes = octets(signature_bytes, "compact signature", 64)
-
-    signature = ffi.new("secp256k1_ecdsa_signature *")
-    if not lib.secp256k1_ecdsa_signature_parse_compact(ctx, signature, signature_bytes):
-        raise ValueError("invalid compact signature")
-    return _serialize_der(signature)
+    return serialize_der(parse_compact(signature_bytes))
 
 
-def _parse_der(signature_bytes: BytesLike) -> CData:
+def parse_der(signature_bytes: BytesLike) -> CData:
     """Parse a DER signature into its internal representation.
+
+    What `keys.parse` is to a public key, and the argument of every
+    private half here: `serialize_der` is what turns it back into bytes,
+    and `parse_compact` reads the other serialization into the same
+    object.
 
     Args:
         signature_bytes: the signature in DER encoding.
@@ -273,18 +360,47 @@ def _parse_der(signature_bytes: BytesLike) -> CData:
     return signature
 
 
-def _serialize_der(sig: CData) -> bytes:
+def parse_compact(signature_bytes: BytesLike) -> CData:
+    """Parse a 64-byte compact signature into its internal representation.
+
+    The other way into the object `parse_der` answers with, and the
+    cheaper one: there is no encoding to walk, only two scalars to prove
+    below the group order.
+
+    Args:
+        signature_bytes: the 64 bytes of r and s.
+
+    Returns:
+        The libsecp256k1 signature object. s is not normalized, which is
+        what `_is_low_s_` asks and `_normalize_` changes.
+
+    Raises:
+        ValueError: if the input is not 64 bytes, or if r or s is not
+            below the group order.
+    """
+    signature_bytes = octets(signature_bytes, "compact signature", 64)
+
+    signature = ffi.new("secp256k1_ecdsa_signature *")
+    if not lib.secp256k1_ecdsa_signature_parse_compact(ctx, signature, signature_bytes):
+        raise ValueError("invalid compact signature")
+    return signature
+
+
+def serialize_der(signature: CData) -> bytes:
     """Serialize an internal signature in DER form.
 
     Args:
-        sig: the libsecp256k1 signature object.
+        signature: the libsecp256k1 signature object, as `parse_der` and
+            `parse_compact` return.
 
     Returns:
         Its DER encoding, at most 72 bytes.
 
     Raises:
-        RuntimeError: if libsecp256k1 fails, which the 72-byte buffer
-            makes unreachable.
+        ValueError: if the object is not a signature libsecp256k1 will
+            read; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            the 72-byte buffer makes unreachable.
     """
     # 72 is the maximum a signature of this curve can encode to, and it
     # is structural rather than generous: secp256k1_ecdsa_sig_serialize
@@ -301,6 +417,36 @@ def _serialize_der(sig: CData) -> bytes:
     # fixed the buffer is unpacked instead, and keys.serialize says why
     sig_bytes = ffi.new("char[72]")
     length = ffi.new("size_t *", ffi.sizeof(sig_bytes))
-    if not lib.secp256k1_ecdsa_signature_serialize_der(ctx, sig_bytes, length, sig):
+    with guarded():
+        serialized = lib.secp256k1_ecdsa_signature_serialize_der(
+            ctx, sig_bytes, length, signature
+        )
+    if not serialized:
         raise RuntimeError("signature serialization failed")
     return ffi.unpack(sig_bytes, length[0])
+
+
+def serialize_compact(signature: CData) -> bytes:
+    """Serialize an internal signature in its 64-byte compact form.
+
+    Args:
+        signature: the libsecp256k1 signature object, as `parse_der` and
+            `parse_compact` return.
+
+    Returns:
+        The 64 bytes of r and s, each big endian and zero padded.
+
+    Raises:
+        ValueError: if the object is not a signature libsecp256k1 will
+            read; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a signature it parsed cannot make it do.
+    """
+    sig_bytes = ffi.new("char[64]")
+    with guarded():
+        serialized = lib.secp256k1_ecdsa_signature_serialize_compact(
+            ctx, sig_bytes, signature
+        )
+    if not serialized:
+        raise RuntimeError("signature serialization failed")
+    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes))

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -10,16 +10,17 @@ from __future__ import annotations
 from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import scalar
 from ._secret import take
-from .context import ctx
+from .context import ctx, guarded
 
 
-def shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
+def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
     """Compute the ECDH shared secret from an already-parsed public key.
 
-    The inner half of `shared_secret`, for a caller who already holds the
-    other party's parsed key -- one exchanging with the same counterparty
-    more than once, or one that validated the key on receipt: see
-    `keys.parse` for what the underscore means throughout.
+    The private half of `shared_secret`, for a caller who already holds
+    the other party's parsed key -- one exchanging with the same
+    counterparty more than once, or one that validated the key on
+    receipt: see the package docstring for what the two underscores mean
+    throughout.
 
     Args:
         pubkey: the other party's already-parsed public key, as
@@ -33,14 +34,21 @@ def shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
 
     Raises:
         ValueError: if the private key is not 32 bytes, does not fit in
-            them, or is not a valid scalar.
+            them, is not a valid scalar, or if the object is not a public
+            key libsecp256k1 will read; see `context.guarded`, without
+            which an unreadable key would answer success and 32 bytes
+            that are a shared secret with nobody.
     """
     prvkey_bytes = scalar(prvkey, "private key")
 
     output = ffi.new("char[32]")
     # a NULL hash function selects secp256k1_ecdh_hash_function_sha256,
     # which writes 32 bytes to output
-    if not lib.secp256k1_ecdh(ctx, output, pubkey, prvkey_bytes, ffi.NULL, ffi.NULL):
+    with guarded():
+        computed = lib.secp256k1_ecdh(
+            ctx, output, pubkey, prvkey_bytes, ffi.NULL, ffi.NULL
+        )
+    if not computed:
         raise ValueError("invalid private key")
     return take(output)
 
@@ -58,9 +66,9 @@ def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
     being available as keys.pubkey_tweak_mul(pubkey_bytes, prvkey),
     itself constant time. A protocol needing another derivation applies
     it to that: SHA256 of it is what this function returns. Wanting both
-    of them is where the inner halves earn their keep -- one
-    `keys.parse`, then `shared_secret_` and `keys.pubkey_tweak_mul_` of
-    it -- the two outer halves parsing the same key twice.
+    of them is where the private halves earn their keep -- one
+    `keys.parse`, then `_shared_secret_` and `keys._pubkey_tweak_mul_` of
+    it -- the two public halves parsing the same key twice.
 
     Args:
         pubkey_bytes: the other party's public key, 33 or 65 bytes.
@@ -75,4 +83,4 @@ def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
             private key is not 32 bytes or does not fit in them, or if
             it is not a valid scalar.
     """
-    return shared_secret_(keys.parse(pubkey_bytes), prvkey)
+    return _shared_secret_(keys.parse(pubkey_bytes), prvkey)

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -10,19 +10,17 @@ https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki
 
 from __future__ import annotations
 
-import secrets
-
 from . import BytesLike, CData, ffi, lib
-from ._scalar import octets, scalar
+from ._scalar import entropy, in_range, octets, scalar
 from ._secret import take
-from .context import ctx
+from .context import ctx, guarded
 from .keys import parse, serialize
 
 
 def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> bytes:
     """Create the 64-byte ElligatorSwift encoding of a private key's public key.
 
-    This is safer than encode(mult_(prvkey)), as the private key itself
+    This is safer than encode(mult_bytes(prvkey)), as the private key itself
     is used as entropy for the encoding.
 
     Args:
@@ -40,52 +38,50 @@ def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> byte
     """
     prvkey_bytes = scalar(prvkey, "private key")
 
-    # entropy is not a serialization: a shorter value is a caller mistake
-    # rather than a small number, and is not padded into a valid argument
-    aux_rand32 = (
-        secrets.token_bytes(32)
-        if aux_rand32 is None
-        else octets(aux_rand32, "aux_rand32", 32)
-    )
-
     ell_bytes = ffi.new("char[64]")
-    if not lib.secp256k1_ellswift_create(ctx, ell_bytes, prvkey_bytes, aux_rand32):
-        raise ValueError("invalid private key")
+    if not lib.secp256k1_ellswift_create(
+        ctx, ell_bytes, prvkey_bytes, entropy(aux_rand32)
+    ):
+        raise ValueError("invalid private key: not in [1, n-1]")
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
-def encode_(pubkey: CData, rnd32: BytesLike | None = None) -> bytes:
+def _encode_(pubkey: CData, aux_rand32: BytesLike | None = None) -> bytes:
     """Encode an already-parsed public key as 64 ElligatorSwift bytes.
 
-    The inner half of `encode`, for a caller who already holds the parsed
-    point -- one encoding a key it has just decoded, or one encoding the
-    same key more than once, which BIP324 does with fresh randomness at
-    every connection: see `keys.parse` for what the underscore means
-    throughout.
+    The private half of `encode`, for a caller who already holds the
+    parsed point -- one encoding a key it has just decoded, or one
+    encoding the same key more than once, which BIP324 does with fresh
+    randomness at every connection: see the package docstring for what
+    the two underscores mean throughout.
 
     Args:
         pubkey: the already-parsed public key, as `keys.parse` returns.
-        rnd32: the 32 bytes deciding which of the encodings of that key
-            is produced, or None for fresh randomness.
+        aux_rand32: the 32 bytes deciding which of the encodings of that
+            key is produced, or None for fresh randomness.
 
     Returns:
         The 64-byte ElligatorSwift encoding.
 
     Raises:
-        ValueError: if rnd32 is given and is not 32 bytes.
+        ValueError: if aux_rand32 is given and is not 32 bytes, or if the
+            object is not a public key libsecp256k1 will read; see
+            `context.guarded`.
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
-    # 32 bytes of entropy, or nothing: see the comment in create
-    rnd32 = secrets.token_bytes(32) if rnd32 is None else octets(rnd32, "rnd32", 32)
-
     ell_bytes = ffi.new("char[64]")
-    if not lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, rnd32):
+    aux_rand32_bytes = entropy(aux_rand32)
+    with guarded():
+        encoded = lib.secp256k1_ellswift_encode(
+            ctx, ell_bytes, pubkey, aux_rand32_bytes
+        )
+    if not encoded:
         raise RuntimeError("ElligatorSwift encoding failed")
     return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
 
 
-def encode(pubkey_bytes: BytesLike, rnd32: BytesLike | None = None) -> bytes:
+def encode(pubkey_bytes: BytesLike, aux_rand32: BytesLike | None = None) -> bytes:
     """Encode a public key as 64 ElligatorSwift bytes.
 
     The randomness must not be a deterministic function of the public
@@ -93,29 +89,29 @@ def encode(pubkey_bytes: BytesLike, rnd32: BytesLike | None = None) -> bytes:
 
     Args:
         pubkey_bytes: the public key to encode, 33 or 65 bytes.
-        rnd32: the 32 bytes deciding which of the encodings of that key
-            is produced, or None for fresh randomness.
+        aux_rand32: the 32 bytes deciding which of the encodings of that
+            key is produced, or None for fresh randomness.
 
     Returns:
         The 64-byte ElligatorSwift encoding, indistinguishable from
         uniform bytes.
 
     Raises:
-        ValueError: if the public key is not a valid point, or if rnd32
-            is given and is not 32 bytes.
+        ValueError: if the public key is not a valid point, or if
+            aux_rand32 is given and is not 32 bytes.
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
-    return encode_(parse(pubkey_bytes), rnd32)
+    return _encode_(parse(pubkey_bytes), aux_rand32)
 
 
-def decode_(ell_bytes: BytesLike) -> CData:
+def _decode_(ell_bytes: BytesLike) -> CData:
     """Decode a 64-byte ElligatorSwift public key into a parsed key.
 
-    The inner half of `decode`, and the one that answers with the point
-    rather than with its serialization: see `keys.parse` for what the
-    underscore means throughout. A decoded key that is about to be
-    tweaked, verified against or encoded again is what this is for --
+    The private half of `decode`, and the one that answers with the point
+    rather than with its serialization: see the package docstring for
+    what the two underscores mean throughout. A decoded key that is about
+    to be tweaked, verified against or encoded again is what this is for --
     libsecp256k1 hands the point over already lifted, and serializing it
     only to lift it back is a field square root nothing asked for.
 
@@ -157,7 +153,7 @@ def decode(ell_bytes: BytesLike, compressed: bool = True) -> bytes:
         RuntimeError: if libsecp256k1 fails to decode or serialize,
             which no 64 bytes can make it do.
     """
-    return serialize(decode_(ell_bytes), compressed)
+    return serialize(_decode_(ell_bytes), compressed)
 
 
 def xdh(
@@ -182,14 +178,15 @@ def xdh(
         so BIP324's initiator goes first.
 
     Raises:
+        TypeError: if the party is not an int.
         ValueError: if either encoding is not 64 bytes, if party is not
             0 or 1, or if the private key is not 32 bytes, does not fit
             in them, or is not a valid scalar.
     """
     ell_a_bytes = octets(ell_a_bytes, "ElligatorSwift public key of A", 64)
     ell_b_bytes = octets(ell_b_bytes, "ElligatorSwift public key of B", 64)
-    if party not in (0, 1):
-        raise ValueError("the party must be 0 (A) or 1 (B)")
+    # 0 is A and 1 is B, which is what the argument's own name says
+    party = in_range(party, "party", 1)
 
     prvkey_bytes = scalar(prvkey, "private key")
 

--- a/btclib_secp256k1/hashes.py
+++ b/btclib_secp256k1/hashes.py
@@ -15,7 +15,7 @@ from ._scalar import octets
 from .context import ctx
 
 
-def tagged_sha256(tag: BytesLike, msg: BytesLike) -> bytes:
+def tagged_sha256(tag_bytes: BytesLike, msg_bytes: BytesLike) -> bytes:
     """Return the BIP340 tagged hash of a message.
 
     That is SHA256(SHA256(tag) || SHA256(tag) || msg): the tag separates
@@ -24,8 +24,8 @@ def tagged_sha256(tag: BytesLike, msg: BytesLike) -> bytes:
     BIP341 taproot tags (TapLeaf, TapBranch, TapTweak) are built with it.
 
     Args:
-        tag: the domain separation tag, of any length.
-        msg: the message to hash, of any length.
+        tag_bytes: the domain separation tag, of any length.
+        msg_bytes: the message to hash, of any length.
 
     Returns:
         The 32-byte tagged hash.
@@ -39,9 +39,11 @@ def tagged_sha256(tag: BytesLike, msg: BytesLike) -> bytes:
         >>> hashes.tagged_sha256(b"TapLeaf", b"").hex()
         '5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb'
     """
-    tag = octets(tag, "tag")
-    msg = octets(msg, "message")
+    tag_bytes = octets(tag_bytes, "tag")
+    msg_bytes = octets(msg_bytes, "message")
     output = ffi.new("char[32]")
-    if not lib.secp256k1_tagged_sha256(ctx, output, tag, len(tag), msg, len(msg)):
+    if not lib.secp256k1_tagged_sha256(
+        ctx, output, tag_bytes, len(tag_bytes), msg_bytes, len(msg_bytes)
+    ):
         raise RuntimeError("tagged hashing failed")
     return ffi.unpack(output, ffi.sizeof(output))

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from . import BytesLike, CData, ffi, lib
+from ._cdata import array
 from ._scalar import octets, scalar
 from ._secret import take
-from .context import check, ctx
+from .context import ctx, guarded
 
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
 # libsecp256k1 flag macros do not survive the preprocessing of the
@@ -93,7 +94,7 @@ def prvkey_negate(prvkey: BytesLike | int) -> bytes:
     """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     if not lib.secp256k1_ec_seckey_negate(ctx, prvkey_buffer):
-        raise ValueError("invalid private key")
+        raise ValueError("invalid private key: not in [1, n-1]")
     return take(prvkey_buffer)
 
 
@@ -101,7 +102,8 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     """Add a tweak to a private key.
 
     This is the private-key side of BIP32 derivation, and of any other
-    scheme adding a scalar to a key.
+    scheme adding a scalar to a key. `xonly.prvkey_tweak_add` is the
+    BIP341 one, which negates the key first where its point has odd y.
 
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -144,14 +146,13 @@ def prvkey_tweak_mul(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     return take(prvkey_buffer)
 
 
-def pubkey_from_prvkey_(prvkey: BytesLike | int) -> CData:
+def _pubkey_from_prvkey_(prvkey: BytesLike | int) -> CData:
     """Return the public key of a private key, as the parsed point.
 
-    The inner half of `pubkey_from_prvkey`, for a caller who is about to
-    hand the point to another wrapper rather than to hold its bytes:
-    `xonly.from_prvkey` is the one this package makes, and a caller
-    aggregating or tweaking a key it has just derived is the other. See
-    `parse` for what the underscore means throughout.
+    The private half of `pubkey_from_prvkey`, for a caller who is about
+    to hand the point to another wrapper rather than to hold its bytes:
+    `xonly.from_prvkey` is the one this package makes. See the package
+    docstring for what the two underscores mean throughout.
 
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -172,11 +173,12 @@ def pubkey_from_prvkey_(prvkey: BytesLike | int) -> CData:
 def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> bytes:
     """Return the public key of a private key, i.e. the point kG.
 
-    This is the generator multiplication of `mult.mult_`, with the
-    serialization flag this module's other producers all take: `mult_`
-    is its `compressed=False` case, and every private-to-public
-    conversion that wants the compressed form -- BIP32 neutering, a
-    fingerprint, an address -- is this call and nothing after it.
+    This is the generator multiplication of `mult.mult_bytes`, with the
+    serialization flag this module's other producers all take:
+    `mult_bytes` is its `compressed=False` case, and every
+    private-to-public conversion that wants the compressed form -- BIP32
+    neutering, a fingerprint, an address -- is this call and nothing
+    after it.
 
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -197,14 +199,15 @@ def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> byte
         >>> keys.pubkey_from_prvkey(1).hex()[:10]
         '0279be667e'
     """
-    return serialize(pubkey_from_prvkey_(prvkey), compressed)
+    return serialize(_pubkey_from_prvkey_(prvkey), compressed)
 
 
-def pubkey_negate_(pubkey: CData) -> CData:
+def _pubkey_negate_(pubkey: CData) -> CData:
     """Negate an already-parsed public key.
 
-    The inner half of `pubkey_negate`, for a caller who already holds the
-    parsed point: see `parse` for what the underscore means throughout.
+    The private half of `pubkey_negate`, for a caller who already holds
+    the parsed point: see the package docstring for what the two
+    underscores mean throughout.
 
     Args:
         pubkey: the already-parsed public key, as `parse` returns.
@@ -214,10 +217,15 @@ def pubkey_negate_(pubkey: CData) -> CData:
         The same object passed in, negated.
 
     Raises:
-        RuntimeError: if libsecp256k1 fails to negate it, which no valid
-            key can make it do.
+        ValueError: if the object is not a public key libsecp256k1 will
+            read -- a NULL pointer, or a `secp256k1_pubkey` nothing has
+            written to; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a key it produced cannot make it do.
     """
-    if not lib.secp256k1_ec_pubkey_negate(ctx, pubkey):
+    with guarded():
+        negated = lib.secp256k1_ec_pubkey_negate(ctx, pubkey)
+    if not negated:
         raise RuntimeError("public key negation failed")
     return pubkey
 
@@ -237,17 +245,18 @@ def pubkey_negate(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
         RuntimeError: if libsecp256k1 fails to negate or serialize it,
             which no valid key can make it do.
     """
-    return serialize(pubkey_negate_(parse(pubkey_bytes)), compressed)
+    return serialize(_pubkey_negate_(parse(pubkey_bytes)), compressed)
 
 
-def pubkey_tweak_add_(pubkey: CData, tweak: BytesLike | int) -> CData:
+def _pubkey_tweak_add_(pubkey: CData, tweak: BytesLike | int) -> CData:
     """Add the generator multiplied by the tweak, to an already-parsed key.
 
-    The inner half of `pubkey_tweak_add`, for a caller who already holds
-    the parsed point and so has no parse left to redo: `PubkeyTweakChain`
-    is the one, walking a BIP32 path one tweak at a time without parsing
-    the point back out of its own serialization at every step. See
-    `parse` for what the underscore means throughout.
+    The private half of `pubkey_tweak_add`, for a caller who already
+    holds the parsed point and so has no parse left to redo:
+    `PubkeyTweakChain` is the one, walking a BIP32 path one tweak at a
+    time without parsing the point back out of its own serialization at
+    every step. See the package docstring for what the two underscores
+    mean throughout.
 
     Args:
         pubkey: the already-parsed public key, as `parse` returns.
@@ -259,9 +268,14 @@ def pubkey_tweak_add_(pubkey: CData, tweak: BytesLike | int) -> CData:
 
     Raises:
         ValueError: if the tweak is not 32 bytes or does not fit in them,
-            or if the tweak or the resulting public key is invalid.
+            if the tweak or the resulting public key is invalid, or if
+            the object is not a public key libsecp256k1 will read; see
+            `context.guarded`.
     """
-    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, scalar(tweak, "tweak")):
+    tweak_bytes = scalar(tweak, "tweak")
+    with guarded():
+        tweaked = lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, tweak_bytes)
+    if not tweaked:
         raise ValueError("invalid tweak or resulting public key")
     return pubkey
 
@@ -291,7 +305,7 @@ def pubkey_tweak_add(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    return serialize(pubkey_tweak_add_(parse(pubkey_bytes), tweak), compressed)
+    return serialize(_pubkey_tweak_add_(parse(pubkey_bytes), tweak), compressed)
 
 
 class PubkeyTweakChain:
@@ -307,6 +321,10 @@ class PubkeyTweakChain:
     only one that pays for a parse, and every step still returns the
     bytes its caller needs.
 
+    `pubkey` is that point without a tweak added, for a caller that has
+    reached the end of the path and wants the key it arrived at, or that
+    wants the key it started from in the other serialization.
+
     Args:
         pubkey_bytes: the public key the chain starts from, 33 or 65
             bytes.
@@ -316,13 +334,15 @@ class PubkeyTweakChain:
 
     Example:
         >>> from btclib_secp256k1 import keys, mult
-        >>> generator = mult.mult_(1)
+        >>> generator = mult.mult_bytes(1)
         >>> chain = keys.PubkeyTweakChain(generator)
         >>> step1 = chain.tweak_add(2)
         >>> step2 = chain.tweak_add(3)
         >>> step1 == keys.pubkey_tweak_add(generator, 2)
         True
         >>> step2 == keys.pubkey_tweak_add(step1, 3)
+        True
+        >>> chain.pubkey() == step2
         True
     """
 
@@ -348,16 +368,48 @@ class PubkeyTweakChain:
             RuntimeError: if libsecp256k1 fails to serialize the result,
                 which no valid input can make it do.
         """
-        return serialize(pubkey_tweak_add_(self._pubkey, tweak), compressed)
+        return serialize(_pubkey_tweak_add_(self._pubkey, tweak), compressed)
+
+    def pubkey(self, compressed: bool = True) -> bytes:
+        """Return the key the chain holds, with no tweak added.
+
+        Returns:
+            The serialized point, with every tweak added so far. Before
+            the first `tweak_add` that is the key the chain was built
+            from, which is how this doubles as the `reserialize` of it.
+
+        Args:
+            compressed: whether to return 33 bytes rather than 65.
+
+        Raises:
+            RuntimeError: if libsecp256k1 fails to serialize it, which
+                no valid input can make it do.
+        """
+        return serialize(self._pubkey, compressed)
+
+    def _pubkey_(self) -> CData:
+        """Return the parsed point the chain holds.
+
+        What `pubkey` answers in octets, for a caller handing the point
+        to a private half rather than holding its bytes -- the end of a
+        BIP32 path that is about to be tweaked into a taproot output
+        key, `xonly._tweak_add_` being where that goes.
+
+        Returns:
+            The libsecp256k1 public key object, which is the chain's own
+            and which the next `tweak_add` mutates.
+        """
+        return self._pubkey
 
 
-def pubkey_tweak_mul_(pubkey: CData, tweak: BytesLike | int) -> CData:
+def _pubkey_tweak_mul_(pubkey: CData, tweak: BytesLike | int) -> CData:
     """Multiply an already-parsed public key by a tweak.
 
-    The inner half of `pubkey_tweak_mul`, for a caller who already holds
-    the parsed point: see `parse` for what the underscore means
-    throughout. This is the shared point of an ECDH exchange, and
-    `ecdh.shared_secret_` is the hash of it from the same parsed key.
+    The private half of `pubkey_tweak_mul`, for a caller who already
+    holds the parsed point: see the package docstring for what the two
+    underscores mean throughout. This is the shared point of an ECDH
+    exchange, and `ecdh._shared_secret_` is the hash of it from the same
+    parsed key.
 
     Args:
         pubkey: the already-parsed public key, as `parse` returns.
@@ -370,9 +422,14 @@ def pubkey_tweak_mul_(pubkey: CData, tweak: BytesLike | int) -> CData:
 
     Raises:
         ValueError: if the tweak is not 32 bytes or does not fit in them,
-            or if it is zero or at or above the group order.
+            if it is zero or at or above the group order, or if the
+            object is not a public key libsecp256k1 will read; see
+            `context.guarded`.
     """
-    if not lib.secp256k1_ec_pubkey_tweak_mul(ctx, pubkey, scalar(tweak, "tweak")):
+    tweak_bytes = scalar(tweak, "tweak")
+    with guarded():
+        multiplied = lib.secp256k1_ec_pubkey_tweak_mul(ctx, pubkey, tweak_bytes)
+    if not multiplied:
         raise ValueError("invalid tweak")
     return pubkey
 
@@ -403,18 +460,19 @@ def pubkey_tweak_mul(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    return serialize(pubkey_tweak_mul_(parse(pubkey_bytes), tweak), compressed)
+    return serialize(_pubkey_tweak_mul_(parse(pubkey_bytes), tweak), compressed)
 
 
-def pubkey_combine_(pubkeys: Sequence[CData]) -> CData:
+def _pubkey_combine_(pubkeys: Sequence[CData]) -> CData:
     """Add already-parsed public keys together.
 
-    The inner half of `pubkey_combine`, and the one that answers with the
-    sum rather than with its serialization: see `parse` for what the
-    underscore means throughout. `pubkey_sort_` is what hands the keys
-    over in the order BIP67 and MuSig2 ask for, and the two together are
-    an aggregation that parses each key once and serializes once, where
-    the outer halves serialize every sorted key only to parse it back.
+    The private half of `pubkey_combine`, and the one that answers with
+    the sum rather than with its serialization: see the package
+    docstring for what the two underscores mean throughout.
+    `_pubkey_sort_` is what hands the keys over in the order BIP67 and
+    MuSig2 ask for, and the two together are an aggregation that parses
+    each key once and serializes once, where the public halves serialize
+    every sorted key only to parse it back.
 
     Args:
         pubkeys: the already-parsed public keys, as `parse` returns. At
@@ -424,17 +482,20 @@ def pubkey_combine_(pubkeys: Sequence[CData]) -> CData:
         The libsecp256k1 public key object of the sum.
 
     Raises:
-        ValueError: if the sequence is empty, or if the sum is the point
-            at infinity, which is no public key.
+        ValueError: if the sequence is empty, if the sum is the point at
+            infinity, which is no public key, or if any object is not a
+            public key libsecp256k1 will read; see `context.guarded`.
     """
     pubkeys = list(pubkeys)
     if not pubkeys:
         raise ValueError("at least one public key is required")
 
     combined = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_combine(
-        ctx, combined, ffi.new("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
-    ):
+    with guarded():
+        summed = lib.secp256k1_ec_pubkey_combine(
+            ctx, combined, array("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
+        )
+    if not summed:
         raise ValueError("invalid public key sum")
     return combined
 
@@ -460,19 +521,19 @@ def pubkey_combine(
             which no valid input can make it do.
     """
     return serialize(
-        pubkey_combine_([parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]),
+        _pubkey_combine_([parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]),
         compressed,
     )
 
 
-def pubkey_cmp_(pubkey1: CData, pubkey2: CData) -> int:
+def _pubkey_cmp_(pubkey1: CData, pubkey2: CData) -> int:
     """Compare two already-parsed public keys, in compressed-form order.
 
-    The inner half of `pubkey_cmp`, for a caller who already holds both
-    parsed points -- sorting keys it has parsed for another reason, where
-    every comparison of a sort would otherwise parse both of its
-    arguments again. See `parse` for what the underscore means
-    throughout.
+    The private half of `pubkey_cmp`, for a caller who already holds
+    both parsed points -- sorting keys it has parsed for another reason,
+    where every comparison of a sort would otherwise parse both of its
+    arguments again. See the package docstring for what the two
+    underscores mean throughout.
 
     Args:
         pubkey1: the first already-parsed public key, as `parse` returns.
@@ -482,8 +543,15 @@ def pubkey_cmp_(pubkey1: CData, pubkey2: CData) -> int:
         A negative number, zero, or a positive number, according to
         whether the first key sorts before, equal to, or after the
         second.
+
+    Raises:
+        ValueError: if either object is not a public key libsecp256k1
+            will read; see `context.guarded`, which is what tells that
+            from the zero of two keys that are equal.
     """
-    return int(lib.secp256k1_ec_pubkey_cmp(ctx, pubkey1, pubkey2))
+    with guarded():
+        order = lib.secp256k1_ec_pubkey_cmp(ctx, pubkey1, pubkey2)
+    return int(order)
 
 
 def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
@@ -504,16 +572,17 @@ def pubkey_cmp(pubkey1_bytes: BytesLike, pubkey2_bytes: BytesLike) -> int:
     Raises:
         ValueError: if either key is not a valid point.
     """
-    return pubkey_cmp_(parse(pubkey1_bytes), parse(pubkey2_bytes))
+    return _pubkey_cmp_(parse(pubkey1_bytes), parse(pubkey2_bytes))
 
 
-def pubkey_sort_(pubkeys: Sequence[CData]) -> list[CData]:
+def _pubkey_sort_(pubkeys: Sequence[CData]) -> list[CData]:
     """Sort already-parsed public keys, in compressed-form order.
 
-    The inner half of `pubkey_sort`, and the one that answers with the
-    keys rather than with their serializations: see `parse` for what the
-    underscore means throughout. Sorting in order to aggregate is this
-    and `pubkey_combine_`, which takes what this returns.
+    The private half of `pubkey_sort`, and the one that answers with the
+    keys rather than with their serializations: see the package
+    docstring for what the two underscores mean throughout. Sorting in
+    order to aggregate is this and `_pubkey_combine_`, which takes what
+    this returns.
 
     Args:
         pubkeys: the already-parsed public keys, as `parse` returns. An
@@ -523,14 +592,25 @@ def pubkey_sort_(pubkeys: Sequence[CData]) -> list[CData]:
         The same objects that were passed in, in ascending order.
 
     Raises:
+        ValueError: if any object is not a public key libsecp256k1 will
+            read; see `context.guarded`.
         RuntimeError: if libsecp256k1 fails to sort them, which no valid
             key can make it do.
     """
     pubkeys = list(pubkeys)
+    # nothing to sort is not a call to make: the array of an empty
+    # sequence is the NULL `_cdata.array` answers, which is what
+    # libsecp256k1 wants beside a count of zero, and there is no
+    # ordering to read back out of it
+    if not pubkeys:
+        return []
+
     # the array holds borrowed pointers, and is what gets reordered: the
     # list above is what keeps the keys it points to alive
-    array = ffi.new("secp256k1_pubkey *[]", pubkeys)
-    if not lib.secp256k1_ec_pubkey_sort(ctx, array, len(pubkeys)):
+    pointers = array("secp256k1_pubkey *[]", pubkeys)
+    with guarded():
+        sorted_ = lib.secp256k1_ec_pubkey_sort(ctx, pointers, len(pubkeys))
+    if not sorted_:
         raise RuntimeError("public key sorting failed")
     # what comes back are the caller's own objects, found by the address
     # each reordered pointer holds -- a cffi pointer hashes and compares
@@ -538,7 +618,7 @@ def pubkey_sort_(pubkeys: Sequence[CData]) -> list[CData]:
     # would hand back pointers that own nothing, and that dangle the
     # moment the caller drops the sequence they point into
     owners = {pubkey: pubkey for pubkey in pubkeys}
-    return [owners[pointer] for pointer in array]
+    return [owners[pointer] for pointer in pointers]
 
 
 def pubkey_sort(
@@ -565,48 +645,28 @@ def pubkey_sort(
     """
     return [
         serialize(pubkey, compressed)
-        for pubkey in pubkey_sort_([
+        for pubkey in _pubkey_sort_([
             parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes
         ])
     ]
 
 
-def parse(pubkey_bytes: BytesLike) -> CData:
+def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
     """Parse a public key into its internal libsecp256k1 representation.
 
     The internal form is what the raw `lib` calls take, and what
     `serialize` turns back into bytes: `serialize(parse(key))` is the
-    compressed form of a key given in either form.
-
-    It is also what a trailing underscore means across these bindings.
-    Every wrapper whose first act is to parse a public key has an inner
-    half spelled with one -- `pubkey_tweak_add_` here, `dsa.verify_`
-    elsewhere -- taking the object this returns in place of the bytes,
-    and the outer half is that inner half with a `parse` in front of it,
-    which is the equality `tests/test_parsed_keys.py` holds every pair
-    to. For a compressed key that parse is a field square root, so a
-    caller who has already paid for one -- having validated the key, or
-    being about to use the same key again -- can hand it on rather than
-    buy it twice. Nothing else about the two halves differs: the
-    remaining arguments are checked exactly as the outer half checks
-    them, a bare pointer's length being what no C return code can report.
-
-    The other side of the boundary is spelled the same way. A wrapper
-    whose last act is to serialize a key libsecp256k1 built for it also
-    has an inner half -- `pubkey_combine_` here, `recovery.recover_` and
-    `ellswift.decode_` elsewhere -- answering with the object where the
-    outer half answers with the bytes, and the outer half is that inner
-    half with a `serialize` behind it. So the underscore means one thing
-    in both directions: the half that speaks in parsed keys, where the
-    outer half speaks in bytes. What it buys is what a composition of two
-    wrappers would otherwise pay between them -- recovering a key and
-    verifying with it, sorting keys and adding them together, decoding an
-    ElligatorSwift encoding and tweaking what came out -- a serialization
-    of a point that was already in hand, and a parse of what was just
-    serialized.
+    compressed form of a key given in either form, which is
+    `reserialize` and the reason it exists. It is also what every
+    private half of this package takes, for which see the package
+    docstring.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.
+        name: what the key is, as the exception should call it, for a
+            caller passing more than one kind of public key --
+            `silentpayments` passes four, and which one was refused is
+            the whole of what its caller needs.
 
     Returns:
         The libsecp256k1 public key object.
@@ -615,10 +675,10 @@ def parse(pubkey_bytes: BytesLike) -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
-    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, name)
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError("invalid public key")
+        raise ValueError(f"invalid {name}")
     return pubkey
 
 
@@ -659,7 +719,7 @@ def reserialize(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
         >>> from btclib_secp256k1 import keys, mult
         >>> compressed = keys.pubkey_from_prvkey(1)
         >>> uncompressed = keys.reserialize(compressed, compressed=False)
-        >>> uncompressed == mult.mult_(1)
+        >>> uncompressed == mult.mult_bytes(1)
         True
         >>> keys.reserialize(uncompressed) == compressed
         True
@@ -681,15 +741,13 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     Raises:
         ValueError: if the object is not a public key libsecp256k1 will
             read -- a NULL pointer, or a `secp256k1_pubkey` nothing has
-            written to. This is the one argument of these bindings that
-            is a libsecp256k1 object rather than bytes, and so the one
-            that cannot be checked before the call.
+            written to; see `context.guarded`.
         RuntimeError: if libsecp256k1 fails for any other reason, which
             a key it produced cannot make it do.
 
     Example:
         >>> from btclib_secp256k1 import keys, mult
-        >>> keys.serialize(keys.parse(mult.mult_(1))).hex()[:10]
+        >>> keys.serialize(keys.parse(mult.mult_bytes(1))).hex()[:10]
         '0279be667e'
     """
     # the size is written once and the capacity derived from it. What is
@@ -704,15 +762,10 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     output = ffi.new(f"char[{size}]")
     length = ffi.new("size_t *", ffi.sizeof(output))
     flags = COMPRESSED if compressed else UNCOMPRESSED
-    if not lib.secp256k1_ec_pubkey_serialize(ctx, output, length, pubkey, flags):
-        # every other argument of these bindings is bytes, checked before
-        # the call; this one is a libsecp256k1 object the caller holds, so
-        # a violated precondition is reachable here and nowhere else.
-        # check() is what turns it back into the message libsecp256k1
-        # wrote -- and, raising it, takes it off the thread. Left there it
-        # would be found by the next check(), which is the one a MuSig2
-        # caller makes through `lib`, and blamed on a call that did not
-        # produce it
-        check()
+    with guarded():
+        serialized = lib.secp256k1_ec_pubkey_serialize(
+            ctx, output, length, pubkey, flags
+        )
+    if not serialized:
         raise RuntimeError("point serialization failed")
     return ffi.unpack(output, ffi.sizeof(output))

--- a/btclib_secp256k1/mult.py
+++ b/btclib_secp256k1/mult.py
@@ -10,6 +10,12 @@ it as an operation on a scalar rather than as the public key of a private
 key: serialized uncompressed, and as a pair of coordinates. The C call is
 `keys.pubkey_from_prvkey`, which is the same multiplication answering in
 either serialization.
+
+`mult_bytes` used to be `mult_`, and was renamed for the trailing
+underscore rather than for anything it does: that underscore now means a
+private half speaking in parsed objects, and this is a public function
+answering octets. `_bytes` is what the rest of this package calls the
+octets of a thing.
 """
 
 from __future__ import annotations
@@ -18,7 +24,7 @@ from . import BytesLike
 from .keys import pubkey_from_prvkey
 
 
-def mult_(num: BytesLike | int) -> bytes:
+def mult_bytes(num: BytesLike | int) -> bytes:
     """Multiply the generator point, in serialized form.
 
     Args:
@@ -40,7 +46,7 @@ def mult_(num: BytesLike | int) -> bytes:
 
     Example:
         >>> from btclib_secp256k1 import mult
-        >>> mult.mult_(1).hex()[:10]
+        >>> mult.mult_bytes(1).hex()[:10]
         '0479be667e'
     """
     return pubkey_from_prvkey(num, compressed=False)
@@ -55,9 +61,10 @@ def mult(num: BytesLike | int) -> tuple[int, int]:
 
     Returns:
         The affine coordinates (x, y) of the resulting point, as ints.
-        This is `mult_` with the two halves of its output read as big
-        endian integers; a caller that wants bytes wants `mult_`, or
-        `keys.pubkey_from_prvkey` for the compressed form.
+        This is `mult_bytes` with the two halves of its output read as
+        big endian integers; a caller that wants bytes wants
+        `mult_bytes`, or `keys.pubkey_from_prvkey` for the compressed
+        form.
 
     Raises:
         ValueError: if the scalar is not 32 bytes or does not fit in
@@ -65,5 +72,5 @@ def mult(num: BytesLike | int) -> tuple[int, int]:
         RuntimeError: if libsecp256k1 fails to serialize the point,
             which no input can make it do.
     """
-    result = mult_(num)
+    result = mult_bytes(num)
     return int.from_bytes(result[1:33], "big"), int.from_bytes(result[33:], "big")

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -3,26 +3,79 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""ECDSA public key recovery."""
+"""ECDSA public key recovery.
+
+A recoverable signature is the compact one and the recovery id together,
+and `parse_compact` and `serialize_compact` are what open and close that
+pair; `dsa.serialize_der` is what writes the same signature without the
+id, which is what `to_der` drops.
+"""
 
 from __future__ import annotations
 
 from . import BytesLike, CData, ffi, lib
-from ._scalar import octets, scalar
-from .context import ctx
+from ._scalar import in_range, octets, optional_entropy, scalar
+from .context import ctx, guarded
+from .dsa import serialize_der
 from .keys import serialize
 
 
+def _sign_(
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+) -> CData:
+    """Create a recoverable ECDSA signature, as the parsed signature.
+
+    The private half of `sign`, and the one that answers with the object
+    rather than with the compact bytes and the id: see the package
+    docstring for what the two underscores mean throughout. A signer
+    about to recover the key it just signed with, or to write the
+    signature as DER, is this and `_recover_` or `_to_der_`, where the
+    public halves serialize the pair only to parse it back.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
+            None for the RFC6979 nonce alone.
+
+    Returns:
+        The libsecp256k1 recoverable signature object.
+
+    Raises:
+        ValueError: if the message hash is not 32 bytes, if aux_rand32 is
+            given and is not 32 bytes, or if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1].
+    """
+    prvkey_bytes = scalar(prvkey, "private key")
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+
+    signature = ffi.new("secp256k1_ecdsa_recoverable_signature *")
+
+    # the default nonce function, and 32 bytes of entropy or nothing:
+    # see the comment in dsa._sign_
+    noncefp = ffi.NULL
+    if not lib.secp256k1_ecdsa_sign_recoverable(
+        ctx,
+        signature,
+        msg_bytes,
+        prvkey_bytes,
+        noncefp,
+        optional_entropy(aux_rand32),
+    ):
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return signature
+
+
 def sign(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, ndata: BytesLike | None = None
+    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
 ) -> tuple[bytes, int]:
     """Create a recoverable ECDSA signature.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
-        ndata: 32 bytes of extra entropy mixed into the nonce, or None
-            for the RFC6979 nonce alone.
+        aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
+            None for the RFC6979 nonce alone.
 
     Returns:
         The 64-byte compact signature and its recovery id. The id is 0
@@ -31,68 +84,45 @@ def sign(
         reaches in practice.
 
     Raises:
-        ValueError: if the message hash is not 32 bytes, if ndata is
+        ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, or if the private key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to serialize the signature,
             which no input can make it do.
     """
-    prvkey_bytes = scalar(prvkey, "private key")
-    msg_bytes = octets(msg_bytes, "message hash", 32)
-
-    sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
-
-    # the default nonce function, and 32 bytes of entropy or nothing:
-    # see the comment in dsa.sign
-    noncefp = ffi.NULL
-    ndata_ptr = ffi.NULL if ndata is None else octets(ndata, "ndata", 32)
-    if not lib.secp256k1_ecdsa_sign_recoverable(
-        ctx, sig, msg_bytes, prvkey_bytes, noncefp, ndata_ptr
-    ):
-        raise ValueError("invalid private key")
-
-    sig_bytes = ffi.new("char[64]")
-    recid = ffi.new("int *")
-    if not lib.secp256k1_ecdsa_recoverable_signature_serialize_compact(
-        ctx, sig_bytes, recid, sig
-    ):
-        raise RuntimeError("signature serialization failed")
-    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes)), recid[0]
+    return serialize_compact(_sign_(msg_bytes, prvkey, aux_rand32))
 
 
-def recover_(msg_bytes: BytesLike, signature_bytes: BytesLike, recid: int) -> CData:
-    """Recover the public key of a recoverable signature, as a parsed key.
+def _recover_(msg_bytes: BytesLike, signature: CData) -> CData:
+    """Recover the public key of an already-parsed recoverable signature.
 
-    The inner half of `recover`, and the one that answers with the point
-    rather than with its serialization: see `keys.parse` for what the
-    underscore means throughout. Recovery is how a caller gets a key it
-    did not have, so what usually follows is a use of it -- verifying the
-    signature against it, comparing it with an expected key, deriving an
-    address -- and libsecp256k1 hands it over already lifted.
+    The private half of `recover`, in both directions at once: it takes
+    the parsed signature and answers the parsed key. See the package
+    docstring for what the two underscores mean throughout. Recovery is
+    how a caller gets a key it did not have, so what usually follows is a
+    use of it -- verifying the signature against it, comparing it with an
+    expected key, deriving an address -- and libsecp256k1 hands it over
+    already lifted.
 
     Args:
         msg_bytes: the 32-byte hash the signature was made over.
-        signature_bytes: the 64-byte compact signature.
-        recid: the recovery id, 0 to 3.
+        signature: the already-parsed recoverable signature, as
+            `parse_compact` returns.
 
     Returns:
         The libsecp256k1 public key object of the recovered key.
 
     Raises:
-        ValueError: if the message hash is not 32 bytes, if the
-            signature is not 64 bytes or has r or s at or above the
-            group order, if recid is outside 0 to 3, or if no key can be
-            recovered.
+        ValueError: if the message hash is not 32 bytes, if no key can be
+            recovered, or if the object is not a recoverable signature
+            libsecp256k1 will read; see `context.guarded`.
     """
     msg_bytes = octets(msg_bytes, "message hash", 32)
-    signature_bytes = octets(signature_bytes, "signature", 64)
-    if recid not in (0, 1, 2, 3):
-        raise ValueError("the recovery id must be 0, 1, 2, or 3")
-
-    signature = _parse(signature_bytes, recid)
 
     pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ecdsa_recover(ctx, pubkey, signature, msg_bytes):
+    with guarded():
+        recovered = lib.secp256k1_ecdsa_recover(ctx, pubkey, signature, msg_bytes)
+    if not recovered:
         raise ValueError("public key recovery failed")
     return pubkey
 
@@ -117,6 +147,7 @@ def recover(
         The serialized recovered public key.
 
     Raises:
+        TypeError: if the recovery id is not an int.
         ValueError: if the message hash is not 32 bytes, if the
             signature is not 64 bytes or has r or s at or above the
             group order, if recid is outside 0 to 3, or if no key can be
@@ -124,7 +155,40 @@ def recover(
         RuntimeError: if libsecp256k1 fails to serialize the key, which
             no input can make it do.
     """
-    return serialize(recover_(msg_bytes, signature_bytes, recid), compressed)
+    return serialize(
+        _recover_(msg_bytes, parse_compact(signature_bytes, recid)), compressed
+    )
+
+
+def _to_der_(signature: CData) -> bytes:
+    """Convert an already-parsed recoverable signature into DER.
+
+    The private half of `to_der`, for a caller who already holds the
+    parsed signature: see the package docstring for what the two
+    underscores mean throughout.
+
+    Args:
+        signature: the already-parsed recoverable signature, as
+            `parse_compact` returns.
+
+    Returns:
+        The same signature in DER encoding, s unchanged and the recovery
+        id dropped.
+
+    Raises:
+        ValueError: if the object is not a recoverable signature
+            libsecp256k1 will read; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails to convert or serialize it,
+            which no input can make it do.
+    """
+    dsa_signature = ffi.new("secp256k1_ecdsa_signature *")
+    with guarded():
+        converted = lib.secp256k1_ecdsa_recoverable_signature_convert(
+            ctx, dsa_signature, signature
+        )
+    if not converted:
+        raise RuntimeError("signature conversion failed")
+    return serialize_der(dsa_signature)
 
 
 def to_der(signature_bytes: BytesLike, recid: int) -> bytes:
@@ -145,32 +209,20 @@ def to_der(signature_bytes: BytesLike, recid: int) -> bytes:
         The same signature in DER encoding, s unchanged.
 
     Raises:
+        TypeError: if the recovery id is not an int.
         ValueError: if the signature is not 64 bytes or has r or s at or
             above the group order, or if recid is outside 0 to 3.
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             signature, which no input can make it do.
     """
-    signature_bytes = octets(signature_bytes, "signature", 64)
-    if recid not in (0, 1, 2, 3):
-        raise ValueError("the recovery id must be 0, 1, 2, or 3")
-
-    signature = _parse(signature_bytes, recid)
-
-    dsa_sig = ffi.new("secp256k1_ecdsa_signature *")
-    if not lib.secp256k1_ecdsa_recoverable_signature_convert(ctx, dsa_sig, signature):
-        raise RuntimeError("signature conversion failed")
-
-    # the buffer, its declared capacity and the length read back: see
-    # dsa._serialize_der, which is the same serialization and says why 72
-    sig_bytes = ffi.new("char[72]")
-    length = ffi.new("size_t *", ffi.sizeof(sig_bytes))
-    if not lib.secp256k1_ecdsa_signature_serialize_der(ctx, sig_bytes, length, dsa_sig):
-        raise RuntimeError("signature serialization failed")
-    return ffi.unpack(sig_bytes, length[0])
+    return _to_der_(parse_compact(signature_bytes, recid))
 
 
-def _parse(signature_bytes: BytesLike, recid: int) -> CData:
+def parse_compact(signature_bytes: BytesLike, recid: int) -> CData:
     """Parse a compact signature and its recovery id.
+
+    What `dsa.parse_compact` is to a signature without an id, and the
+    argument of the private halves here.
 
     Args:
         signature_bytes: the 64-byte compact signature.
@@ -180,11 +232,44 @@ def _parse(signature_bytes: BytesLike, recid: int) -> CData:
         The libsecp256k1 recoverable signature object.
 
     Raises:
-        ValueError: if r or s is at or above the group order.
+        TypeError: if the recovery id is not an int.
+        ValueError: if the signature is not 64 bytes, if r or s is at or
+            above the group order, or if recid is outside 0 to 3.
     """
+    signature_bytes = octets(signature_bytes, "signature", 64)
+    recid = in_range(recid, "recovery id", 3)
+
     signature = ffi.new("secp256k1_ecdsa_recoverable_signature *")
     if not lib.secp256k1_ecdsa_recoverable_signature_parse_compact(
         ctx, signature, signature_bytes, recid
     ):
         raise ValueError("invalid compact signature")
     return signature
+
+
+def serialize_compact(signature: CData) -> tuple[bytes, int]:
+    """Serialize an internal recoverable signature, id and all.
+
+    Args:
+        signature: the libsecp256k1 recoverable signature object, as
+            `parse_compact` returns.
+
+    Returns:
+        The 64-byte compact signature and its recovery id, which is the
+        pair `parse_compact` reads back.
+
+    Raises:
+        ValueError: if the object is not a recoverable signature
+            libsecp256k1 will read; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a signature it parsed cannot make it do.
+    """
+    sig_bytes = ffi.new("char[64]")
+    recid = ffi.new("int *")
+    with guarded():
+        serialized = lib.secp256k1_ecdsa_recoverable_signature_serialize_compact(
+            ctx, sig_bytes, recid, signature
+        )
+    if not serialized:
+        raise RuntimeError("signature serialization failed")
+    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes)), recid[0]

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -16,17 +16,23 @@ it -- which is why every function here takes keys and a serialized
 outpoint rather than a transaction, and why deciding which inputs are
 eligible, and which of the eligible ones are taproot, is the caller's:
 BIP352 states those rules over scripts, and there is no script here.
+
+This is the module with the most keys to parse per call, and so the one
+where the private halves earn the most: a wallet scanning block after
+block parses each of its own keys once and hands the objects to
+`_scan_outputs_`, where `scan_outputs` parses the spend key and every
+transaction output again at every transaction.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 
-from . import BytesLike, CData, ffi, lib
-from ._scalar import octets, scalar
-from ._secret import take, wipe
-from .context import ctx
-from .keys import serialize
+from . import BytesLike, CData, ffi, keys, lib, xonly
+from ._cdata import array
+from ._scalar import in_range, octets, scalar
+from ._secret import keypair, take, wipe
+from .context import ctx, guarded
 
 # the two widths this module has to check, neither of them a macro that
 # survives the preprocessing of the headers into cffi definitions. The
@@ -38,8 +44,94 @@ SUMMARY_SIZE = ffi.sizeof("secp256k1_silentpayments_prevouts_summary")
 LABEL_SIZE = 33
 
 
+def _create_outputs_(
+    recipients: Sequence[tuple[CData, CData]],
+    outpoint_smallest36: BytesLike,
+    taproot_prvkeys: Sequence[BytesLike | int] = (),
+    prvkeys: Sequence[BytesLike | int] = (),
+) -> list[CData]:
+    """Create the taproot outputs paying already-parsed recipient keys.
+
+    The private half of `create_outputs`, in both directions: it takes
+    the parsed scan and spend keys and answers the parsed outputs. See
+    the package docstring for what the two underscores mean throughout.
+    A sender paying the same recipient in transaction after transaction
+    parses that address once, where the public half is two field square
+    roots per output.
+
+    The private keys are not part of that trade and stay octets: they are
+    consumed as scalars, the keypair a taproot input needs is built and
+    wiped inside this call, and handing that lifetime to a caller would
+    be a secret in memory nothing here could take back.
+
+    Args:
+        recipients: the addresses to pay, each a pair of the recipient's
+            already-parsed scan and spend public keys. At least one is
+            required.
+        outpoint_smallest36: the 36-byte serialization of the
+            lexicographically smallest outpoint of *all* the transaction
+            inputs, eligible or not.
+        taproot_prvkeys: the private keys of the taproot inputs, 32
+            bytes or an int below 2**256 each.
+        prvkeys: the private keys of the other eligible inputs.
+
+    Returns:
+        The libsecp256k1 x-only public key object of one taproot output
+        per recipient, in the order the recipients were given.
+
+    Raises:
+        ValueError: if no recipient or no private key is given, if the
+            outpoint is not 36 bytes, if any private key is not 32 bytes,
+            does not fit in them, or is not in [1, n-1], if libsecp256k1
+            refuses the set, or if any object is not a public key it will
+            read; see `context.guarded`.
+    """
+    if not recipients:
+        raise ValueError("at least one recipient is required")
+    if not taproot_prvkeys and not prvkeys:
+        raise ValueError("at least one private key is required")
+    outpoint_smallest36 = octets(outpoint_smallest36, "smallest outpoint", 36)
+
+    recipient_objs = [
+        _recipient(scan_pubkey, spend_pubkey, index)
+        for index, (scan_pubkey, spend_pubkey) in enumerate(recipients)
+    ]
+    outputs = [ffi.new("secp256k1_xonly_pubkey *") for _ in recipient_objs]
+
+    # the two key lists are built inside the try, not before it: each
+    # element carries a private key and the next one can raise, so what
+    # wipes them has to already be in force while they are being made
+    keypairs: list[CData] = []
+    seckeys: list[CData] = []
+    try:
+        keypairs.extend(keypair(prvkey) for prvkey in taproot_prvkeys)
+        seckeys.extend(
+            ffi.new("unsigned char[32]", scalar(prvkey, "private key"))
+            for prvkey in prvkeys
+        )
+        with guarded():
+            created = lib.secp256k1_silentpayments_sender_create_outputs(
+                ctx,
+                array("secp256k1_xonly_pubkey *[]", outputs),
+                array("secp256k1_silentpayments_recipient *[]", recipient_objs),
+                len(recipient_objs),
+                outpoint_smallest36,
+                array("secp256k1_keypair *[]", keypairs),
+                len(keypairs),
+                array("unsigned char *[]", seckeys),
+                len(seckeys),
+            )
+    finally:
+        for buffer in (*keypairs, *seckeys):
+            wipe(buffer)
+
+    if not created:
+        raise ValueError("silent payment output creation failed")
+    return outputs
+
+
 def create_outputs(
-    recipients: Sequence[tuple[BytesLike, BytesLike]],
+    recipients_bytes: Sequence[tuple[BytesLike, BytesLike]],
     outpoint_smallest36: BytesLike,
     taproot_prvkeys: Sequence[BytesLike | int] = (),
     prvkeys: Sequence[BytesLike | int] = (),
@@ -58,10 +150,10 @@ def create_outputs(
     being over the whole set.
 
     Args:
-        recipients: the addresses to pay, each a pair of the recipient's
-            scan and spend public keys, 33 or 65 bytes each. The same
-            address may appear more than once, which pays it that many
-            outputs. At least one is required.
+        recipients_bytes: the addresses to pay, each a pair of the
+            recipient's scan and spend public keys, 33 or 65 bytes each.
+            The same address may appear more than once, which pays it
+            that many outputs. At least one is required.
         outpoint_smallest36: the 36-byte serialization of the
             lexicographically smallest outpoint of *all* the transaction
             inputs, eligible or not. Choosing it is the caller's, and
@@ -95,61 +187,30 @@ def create_outputs(
         >>> len(outputs), len(outputs[0])
         (1, 32)
     """
-    if not recipients:
-        raise ValueError("at least one recipient is required")
-    if not taproot_prvkeys and not prvkeys:
-        raise ValueError("at least one private key is required")
-    outpoint_smallest36 = octets(outpoint_smallest36, "smallest outpoint", 36)
-
-    recipient_objs = [
-        _recipient(scan_pubkey_bytes, spend_pubkey_bytes, index)
-        for index, (scan_pubkey_bytes, spend_pubkey_bytes) in enumerate(recipients)
+    recipients = [
+        (
+            keys.parse(scan_pubkey_bytes, "scan public key"),
+            keys.parse(spend_pubkey_bytes, "spend public key"),
+        )
+        for scan_pubkey_bytes, spend_pubkey_bytes in recipients_bytes
     ]
-    outputs = [ffi.new("secp256k1_xonly_pubkey *") for _ in recipient_objs]
-
-    # the two key lists are built inside the try, not before it: each
-    # element carries a private key and the next one can raise, so what
-    # wipes them has to already be in force while they are being made
-    keypairs: list[CData] = []
-    seckeys: list[CData] = []
-    try:
-        keypairs.extend(_keypair(prvkey) for prvkey in taproot_prvkeys)
-        seckeys.extend(
-            ffi.new("unsigned char[32]", scalar(prvkey, "private key"))
-            for prvkey in prvkeys
+    return [
+        xonly.serialize(output)
+        for output in _create_outputs_(
+            recipients, outpoint_smallest36, taproot_prvkeys, prvkeys
         )
-        created = lib.secp256k1_silentpayments_sender_create_outputs(
-            ctx,
-            ffi.new("secp256k1_xonly_pubkey *[]", outputs),
-            # the array holds borrowed pointers: the list above is what
-            # keeps the recipients it points to alive, and libsecp256k1
-            # reorders the array rather than the objects
-            ffi.new("secp256k1_silentpayments_recipient *[]", recipient_objs),
-            len(recipient_objs),
-            outpoint_smallest36,
-            _array("secp256k1_keypair *[]", keypairs),
-            len(keypairs),
-            _array("unsigned char *[]", seckeys),
-            len(seckeys),
-        )
-    finally:
-        for buffer in (*keypairs, *seckeys):
-            wipe(buffer)
-
-    if not created:
-        raise ValueError("silent payment output creation failed")
-    return [_serialize_xonly(output) for output in outputs]
+    ]
 
 
-def label_(scan_prvkey: BytesLike | int, m: int) -> tuple[CData, bytes]:
+def _label_(scan_prvkey: BytesLike | int, m: int) -> tuple[CData, bytes]:
     """Create the m-th label of a scan key as a parsed label, and its tweak.
 
-    The inner half of `label`, and the one that answers with the label
-    object rather than with its 33 bytes: see `keys.parse` for what the
-    underscore means throughout. A label is a point, so parsing those 33
-    bytes back is a field square root -- which is what a recipient
-    publishing a labeled address pays between `label` and
-    `labeled_spend_pubkey`, and what this and `labeled_spend_pubkey_`
+    The private half of `label`, and the one that answers with the label
+    object rather than with its 33 bytes: see the package docstring for
+    what the two underscores mean throughout. A label is a point, so
+    parsing those 33 bytes back is a field square root -- which is what a
+    recipient publishing a labeled address pays between `label` and
+    `labeled_spend_pubkey`, and what this and `_labeled_spend_pubkey_`
     are for. The 33 bytes are still wanted, being what `scan_outputs` is
     keyed on: `serialize_label` is where they come from.
 
@@ -164,14 +225,14 @@ def label_(scan_prvkey: BytesLike | int, m: int) -> tuple[CData, bytes]:
         what was paid to it.
 
     Raises:
+        TypeError: if m is not an int.
         ValueError: if m is out of range, or if the scan key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
     """
     scan_prvkey_bytes = scalar(scan_prvkey, "scan private key")
     # uint32_t: cffi would answer an out of range m with OverflowError,
     # which is not how this package reports an argument out of domain
-    if not 0 <= m < 2**32:
-        raise ValueError("the label m must fit in 4 bytes")
+    m = in_range(m, "label m", 2**32 - 1)
 
     label_obj = ffi.new("secp256k1_silentpayments_label *")
     tweak = ffi.new("char[32]")
@@ -208,6 +269,7 @@ def label(scan_prvkey: BytesLike | int, m: int) -> tuple[bytes, bytes]:
         to it.
 
     Raises:
+        TypeError: if m is not an int.
         ValueError: if m is out of range, or if the scan key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
 
@@ -217,25 +279,25 @@ def label(scan_prvkey: BytesLike | int, m: int) -> tuple[bytes, bytes]:
         >>> len(label), len(tweak)
         (33, 32)
     """
-    label_obj, tweak = label_(scan_prvkey, m)
+    label_obj, tweak = _label_(scan_prvkey, m)
     return serialize_label(label_obj), tweak
 
 
-def labeled_spend_pubkey_(spend_pubkey: CData, label_obj: CData) -> CData:
+def _labeled_spend_pubkey_(spend_pubkey: CData, label_obj: CData) -> CData:
     """Add an already-parsed label to an already-parsed spend public key.
 
-    The inner half of `labeled_spend_pubkey`, taking both parsed objects
-    and answering with a third: see `keys.parse` for what the underscore
-    means throughout. A recipient publishing a labeled address holds
-    both of them already -- the label from `label_`, the spend key from
-    `keys.parse` -- so this is the pair of C calls BIP352 asks for with
-    no serialization between them, and `keys.serialize` is how what comes
-    out becomes an address.
+    The private half of `labeled_spend_pubkey`, taking both parsed
+    objects and answering with a third: see the package docstring for
+    what the two underscores mean throughout. A recipient publishing a
+    labeled address holds both of them already -- the label from
+    `_label_`, the spend key from `keys.parse` -- so this is the pair of
+    C calls BIP352 asks for with no serialization between them, and
+    `keys.serialize` is how what comes out becomes an address.
 
     Args:
         spend_pubkey: the recipient's already-parsed unlabeled spend
             public key, as `keys.parse` returns.
-        label_obj: the parsed label, as `label_` returns and as
+        label_obj: the parsed label, as `_label_` returns and as
             `parse_label` reads back.
 
     Returns:
@@ -243,12 +305,16 @@ def labeled_spend_pubkey_(spend_pubkey: CData, label_obj: CData) -> CData:
 
     Raises:
         ValueError: if the two sum to the point at infinity, which has no
-            serialization and which a label BIP352 made cannot produce.
+            serialization and which a label BIP352 made cannot produce,
+            or if either object is not one libsecp256k1 will read; see
+            `context.guarded`.
     """
     labeled = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_silentpayments_recipient_create_labeled_spend_pubkey(
-        ctx, labeled, spend_pubkey, label_obj
-    ):
+    with guarded():
+        added = lib.secp256k1_silentpayments_recipient_create_labeled_spend_pubkey(
+            ctx, labeled, spend_pubkey, label_obj
+        )
+    if not added:
         raise ValueError("invalid labeled spend public key")
     return labeled
 
@@ -287,18 +353,73 @@ def labeled_spend_pubkey(
         >>> len(silentpayments.labeled_spend_pubkey(spend_pubkey, label))
         33
     """
-    return serialize(
-        labeled_spend_pubkey_(
-            _pubkey(spend_pubkey_bytes, "spend public key"), parse_label(label_bytes)
+    return keys.serialize(
+        _labeled_spend_pubkey_(
+            keys.parse(spend_pubkey_bytes, "spend public key"),
+            parse_label(label_bytes),
         ),
         compressed,
     )
 
 
+def _prevouts_summary_(
+    outpoint_smallest36: BytesLike,
+    taproot_pubkeys: Sequence[CData] = (),
+    pubkeys: Sequence[CData] = (),
+) -> CData:
+    """Summarize already-parsed input keys, as the summary object.
+
+    The private half of `prevouts_summary`, and the one that answers with
+    the object rather than with the octets of it: see the package
+    docstring for what the two underscores mean throughout. What it saves
+    is a round trip of the summary itself -- `_scan_outputs_` takes this
+    object, where the public halves write those octets out of one struct
+    and back into another -- and, for a caller holding the input keys
+    parsed, their parse.
+
+    Args:
+        outpoint_smallest36: the 36-byte serialization of the
+            lexicographically smallest outpoint of all the transaction
+            inputs, eligible or not.
+        taproot_pubkeys: the already-parsed x-only public keys of the
+            taproot inputs, as `xonly.parse` returns.
+        pubkeys: the already-parsed public keys of the other eligible
+            inputs, as `keys.parse` returns.
+
+    Returns:
+        The libsecp256k1 summary object.
+
+    Raises:
+        ValueError: if no public key is given, if the outpoint is not 36
+            bytes, if the inputs sum to the point at infinity, which is
+            BIP352's "not a Silent Payments transaction" and which the
+            recipient skips, or if any object is not a key libsecp256k1
+            will read; see `context.guarded`.
+    """
+    if not taproot_pubkeys and not pubkeys:
+        raise ValueError("at least one public key is required")
+    outpoint_smallest36 = octets(outpoint_smallest36, "smallest outpoint", 36)
+
+    summary = ffi.new("secp256k1_silentpayments_prevouts_summary *")
+    with guarded():
+        summarized = lib.secp256k1_silentpayments_recipient_prevouts_summary_create(
+            ctx,
+            summary,
+            outpoint_smallest36,
+            array("secp256k1_xonly_pubkey *[]", taproot_pubkeys),
+            len(taproot_pubkeys),
+            array("secp256k1_pubkey *[]", pubkeys),
+            len(pubkeys),
+        )
+    if not summarized:
+        raise ValueError("not a silent payments transaction")
+    return summary
+
+
 def prevouts_summary(
     outpoint_smallest36: BytesLike,
-    taproot_pubkeys: Sequence[BytesLike] = (),
-    pubkeys: Sequence[BytesLike] = (),
+    taproot_pubkeys_bytes: Sequence[BytesLike] = (),
+    pubkeys_bytes: Sequence[BytesLike] = (),
 ) -> bytes:
     """Summarize the inputs of a transaction, for scanning it.
 
@@ -315,10 +436,11 @@ def prevouts_summary(
         outpoint_smallest36: the 36-byte serialization of the
             lexicographically smallest outpoint of all the transaction
             inputs, eligible or not.
-        taproot_pubkeys: the 32-byte x-only public keys of the taproot
-            inputs.
-        pubkeys: the public keys of the other eligible inputs, 33 or 65
-            bytes each.
+        taproot_pubkeys_bytes: the x-only public keys of the taproot
+            inputs, 32, 33 or 65 bytes each: an x names the even-y
+            point whichever way it arrives, for which see `xonly.parse`.
+        pubkeys_bytes: the public keys of the other eligible inputs, 33
+            or 65 bytes each.
 
     Returns:
         The summary, as the bytes libsecp256k1 holds it in. They are
@@ -336,37 +458,129 @@ def prevouts_summary(
     Example:
         >>> from btclib_secp256k1 import keys, silentpayments
         >>> summary = silentpayments.prevouts_summary(
-        ...     bytes(36), pubkeys=[keys.pubkey_from_prvkey(3)]
+        ...     bytes(36), pubkeys_bytes=[keys.pubkey_from_prvkey(3)]
         ... )
         >>> len(summary) == silentpayments.SUMMARY_SIZE
         True
     """
-    if not taproot_pubkeys and not pubkeys:
-        raise ValueError("at least one public key is required")
-    outpoint_smallest36 = octets(outpoint_smallest36, "smallest outpoint", 36)
-
-    xonly_pubkeys = [
-        _xonly_pubkey(pubkey_bytes, "taproot public key")
-        for pubkey_bytes in taproot_pubkeys
-    ]
-    full_pubkeys = [_pubkey(pubkey_bytes, "public key") for pubkey_bytes in pubkeys]
-
-    summary = ffi.new("secp256k1_silentpayments_prevouts_summary *")
-    if not lib.secp256k1_silentpayments_recipient_prevouts_summary_create(
-        ctx,
-        summary,
+    summary = _prevouts_summary_(
         outpoint_smallest36,
-        _array("secp256k1_xonly_pubkey *[]", xonly_pubkeys),
-        len(xonly_pubkeys),
-        _array("secp256k1_pubkey *[]", full_pubkeys),
-        len(full_pubkeys),
-    ):
-        raise ValueError("not a silent payments transaction")
+        [
+            xonly.parse(pubkey_bytes, "taproot public key")
+            for pubkey_bytes in taproot_pubkeys_bytes
+        ],
+        [keys.parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes],
+    )
     return bytes(ffi.buffer(summary))
 
 
+def _scan_outputs_(
+    tx_outputs: Sequence[CData],
+    scan_prvkey: BytesLike | int,
+    summary: CData,
+    spend_pubkey: CData,
+    labels: Mapping[bytes, BytesLike] | None = None,
+) -> list[tuple[bytes, bytes, bytes | None]]:
+    """Find the outputs paying an already-parsed Silent Payments address.
+
+    The private half of `scan_outputs`: see the package docstring for
+    what the two underscores mean throughout. A wallet scanning every
+    transaction of a block parses its own spend key once here, where the
+    public half parses it once per transaction, and takes the summary
+    `_prevouts_summary_` built rather than octets to be written back into
+    a struct.
+
+    What it answers is octets even so: an output's tweak is a secret this
+    call takes back out of libsecp256k1's memory before returning, and
+    its x-only key is 32 bytes a caller compares rather than computes
+    with.
+
+    Args:
+        tx_outputs: the already-parsed x-only public keys of the
+            transaction's taproot outputs, in vout order, as
+            `xonly.parse` returns. At least one is required.
+        scan_prvkey: the recipient's scan private key, 32 bytes or an
+            int below 2**256.
+        summary: the summary of the transaction's inputs, as
+            `_prevouts_summary_` returns.
+        spend_pubkey: the recipient's already-parsed unlabeled spend
+            public key, as `keys.parse` returns.
+        labels: the recipient's label cache, mapping each 33-byte label
+            to its 32-byte tweak, or None where no labeled address was
+            published.
+
+    Returns:
+        One triple per output found, in vout order: its 32-byte x-only
+        public key, the 32-byte tweak to add to the spend private key to
+        spend it, and the 33-byte label it was found with, or None where
+        it was paid to the unlabeled address.
+
+    Raises:
+        ValueError: if no output is given, if the scan key is not 32
+            bytes, does not fit in them, or is not in [1, n-1], if a
+            label or a label tweak is the wrong length, if libsecp256k1
+            refuses the scan, or if any object is not one it will read;
+            see `context.guarded`.
+    """
+    if not tx_outputs:
+        raise ValueError("at least one transaction output is required")
+    scan_prvkey_bytes = scalar(scan_prvkey, "scan private key")
+
+    # the found outputs array is as long as the outputs one, as the
+    # header requires, and libsecp256k1 says through n_found how much of
+    # it it wrote
+    found_objs = [
+        ffi.new("secp256k1_silentpayments_found_output *") for _ in tx_outputs
+    ]
+    n_found = ffi.new("uint32_t *")
+
+    # the cache is filled inside the try, not built before it: every
+    # entry carries a tweak and the next one can raise, so what wipes them
+    # has to already be in force while they are being made -- create_outputs
+    # builds its two key lists the same way and for the same reason. A
+    # `dict` filled entry by entry is what makes that reachable, where a
+    # comprehension would drop the ones already made along with the
+    # exception
+    cache: dict[bytes, CData] = {}
+    # a NULL lookup is how libsecp256k1 is told no label is in play, and
+    # it is not the same as one that never matches: with it the scan skips
+    # the label branch altogether. What decides it is `labels`, an empty
+    # mapping being a cache with nothing in it rather than the absence of
+    # one; the callback is held in a local because it has to outlive the
+    # call it is passed to
+    lookup = ffi.NULL
+    try:
+        if labels is not None:
+            _fill_label_cache(labels, cache)
+            lookup = ffi.callback(
+                "secp256k1_silentpayments_label_lookup", _lookup(cache)
+            )
+        with guarded():
+            scanned = lib.secp256k1_silentpayments_recipient_scan_outputs(
+                ctx,
+                array("secp256k1_silentpayments_found_output *[]", found_objs),
+                n_found,
+                array("secp256k1_xonly_pubkey *[]", tx_outputs),
+                len(tx_outputs),
+                scan_prvkey_bytes,
+                summary,
+                spend_pubkey,
+                lookup,
+                ffi.NULL,
+            )
+        if not scanned:
+            raise ValueError("silent payment scanning failed")
+        return [_found_output(found) for found in found_objs[: n_found[0]]]
+    finally:
+        # every found output carries the tweak that spends it, and the
+        # cache the tweaks of the labels: both are secrets in memory this
+        # package owns, and so both are taken back
+        for buffer in (*found_objs, *cache.values()):
+            wipe(buffer)
+
+
 def scan_outputs(
-    tx_outputs: Sequence[BytesLike],
+    tx_outputs_bytes: Sequence[BytesLike],
     scan_prvkey: BytesLike | int,
     summary_bytes: BytesLike,
     spend_pubkey_bytes: BytesLike,
@@ -380,8 +594,9 @@ def scan_outputs(
     what a label changes is the address, not what is scanned for.
 
     Args:
-        tx_outputs: the 32-byte x-only public keys of the transaction's
-            taproot outputs, in vout order. At least one is required.
+        tx_outputs_bytes: the 32-byte x-only public keys of the
+            transaction's taproot outputs, in vout order. At least one is
+            required.
         scan_prvkey: the recipient's scan private key, 32 bytes or an
             int below 2**256.
         summary_bytes: the summary of the transaction's inputs, as
@@ -419,7 +634,7 @@ def scan_outputs(
         ...     [(scan_pubkey, spend_pubkey)], bytes(36), prvkeys=[3]
         ... )
         >>> summary = silentpayments.prevouts_summary(
-        ...     bytes(36), pubkeys=[keys.pubkey_from_prvkey(3)]
+        ...     bytes(36), pubkeys_bytes=[keys.pubkey_from_prvkey(3)]
         ... )
         >>> found = silentpayments.scan_outputs(
         ...     outputs, 1, summary, spend_pubkey
@@ -427,70 +642,23 @@ def scan_outputs(
         >>> [pubkey for pubkey, _tweak, _label in found] == outputs
         True
     """
-    if not tx_outputs:
-        raise ValueError("at least one transaction output is required")
-    scan_prvkey_bytes = scalar(scan_prvkey, "scan private key")
     summary_bytes = octets(summary_bytes, "prevouts summary", SUMMARY_SIZE)
-    spend_pubkey = _pubkey(spend_pubkey_bytes, "spend public key")
-
-    output_objs = [
-        _xonly_pubkey(pubkey_bytes, "transaction output") for pubkey_bytes in tx_outputs
-    ]
     # the summary is opaque both ways: what came out of prevouts_summary
     # is written straight back into a struct of the same size, there
     # being no parser for it and nothing here that reads it
     summary = ffi.new("secp256k1_silentpayments_prevouts_summary *")
     ffi.buffer(summary)[:] = summary_bytes
-    # the found outputs array is as long as the outputs one, as the
-    # header requires, and libsecp256k1 says through n_found how much of
-    # it it wrote
-    found_objs = [
-        ffi.new("secp256k1_silentpayments_found_output *") for _ in output_objs
-    ]
-    n_found = ffi.new("uint32_t *")
 
-    # the cache is filled inside the try, not built before it: every
-    # entry carries a tweak and the next one can raise, so what wipes them
-    # has to already be in force while they are being made -- create_outputs
-    # builds its two key lists the same way and for the same reason. A
-    # `dict` filled entry by entry is what makes that reachable, where a
-    # comprehension would drop the ones already made along with the
-    # exception
-    cache: dict[bytes, CData] = {}
-    # a NULL lookup is how libsecp256k1 is told no label is in play, and
-    # it is not the same as one that never matches: with it the scan skips
-    # the label branch altogether. What decides it is `labels`, an empty
-    # mapping being a cache with nothing in it rather than the absence of
-    # one; the callback is held in a local because it has to outlive the
-    # call it is passed to
-    lookup = ffi.NULL
-    try:
-        if labels is not None:
-            _fill_label_cache(labels, cache)
-            lookup = ffi.callback(
-                "secp256k1_silentpayments_label_lookup", _lookup(cache)
-            )
-        scanned = lib.secp256k1_silentpayments_recipient_scan_outputs(
-            ctx,
-            ffi.new("secp256k1_silentpayments_found_output *[]", found_objs),
-            n_found,
-            ffi.new("secp256k1_xonly_pubkey *[]", output_objs),
-            len(output_objs),
-            scan_prvkey_bytes,
-            summary,
-            spend_pubkey,
-            lookup,
-            ffi.NULL,
-        )
-        if not scanned:
-            raise ValueError("silent payment scanning failed")
-        return [_found_output(found) for found in found_objs[: n_found[0]]]
-    finally:
-        # every found output carries the tweak that spends it, and the
-        # cache the tweaks of the labels: both are secrets in memory this
-        # package owns, and so both are taken back
-        for buffer in (*found_objs, *cache.values()):
-            wipe(buffer)
+    return _scan_outputs_(
+        [
+            xonly.parse(pubkey_bytes, "transaction output")
+            for pubkey_bytes in tx_outputs_bytes
+        ],
+        scan_prvkey,
+        summary,
+        keys.parse(spend_pubkey_bytes, "spend public key"),
+        labels,
+    )
 
 
 def _fill_label_cache(
@@ -505,7 +673,7 @@ def _fill_label_cache(
 
     The dictionary is filled rather than returned, so that a tweak copied
     before a later entry is refused is one the caller can still wipe: see
-    `scan_outputs`, which owns it and does.
+    `_scan_outputs_`, which owns it and does.
 
     Args:
         labels: the caller's mapping of 33-byte labels to 32-byte tweaks.
@@ -558,124 +726,37 @@ def _found_output(found: CData) -> tuple[bytes, bytes, bytes | None]:
         RuntimeError: if libsecp256k1 fails to serialize either, which
             an output it produced cannot make it do.
     """
-    pubkey = _serialize_xonly(ffi.addressof(found, "output"))
+    pubkey = xonly.serialize(ffi.addressof(found, "output"))
+    # `ffi.buffer` and not `ffi.unpack`, which every fixed-size read in
+    # this package is: the field is an `unsigned char[32]` rather than a
+    # `char[32]`, and unpacking one answers a list of 32 ints
     tweak = bytes(ffi.buffer(found.tweak))
     if not found.found_with_label:
         return pubkey, tweak, None
     return pubkey, tweak, serialize_label(ffi.addressof(found, "label"))
 
 
-def _array(cdecl: str, items: list[CData]) -> CData:
-    """Build the array of borrowed pointers libsecp256k1 takes, or NULL.
+def _recipient(scan_pubkey: CData, spend_pubkey: CData, index: int) -> CData:
+    """Build one recipient of `_create_outputs_`.
 
     Args:
-        cdecl: the cffi declaration of the array type.
-        items: the objects to point at, which the caller keeps alive.
-
-    Returns:
-        The array, or NULL where there is nothing to point at, which is
-        what libsecp256k1 requires rather than merely accepts: it reads
-        the count against the pointer, and a non-NULL one with a count of
-        zero fails an ARG_CHECK -- `n_xonly_pubkeys > 0`, reported through
-        the illegal callback. cffi would hand over an array of length
-        zero quite happily, `keys.pubkey_sort` passing one for an empty
-        sequence, so it is this call that has to say NULL.
-    """
-    return ffi.new(cdecl, items) if items else ffi.NULL
-
-
-def _recipient(
-    scan_pubkey_bytes: BytesLike, spend_pubkey_bytes: BytesLike, index: int
-) -> CData:
-    """Build one recipient of `create_outputs`.
-
-    Args:
-        scan_pubkey_bytes: the recipient's scan public key, 33 or 65
-            bytes.
-        spend_pubkey_bytes: the recipient's spend public key, labeled or
-            not -- which of the two it is the sender neither knows nor
-            needs to.
+        scan_pubkey: the recipient's already-parsed scan public key.
+        spend_pubkey: the recipient's already-parsed spend public key,
+            labeled or not -- which of the two it is the sender neither
+            knows nor needs to.
         index: the position of this recipient among them, which is what
             libsecp256k1 orders the outputs it returns by.
 
     Returns:
         The libsecp256k1 recipient object.
-
-    Raises:
-        ValueError: if either key is not a valid point.
     """
     recipient = ffi.new("secp256k1_silentpayments_recipient *")
     # assigning a struct to a struct field copies it, so the parsed keys
     # need not outlive this call
-    recipient.scan_pubkey = _pubkey(scan_pubkey_bytes, "scan public key")[0]
-    recipient.spend_pubkey = _pubkey(spend_pubkey_bytes, "spend public key")[0]
+    recipient.scan_pubkey = scan_pubkey[0]
+    recipient.spend_pubkey = spend_pubkey[0]
     recipient.index = index
     return recipient
-
-
-def _pubkey(pubkey_bytes: BytesLike, name: str) -> CData:
-    """Parse a public key, named as the exception should call it.
-
-    `keys.parse` is the same call and says "public key"; this module
-    passes four kinds of them -- scan, spend, taproot input, other input
-    -- and which one was refused is the whole of what the caller needs.
-
-    Args:
-        pubkey_bytes: the public key, 33 or 65 bytes.
-        name: what the key is, as the exception should call it.
-
-    Returns:
-        The libsecp256k1 public key object.
-
-    Raises:
-        ValueError: if the bytes are not a valid point in either
-            serialization.
-    """
-    pubkey_bytes = octets(pubkey_bytes, name)
-    pubkey = ffi.new("secp256k1_pubkey *")
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError(f"invalid {name}")
-    return pubkey
-
-
-def _xonly_pubkey(pubkey_bytes: BytesLike, name: str) -> CData:
-    """Parse a 32-byte x-only public key, named as the exception calls it.
-
-    Args:
-        pubkey_bytes: the 32-byte x coordinate.
-        name: what the key is, as the exception should call it.
-
-    Returns:
-        The libsecp256k1 x-only public key object.
-
-    Raises:
-        ValueError: if it is not 32 bytes, or not a valid x coordinate.
-    """
-    # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    pubkey_bytes = octets(pubkey_bytes, name, 32)
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
-        raise ValueError(f"invalid {name}")
-    return xonly_pubkey
-
-
-def _serialize_xonly(xonly_pubkey: CData) -> bytes:
-    """Serialize an x-only public key libsecp256k1 produced.
-
-    Args:
-        xonly_pubkey: the libsecp256k1 x-only public key object.
-
-    Returns:
-        Its 32-byte x coordinate.
-
-    Raises:
-        RuntimeError: if libsecp256k1 fails to serialize it, which a key
-            it produced cannot make it do.
-    """
-    output = ffi.new("char[32]")
-    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
-        raise RuntimeError("x-only public key serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
 
 
 def parse_label(label_bytes: BytesLike) -> CData:
@@ -685,8 +766,8 @@ def parse_label(label_bytes: BytesLike) -> CData:
     same reason: those 33 bytes are a compressed point, so reading them
     back is a field square root. A recipient that keeps its labels as
     bytes -- the cache `scan_outputs` takes is exactly that -- parses one
-    here and hands it to `labeled_spend_pubkey_`, rather than through the
-    outer half which parses it again at every address.
+    here and hands it to `_labeled_spend_pubkey_`, rather than through
+    the public half which parses it again at every address.
 
     Args:
         label_bytes: the label, as `label` returned it.
@@ -713,37 +794,22 @@ def serialize_label(label_obj: CData) -> bytes:
     recipient keys its label cache on, and what `label` answers with.
 
     Args:
-        label_obj: the libsecp256k1 label object, as `label_` returns.
+        label_obj: the libsecp256k1 label object, as `_label_` returns.
 
     Returns:
         Its 33 bytes, which are the compressed point it is.
 
     Raises:
-        RuntimeError: if libsecp256k1 fails to serialize it, which a
-            label it produced cannot make it do.
+        ValueError: if the object is not a label libsecp256k1 will read;
+            see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a label it produced cannot make it do.
     """
     output = ffi.new(f"char[{LABEL_SIZE}]")
-    if not lib.secp256k1_silentpayments_recipient_label_serialize(
-        ctx, output, label_obj
-    ):
+    with guarded():
+        serialized = lib.secp256k1_silentpayments_recipient_label_serialize(
+            ctx, output, label_obj
+        )
+    if not serialized:
         raise RuntimeError("label serialization failed")
     return ffi.unpack(output, ffi.sizeof(output))
-
-
-def _keypair(prvkey: BytesLike | int) -> CData:
-    """Create a keypair from a private key.
-
-    Args:
-        prvkey: the private key, 32 bytes or an int below 2**256.
-
-    Returns:
-        The libsecp256k1 keypair object.
-
-    Raises:
-        ValueError: if the key is not 32 bytes, does not fit in them, or
-            is not in [1, n-1].
-    """
-    keypair = ffi.new("secp256k1_keypair *")
-    if not lib.secp256k1_keypair_create(ctx, keypair, scalar(prvkey, "private key")):
-        raise ValueError("invalid private key")
-    return keypair

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -11,13 +11,12 @@ https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 
 from __future__ import annotations
 
-import secrets
 from types import TracebackType
 
 from . import BytesLike, CData, ffi, lib, xonly
-from ._scalar import octets, scalar
-from ._secret import wipe
-from .context import ctx
+from ._scalar import entropy, octets
+from ._secret import keypair, wipe
+from .context import ctx, guarded
 
 # SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC: the libsecp256k1 macros do not
 # survive the preprocessing of the headers into cffi definitions
@@ -57,18 +56,18 @@ def sign(
     Example:
         >>> from btclib_secp256k1 import ssa, xonly, mult
         >>> msg, prvkey = bytes(32), 1
-        >>> pubkey, _ = xonly.from_pubkey(mult.mult_(prvkey))
+        >>> pubkey, _ = xonly.from_pubkey(mult.mult_bytes(prvkey))
         >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
         True
     """
-    keypair = _keypair(prvkey)
+    keypair_obj = keypair(prvkey)
     try:
-        return _sign32(msg_bytes, keypair, aux_rand32)
+        return _sign32(msg_bytes, keypair_obj, aux_rand32)
     finally:
         # a keypair carries the private key: overwrite it whether the
         # signature was made, refused, or never attempted, the argument
         # checks inside being able to raise between the two
-        wipe(keypair)
+        wipe(keypair_obj)
 
 
 def sign_custom(
@@ -100,12 +99,12 @@ def sign_custom(
         RuntimeError: if libsecp256k1 fails to sign, which no input can
             make it do.
     """
-    keypair = _keypair(prvkey)
+    keypair_obj = keypair(prvkey)
     try:
-        return _sign_custom(msg_bytes, keypair, aux_rand32)
+        return _sign_custom(msg_bytes, keypair_obj, aux_rand32)
     finally:
         # the keypair carries the private key: see sign
-        wipe(keypair)
+        wipe(keypair_obj)
 
 
 class Signer:
@@ -151,7 +150,7 @@ class Signer:
     Example:
         >>> from btclib_secp256k1 import ssa, xonly, mult
         >>> msg, prvkey = bytes(32), 1
-        >>> pubkey, _ = xonly.from_pubkey(mult.mult_(prvkey))
+        >>> pubkey, _ = xonly.from_pubkey(mult.mult_bytes(prvkey))
         >>> with ssa.Signer(prvkey) as signer:
         ...     sig = signer.sign(msg, bytes(32))
         >>> sig == ssa.sign(msg, prvkey, bytes(32))
@@ -165,7 +164,7 @@ class Signer:
     def __init__(self, prvkey: BytesLike | int) -> None:  # noqa: D107
         # None once wiped, which is what tells the two states apart: a
         # wiped keypair is 96 zero octets and looks like any other
-        self._keypair: CData | None = _keypair(prvkey)
+        self._keypair: CData | None = keypair(prvkey)
 
     def sign(self, msg_bytes: BytesLike, aux_rand32: BytesLike | None = None) -> bytes:
         """Create a Schnorr signature of a 32-byte message hash.
@@ -297,16 +296,17 @@ class Signer:
         return self._keypair
 
 
-def verify_(
+def _verify_(
     msg_bytes: BytesLike, xonly_pubkey: CData, signature_bytes: BytesLike
 ) -> bool:
     """Verify a Schnorr signature against an already-parsed x-only key.
 
-    The inner half of `verify`, for a caller who already holds the parsed
-    key -- one that proved 32 bytes to be the x coordinate of a point,
+    The private half of `verify`, for a caller who already holds the
+    parsed key -- one that proved octets the x coordinate of a point,
     which is what `xonly.parse` answers and what this verification would
     ask again, or one checking several signatures against the same key:
-    see `keys.parse` for what the underscore means throughout.
+    see the package docstring for what the two underscores mean
+    throughout.
 
     Args:
         msg_bytes: the message, of any length.
@@ -318,18 +318,19 @@ def verify_(
         True if the signature is valid for that key and message.
 
     Raises:
-        ValueError: if the signature is not 64 bytes. A well-formed
-            signature that simply does not verify is False, not an
-            exception.
+        ValueError: if the signature is not 64 bytes, or if the object is
+            not an x-only public key libsecp256k1 will read; see
+            `context.guarded`, without which an unreadable key would
+            answer False, which is a verdict a caller would believe.
     """
     msg_bytes = octets(msg_bytes, "message")
     signature_bytes = octets(signature_bytes, "signature", 64)
 
-    return bool(
-        lib.secp256k1_schnorrsig_verify(
+    with guarded():
+        verified = lib.secp256k1_schnorrsig_verify(
             ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
         )
-    )
+    return bool(verified)
 
 
 def verify(
@@ -359,11 +360,11 @@ def verify(
             A well-formed signature that simply does not verify is False,
             not an exception.
     """
-    return verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
+    return _verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
 
 
 def _sign32(
-    msg_bytes: BytesLike, keypair: CData, aux_rand32: BytesLike | None
+    msg_bytes: BytesLike, keypair_obj: CData, aux_rand32: BytesLike | None
 ) -> bytes:
     """Sign a 32-byte message hash with a keypair somebody else owns.
 
@@ -375,7 +376,7 @@ def _sign32(
 
     Args:
         msg_bytes: the 32-byte message hash.
-        keypair: the libsecp256k1 keypair to sign with, wiped by
+        keypair_obj: the libsecp256k1 keypair to sign with, wiped by
             whoever built it and not here.
         aux_rand32: the 32 bytes of auxiliary randomness, or None for
             fresh randomness.
@@ -393,14 +394,14 @@ def _sign32(
 
     sig = ffi.new("char[64]")
     if not lib.secp256k1_schnorrsig_sign32(
-        ctx, sig, msg_bytes, keypair, _aux_rand32(aux_rand32)
+        ctx, sig, msg_bytes, keypair_obj, entropy(aux_rand32)
     ):
         raise RuntimeError("schnorr signing failed")
     return ffi.unpack(sig, ffi.sizeof(sig))
 
 
 def _sign_custom(
-    msg_bytes: BytesLike, keypair: CData, aux_rand32: BytesLike | None
+    msg_bytes: BytesLike, keypair_obj: CData, aux_rand32: BytesLike | None
 ) -> bytes:
     """Sign a message of any length with a keypair somebody else owns.
 
@@ -408,7 +409,7 @@ def _sign_custom(
 
     Args:
         msg_bytes: the message, of any length.
-        keypair: the libsecp256k1 keypair to sign with, wiped by
+        keypair_obj: the libsecp256k1 keypair to sign with, wiped by
             whoever built it and not here.
         aux_rand32: the 32 bytes of auxiliary randomness, or None for
             fresh randomness.
@@ -424,7 +425,7 @@ def _sign_custom(
     msg_bytes = octets(msg_bytes, "message")
 
     sig = ffi.new("char[64]")
-    ndata = ffi.new("char[32]", _aux_rand32(aux_rand32))
+    ndata = ffi.new("char[32]", entropy(aux_rand32))
     extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
     extraparams.magic = EXTRAPARAMS_MAGIC
     extraparams.noncefp = ffi.NULL
@@ -433,49 +434,7 @@ def _sign_custom(
     extraparams.ndata = ndata
 
     if not lib.secp256k1_schnorrsig_sign_custom(
-        ctx, sig, msg_bytes, len(msg_bytes), keypair, extraparams
+        ctx, sig, msg_bytes, len(msg_bytes), keypair_obj, extraparams
     ):
         raise RuntimeError("schnorr signing failed")
     return ffi.unpack(sig, ffi.sizeof(sig))
-
-
-def _keypair(prvkey: BytesLike | int) -> CData:
-    """Create a keypair from a private key.
-
-    Args:
-        prvkey: the private key, 32 bytes or an int below 2**256.
-
-    Returns:
-        The libsecp256k1 keypair object.
-
-    Raises:
-        ValueError: if the key is not 32 bytes, does not fit in them, or
-            is not in [1, n-1].
-    """
-    keypair = ffi.new("secp256k1_keypair *")
-    if not lib.secp256k1_keypair_create(ctx, keypair, scalar(prvkey, "private key")):
-        raise ValueError("invalid private key")
-    return keypair
-
-
-def _aux_rand32(aux_rand32: BytesLike | None) -> bytes:
-    """Check the auxiliary randomness of BIP340 signing.
-
-    It is freshly generated when not provided, BIP340 recommending fresh
-    randomness at every signature; given, it is exactly 32 bytes, being
-    the entropy of a nonce and not a serialization: a shorter value is a
-    caller mistake rather than a small number, and padding it here would
-    turn one into a valid argument.
-
-    Args:
-        aux_rand32: the 32 bytes given by the caller, or None.
-
-    Returns:
-        Those 32 bytes, or 32 freshly generated ones.
-
-    Raises:
-        ValueError: if a value is given and is not 32 bytes.
-    """
-    if aux_rand32 is None:
-        return secrets.token_bytes(32)
-    return octets(aux_rand32, "aux_rand32", 32)

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -31,20 +31,20 @@ square root at 2.343.
 from __future__ import annotations
 
 from . import BytesLike, CData, ffi, keys, lib
-from ._scalar import octets, scalar
-from ._secret import take, wipe
-from .context import check, ctx
+from ._scalar import in_range, octets, scalar
+from ._secret import keypair, take, wipe
+from .context import ctx, guarded
 
 # the x-only serialization, which is the whole of the key: the other
 # two lengths this module takes are a full public key, whose x it is
 _XONLY_SIZE = 32
 
 
-def _from_pubkey(pubkey: CData) -> tuple[CData, int]:
+def _drop_y(pubkey: CData) -> tuple[CData, int]:
     """Convert a parsed public key into a parsed x-only key and the parity.
 
     The conversion itself, which is where the y is dropped, without the
-    serialization that follows it in `from_pubkey_`: `tweak_add_` wants
+    serialization that follows it in `_from_pubkey_`: `_tweak_add_` wants
     the object and not the 32 bytes, having a tweak to add to it.
 
     Args:
@@ -55,41 +55,28 @@ def _from_pubkey(pubkey: CData) -> tuple[CData, int]:
         y that was dropped: 0 for even, 1 for odd.
 
     Raises:
-        RuntimeError: if libsecp256k1 fails to convert it, which no valid
-            key can make it do.
+        ValueError: if the object is not a public key libsecp256k1 will
+            read; see `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            no valid key can make it do.
     """
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     parity = ffi.new("int *")
-    if not lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey):
+    with guarded():
+        converted = lib.secp256k1_xonly_pubkey_from_pubkey(
+            ctx, xonly_pubkey, parity, pubkey
+        )
+    if not converted:
         raise RuntimeError("x-only public key conversion failed")
     return xonly_pubkey, parity[0]
 
 
-def _serialize(xonly_pubkey: CData) -> bytes:
-    """Return the 32 bytes of a parsed x-only public key.
-
-    Args:
-        xonly_pubkey: the x-only public key object, as `parse` returns.
-
-    Returns:
-        The 32-byte x coordinate.
-
-    Raises:
-        RuntimeError: if libsecp256k1 fails to serialize it, which no
-            valid key can make it do.
-    """
-    output = ffi.new("char[32]")
-    if not lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey):
-        raise RuntimeError("x-only public key serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
-
-
-def from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
+def _from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
     """Convert an already-parsed public key into its x-only form and parity.
 
-    The inner half of `from_pubkey`, for a caller who already holds the
-    parsed point: see `keys.parse` for what the underscore means
-    throughout.
+    The private half of `from_pubkey`, for a caller who already holds the
+    parsed point: see the package docstring for what the two underscores
+    mean throughout.
 
     Args:
         pubkey: the already-parsed public key, as `keys.parse` returns.
@@ -99,11 +86,13 @@ def from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
         odd.
 
     Raises:
+        ValueError: if the object is not a public key libsecp256k1 will
+            read; see `context.guarded`.
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
-    xonly_pubkey, parity = _from_pubkey(pubkey)
-    return _serialize(xonly_pubkey), parity
+    xonly_pubkey, parity = _drop_y(pubkey)
+    return serialize(xonly_pubkey), parity
 
 
 def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
@@ -128,8 +117,8 @@ def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
     pubkey_bytes = octets(pubkey_bytes, "public key")
     if len(pubkey_bytes) == _XONLY_SIZE:
         # already the x, and the conversion is the proof that it is one
-        return _serialize(parse(pubkey_bytes)), 0
-    return from_pubkey_(keys.parse(pubkey_bytes))
+        return serialize(parse(pubkey_bytes)), 0
+    return _from_pubkey_(keys.parse(pubkey_bytes))
 
 
 def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
@@ -162,10 +151,10 @@ def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
         >>> xonly.from_prvkey(1) == xonly.from_pubkey(pubkey)
         True
     """
-    return from_pubkey_(keys.pubkey_from_prvkey_(prvkey))
+    return _from_pubkey_(keys._pubkey_from_prvkey_(prvkey))
 
 
-def from_keypair(keypair: CData) -> tuple[bytes, int]:
+def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
     """Return the x-only public key of a keypair, and the y parity.
 
     The keypair already holds the point, so this is a read of it rather
@@ -175,8 +164,8 @@ def from_keypair(keypair: CData) -> tuple[bytes, int]:
     the private key and no keypair.
 
     Args:
-        keypair: the libsecp256k1 keypair object, as `ssa.Signer` holds
-            and as `secp256k1_keypair_create` writes.
+        keypair_obj: the libsecp256k1 keypair object, as `ssa.Signer`
+            holds and as `secp256k1_keypair_create` writes.
 
     Returns:
         The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
@@ -185,25 +174,56 @@ def from_keypair(keypair: CData) -> tuple[bytes, int]:
 
     Raises:
         ValueError: if the object is not a keypair libsecp256k1 will read
-            -- a NULL pointer, or one that has been wiped. This and
-            `keys.serialize` are the two arguments of these bindings that
-            are libsecp256k1 objects rather than bytes, and so the two
-            that cannot be checked before the call.
+            -- a NULL pointer, or one that has been wiped, which is
+            reported as the zero it holds where the x of a point should
+            be; see `context.guarded`.
         RuntimeError: if libsecp256k1 fails for any other reason, or
             fails to serialize the result, which a keypair it built
             cannot make it do.
     """
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     parity = ffi.new("int *")
-    if not lib.secp256k1_keypair_xonly_pub(ctx, xonly_pubkey, parity, keypair):
-        # the keypair is the caller's object, so a violated precondition
-        # is reachable here as it is in `keys.serialize`, which says why
-        # raising it is also what takes it off the thread. A wiped
-        # keypair is the reachable way in, and what it is reported as is
-        # the zero it holds where the x of a point should be
-        check()
+    with guarded():
+        converted = lib.secp256k1_keypair_xonly_pub(
+            ctx, xonly_pubkey, parity, keypair_obj
+        )
+    if not converted:
         raise RuntimeError("x-only public key conversion failed")
-    return _serialize(xonly_pubkey), parity[0]
+    return serialize(xonly_pubkey), parity[0]
+
+
+def _tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
+    """Add the generator multiplied by the tweak, to an already-parsed key.
+
+    The private half of `tweak_add`, for a caller who already holds the
+    parsed point: see the package docstring for what the two underscores
+    mean throughout. The parsed point is a full public key, and the
+    x-only form of it is `secp256k1_xonly_pubkey_from_pubkey`, which
+    lifts nothing; reaching `tweak_add` from there instead means
+    serializing the x and parsing it back, and that parse is a field
+    square root -- of an x whose y the caller is holding.
+
+    The point is taken as BIP341 takes an internal key, x-only: an odd-y
+    key is tweaked as its negation, and answers the output key
+    `tweak_add` answers for the same 32 bytes. `_from_pubkey_` is where
+    that parity is read, and takes the same object.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+        tweak: the tweak, 32 bytes or an int below 2**256.
+
+    Returns:
+        The 32-byte tweaked x-only key, and the parity of its y.
+
+    Raises:
+        ValueError: if the tweak is not 32 bytes or does not fit in them,
+            if the tweak or the resulting key is invalid, or if the
+            object is not a public key libsecp256k1 will read; see
+            `context.guarded`.
+        RuntimeError: if libsecp256k1 fails to convert or serialize the
+            result, which no valid input can make it do.
+    """
+    return _tweak_xonly(_drop_y(pubkey)[0], tweak)
 
 
 def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, int]:
@@ -229,50 +249,18 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             result, which no valid input can make it do.
     """
-    return _tweak_add(parse(pubkey_bytes), tweak)
+    return _tweak_xonly(parse(pubkey_bytes), tweak)
 
 
-def tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
-    """Add the generator multiplied by the tweak, to an already-parsed key.
-
-    The inner half of `tweak_add`, for a caller who already holds the
-    parsed point: see `keys.parse` for what the underscore means
-    throughout. The parsed point is a full public key, and the x-only
-    form of it is `secp256k1_xonly_pubkey_from_pubkey`, which lifts
-    nothing; reaching `tweak_add` from there instead means serializing the
-    x and parsing it back, and that parse is a field square root -- of an
-    x whose y the caller is holding.
-
-    The point is taken as BIP341 takes an internal key, x-only: an odd-y
-    key is tweaked as its negation, and answers the output key
-    `tweak_add` answers for the same 32 bytes. `from_pubkey_` is where
-    that parity is read, and takes the same object.
-
-    Args:
-        pubkey: the already-parsed public key, as `keys.parse` returns.
-        tweak: the tweak, 32 bytes or an int below 2**256.
-
-    Returns:
-        The 32-byte tweaked x-only key, and the parity of its y.
-
-    Raises:
-        ValueError: if the tweak is not 32 bytes or does not fit in them,
-            or if the tweak or the resulting key is invalid.
-        RuntimeError: if libsecp256k1 fails to convert or serialize the
-            result, which no valid input can make it do.
-    """
-    return _tweak_add(_from_pubkey(pubkey)[0], tweak)
-
-
-def _tweak_add(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
+def _tweak_xonly(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
     """Add the generator multiplied by the tweak to a parsed x-only key.
 
     What the two halves above share, once each has reached the x-only key
-    its own way: `parse` from the 32 bytes, or `_from_pubkey` from the
-    point.
+    its own way: `parse` from the octets, or `_drop_y` from the point.
 
     Args:
-        internal_pubkey: the x-only public key object.
+        internal_pubkey: the x-only public key object, which this module
+            made and not the caller.
         tweak: the tweak, 32 bytes or an int below 2**256.
 
     Returns:
@@ -291,7 +279,7 @@ def _tweak_add(internal_pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, i
         ctx, tweaked_pubkey, internal_pubkey, tweak_bytes
     ):
         raise ValueError("invalid tweak or resulting public key")
-    return from_pubkey_(tweaked_pubkey)
+    return _from_pubkey_(tweaked_pubkey)
 
 
 def tweak_add_check(
@@ -320,15 +308,17 @@ def tweak_add_check(
         over recomputing the tweak comes from.
 
     Raises:
+        TypeError: if the parity is not an int.
         ValueError: if either key is not 32 bytes, if the internal key
             is not a valid x coordinate, if the parity is not 0 or 1, or
             if the tweak is not 32 bytes or does not fit in them. The
             tweaked key is not parsed, and so is never invalid: see
             Returns.
     """
-    tweaked_pubkey_bytes = octets(tweaked_pubkey_bytes, "tweaked x-only public key", 32)
-    if tweaked_parity not in (0, 1):
-        raise ValueError("the parity must be 0 or 1")
+    tweaked_pubkey_bytes = octets(
+        tweaked_pubkey_bytes, "tweaked x-only public key", _XONLY_SIZE
+    )
+    tweaked_parity = in_range(tweaked_parity, "parity", 1)
 
     internal_pubkey = parse(pubkey_bytes)
     tweak_bytes = scalar(tweak, "tweak")
@@ -363,28 +353,28 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
         RuntimeError: if libsecp256k1 fails to extract the key, which no
             valid input can make it do.
     """
-    keypair = _keypair(prvkey)
+    keypair_obj = keypair(prvkey)
     prvkey_buffer = ffi.new("char[32]")
     try:
         tweak_bytes = scalar(tweak, "tweak")
-        if not lib.secp256k1_keypair_xonly_tweak_add(ctx, keypair, tweak_bytes):
+        if not lib.secp256k1_keypair_xonly_tweak_add(ctx, keypair_obj, tweak_bytes):
             raise ValueError("invalid tweak or resulting private key")
 
-        if not lib.secp256k1_keypair_sec(ctx, prvkey_buffer, keypair):
+        if not lib.secp256k1_keypair_sec(ctx, prvkey_buffer, keypair_obj):
             raise RuntimeError("private key extraction failed")
         return take(prvkey_buffer)
     finally:
         # a keypair carries the private key -- the tweaked one here,
         # which is the one that signs -- so it is overwritten on the way
         # out whether that was reached or refused
-        wipe(keypair)
+        wipe(keypair_obj)
 
 
-def parse(pubkey_bytes: BytesLike) -> CData:
+def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
     """Parse a public key, in any of its serializations, into its x.
 
     The x-only counterpart of `keys.parse`, and the argument of
-    `ssa.verify_`: a caller that has proved octets a public key has made
+    `ssa._verify_`: a caller that has proved octets a public key has made
     the call BIP340 verification makes anyway, and can hand the result on
     rather than make it twice.
 
@@ -396,12 +386,13 @@ def parse(pubkey_bytes: BytesLike) -> CData:
     the x-only conversion that follows it reads the y rather than lifting
     one.
 
-    There is no `serialize` beside it, and that is not an omission:
-    nothing here hands back a parsed x-only key except this, `from_pubkey`
-    and `tweak_add` answering with the 32 bytes and the parity instead.
-
     Args:
         pubkey_bytes: the public key, 32, 33 or 65 bytes.
+        name: what the key is, as the exception should call it, for a
+            caller passing more than one kind of x-only key --
+            `silentpayments` passes a taproot input and a transaction
+            output, and which one was refused is the whole of what its
+            caller needs.
 
     Returns:
         The libsecp256k1 x-only public key object.
@@ -411,30 +402,41 @@ def parse(pubkey_bytes: BytesLike) -> CData:
             bytes.
     """
     # secp256k1_xonly_pubkey_parse takes a bare pointer to 32 bytes
-    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey_bytes = octets(pubkey_bytes, name)
     if len(pubkey_bytes) != _XONLY_SIZE:
-        return _from_pubkey(keys.parse(pubkey_bytes))[0]
+        return _drop_y(keys.parse(pubkey_bytes, name))[0]
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
-        raise ValueError("invalid x-only public key")
+        raise ValueError(f"invalid {name}")
     return xonly_pubkey
 
 
-def _keypair(prvkey: BytesLike | int) -> CData:
-    """Create a keypair from a private key.
+def serialize(xonly_pubkey: CData) -> bytes:
+    """Return the 32 bytes of a parsed x-only public key.
+
+    What `keys.serialize` is to a full public key, and the other half of
+    `parse`: there is no compression flag beside it, an x-only key having
+    one serialization and it being the x.
 
     Args:
-        prvkey: the private key, 32 bytes or an int below 2**256.
+        xonly_pubkey: the libsecp256k1 x-only public key object, as
+            `parse` returns.
 
     Returns:
-        The libsecp256k1 keypair object.
+        The 32-byte x coordinate.
 
     Raises:
-        ValueError: if the key is not 32 bytes, does not fit in them, or
-            is not in [1, n-1].
+        ValueError: if the object is not an x-only public key
+            libsecp256k1 will read -- a NULL pointer, or a
+            `secp256k1_xonly_pubkey` nothing has written to; see
+            `context.guarded`.
+        RuntimeError: if libsecp256k1 fails for any other reason, which
+            a key it produced cannot make it do.
     """
-    keypair = ffi.new("secp256k1_keypair *")
-    if not lib.secp256k1_keypair_create(ctx, keypair, scalar(prvkey, "private key")):
-        raise ValueError("invalid private key")
-    return keypair
+    output = ffi.new(f"char[{_XONLY_SIZE}]")
+    with guarded():
+        serialized = lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey)
+    if not serialized:
+        raise RuntimeError("x-only public key serialization failed")
+    return ffi.unpack(output, ffi.sizeof(output))

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -29,6 +29,7 @@ from btclib_secp256k1 import (
     dsa,
     ecdh,
     ellswift,
+    ffi,
     hashes,
     keys,
     mult,
@@ -49,6 +50,7 @@ XONLY, PARITY = xonly.from_pubkey(PUBKEY)
 PARSED = keys.parse(PUBKEY)
 PARSED_XONLY = xonly.parse(XONLY)
 DER = dsa.sign(MSG, PRVKEY)
+PARSED_DER = dsa.parse_der(DER)
 COMPACT = dsa.to_compact(DER)
 SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
 RECOVERABLE, RECID = recovery.sign(MSG, PRVKEY)
@@ -67,7 +69,7 @@ OUTPOINT = bytes(36)
 SP_OUTPUTS = silentpayments.create_outputs(
     [(SCAN_PUBKEY, SPEND_PUBKEY)], OUTPOINT, prvkeys=[PRVKEY]
 )
-SP_SUMMARY = silentpayments.prevouts_summary(OUTPOINT, pubkeys=[PUBKEY])
+SP_SUMMARY = silentpayments.prevouts_summary(OUTPOINT, pubkeys_bytes=[PUBKEY])
 SP_LABEL, SP_LABEL_TWEAK = silentpayments.label(SCAN_PRVKEY, 0)
 
 
@@ -110,7 +112,7 @@ def created(prvkey: Any) -> bytes:
     Returns:
         The compressed public key, which is what the outer half answers.
     """
-    return keys.serialize(keys.pubkey_from_prvkey_(prvkey))
+    return keys.serialize(keys._pubkey_from_prvkey_(prvkey))
 
 
 def decoded(ell_bytes: Any) -> bytes:
@@ -122,7 +124,7 @@ def decoded(ell_bytes: Any) -> bytes:
     Returns:
         The compressed public key.
     """
-    return keys.serialize(ellswift.decode_(ell_bytes))
+    return keys.serialize(ellswift._decode_(ell_bytes))
 
 
 def recovered(msg_bytes: Any, signature_bytes: Any, recid: int) -> bytes:
@@ -136,7 +138,9 @@ def recovered(msg_bytes: Any, signature_bytes: Any, recid: int) -> bytes:
     Returns:
         The compressed recovered public key.
     """
-    return keys.serialize(recovery.recover_(msg_bytes, signature_bytes, recid))
+    return keys.serialize(
+        recovery._recover_(msg_bytes, recovery.parse_compact(signature_bytes, recid))
+    )
 
 
 def labeled(scan_prvkey: Any, m: int) -> tuple[bytes, bytes]:
@@ -150,8 +154,99 @@ def labeled(scan_prvkey: Any, m: int) -> tuple[bytes, bytes]:
         The 33-byte label and its 32-byte tweak, which is what the outer
         half answers.
     """
-    label_obj, tweak = silentpayments.label_(scan_prvkey, m)
+    label_obj, tweak = silentpayments._label_(scan_prvkey, m)
     return silentpayments.serialize_label(label_obj), tweak
+
+
+def signed_dsa(msg_bytes: Any, prvkey: Any, aux_rand32: Any) -> bytes:
+    """Sign through the private half, and serialize what it built.
+
+    Args:
+        msg_bytes: the 32-byte message hash.
+        prvkey: the private key.
+        aux_rand32: the 32 bytes of extra entropy.
+
+    Returns:
+        The DER signature, which is what the public half answers.
+    """
+    return dsa.serialize_der(dsa._sign_(msg_bytes, prvkey, aux_rand32))
+
+
+def signed_recoverable(
+    msg_bytes: Any, prvkey: Any, aux_rand32: Any
+) -> tuple[bytes, int]:
+    """Sign recoverably through the private half, and serialize the pair.
+
+    Args:
+        msg_bytes: the 32-byte message hash.
+        prvkey: the private key.
+        aux_rand32: the 32 bytes of extra entropy.
+
+    Returns:
+        The 64-byte compact signature and its recovery id.
+    """
+    return recovery.serialize_compact(recovery._sign_(msg_bytes, prvkey, aux_rand32))
+
+
+def created_outputs(outpoint_smallest36: Any, prvkeys: Any) -> list[bytes]:
+    """Create silent payment outputs through the private half.
+
+    The recipient's keys are parsed here rather than retyped: what this
+    sweeps is the outpoint and the private keys, which are the octets
+    that half still takes.
+
+    Args:
+        outpoint_smallest36: the 36-byte smallest outpoint.
+        prvkeys: the private keys of the eligible inputs.
+
+    Returns:
+        The 32-byte x-only key of each output.
+    """
+    return [
+        xonly.serialize(output)
+        for output in silentpayments._create_outputs_(
+            [(keys.parse(SCAN_PUBKEY), keys.parse(SPEND_PUBKEY))],
+            outpoint_smallest36,
+            prvkeys=prvkeys,
+        )
+    ]
+
+
+def summarized(outpoint_smallest36: Any) -> bytes:
+    """Summarize the inputs through the private half, and read the struct.
+
+    Args:
+        outpoint_smallest36: the 36-byte smallest outpoint.
+
+    Returns:
+        The octets `prevouts_summary` answers with.
+    """
+    return bytes(
+        ffi.buffer(
+            silentpayments._prevouts_summary_(
+                outpoint_smallest36, pubkeys=[keys.parse(PUBKEY)]
+            )
+        )
+    )
+
+
+def scanned(scan_prvkey: Any, labels: Any) -> list[tuple[bytes, bytes, bytes | None]]:
+    """Scan the transaction through the private half.
+
+    Args:
+        scan_prvkey: the recipient's scan private key.
+        labels: the label cache.
+
+    Returns:
+        One triple per output found.
+    """
+    return silentpayments._scan_outputs_(
+        [xonly.parse(output) for output in SP_OUTPUTS],
+        scan_prvkey,
+        silentpayments._prevouts_summary_(OUTPOINT, pubkeys=[keys.parse(PUBKEY)]),
+        keys.parse(SPEND_PUBKEY),
+        labels,
+    )
 
 
 # every entry point taking an argument that crosses as a bare pointer,
@@ -166,7 +261,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     # those are equal to nothing at all: each is driven through a
     # function above which serializes what it built, so what the sweep
     # compares is the bytes its outer half would have answered
-    ("keys.pubkey_from_prvkey_", created, (PRVKEY,), {}),
+    ("keys._pubkey_from_prvkey_", created, (PRVKEY,), {}),
     ("keys.pubkey_verify", keys.pubkey_verify, (PUBKEY,), {}),
     ("keys.pubkey_negate", keys.pubkey_negate, (PUBKEY,), {}),
     ("keys.pubkey_tweak_add", keys.pubkey_tweak_add, (PUBKEY, TWEAK), {}),
@@ -175,12 +270,13 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.reserialize", keys.reserialize, (PUBKEY,), {}),
     ("keys.pubkey_cmp", keys.pubkey_cmp, (PUBKEY, PUBKEY_LONG), {}),
     ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
-    ("mult.mult_", mult.mult_, (PRVKEY,), {}),
+    ("mult.mult_bytes", mult.mult_bytes, (PRVKEY,), {}),
     ("mult.mult", mult.mult, (PRVKEY,), {}),
     ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),
     ("dsa.sign", dsa.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("dsa.verify", dsa.verify, (MSG, PUBKEY, DER), {}),
-    ("dsa.verify_", dsa.verify_, (MSG, PARSED, DER), {}),
+    ("dsa._verify_", dsa._verify_, (MSG, PARSED, PARSED_DER), {}),
+    ("dsa._sign_", signed_dsa, (MSG, PRVKEY, bytes(32)), {}),
     ("dsa.normalize", dsa.normalize, (DER,), {}),
     ("dsa.is_low_s", dsa.is_low_s, (DER,), {}),
     ("dsa.to_compact", dsa.to_compact, (DER,), {}),
@@ -195,13 +291,13 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("ssa.Signer.sign", signed, (PRVKEY, MSG, bytes(32)), {}),
     ("ssa.Signer.sign_custom", signed_custom, (PRVKEY, b"a message", bytes(32)), {}),
     ("ssa.verify", ssa.verify, (MSG, XONLY, SSA_SIG), {}),
-    ("ssa.verify_", ssa.verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
+    ("ssa._verify_", ssa._verify_, (MSG, PARSED_XONLY, SSA_SIG), {}),
     ("xonly.from_pubkey", xonly.from_pubkey, (PUBKEY,), {}),
     ("xonly.from_prvkey", xonly.from_prvkey, (PRVKEY,), {}),
     ("xonly.tweak_add", xonly.tweak_add, (XONLY, TWEAK), {}),
     # the parsed key is not retyped, being no bytes; the tweak beside it
     # is, and what comes back is 32 bytes and a parity, which compare
-    ("xonly.tweak_add_", xonly.tweak_add_, (PARSED, TWEAK), {}),
+    ("xonly._tweak_add_", xonly._tweak_add_, (PARSED, TWEAK), {}),
     (
         "xonly.tweak_add_check",
         xonly.tweak_add_check,
@@ -210,18 +306,19 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ),
     ("xonly.prvkey_tweak_add", xonly.prvkey_tweak_add, (PRVKEY, TWEAK), {}),
     ("recovery.sign", recovery.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("recovery._sign_", signed_recoverable, (MSG, PRVKEY, bytes(32)), {}),
     ("recovery.recover", recovery.recover, (MSG, RECOVERABLE, RECID), {}),
-    ("recovery.recover_", recovered, (MSG, RECOVERABLE, RECID), {}),
+    ("recovery._recover_", recovered, (MSG, RECOVERABLE, RECID), {}),
     ("recovery.to_der", recovery.to_der, (RECOVERABLE, RECID), {}),
     ("ecdh.shared_secret", ecdh.shared_secret, (PUBKEY, PRVKEY), {}),
-    ("ecdh.shared_secret_", ecdh.shared_secret_, (PARSED, PRVKEY), {}),
+    ("ecdh._shared_secret_", ecdh._shared_secret_, (PARSED, PRVKEY), {}),
     ("ellswift.create", ellswift.create, (PRVKEY, bytes(32)), {}),
     ("ellswift.encode", ellswift.encode, (PUBKEY, bytes(32)), {}),
     # the parsed key is not retyped, being no bytes; the randomness
     # beside it is, and pinning it is what makes two encodings comparable
-    ("ellswift.encode_", ellswift.encode_, (PARSED, bytes(32)), {}),
+    ("ellswift._encode_", ellswift._encode_, (PARSED, bytes(32)), {}),
     ("ellswift.decode", ellswift.decode, (ELL_A,), {}),
-    ("ellswift.decode_", decoded, (ELL_A,), {}),
+    ("ellswift._decode_", decoded, (ELL_A,), {}),
     ("ellswift.xdh", ellswift.xdh, (ELL_A, ELL_B, PRVKEY, 0), {}),
     # the silentpayments arguments are passed positionally, keyword
     # defaults though they are: what is retyped below is `args`, so a
@@ -233,12 +330,20 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
         ([(SCAN_PUBKEY, SPEND_PUBKEY)], OUTPOINT, (), [PRVKEY]),
         {},
     ),
+    ("silentpayments._create_outputs_", created_outputs, (OUTPOINT, [PRVKEY]), {}),
     ("silentpayments.label", silentpayments.label, (SCAN_PRVKEY, 0), {}),
-    ("silentpayments.label_", labeled, (SCAN_PRVKEY, 0), {}),
+    ("silentpayments._label_", labeled, (SCAN_PRVKEY, 0), {}),
     (
         "silentpayments.labeled_spend_pubkey",
         silentpayments.labeled_spend_pubkey,
         (SPEND_PUBKEY, SP_LABEL),
+        {},
+    ),
+    ("silentpayments._prevouts_summary_", summarized, (OUTPOINT,), {}),
+    (
+        "silentpayments._scan_outputs_",
+        scanned,
+        (SCAN_PRVKEY, {SP_LABEL: SP_LABEL_TWEAK}),
         {},
     ),
     (
@@ -275,40 +380,52 @@ MODULES = {
 }
 
 # the ones that take no argument crossing as a bare pointer, or nothing
-# this sweep has not already exercised. All three `parse` functions take
-# one and are covered through every wrapper above, `parse_label` through
-# `silentpayments.labeled_spend_pubkey`; `serialize`, `serialize_label`,
-# `pubkey_negate_`, `pubkey_cmp_`, `from_pubkey_`, `from_keypair` and
-# `labeled_spend_pubkey_` take the libsecp256k1 objects a `parse`, a
-# producing inner half or `ssa.Signer` hands back, and no bytes at all --
-# as do `pubkey_combine_` and `pubkey_sort_`, whose sequences hold those
-# same objects and no bytes to retype. The two
-# tweaking inner halves do take a tweak, and it is the retyped one of
-# `keys.pubkey_tweak_add` and `keys.pubkey_tweak_mul` above, which pass
-# theirs straight in: what they answer with is the parsed key they
-# mutated, and two calls of it are never equal. `PubkeyTweakChain` is the
-# same, calling `parse` on construction and reaching `scalar` through
-# `pubkey_tweak_add_` on every `tweak_add`. `ssa.Signer` is a class too
-# and its private key does cross as a bare pointer, but it is swept: the
-# two entries above build one and sign through it, which is every
-# argument of the constructor and of both methods
+# this sweep has not already exercised. Every `parse` takes one and is
+# covered through the wrappers above -- `keys.parse` and `xonly.parse`
+# through all of them, `dsa.parse_der` through `dsa.normalize`,
+# `dsa.parse_compact` through `dsa.to_der`, `recovery.parse_compact`
+# through `recovery.recover`, `parse_label` through
+# `silentpayments.labeled_spend_pubkey` -- and what each answers with is
+# a cffi object, which is equal to no other. Every `serialize` is the
+# other side of that: it takes the object and no bytes at all, as do the
+# private halves listed here, whose sequences and structs hold those same
+# objects. The two tweaking private halves do take a tweak, and it is the
+# retyped one of `keys.pubkey_tweak_add` and `keys.pubkey_tweak_mul`
+# above, which pass theirs straight in: what they answer with is the
+# parsed key they mutated, and two calls of it are never equal.
+# `PubkeyTweakChain` is the same, calling `parse` on construction and
+# reaching `scalar` through `_pubkey_tweak_add_` on every `tweak_add`.
+# `ssa.Signer` is a class too and its private key does cross as a bare
+# pointer, but it is swept: the two entries above build one and sign
+# through it, which is every argument of the constructor and of both
+# methods
 NOT_SWEPT = {
-    "keys.serialize",
+    "dsa.parse_compact",
+    "dsa.parse_der",
+    "dsa.serialize_compact",
+    "dsa.serialize_der",
+    "dsa._is_low_s_",
+    "dsa._normalize_",
     "keys.parse",
-    "keys.pubkey_negate_",
-    "keys.pubkey_tweak_add_",
-    "keys.pubkey_tweak_mul_",
-    "keys.pubkey_cmp_",
-    "keys.pubkey_combine_",
-    "keys.pubkey_sort_",
+    "keys.serialize",
     "keys.PubkeyTweakChain",
-    "ssa.Signer",
-    "xonly.parse",
-    "xonly.from_pubkey_",
-    "xonly.from_keypair",
+    "keys._pubkey_combine_",
+    "keys._pubkey_cmp_",
+    "keys._pubkey_negate_",
+    "keys._pubkey_sort_",
+    "keys._pubkey_tweak_add_",
+    "keys._pubkey_tweak_mul_",
+    "recovery.parse_compact",
+    "recovery.serialize_compact",
+    "recovery._to_der_",
     "silentpayments.parse_label",
     "silentpayments.serialize_label",
-    "silentpayments.labeled_spend_pubkey_",
+    "silentpayments._labeled_spend_pubkey_",
+    "ssa.Signer",
+    "xonly.from_keypair",
+    "xonly.parse",
+    "xonly.serialize",
+    "xonly._from_pubkey_",
 }
 
 
@@ -363,23 +480,47 @@ def test_answers_the_same_for_every_bytes_like(
     assert call(*args, **kwargs) == call(*(retyped(a, kind) for a in args), **kwargs)
 
 
+def at_the_boundary(name: str) -> bool:
+    """Return True if a module attribute is one a caller passes octets to.
+
+    The public functions, and the `_foo_` halves beside them: those are
+    private to callers but they take octets like any other entry point --
+    a message hash, a tweak, a private key -- and a length check missed
+    there is missed exactly as badly. What is left out is the ordinary
+    private helper, which is reached through the two above.
+
+    Args:
+        name: the attribute's name.
+
+    Returns:
+        True if the sweep has to account for it.
+    """
+    if name.startswith("__"):
+        return False
+    return not name.startswith("_") or name.endswith("_")
+
+
 def test_the_sweep_is_whole() -> None:
-    """Every public function of every wrapped module is swept, or excused.
+    """Every entry point of every wrapped module is swept, or excused.
 
     A function added to the boundary and not added to `CALLS` is a hole
     this sweep would not cover and nothing else would report, so the
-    list is checked against what the modules actually export rather than
+    list is checked against what the modules actually carry rather than
     trusted to have been kept up to date.
     """
     swept = {name for name, *_ in CALLS} | NOT_SWEPT
-    exported = {
+    at_boundary = {
         f"{module_name}.{name}"
         for module_name, module in MODULES.items()
         for name in dir(module)
-        if not name.startswith("_")
+        if at_the_boundary(name)
         and callable(getattr(module, name))
         and getattr(getattr(module, name), "__module__", "")
         == f"btclib_secp256k1.{module_name}"
     }
 
-    assert exported - swept == set()
+    assert at_boundary - swept == set()
+    # and the sweep names nothing the modules do not have: an entry left
+    # behind by a rename would otherwise excuse a function that no longer
+    # exists, and cover nothing
+    assert NOT_SWEPT - at_boundary == set()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -45,23 +45,23 @@ def test_concurrent_round_trips() -> None:
     deterministic. `map` is consumed rather than discarded, an assertion
     failing in a worker being raised only when its result is read.
     """
-    pubkey_bytes = mult.mult_(prvkey)
+    pubkey_bytes = mult.mult_bytes(prvkey)
     xonly_bytes, _ = xonly.from_pubkey(pubkey_bytes)
     dsa_sig = dsa.sign(msg, prvkey)
     ssa_sig = ssa.sign(msg, prvkey, aux_rand32)
     secret = ecdh.shared_secret(pubkey_bytes, tweak)
     tweaked = xonly.tweak_add(xonly_bytes, tweak)
-    combined = keys.pubkey_combine([pubkey_bytes, mult.mult_(tweak)])
+    combined = keys.pubkey_combine([pubkey_bytes, mult.mult_bytes(tweak)])
 
     def round_trip(_: int) -> None:
         assert dsa.sign(msg, prvkey) == dsa_sig
         assert dsa.verify(msg, pubkey_bytes, dsa_sig)
         assert ssa.sign(msg, prvkey, aux_rand32) == ssa_sig
         assert ssa.verify(msg, xonly_bytes, ssa_sig)
-        assert mult.mult_(prvkey) == pubkey_bytes
+        assert mult.mult_bytes(prvkey) == pubkey_bytes
         assert ecdh.shared_secret(pubkey_bytes, tweak) == secret
         assert xonly.tweak_add(xonly_bytes, tweak) == tweaked
-        assert keys.pubkey_combine([pubkey_bytes, mult.mult_(tweak)]) == combined
+        assert keys.pubkey_combine([pubkey_bytes, mult.mult_bytes(tweak)]) == combined
 
     with ThreadPoolExecutor(max_workers=WORKERS) as pool:
         # map is lazy: the results have to be consumed for an assertion

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,7 +27,9 @@ from btclib_secp256k1 import (
     lib,
     mult,
     recovery,
+    silentpayments,
     ssa,
+    xonly,
 )
 
 prvkey = 1
@@ -59,7 +61,7 @@ def test_sign_and_verify() -> None:
     custom_sig = dsa.sign(msg, prvkey, b"\x01" * 32)
     assert custom_sig != dsa_sig
     assert dsa.verify(msg, pubkey_bytes, custom_sig)
-    with pytest.raises(ValueError, match="ndata must be 32 bytes"):
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
         dsa.sign(msg, prvkey, b"\x01")
 
     ssa_sig = ssa.sign(msg, prvkey)
@@ -144,7 +146,7 @@ def test_mult() -> None:
     `mult_` answers the serialized public key and `mult` the coordinates,
     so the x of the second is the x the first carries.
     """
-    pubkey_ = mult.mult_(prvkey)
+    pubkey_ = mult.mult_bytes(prvkey)
     assert pubkey_[1:33] == pubkey_bytes[1:]
     pubkey = mult.mult(prvkey)
     assert pubkey[0] == int.from_bytes(pubkey_bytes[1:], "big")
@@ -154,7 +156,7 @@ def test_invalid_inputs() -> None:
     """Every argument out of the domain is refused at the boundary.
 
     A zero private key, a message hash that is not 32 octets, an
-    ndata that is not, a signature that is not DER, and a public key
+    aux_rand32 that is not, a signature that is not DER, and a public key
     that does not parse -- each raising ValueError with the message
     naming the argument, which is what a caller catches rather than
     finding out from libsecp256k1's return code.
@@ -166,7 +168,7 @@ def test_invalid_inputs() -> None:
         dsa.sign(msg, 0)
     with pytest.raises(ValueError, match="32 bytes"):
         dsa.sign(msg[1:], prvkey)
-    with pytest.raises(ValueError, match="ndata must be 32 bytes"):
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
         dsa.sign(msg, prvkey, b"\x01" * 33)
     with pytest.raises(ValueError, match="message hash"):
         dsa.verify(msg[1:], pubkey_bytes, dsa_sig)
@@ -184,7 +186,7 @@ def test_invalid_inputs() -> None:
         ssa.sign(msg, prvkey, b"\x01" * 33)
     with pytest.raises(ValueError, match="64 bytes"):
         ssa.verify(msg, xonly_bytes, ssa_sig[1:])
-    with pytest.raises(ValueError, match="invalid x-only public key"):
+    with pytest.raises(ValueError, match="invalid public key"):
         # 32 bytes which are not the x coordinate of a curve point
         ssa.verify(msg, b"\x00" * 32, ssa_sig)
 
@@ -221,7 +223,7 @@ def test_type_checks_refuse_what_merely_has_a_length() -> None:
     that says mypy already knew.
     """
     prvkey = 7
-    pubkey_bytes = mult.mult_(prvkey)
+    pubkey_bytes = mult.mult_bytes(prvkey)
 
     with pytest.raises(TypeError, match="tag must be bytes, not str"):
         hashes.tagged_sha256("TapLeaf", b"")  # type: ignore[arg-type]
@@ -251,7 +253,7 @@ def test_a_bool_is_not_a_scalar() -> None:
     This is the one type whose acceptance could not be seen in the
     answer. `keys.prvkey_verify(False)` returned False, which is the
     correct verdict on the scalar zero and indistinguishable from the
-    correct verdict on whatever the caller meant; `mult.mult_(True)`
+    correct verdict on whatever the caller meant; `mult.mult_bytes(True)`
     returned the generator. A `float` or a `str` in the same place is a
     typo that raises, and always did.
 
@@ -276,6 +278,35 @@ def test_a_bool_is_not_a_scalar() -> None:
     sig_bytes, recid = recovery.sign(msg, 7)
     assert recid in (0, 1)
     assert recovery.recover(msg, sig_bytes, bool(recid)) == keys.pubkey_from_prvkey(7)
+
+
+def test_a_flag_that_is_not_an_int_is_refused_by_name() -> None:
+    """What a flag refuses is what is not a number at all.
+
+    A recovery id, a y parity, an ElligatorSwift party and a label index
+    are each a small number libsecp256k1 takes as a C int, and each is
+    held to one place -- so a `float` is refused by all four alike, and
+    the message names the argument. `0.0` is the value that makes the
+    check worth making: it passes an `in (0, 1)` test, python holding it
+    equal to the int, and what it would reach cffi as is a float.
+    """
+    msg = b"\x01" * 32
+    sig_bytes, _ = recovery.sign(msg, 7)
+    xonly_bytes, parity = xonly.from_pubkey(keys.pubkey_from_prvkey(7))
+    tweaked, tweaked_parity = xonly.tweak_add(xonly_bytes, 11)
+    ell = ellswift.create(7, bytes(32))
+
+    with pytest.raises(TypeError, match="recovery id must be an int, not float"):
+        recovery.recover(msg, sig_bytes, 0.0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="parity must be an int, not float"):
+        xonly.tweak_add_check(tweaked, float(tweaked_parity), xonly_bytes, 11)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="party must be an int, not float"):
+        ellswift.xdh(ell, ell, 7, 0.0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="label m must be an int, not float"):
+        silentpayments.label(7, 0.0)  # type: ignore[arg-type]
+
+    # and the y parity of a key is unchanged by any of it
+    assert parity in (0, 1)
 
 
 def test_a_memoryview_of_wider_items_is_not_octets() -> None:
@@ -327,7 +358,7 @@ def test_size_checks_refuse_both_sides() -> None:
     """
     msg = b"\x01" * 32
     prvkey = 7
-    pubkey_bytes = mult.mult_(prvkey)
+    pubkey_bytes = mult.mult_bytes(prvkey)
     der_bytes = dsa.sign(msg, prvkey)
     ssa_sig = ssa.sign(msg, prvkey)
     xonly_bytes = pubkey_bytes[1:33]

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -86,12 +86,12 @@ def test_pubkey_from_prvkey() -> None:
 
     # the odd y, which 1G cannot exhibit
     assert mult.mult(6)[1] & 1
-    assert keys.pubkey_from_prvkey(6) == b"\x03" + mult.mult_(6)[1:33]
+    assert keys.pubkey_from_prvkey(6) == b"\x03" + mult.mult_bytes(6)[1:33]
 
     # mult_ is this function with the compressed flag off
     for prvkey in (1, 6, N - 1):
-        assert mult.mult_(prvkey) == keys.pubkey_from_prvkey(prvkey, False)
-        assert keys.pubkey_from_prvkey(prvkey) == compress(mult.mult_(prvkey))
+        assert mult.mult_bytes(prvkey) == keys.pubkey_from_prvkey(prvkey, False)
+        assert keys.pubkey_from_prvkey(prvkey) == compress(mult.mult_bytes(prvkey))
 
     # zero is no private key, and neither is the group order
     with pytest.raises(ValueError, match="private key"):
@@ -107,24 +107,24 @@ def test_pubkey_from_prvkey() -> None:
 def test_pubkey_algebra() -> None:
     """Tweaking a public key matches tweaking the private key under it.
 
-    Add, multiply and negate, each against `mult.mult_` of the tweaked
+    Add, multiply and negate, each against `mult.mult_bytes` of the tweaked
     scalar, with negation checked to be its own inverse. Combining keys
     matches adding their scalars and does not depend on the order they are
     given in; one key combines to itself. A sum landing on the point at
     infinity is refused, that point having no public key.
     """
     a, b = 3, 5
-    pubkey_a, pubkey_b = mult.mult_(a), mult.mult_(b)
+    pubkey_a, pubkey_b = mult.mult_bytes(a), mult.mult_bytes(b)
 
     # tweaking a public key matches tweaking its private key
-    assert keys.pubkey_tweak_add(pubkey_a, b) == (compress(mult.mult_(a + b)))
-    assert keys.pubkey_tweak_mul(pubkey_a, b) == (compress(mult.mult_(a * b)))
-    assert keys.pubkey_negate(pubkey_a) == (compress(mult.mult_(N - a)))
+    assert keys.pubkey_tweak_add(pubkey_a, b) == (compress(mult.mult_bytes(a + b)))
+    assert keys.pubkey_tweak_mul(pubkey_a, b) == (compress(mult.mult_bytes(a * b)))
+    assert keys.pubkey_negate(pubkey_a) == (compress(mult.mult_bytes(N - a)))
     assert keys.pubkey_negate(keys.pubkey_negate(pubkey_a)) == (compress(pubkey_a))
 
     # adding public keys matches adding their private keys
     combined = keys.pubkey_combine([pubkey_a, pubkey_b])
-    assert combined == compress(mult.mult_(a + b))
+    assert combined == compress(mult.mult_bytes(a + b))
     assert combined == keys.pubkey_combine([pubkey_b, pubkey_a])
     # a single key is combined with itself only
     assert keys.pubkey_combine([pubkey_a]) == compress(pubkey_a)
@@ -144,7 +144,7 @@ def test_pubkey_tweak_chain() -> None:
     uncompressed both, and to refuse the same invalid tweak and the same
     landing on the point at infinity.
     """
-    pubkey_bytes = mult.mult_(3)
+    pubkey_bytes = mult.mult_bytes(3)
     tweaks = (5, N - 1, 11)
 
     chain = keys.PubkeyTweakChain(pubkey_bytes)
@@ -166,7 +166,7 @@ def test_pubkey_tweak_chain() -> None:
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
         keys.PubkeyTweakChain(pubkey_bytes).tweak_add(b"\x01" * 33)
     with pytest.raises(ValueError, match="tweak or resulting public key"):
-        keys.PubkeyTweakChain(mult.mult_(7)).tweak_add(N - 7)
+        keys.PubkeyTweakChain(mult.mult_bytes(7)).tweak_add(N - 7)
 
 
 def test_pubkey_serialization() -> None:
@@ -175,7 +175,7 @@ def test_pubkey_serialization() -> None:
     The uncompressed form is 65 octets opening with 0x04, the compressed
     33 whose first octet carries the parity of the y being dropped.
     """
-    pubkey_bytes = mult.mult_(7)
+    pubkey_bytes = mult.mult_bytes(7)
 
     # both forms parse, and either can be serialized from the other
     compressed = keys.serialize(keys.parse(pubkey_bytes))
@@ -194,7 +194,7 @@ def test_pubkey_order() -> None:
     key against itself in the other form; sorting no key is no key rather
     than an error, and a key that does not parse is refused.
     """
-    uncompressed = [mult.mult_(k) for k in (5, 2, 9, 1)]
+    uncompressed = [mult.mult_bytes(k) for k in (5, 2, 9, 1)]
     compressed = [compress(pubkey_bytes) for pubkey_bytes in uncompressed]
     # what libsecp256k1 orders by is the compressed serialization, so
     # python sorting the same bytes is an independent reference
@@ -235,10 +235,10 @@ def test_sorting_and_adding_the_same_parsed_keys() -> None:
     compare equal to one and dangle the moment the list it points into
     was dropped.
     """
-    pubkeys_bytes = [mult.mult_(k) for k in (5, 2, 9, 1)]
+    pubkeys_bytes = [mult.mult_bytes(k) for k in (5, 2, 9, 1)]
     parsed = [keys.parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes]
 
-    ordered = keys.pubkey_sort_(parsed)
+    ordered = keys._pubkey_sort_(parsed)
     assert [keys.serialize(pubkey) for pubkey in ordered] == keys.pubkey_sort(
         pubkeys_bytes
     )
@@ -247,19 +247,19 @@ def test_sorting_and_adding_the_same_parsed_keys() -> None:
         id(pubkey) for pubkey in parsed
     )
 
-    assert keys.serialize(keys.pubkey_combine_(ordered)) == keys.pubkey_combine(
+    assert keys.serialize(keys._pubkey_combine_(ordered)) == keys.pubkey_combine(
         keys.pubkey_sort(pubkeys_bytes)
     )
     # sorting no key at all is no key at all here too
-    assert keys.pubkey_sort_([]) == []
+    assert keys._pubkey_sort_([]) == []
     # and what the outer half refuses, this refuses: an empty sum, and
     # one that lands on the point at infinity
     with pytest.raises(ValueError, match="at least one public key"):
-        keys.pubkey_combine_([])
+        keys._pubkey_combine_([])
     with pytest.raises(ValueError, match="invalid public key sum"):
-        keys.pubkey_combine_([
-            keys.parse(mult.mult_(7)),
-            keys.parse(keys.pubkey_negate(mult.mult_(7))),
+        keys._pubkey_combine_([
+            keys.parse(mult.mult_bytes(7)),
+            keys.parse(keys.pubkey_negate(mult.mult_bytes(7))),
         ])
 
 
@@ -293,7 +293,7 @@ def test_keys_invalid_inputs() -> None:
     two products that reach zero or infinity -- neither of which has a key
     to answer with.
     """
-    pubkey_bytes = mult.mult_(7)
+    pubkey_bytes = mult.mult_bytes(7)
 
     with pytest.raises(ValueError, match="private key"):
         keys.prvkey_negate(b"\x01" * 31)
@@ -313,7 +313,7 @@ def test_keys_invalid_inputs() -> None:
     # tweaking by the negation of the private key lands on the point at
     # infinity, which has no serialization
     with pytest.raises(ValueError, match="tweak or resulting public key"):
-        keys.pubkey_tweak_add(mult.mult_(7), N - 7)
+        keys.pubkey_tweak_add(mult.mult_bytes(7), N - 7)
 
 
 def test_xonly_from_pubkey() -> None:
@@ -324,7 +324,7 @@ def test_xonly_from_pubkey() -> None:
     lift the x back to the point it came from.
     """
     for prvkey in (1, 2, 3):
-        pubkey_bytes = mult.mult_(prvkey)
+        pubkey_bytes = mult.mult_bytes(prvkey)
         xonly_bytes, parity = xonly.from_pubkey(pubkey_bytes)
         assert xonly_bytes == pubkey_bytes[1:33]
         assert parity == pubkey_bytes[64] & 1
@@ -347,7 +347,7 @@ def test_xonly_tweak_add() -> None:
     and fails on a different tweak, key or parity.
     """
     prvkey, tweak = 11, hashlib.sha256(b"taproot tweak").digest()
-    xonly_bytes, _ = xonly.from_pubkey(mult.mult_(prvkey))
+    xonly_bytes, _ = xonly.from_pubkey(mult.mult_bytes(prvkey))
 
     tweaked_bytes, parity = xonly.tweak_add(xonly_bytes, tweak)
 
@@ -359,8 +359,8 @@ def test_xonly_tweak_add() -> None:
     # a full public key is accepted and names the same key: the public
     # key of 11 has odd y, and BIP340 reads it as the x it shares with
     # its negation rather than as another point
-    assert mult.mult_(prvkey)[64] & 1
-    for form in (mult.mult_(prvkey), compress(mult.mult_(prvkey))):
+    assert mult.mult_bytes(prvkey)[64] & 1
+    for form in (mult.mult_bytes(prvkey), compress(mult.mult_bytes(prvkey))):
         assert xonly.tweak_add(form, tweak) == (tweaked_bytes, parity)
 
     # the commitment can be checked without recomputing it
@@ -368,7 +368,7 @@ def test_xonly_tweak_add() -> None:
     # a different tweak, key, or parity does not check out
     assert not xonly.tweak_add_check(tweaked_bytes, parity, xonly_bytes, b"\x01" * 32)
     assert not xonly.tweak_add_check(
-        tweaked_bytes, parity, xonly.from_pubkey(mult.mult_(12))[0], tweak
+        tweaked_bytes, parity, xonly.from_pubkey(mult.mult_bytes(12))[0], tweak
     )
     assert not xonly.tweak_add_check(tweaked_bytes, 1 - parity, xonly_bytes, tweak)
 
@@ -377,19 +377,19 @@ def test_xonly_tweak_add() -> None:
     # instead of parsing it, which is the whole of what it saves over
     # recomputing the tweak. The internal key is parsed, and does raise
     assert not xonly.tweak_add_check(b"\xff" * 32, parity, xonly_bytes, tweak)
-    with pytest.raises(ValueError, match="invalid x-only public key"):
+    with pytest.raises(ValueError, match="invalid public key"):
         xonly.tweak_add_check(tweaked_bytes, parity, b"\xff" * 32, tweak)
 
 
 def test_taproot_key_path() -> None:
     """Sign a taproot key path spending with a tweaked private key."""
     prvkey, tweak = 11, hashlib.sha256(b"taproot tweak").digest()
-    internal_bytes, _ = xonly.from_pubkey(mult.mult_(prvkey))
+    internal_bytes, _ = xonly.from_pubkey(mult.mult_bytes(prvkey))
     output_bytes, _ = xonly.tweak_add(internal_bytes, tweak)
 
     tweaked_prvkey = xonly.prvkey_tweak_add(prvkey, tweak)
     # the tweaked private key is the one of the tweaked x-only key
-    assert xonly.from_pubkey(mult.mult_(tweaked_prvkey))[0] == (output_bytes)
+    assert xonly.from_pubkey(mult.mult_bytes(tweaked_prvkey))[0] == (output_bytes)
     # hence it signs for the taproot output key
     signature_bytes = ssa.sign(msg, tweaked_prvkey)
     assert ssa.verify(msg, output_bytes, signature_bytes)
@@ -406,9 +406,9 @@ def test_xonly_invalid_inputs() -> None:
     negation of the scalar, which land on the point at infinity and have
     no x-only form to answer with.
     """
-    xonly_bytes, parity = xonly.from_pubkey(mult.mult_(11))
+    xonly_bytes, parity = xonly.from_pubkey(mult.mult_bytes(11))
 
-    with pytest.raises(ValueError, match="invalid x-only public key"):
+    with pytest.raises(ValueError, match="invalid public key"):
         # 32 bytes which are not a valid x coordinate
         xonly.tweak_add(b"\xff" * 32, b"\x01" * 32)
     with pytest.raises(ValueError, match="invalid public key"):
@@ -427,7 +427,7 @@ def test_xonly_invalid_inputs() -> None:
     # tweaking by the negation of the private key of the even y point
     # lands on the point at infinity, which has no x-only form
     with pytest.raises(ValueError, match="tweak or resulting public key"):
-        xonly.tweak_add(xonly.from_pubkey(mult.mult_(1))[0], N - 1)
+        xonly.tweak_add(xonly.from_pubkey(mult.mult_bytes(1))[0], N - 1)
     with pytest.raises(ValueError, match="tweak or resulting private key"):
         xonly.prvkey_tweak_add(1, N - 1)
 
@@ -441,7 +441,7 @@ def test_dsa_signature_forms() -> None:
     refused, and the DER rebuilt from the compact form still verifies.
     """
     prvkey = 7
-    pubkey_bytes = compress(mult.mult_(prvkey))
+    pubkey_bytes = compress(mult.mult_bytes(prvkey))
     der_bytes = dsa.sign(msg, prvkey)
 
     compact_bytes = dsa.to_compact(der_bytes)
@@ -474,7 +474,7 @@ def test_dsa_low_s() -> None:
     the original byte for byte and that verifies.
     """
     prvkey = 7
-    pubkey_bytes = compress(mult.mult_(prvkey))
+    pubkey_bytes = compress(mult.mult_bytes(prvkey))
     der_bytes = dsa.sign(msg, prvkey)
 
     # signatures are created in the normalized lower-s form
@@ -505,7 +505,7 @@ def test_dsa_verify_normalizes_when_it_is_told_to() -> None:
     is asserted here too, that being the promise the keyword is behind.
     """
     prvkey = 7
-    pubkey_bytes = compress(mult.mult_(prvkey))
+    pubkey_bytes = compress(mult.mult_bytes(prvkey))
     pubkey = keys.parse(pubkey_bytes)
     der_bytes = dsa.sign(msg, prvkey)
 
@@ -513,18 +513,28 @@ def test_dsa_verify_normalizes_when_it_is_told_to() -> None:
     s = int.from_bytes(compact_bytes[32:], "big")
     malleated_bytes = dsa.to_der(compact_bytes[:32] + (N - s).to_bytes(32, "big"))
 
-    # the same answer the round trip through DER gives, and the outer and
-    # inner halves agree on it
+    # the same answer the round trip through DER gives, and the public and
+    # private halves agree on it. The private one is handed a parsed
+    # signature of its own each time: `normalize=True` mutates it, which
+    # is the saving over parsing the normalized bytes back
     assert dsa.verify(msg, pubkey_bytes, malleated_bytes, True)
-    assert dsa.verify_(msg, pubkey, malleated_bytes, True)
+    assert dsa._verify_(msg, pubkey, dsa.parse_der(malleated_bytes), True)
     # a signature already low-s is normalized to itself, so nothing about
     # the ordinary case changes
     assert dsa.verify(msg, pubkey_bytes, der_bytes, True)
-    assert dsa.verify_(msg, pubkey, der_bytes, True)
+    assert dsa._verify_(msg, pubkey, dsa.parse_der(der_bytes), True)
 
     # and the default is still the refusal, through both halves
     assert not dsa.verify(msg, pubkey_bytes, malleated_bytes)
-    assert not dsa.verify_(msg, pubkey, malleated_bytes)
+    assert not dsa._verify_(msg, pubkey, dsa.parse_der(malleated_bytes))
+
+    # what `normalize=True` mutated is the caller's own object, and it is
+    # the lower-s signature afterwards rather than the one handed in
+    malleated = dsa.parse_der(malleated_bytes)
+    assert not dsa._is_low_s_(malleated)
+    assert dsa._verify_(msg, pubkey, malleated, True)
+    assert dsa._is_low_s_(malleated)
+    assert dsa.serialize_der(malleated) == der_bytes
 
     # normalizing s says nothing about the message: a signature of
     # another one is False either way
@@ -541,7 +551,7 @@ def test_size_checks_refuse_both_sides() -> None:
     the other edge, and the first mutation session found both checks
     surviving a `!=` turned into `>`.
     """
-    xonly_bytes, parity = xonly.from_pubkey(mult.mult_(11))
+    xonly_bytes, parity = xonly.from_pubkey(mult.mult_bytes(11))
 
     # parse, reached through both entry points: 31 octets are none of the
     # three serializations, and libsecp256k1 is never handed them
@@ -565,7 +575,7 @@ def test_pubkey_verify_is_the_parse_with_nothing_kept() -> None:
     """
     prvkey = 11
     compressed = keys.pubkey_from_prvkey(prvkey)
-    uncompressed = mult.mult_(prvkey)
+    uncompressed = mult.mult_bytes(prvkey)
 
     for form in (compressed, uncompressed):
         assert keys.pubkey_verify(form)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -58,13 +58,13 @@ def test_ecdh() -> None:
     protocol wanting another derivation applying it to the point.
     """
     prvkey_a, prvkey_b = 3, 5
-    pubkey_a, pubkey_b = mult.mult_(prvkey_a), mult.mult_(prvkey_b)
+    pubkey_a, pubkey_b = mult.mult_bytes(prvkey_a), mult.mult_bytes(prvkey_b)
 
     secret = ecdh.shared_secret(pubkey_b, prvkey_a)
     # both parties compute the same secret
     assert secret == ecdh.shared_secret(pubkey_a, prvkey_b)
     # which is the SHA256 of the compressed shared point
-    shared_point = mult.mult_(prvkey_a * prvkey_b)
+    shared_point = mult.mult_bytes(prvkey_a * prvkey_b)
     assert secret == hashlib.sha256(compress(shared_point)).digest()
     # bytes and int private keys are interchangeable
     assert secret == ecdh.shared_secret(pubkey_b, prvkey_a.to_bytes(32, "big"))
@@ -77,7 +77,7 @@ def test_ecdh() -> None:
 
 def test_ecdh_invalid_inputs() -> None:
     """A zero key, a short key and an unparsable public key are refused."""
-    pubkey_bytes = mult.mult_(1)
+    pubkey_bytes = mult.mult_bytes(1)
 
     with pytest.raises(ValueError, match="private key"):
         ecdh.shared_secret(pubkey_bytes, 0)
@@ -97,7 +97,7 @@ def test_recovery() -> None:
     still recoverable.
     """
     prvkey = 7
-    pubkey_bytes = compress(mult.mult_(prvkey))
+    pubkey_bytes = compress(mult.mult_bytes(prvkey))
 
     signature_bytes, recid = recovery.sign(msg, prvkey)
     assert len(signature_bytes) == 64
@@ -117,7 +117,7 @@ def test_recovery() -> None:
     # the recovered key comes back in either form, this being
     # keys.serialize and the same point either way
     uncompressed = recovery.recover(msg, signature_bytes, recid, compressed=False)
-    assert uncompressed == mult.mult_(prvkey)
+    assert uncompressed == mult.mult_bytes(prvkey)
     assert compress(uncompressed) == pubkey_bytes
 
 
@@ -150,7 +150,7 @@ def test_recovery_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="recovery failed"):
         # a zero r parses, but no point can be recovered from it
         recovery.recover(msg, b"\x00" * 64, 0)
-    with pytest.raises(ValueError, match="ndata must be 32 bytes"):
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
         recovery.sign(msg, 7, b"\x01" * 33)
 
 
@@ -164,7 +164,7 @@ def test_ellswift() -> None:
     naming their own side, and swapping the roles changes it.
     """
     prvkey_a, prvkey_b = 11, 13
-    pubkey_a = compress(mult.mult_(prvkey_a))
+    pubkey_a = compress(mult.mult_bytes(prvkey_a))
 
     ell_a = ellswift.create(prvkey_a, b"\x01" * 32)
     assert len(ell_a) == 64
@@ -181,7 +181,7 @@ def test_ellswift() -> None:
     assert ellswift.create(prvkey_a) != ell_a
     # and the decoding comes back in either form, this being
     # keys.serialize and the same point either way
-    assert ellswift.decode(ell_a, compressed=False) == mult.mult_(prvkey_a)
+    assert ellswift.decode(ell_a, compressed=False) == mult.mult_bytes(prvkey_a)
 
     # x-only ECDH: both parties agree on the BIP324 shared secret
     ell_b = ellswift.create(prvkey_b)
@@ -209,8 +209,8 @@ def test_ellswift_invalid_inputs() -> None:
         ellswift.create(11, b"\x01" * 33)
     with pytest.raises(ValueError, match="public key"):
         ellswift.encode(b"\x02" + b"\x00" * 32)
-    with pytest.raises(ValueError, match="rnd32 must be 32 bytes"):
-        ellswift.encode(mult.mult_(11), b"\x01" * 31)
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
+        ellswift.encode(mult.mult_bytes(11), b"\x01" * 31)
     with pytest.raises(ValueError, match="64 bytes"):
         ellswift.decode(ell[1:])
     with pytest.raises(ValueError, match="64 bytes"):
@@ -321,7 +321,7 @@ def test_size_checks_refuse_both_sides() -> None:
 
     with pytest.raises(ValueError, match="message hash"):
         recovery.sign(msg + b"\x01", prvkey)
-    with pytest.raises(ValueError, match="ndata"):
+    with pytest.raises(ValueError, match="aux_rand32"):
         recovery.sign(msg, prvkey, b"\x01" * 31)
     with pytest.raises(ValueError, match="message hash"):
         recovery.recover(msg + b"\x01", signature_bytes, recid)
@@ -332,8 +332,8 @@ def test_size_checks_refuse_both_sides() -> None:
 
     with pytest.raises(ValueError, match="aux_rand32"):
         ellswift.create(prvkey, b"\x01" * 31)
-    with pytest.raises(ValueError, match="rnd32"):
-        ellswift.encode(mult.mult_(prvkey), b"\x01" * 33)
+    with pytest.raises(ValueError, match="aux_rand32"):
+        ellswift.encode(mult.mult_bytes(prvkey), b"\x01" * 33)
     with pytest.raises(ValueError, match="64 bytes"):
         ellswift.decode(ell + b"\x01")
     with pytest.raises(ValueError, match="64 bytes"):
@@ -388,7 +388,7 @@ SP_OUTPOINT = bytes(36)
 
 def sp_summary() -> bytes:
     """Summarize the one-input transaction this section's payment funds."""
-    return silentpayments.prevouts_summary(SP_OUTPOINT, pubkeys=[SP_INPUT_PUBKEY])
+    return silentpayments.prevouts_summary(SP_OUTPOINT, pubkeys_bytes=[SP_INPUT_PUBKEY])
 
 
 def test_a_silent_payment_is_found_by_the_key_it_was_paid_to() -> None:
@@ -528,7 +528,7 @@ def test_a_taproot_input_pays_as_its_even_y_key() -> None:
         [(SP_SCAN_PUBKEY, SP_SPEND_PUBKEY)], SP_OUTPOINT, taproot_prvkeys=[prvkey]
     )
     summary = silentpayments.prevouts_summary(
-        SP_OUTPOINT, taproot_pubkeys=[xonly_pubkey]
+        SP_OUTPOINT, taproot_pubkeys_bytes=[xonly_pubkey]
     )
     found = silentpayments.scan_outputs(
         outputs, SP_SCAN_PRVKEY, summary, SP_SPEND_PUBKEY
@@ -571,7 +571,7 @@ def test_a_label_is_a_point_and_round_trips_through_its_33_bytes() -> None:
     # through the serialization at every address
     assert (
         keys.serialize(
-            silentpayments.labeled_spend_pubkey_(
+            silentpayments._labeled_spend_pubkey_(
                 keys.parse(SP_SPEND_PUBKEY), silentpayments.parse_label(label)
             )
         )
@@ -653,7 +653,9 @@ def test_a_label_m_outside_four_bytes_is_refused() -> None:
     that kills that mutant.
     """
     for m in (-1, 2**32, 2**32 + 1):
-        with pytest.raises(ValueError, match="the label m must fit in 4 bytes"):
+        with pytest.raises(
+            ValueError, match=r"the label m must be in \[0, 4294967295\]"
+        ):
             silentpayments.label(SP_SCAN_PRVKEY, m)
 
 
@@ -692,7 +694,7 @@ def test_a_prevouts_summary_of_no_input_is_refused() -> None:
 def test_a_prevouts_summary_of_an_unparsable_taproot_key_is_refused() -> None:
     """An x that is not on the curve is not a taproot input key."""
     with pytest.raises(ValueError, match="invalid taproot public key"):
-        silentpayments.prevouts_summary(SP_OUTPOINT, taproot_pubkeys=[bytes(32)])
+        silentpayments.prevouts_summary(SP_OUTPOINT, taproot_pubkeys_bytes=[bytes(32)])
 
 
 def test_scanning_refuses_an_empty_output_list() -> None:

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -3,17 +3,18 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Every inner half answers what its outer half answers.
+"""Every private half answers what its public half answers.
 
-A trailing underscore means one thing across these bindings, and
-`keys.parse` states it: the wrapper takes the parsed public key in place
-of the bytes, and the outer half is that same call with a `parse` in
-front of it. That is an equality, so it is written as one here, pair by
-pair and over both serializations of the key -- which is what keeps the
-two halves from drifting into two implementations of the same thing.
+`_foo_` means one thing across these bindings, and the package docstring
+states it: the wrapper takes the parsed object in place of the octets,
+and the public half is that same call with a `parse` in front of it, a
+`serialize` behind it, or both. That is an equality, so it is written as
+one here, pair by pair and -- where the object is a public key -- over
+both serializations of it, which is what keeps the two halves from
+drifting into two implementations of the same thing.
 
-`test_every_inner_half_is_paired` holds the table to the modules' own
-contents, so an inner half added and not paired here is visible as an
+`test_every_private_half_is_paired` holds the tables to the modules' own
+contents, so a private half added and not paired here is visible as an
 absence rather than as a test nobody wrote.
 """
 
@@ -29,6 +30,7 @@ from btclib_secp256k1 import (
     dsa,
     ecdh,
     ellswift,
+    ffi,
     keys,
     mult,
     recovery,
@@ -48,138 +50,230 @@ MSG = hashlib.sha256(b"btclib_secp256k1").digest()
 # is what the encoding takes by default, and two of those never agree
 RND32 = bytes(32)
 
-PUBKEY_LONG = mult.mult_(PRVKEY)
+PUBKEY_LONG = mult.mult_bytes(PRVKEY)
 PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
 OTHER = keys.pubkey_from_prvkey(3)
 XONLY, PARITY = xonly.from_pubkey(PUBKEY)
 DER = dsa.sign(MSG, PRVKEY)
+# the same signature with s negated, which is the malleation the lower-s
+# rule rules out: `normalize` is what puts it back
+HIGH_S = dsa.to_der(
+    dsa.to_compact(DER)[:32]
+    + (N - int.from_bytes(dsa.to_compact(DER)[32:], "big")).to_bytes(32, "big")
+)
 SSA_SIG = ssa.sign(MSG, PRVKEY, bytes(32))
 TWEAKED, TWEAKED_PARITY = xonly.tweak_add(XONLY, TWEAK)
 RECOVERABLE, RECID = recovery.sign(MSG, PRVKEY)
 ELL = ellswift.create(PRVKEY, RND32)
 LABEL, LABEL_TWEAK = silentpayments.label(SCAN_PRVKEY, 0)
 
+# the Silent Payments transaction the two sides of that module are held
+# to: one recipient, one input, and the outputs the sender creates
+SP_OUTPOINT = bytes(36)
+SP_SCAN_PUBKEY = keys.pubkey_from_prvkey(SCAN_PRVKEY)
+SP_SPEND_PUBKEY = keys.pubkey_from_prvkey(PRVKEY)
+SP_INPUT_PRVKEY = 3
+SP_INPUT_PUBKEY = keys.pubkey_from_prvkey(SP_INPUT_PRVKEY)
+SP_OUTPUTS = silentpayments.create_outputs(
+    [(SP_SCAN_PUBKEY, SP_SPEND_PUBKEY)], SP_OUTPOINT, prvkeys=[SP_INPUT_PRVKEY]
+)
+SP_SUMMARY = silentpayments.prevouts_summary(
+    SP_OUTPOINT, pubkeys_bytes=[SP_INPUT_PUBKEY]
+)
 
-def label_through_the_inner_half() -> tuple[bytes, bytes]:
-    """Create a label through `label_`, and serialize what it answered.
+
+def label_through_the_private_half() -> tuple[bytes, bytes]:
+    """Create a label through `_label_`, and serialize what it answered.
 
     Returns:
         The 33-byte label and its 32-byte tweak, which is the pair
         `silentpayments.label` answers with.
     """
-    label_obj, tweak = silentpayments.label_(SCAN_PRVKEY, 0)
+    label_obj, tweak = silentpayments._label_(SCAN_PRVKEY, 0)
     return silentpayments.serialize_label(label_obj), tweak
 
 
-# every pair of the convention: the name of the outer half, that half as
-# a call of the serialized key alone, and the inner half as a call of the
-# parsed one. The arguments that are not the key are closed over, being
-# the same on both sides by construction. Two of the inner halves answer
-# with the key they mutated, and a cffi object is equal to no other, so
-# those are compared through `keys.serialize` -- which is what their
-# outer halves do with the same object
+def scan_through_the_private_half() -> list[tuple[bytes, bytes, bytes | None]]:
+    """Scan the transaction with every argument already parsed.
+
+    Returns:
+        What `silentpayments.scan_outputs` answers for the same
+        transaction, which is a list of triples of octets either way.
+    """
+    return silentpayments._scan_outputs_(
+        [xonly.parse(output) for output in SP_OUTPUTS],
+        SCAN_PRVKEY,
+        silentpayments._prevouts_summary_(
+            SP_OUTPOINT, pubkeys=[keys.parse(SP_INPUT_PUBKEY)]
+        ),
+        keys.parse(SP_SPEND_PUBKEY),
+    )
+
+
+# every pair whose object is a public key: the private half's name, the
+# public half as a call of the serialized key alone, and the private one
+# as a call of the parsed key. The arguments that are not the key are
+# closed over, being the same on both sides by construction. Two of the
+# private halves answer with the key they mutated, and a cffi object is
+# equal to no other, so those are compared through `keys.serialize` --
+# which is what their public halves do with the same object
 PAIRS: list[tuple[str, Callable[[bytes], Any], Callable[[Any], Any]]] = [
     (
-        "keys.pubkey_negate",
+        "keys._pubkey_negate_",
         keys.pubkey_negate,
-        lambda pubkey: keys.serialize(keys.pubkey_negate_(pubkey)),
+        lambda pubkey: keys.serialize(keys._pubkey_negate_(pubkey)),
     ),
     (
-        "keys.pubkey_tweak_add",
+        "keys._pubkey_tweak_add_",
         lambda pubkey_bytes: keys.pubkey_tweak_add(pubkey_bytes, TWEAK),
-        lambda pubkey: keys.serialize(keys.pubkey_tweak_add_(pubkey, TWEAK)),
+        lambda pubkey: keys.serialize(keys._pubkey_tweak_add_(pubkey, TWEAK)),
     ),
     (
-        "keys.pubkey_tweak_mul",
+        "keys._pubkey_tweak_mul_",
         lambda pubkey_bytes: keys.pubkey_tweak_mul(pubkey_bytes, TWEAK),
-        lambda pubkey: keys.serialize(keys.pubkey_tweak_mul_(pubkey, TWEAK)),
+        lambda pubkey: keys.serialize(keys._pubkey_tweak_mul_(pubkey, TWEAK)),
     ),
     (
-        "keys.pubkey_cmp",
+        "keys._pubkey_cmp_",
         lambda pubkey_bytes: keys.pubkey_cmp(pubkey_bytes, OTHER),
-        lambda pubkey: keys.pubkey_cmp_(pubkey, keys.parse(OTHER)),
+        lambda pubkey: keys._pubkey_cmp_(pubkey, keys.parse(OTHER)),
     ),
-    ("xonly.from_pubkey", xonly.from_pubkey, xonly.from_pubkey_),
+    ("xonly._from_pubkey_", xonly.from_pubkey, xonly._from_pubkey_),
     (
-        "ecdh.shared_secret",
+        "ecdh._shared_secret_",
         lambda pubkey_bytes: ecdh.shared_secret(pubkey_bytes, PRVKEY),
-        lambda pubkey: ecdh.shared_secret_(pubkey, PRVKEY),
+        lambda pubkey: ecdh._shared_secret_(pubkey, PRVKEY),
     ),
     (
-        "dsa.verify",
+        "dsa._verify_",
         lambda pubkey_bytes: dsa.verify(MSG, pubkey_bytes, DER),
-        lambda pubkey: dsa.verify_(MSG, pubkey, DER),
+        lambda pubkey: dsa._verify_(MSG, pubkey, dsa.parse_der(DER)),
     ),
     (
-        "ellswift.encode",
+        "ellswift._encode_",
         lambda pubkey_bytes: ellswift.encode(pubkey_bytes, RND32),
-        lambda pubkey: ellswift.encode_(pubkey, RND32),
+        lambda pubkey: ellswift._encode_(pubkey, RND32),
     ),
 ]
 
-# and the halves on the other side of the boundary: the ones that answer
-# with the key instead of with its bytes, whose outer half is the same
-# call with a `serialize` behind it rather than a `parse` in front. Each
-# is written as the pair of calls it is, the key being what they produce
-# rather than what they take -- so there are no two serializations of an
-# argument to drive them with, and the equality is over the answer alone
-PRODUCERS: list[tuple[str, Callable[[], Any], Callable[[], Any]]] = [
+# and every other pair, whose object is produced rather than taken, or is
+# a signature, a label or a summary rather than a key: each is written as
+# the pair of calls it is, so there are no two serializations of an
+# argument to drive them with and the equality is over the answer alone
+EQUALITIES: list[tuple[str, Callable[[], Any], Callable[[], Any]]] = [
     (
-        "keys.pubkey_from_prvkey",
+        "keys._pubkey_from_prvkey_",
         lambda: keys.pubkey_from_prvkey(PRVKEY),
-        lambda: keys.serialize(keys.pubkey_from_prvkey_(PRVKEY)),
+        lambda: keys.serialize(keys._pubkey_from_prvkey_(PRVKEY)),
     ),
     (
-        "keys.pubkey_combine",
+        "keys._pubkey_combine_",
         lambda: keys.pubkey_combine([PUBKEY, OTHER]),
         lambda: keys.serialize(
-            keys.pubkey_combine_([keys.parse(PUBKEY), keys.parse(OTHER)])
+            keys._pubkey_combine_([keys.parse(PUBKEY), keys.parse(OTHER)])
         ),
     ),
     (
-        "keys.pubkey_sort",
+        "keys._pubkey_sort_",
         lambda: keys.pubkey_sort([PUBKEY, OTHER]),
         lambda: [
             keys.serialize(pubkey)
-            for pubkey in keys.pubkey_sort_([keys.parse(PUBKEY), keys.parse(OTHER)])
+            for pubkey in keys._pubkey_sort_([keys.parse(PUBKEY), keys.parse(OTHER)])
         ],
     ),
     (
-        "recovery.recover",
+        "dsa._sign_",
+        lambda: dsa.sign(MSG, PRVKEY),
+        lambda: dsa.serialize_der(dsa._sign_(MSG, PRVKEY)),
+    ),
+    (
+        "dsa._normalize_",
+        lambda: dsa.normalize(HIGH_S),
+        lambda: dsa.serialize_der(dsa._normalize_(dsa.parse_der(HIGH_S))),
+    ),
+    (
+        "dsa._is_low_s_",
+        lambda: dsa.is_low_s(HIGH_S),
+        lambda: dsa._is_low_s_(dsa.parse_der(HIGH_S)),
+    ),
+    (
+        "recovery._sign_",
+        lambda: recovery.sign(MSG, PRVKEY),
+        lambda: recovery.serialize_compact(recovery._sign_(MSG, PRVKEY)),
+    ),
+    (
+        "recovery._recover_",
         lambda: recovery.recover(MSG, RECOVERABLE, RECID),
-        lambda: keys.serialize(recovery.recover_(MSG, RECOVERABLE, RECID)),
+        lambda: keys.serialize(
+            recovery._recover_(MSG, recovery.parse_compact(RECOVERABLE, RECID))
+        ),
     ),
     (
-        "ellswift.decode",
+        "recovery._to_der_",
+        lambda: recovery.to_der(RECOVERABLE, RECID),
+        lambda: recovery._to_der_(recovery.parse_compact(RECOVERABLE, RECID)),
+    ),
+    (
+        "ellswift._decode_",
         lambda: ellswift.decode(ELL),
-        lambda: keys.serialize(ellswift.decode_(ELL)),
+        lambda: keys.serialize(ellswift._decode_(ELL)),
     ),
     (
-        "silentpayments.label",
+        "silentpayments._label_",
         lambda: silentpayments.label(SCAN_PRVKEY, 0),
-        label_through_the_inner_half,
+        label_through_the_private_half,
     ),
     (
-        "silentpayments.labeled_spend_pubkey",
+        "silentpayments._labeled_spend_pubkey_",
         lambda: silentpayments.labeled_spend_pubkey(PUBKEY, LABEL),
         lambda: keys.serialize(
-            silentpayments.labeled_spend_pubkey_(
+            silentpayments._labeled_spend_pubkey_(
                 keys.parse(PUBKEY), silentpayments.parse_label(LABEL)
             )
         ),
+    ),
+    (
+        "silentpayments._create_outputs_",
+        lambda: SP_OUTPUTS,
+        lambda: [
+            xonly.serialize(output)
+            for output in silentpayments._create_outputs_(
+                [(keys.parse(SP_SCAN_PUBKEY), keys.parse(SP_SPEND_PUBKEY))],
+                SP_OUTPOINT,
+                prvkeys=[SP_INPUT_PRVKEY],
+            )
+        ],
+    ),
+    (
+        "silentpayments._prevouts_summary_",
+        lambda: SP_SUMMARY,
+        lambda: bytes(
+            ffi.buffer(
+                silentpayments._prevouts_summary_(
+                    SP_OUTPOINT, pubkeys=[keys.parse(SP_INPUT_PUBKEY)]
+                )
+            )
+        ),
+    ),
+    (
+        "silentpayments._scan_outputs_",
+        lambda: silentpayments.scan_outputs(
+            SP_OUTPUTS, SCAN_PRVKEY, SP_SUMMARY, SP_SPEND_PUBKEY
+        ),
+        scan_through_the_private_half,
     ),
 ]
 
 
 @pytest.mark.parametrize("pubkey_bytes", [PUBKEY, PUBKEY_LONG], ids=["33", "65"])
-@pytest.mark.parametrize("name,outer,inner", PAIRS, ids=[pair[0] for pair in PAIRS])
-def test_the_inner_half_is_the_outer_one_without_the_parse(
+@pytest.mark.parametrize("name,public,private", PAIRS, ids=[pair[0] for pair in PAIRS])
+def test_the_private_half_is_the_public_one_without_the_parse(
     name: str,
-    outer: Callable[[bytes], Any],
-    inner: Callable[[Any], Any],
+    public: Callable[[bytes], Any],
+    private: Callable[[Any], Any],
     pubkey_bytes: bytes,
 ) -> None:
-    """`outer(key_bytes)` is `inner(parse(key_bytes))`, in both forms.
+    """`public(key_bytes)` is `private(parse(key_bytes))`, in both forms.
 
     Both serializations, because the parse is what tells them apart: the
     compressed one costs a field square root the uncompressed one does
@@ -187,60 +281,61 @@ def test_the_inner_half_is_the_outer_one_without_the_parse(
     ends at is the same point either way.
 
     Args:
-        name: the outer half, for the test id.
-        outer: it, as a call of the serialized key.
-        inner: the inner half, as a call of the parsed key.
+        name: the private half, for the test id.
+        public: the public half, as a call of the serialized key.
+        private: the private half, as a call of the parsed key.
         pubkey_bytes: the key, compressed or not.
     """
-    assert outer(pubkey_bytes) == inner(keys.parse(pubkey_bytes))
+    assert public(pubkey_bytes) == private(keys.parse(pubkey_bytes))
 
 
 @pytest.mark.parametrize(
-    "name,outer,inner", PRODUCERS, ids=[producer[0] for producer in PRODUCERS]
+    "name,public,private", EQUALITIES, ids=[pair[0] for pair in EQUALITIES]
 )
-def test_the_producing_half_is_the_outer_one_without_the_serialize(
-    name: str, outer: Callable[[], Any], inner: Callable[[], Any]
+def test_the_private_half_answers_what_the_public_one_answers(
+    name: str, public: Callable[[], Any], private: Callable[[], Any]
 ) -> None:
-    """`outer(...)` is `serialize(inner(...))`, key for key.
+    """`public(...)` is the private half with the serialization around it.
 
     The same equality read the other way round: where the halves above
-    take the key, these produce it, so what the outer half adds is the
-    serialization behind the call rather than the parse in front of it.
-    A caller who hands the key straight to another wrapper -- which is
-    what these are for -- never pays for either.
+    take a key, these produce one, or take an object that is not a key at
+    all -- a signature, a label, the summary of a transaction's inputs.
+    What the public half adds is the parse in front, the serialize
+    behind, or both; a caller that hands the object straight to another
+    wrapper never pays for either.
 
     Args:
-        name: the outer half, for the test id.
-        outer: it, as a call of its own arguments.
-        inner: the inner half, with what serializes its answer.
+        name: the private half, for the test id.
+        public: the public half, as a call of its own arguments.
+        private: the private half, with what serializes its answer.
     """
-    assert outer() == inner()
+    assert public() == private()
 
 
 def test_the_schnorr_pair_parses_the_x_only_key() -> None:
-    """`ssa.verify` is `ssa.verify_` behind `xonly.parse`.
+    """`ssa.verify` is `ssa._verify_` behind `xonly.parse`.
 
     The one pair whose parsed key is not `keys.parse`'s: BIP340 verifies
-    against the 32-byte x-only key, so what a caller holds is what
-    `xonly.parse` returns, and proving those 32 bytes to be the x
-    coordinate of a point is the call the verification would make again.
+    against the x coordinate, so what a caller holds is what
+    `xonly.parse` returns, and proving those octets the x of a point is
+    the call the verification would make again.
     """
     assert ssa.verify(MSG, XONLY, SSA_SIG)
-    assert ssa.verify_(MSG, xonly.parse(XONLY), SSA_SIG)
+    assert ssa._verify_(MSG, xonly.parse(XONLY), SSA_SIG)
     # and a signature that does not verify is False through both, rather
     # than an equality that holds because everything is True
     tampered = bytes([SSA_SIG[0] ^ 1]) + SSA_SIG[1:]
     assert not ssa.verify(MSG, XONLY, tampered)
-    assert not ssa.verify_(MSG, xonly.parse(XONLY), tampered)
+    assert not ssa._verify_(MSG, xonly.parse(XONLY), tampered)
 
 
 def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
-    """`xonly.tweak_add_` is `xonly.tweak_add` of the key's own x.
+    """`xonly._tweak_add_` is `xonly.tweak_add` of the key's own x.
 
-    The other pair whose parsed key is not the one its outer half makes:
-    `tweak_add` takes 32 bytes and lifts them, `tweak_add_` takes the
-    point those bytes are the x of, which is what a caller that validated
-    a full public key is already holding.
+    The other pair whose parsed key is not the one its public half makes:
+    `tweak_add` takes the x and lifts it, `_tweak_add_` takes the point
+    that x belongs to, which is what a caller that validated a full
+    public key is already holding.
 
     The odd-y key is the case worth writing down: BIP341's internal key
     is x-only, so the point is tweaked as its negation and answers the
@@ -250,7 +345,7 @@ def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
     for pubkey_bytes in (PUBKEY, PUBKEY_LONG, keys.pubkey_negate(PUBKEY)):
         x_only, _ = xonly.from_pubkey(pubkey_bytes)
         assert x_only == XONLY
-        assert xonly.tweak_add_(keys.parse(pubkey_bytes), TWEAK) == xonly.tweak_add(
+        assert xonly._tweak_add_(keys.parse(pubkey_bytes), TWEAK) == xonly.tweak_add(
             x_only, TWEAK
         )
 
@@ -299,6 +394,27 @@ def test_reserialize_is_the_two_calls_it_replaces() -> None:
         keys.reserialize(b"\x02" + bytes(32))
 
 
+def test_a_chain_hands_out_the_point_it_holds() -> None:
+    """`PubkeyTweakChain.pubkey` is the key without a tweak added.
+
+    What `Signer.pubkey` is to a signer: the object is already there, so
+    the answer is a serialization rather than a walk of the path again.
+    Before the first tweak it is the key the chain was built from, which
+    makes it that key's `reserialize`; `_pubkey_` is the same answer for
+    a caller handing the point to a private half.
+    """
+    chain = keys.PubkeyTweakChain(PUBKEY)
+    assert chain.pubkey() == PUBKEY
+    assert chain.pubkey(compressed=False) == PUBKEY_LONG
+
+    step = chain.tweak_add(TWEAK)
+    assert chain.pubkey() == step
+    assert keys.serialize(chain._pubkey_()) == step
+    # and it is the point itself, not a copy of its bytes: the next tweak
+    # is added to what the accessor answered
+    assert xonly._from_pubkey_(chain._pubkey_()) == xonly.from_pubkey(step)
+
+
 def test_a_parsed_key_verifies_more_than_once() -> None:
     """The motivating case: one parse, several signatures.
 
@@ -311,62 +427,78 @@ def test_a_parsed_key_verifies_more_than_once() -> None:
     pubkey = keys.parse(PUBKEY)
     for index in range(3):
         msg = hashlib.sha256(index.to_bytes(4, "big")).digest()
-        assert dsa.verify_(msg, pubkey, dsa.sign(msg, PRVKEY))
-        assert not dsa.verify_(msg, pubkey, DER)
+        assert dsa._verify_(msg, pubkey, dsa.parse_der(dsa.sign(msg, PRVKEY)))
+        assert not dsa._verify_(msg, pubkey, dsa.parse_der(DER))
     assert keys.serialize(pubkey) == PUBKEY
 
 
-def test_an_inner_half_still_checks_everything_but_the_key() -> None:
-    """What the underscore drops is the parse, and nothing else.
+def test_a_parsed_signature_is_asked_and_verified_without_a_second_parse() -> None:
+    """The same motivating case for a signature: one parse, two questions.
 
-    Each remaining argument is refused exactly as the outer half refuses
-    it: a message hash that is not 32 octets, a DER signature that is
-    malformed, a signature that is not 64, a private key that is not a
-    scalar, a tweak that is not 32 octets. A bare pointer's length is
-    what no C return code can report, so an inner half that skipped these
-    would be reading past the end of a short value.
+    `is_low_s` and `verify` each parse the DER they are given, so a
+    caller enforcing the lower-s rule and then verifying parses twice
+    where the private halves take the object once.
+    """
+    signature = dsa.parse_der(DER)
+    assert dsa._is_low_s_(signature)
+    assert dsa._verify_(MSG, keys.parse(PUBKEY), signature)
+    # and the two serializations are one object read twice, rather than
+    # a conversion through the other
+    assert dsa.serialize_der(signature) == DER
+    assert dsa.serialize_compact(signature) == dsa.to_compact(DER)
+    assert dsa.serialize_der(dsa.parse_compact(dsa.to_compact(DER))) == DER
+
+
+def test_a_private_half_still_checks_everything_but_the_object() -> None:
+    """What the underscores drop is the parse, and nothing else.
+
+    Each remaining argument is refused exactly as the public half refuses
+    it: a message hash that is not 32 octets, a signature that is not 64,
+    a private key that is not a scalar, a tweak that is not 32 octets. A
+    bare pointer's length is what no C return code can report, so a
+    private half that skipped these would be reading past the end of a
+    short value.
     """
     pubkey = keys.parse(PUBKEY)
 
     with pytest.raises(ValueError, match="message hash"):
-        dsa.verify_(MSG[1:], pubkey, DER)
+        dsa._verify_(MSG[1:], pubkey, dsa.parse_der(DER))
     with pytest.raises(ValueError, match="DER"):
-        dsa.verify_(MSG, pubkey, b"\x00" * 10)
+        dsa.parse_der(b"\x00" * 10)
     with pytest.raises(ValueError, match="signature must be 64 bytes"):
-        ssa.verify_(MSG, xonly.parse(XONLY), SSA_SIG[1:])
+        ssa._verify_(MSG, xonly.parse(XONLY), SSA_SIG[1:])
     with pytest.raises(ValueError, match="private key"):
-        ecdh.shared_secret_(pubkey, 0)
+        ecdh._shared_secret_(pubkey, 0)
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
-        keys.pubkey_tweak_add_(pubkey, b"\x01" * 31)
+        keys._pubkey_tweak_add_(pubkey, b"\x01" * 31)
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
-        keys.pubkey_tweak_mul_(pubkey, b"\x01" * 33)
+        keys._pubkey_tweak_mul_(pubkey, b"\x01" * 33)
     with pytest.raises(ValueError, match="tweak must be 32 bytes"):
-        xonly.tweak_add_(pubkey, b"\x01" * 31)
+        xonly._tweak_add_(pubkey, b"\x01" * 31)
+    with pytest.raises(ValueError, match="message hash"):
+        recovery._recover_(MSG[1:], recovery.parse_compact(RECOVERABLE, RECID))
 
     # and the two verdicts libsecp256k1 gives on a tweak, through the
-    # inner halves: the sum that is the point at infinity, and the zero
+    # private halves: the sum that is the point at infinity, and the zero
     # multiplier
     with pytest.raises(ValueError, match="tweak or resulting public key"):
-        keys.pubkey_tweak_add_(keys.parse(mult.mult_(7)), N - 7)
+        keys._pubkey_tweak_add_(keys.parse(mult.mult_bytes(7)), N - 7)
     with pytest.raises(ValueError, match="invalid tweak"):
-        keys.pubkey_tweak_mul_(pubkey, 0)
+        keys._pubkey_tweak_mul_(pubkey, 0)
 
 
-def test_every_inner_half_is_paired() -> None:
-    """Every trailing underscore of the boundary is in the table above.
+def test_every_private_half_is_paired() -> None:
+    """Every `_foo_` of the boundary is in one of the tables above.
 
     The convention is a claim about every function spelled that way, so
-    the table is checked against what the modules export rather than
-    trusted to have been kept up to date. `mult.mult_` is the one
-    exception and is named as one: its underscore is older and means the
-    other thing, the serialized point against the pair of coordinates
-    `mult` answers with, and there is no key to hand it already parsed.
+    the tables are checked against what the modules carry rather than
+    trusted to have been kept up to date.
 
-    `ssa.verify_` and `xonly.tweak_add_` are paired in tests of their own
-    rather than in the table: the parsed key of the first is
-    `xonly.parse`'s and not `keys.parse`'s, and the second takes the point
-    whose x its outer half is given, so neither equality is the one
-    parametrized above.
+    `ssa._verify_` and `xonly._tweak_add_` are paired in tests of their
+    own rather than in a table: the parsed key of the first is
+    `xonly.parse`'s and not `keys.parse`'s, and the second takes the
+    point whose x its public half is given, so neither equality is the
+    one parametrized above.
     """
     modules = {
         "dsa": dsa,
@@ -380,21 +512,22 @@ def test_every_inner_half_is_paired() -> None:
         "xonly": xonly,
     }
     paired = (
-        {f"{name}_" for name, *_ in PAIRS}
-        | {f"{name}_" for name, *_ in PRODUCERS}
-        | {"ssa.verify_", "xonly.tweak_add_"}
+        {name for name, *_ in PAIRS}
+        | {name for name, *_ in EQUALITIES}
+        | {"ssa._verify_", "xonly._tweak_add_"}
     )
-    inner_halves = {
+    private_halves = {
         f"{module_name}.{name}"
         for module_name, module in modules.items()
         for name in dir(module)
-        if name.endswith("_")
-        and not name.startswith("_")
+        if name.startswith("_")
+        and name.endswith("_")
+        and not name.startswith("__")
         and callable(getattr(module, name))
         and getattr(getattr(module, name), "__module__", "")
         == f"btclib_secp256k1.{module_name}"
     }
 
-    assert inner_halves - paired == {"mult.mult_"}
-    # and the table names nothing the modules do not have
-    assert paired - inner_halves == set()
+    assert private_halves - paired == set()
+    # and the tables name nothing the modules do not have
+    assert paired - private_halves == set()

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -85,7 +85,7 @@ def test_serialization_round_trips() -> None:
     a fixed key exercises one of them.
     """
     for prvkey in derived(b"serialization"):
-        uncompressed = mult.mult_(prvkey)
+        uncompressed = mult.mult_bytes(prvkey)
         compressed = compress(uncompressed)
 
         # either form parses, and serializes back to either form
@@ -105,7 +105,7 @@ def test_serialization_round_trips() -> None:
         assert keys.prvkey_negate(keys.prvkey_negate(prvkey)) == prvkey
         assert keys.pubkey_negate(keys.pubkey_negate(compressed)) == compressed
         # and negating the private key negates the point, i.e. flips y
-        negated = mult.mult_(keys.prvkey_negate(prvkey))
+        negated = mult.mult_bytes(keys.prvkey_negate(prvkey))
         assert negated[1:33] == uncompressed[1:33]
         assert negated[64] & 1 != uncompressed[64] & 1
 
@@ -119,23 +119,23 @@ def test_scalar_algebra_matches_point_algebra() -> None:
     and combining two points to be adding their scalars.
     """
     for prvkey, tweak in zip(derived(b"scalar"), derived(b"tweak"), strict=True):
-        pubkey = compress(mult.mult_(prvkey))
+        pubkey = compress(mult.mult_bytes(prvkey))
 
         # (d + t)G == dG + tG, and (d * t)G == t(dG)
-        assert mult.mult_(keys.prvkey_tweak_add(prvkey, tweak)) == mult.mult_(
+        assert mult.mult_bytes(keys.prvkey_tweak_add(prvkey, tweak)) == mult.mult_bytes(
             keys.prvkey_tweak_add(tweak, prvkey)
         )
         assert compress(
-            mult.mult_(keys.prvkey_tweak_add(prvkey, tweak))
+            mult.mult_bytes(keys.prvkey_tweak_add(prvkey, tweak))
         ) == keys.pubkey_tweak_add(pubkey, tweak)
         assert compress(
-            mult.mult_(keys.prvkey_tweak_mul(prvkey, tweak))
+            mult.mult_bytes(keys.prvkey_tweak_mul(prvkey, tweak))
         ) == keys.pubkey_tweak_mul(pubkey, tweak)
 
         # combining points is adding scalars
         assert keys.pubkey_combine([
             pubkey,
-            compress(mult.mult_(tweak)),
+            compress(mult.mult_bytes(tweak)),
         ]) == keys.pubkey_tweak_add(pubkey, tweak)
 
 
@@ -148,7 +148,7 @@ def test_ecdsa_signature_forms() -> None:
     signature and the result still verifies.
     """
     for prvkey, entropy in zip(derived(b"ecdsa"), derived(b"ndata"), strict=True):
-        pubkey = compress(mult.mult_(prvkey))
+        pubkey = compress(mult.mult_bytes(prvkey))
         msg = hashlib.sha256(prvkey).digest()
 
         sig = dsa.sign(msg, prvkey)
@@ -178,7 +178,7 @@ def test_recovery_recovers_the_signer() -> None:
     the ValueError is suppressed rather than expected.
     """
     for prvkey in derived(b"recovery"):
-        pubkey = compress(mult.mult_(prvkey))
+        pubkey = compress(mult.mult_bytes(prvkey))
         msg = hashlib.sha256(prvkey).digest()
 
         signature, recid = recovery.sign(msg, prvkey)
@@ -202,7 +202,7 @@ def test_schnorr_and_taproot_tweaking() -> None:
     can confirm.
     """
     for prvkey, tweak in zip(derived(b"schnorr"), derived(b"taptweak"), strict=True):
-        pubkey = compress(mult.mult_(prvkey))
+        pubkey = compress(mult.mult_bytes(prvkey))
         msg = hashlib.sha256(prvkey).digest()
         aux_rand32 = hashlib.sha256(msg).digest()
 
@@ -238,8 +238,8 @@ def test_ecdh_and_ellswift_agree() -> None:
     one value to the two parties naming their own side.
     """
     for prvkey_a, prvkey_b in zip(derived(b"ecdh a"), derived(b"ecdh b"), strict=True):
-        pubkey_a = compress(mult.mult_(prvkey_a))
-        pubkey_b = compress(mult.mult_(prvkey_b))
+        pubkey_a = compress(mult.mult_bytes(prvkey_a))
+        pubkey_b = compress(mult.mult_bytes(prvkey_b))
 
         # both parties reach the same secret, which is the SHA256 of the
         # shared point keys returns
@@ -268,7 +268,7 @@ def test_public_key_ordering() -> None:
     to the order rather than only the sort to the comparison.
     """
     prvkeys = list(derived(b"ordering", 8))
-    pubkeys = [compress(mult.mult_(prvkey)) for prvkey in prvkeys]
+    pubkeys = [compress(mult.mult_bytes(prvkey)) for prvkey in prvkeys]
 
     # the ordering is the one of the compressed serialization, which
     # sorting those same bytes is an independent way to obtain
@@ -303,7 +303,7 @@ def test_scalar_range_ends() -> None:
     msg = hashlib.sha256(b"edge").digest()
     for scalar in (1, N - 1):
         assert keys.prvkey_verify(scalar)
-        pubkey = compress(mult.mult_(scalar))
+        pubkey = compress(mult.mult_bytes(scalar))
         assert dsa.verify(msg, pubkey, dsa.sign(msg, scalar))
         assert ssa.verify(msg, pubkey[1:], ssa.sign(msg, scalar))
     # and they are each other's negation
@@ -324,7 +324,7 @@ def test_pinned_zero_leading_x() -> None:
     prvkey = bytes.fromhex(
         "ee69f731efff2c96989416d78ac759f38e5668927f2ffdb4d782a84e36ae48b6"
     )
-    uncompressed = mult.mult_(prvkey)
+    uncompressed = mult.mult_bytes(prvkey)
     assert uncompressed[1] == 0
 
     assert keys.serialize(keys.parse(uncompressed)) == compress(uncompressed)
@@ -353,7 +353,7 @@ def test_pinned_short_der_signature() -> None:
     sig = dsa.sign(msg, prvkey)
     assert len(sig) == 69
 
-    assert dsa.verify(msg, compress(mult.mult_(prvkey)), sig)
+    assert dsa.verify(msg, compress(mult.mult_bytes(prvkey)), sig)
     assert dsa.to_der(dsa.to_compact(sig)) == sig
     assert dsa.normalize(sig) == sig
     signature, recid = recovery.sign(msg, prvkey)

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -748,12 +748,14 @@ def test_bip352_receiving_vector(case: dict[str, Any]) -> None:
             assert expected["outputs"] == []
             with pytest.raises(ValueError, match=r"public key|silent payments"):
                 silentpayments.prevouts_summary(
-                    outpoint, taproot_pubkeys=taproot_pubkeys, pubkeys=pubkeys
+                    outpoint,
+                    taproot_pubkeys_bytes=taproot_pubkeys,
+                    pubkeys_bytes=pubkeys,
                 )
             continue
 
         summary = silentpayments.prevouts_summary(
-            outpoint, taproot_pubkeys=taproot_pubkeys, pubkeys=pubkeys
+            outpoint, taproot_pubkeys_bytes=taproot_pubkeys, pubkeys_bytes=pubkeys
         )
         found = silentpayments.scan_outputs(
             [bytes.fromhex(output) for output in given["outputs"]],
@@ -1016,7 +1018,7 @@ def test_rfc6979_ecdsa_vector(
     der = dsa.sign(msg32, bytes.fromhex(seckey_hex))
     assert der_decode(der) == (r, min(s, N - s))
 
-    pubkey = mult.mult_(bytes.fromhex(seckey_hex))
+    pubkey = mult.mult_bytes(bytes.fromhex(seckey_hex))
     assert dsa.verify(msg32, pubkey, der)
 
 
@@ -1057,7 +1059,7 @@ def test_trezor_ecdsa_vector(seckey_hex: str, digest_hex: str, sig_hex: str) -> 
     der = dsa.sign(digest, bytes.fromhex(seckey_hex))
     assert der_decode(der) == (r, min(s, N - s))
 
-    pubkey = mult.mult_(bytes.fromhex(seckey_hex))
+    pubkey = mult.mult_bytes(bytes.fromhex(seckey_hex))
     assert dsa.verify(digest, pubkey, der)
 
 
@@ -1138,7 +1140,7 @@ def test_secp256k1py_ecdsa_vectors() -> None:
         der = bytes.fromhex(vector["sig"])[:-1]
 
         assert dsa.sign(msg32, prvkey) == der
-        pubkey = mult.mult_(prvkey)
+        pubkey = mult.mult_bytes(prvkey)
         assert dsa.verify(msg32, pubkey, der)
 
 
@@ -1163,7 +1165,7 @@ def test_secp256k1py_custom_nonce_vectors() -> None:
         r, s = der_decode(der)
         assert s <= N // 2, "not a low-s signature"
         assert r == mult.mult(k)[0] % N
-        pubkey = mult.mult_(prvkey)
+        pubkey = mult.mult_bytes(prvkey)
         assert dsa.verify(msg32, pubkey, der)
 
 
@@ -1177,7 +1179,7 @@ def test_der_parsing() -> None:
     the two lists exist to catch.
     """
     msg32 = b"\x01" * 32
-    pubkey = mult.mult_(1)
+    pubkey = mult.mult_bytes(1)
     for der_hex in PARSED_DER:
         # parses fine, does not verify
         assert not dsa.verify(msg32, pubkey, bytes.fromhex(der_hex))


### PR DESCRIPTION
Rationalizzazione dei wrapper, dopo l'analisi di coerenza: quattro cose,
tutte nella stessa direzione di #161 — la superficie pubblica parla in
ottetti, l'oggetto libsecp256k1 è un dettaglio interno. Rebasata su #164.

**Ogni `foo_` diventa `_foo_`.** L'underscore finale diceva "prende
l'oggetto già parsato"; quello che non diceva è che una chiamata così è
oltre il confine che verifica qualcosa. L'iniziale lo dice. `mult.mult_`
diventa `mult.mult_bytes`, il suo underscore avendo sempre significato
altro. La tabella completa delle rinomine è in HISTORY.md.

**`context.guarded` risponde per l'oggetto che nessun controllo python
può provare.** Tre docstring e un test dichiaravano che una precondizione
violata fosse raggiungibile attraverso "due" wrapper: era raggiungibile
attraverso ogni metà privata, e il comportamento è stato misurato, non
dedotto — `dsa._verify_` rispondeva `False`, `keys._pubkey_cmp_` lo `0`
di due chiavi uguali, `ecdh._shared_secret_` successo e 32 byte che sono
un segreto condiviso con nessuno, ognuno lasciando il messaggio di
libsecp256k1 sul thread per il `check()` successivo — quello di un
chiamante MuSig2 — che lo avrebbe attribuito a una chiamata altrui. Costo
misurato: 0.48 us a chiamata, nulla su una verifica, quasi tutta la
chiamata su un confronto; le due scritture più economiche sono misurate e
scartate nel CHANGELOG.

**Le duplicazioni sono rimosse**, ognuna due scritture della stessa
chiamata: `_secret.keypair`, `xonly.serialize`, il parametro `name` su
`keys.parse` e `xonly.parse`, `dsa.serialize_der` riusata da `recovery`,
`_scalar.entropy`/`optional_entropy`/`in_range`, `_cdata.array`.

**E la convenzione è simmetrica**: ogni tipo di oggetto ha la sua coppia
`parse`/`serialize` pubblica (firme DSA e recoverable incluse) e ogni
wrapper con un parse o un serialize da risparmiare ha la sua metà privata
— le tre di `silentpayments` incluse, che sono quelle che un wallet paga
per transazione mentre scansiona.

Nessun conteggio dichiarato da nessuna parte: `tests/test_bytes_like.py` e
`tests/test_parsed_keys.py` leggono i moduli invece di fidarsi di un
elenco, e falliscono su una metà privata che nessuna tabella accoppia.

Gate: `pre-commit run --all-files` verde, 532 test, copertura 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)