### PR TITLE
Say the public key parse once, and let the two callers differ after it

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1835
+        "line_number": 1850
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T15:36:34Z"
+  "generated_at": "2026-08-15T15:42:44Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,21 @@ release-notes length in the first place, and are still in
   it refuses a `float`, which `recid not in (0, 1, 2, 3)` accepted as
   `0.0`. `_cdata.array` is the borrowed-pointer array `keys` built inline
   and `silentpayments` had a helper for
+- **`keys.pubkey_verify` and `keys.parse` are one parse now** (#164,
+  landed while this was open). Both are `secp256k1_ec_pubkey_parse` and
+  they differ in what they do with it: `parse` keeps the object and
+  raises when there is none, `pubkey_verify` keeps nothing and answers
+  the verdict. `_parsed` is that call, answering the key or None, and the
+  two are a line of policy each. It costs `parse` a python call, measured
+  on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 7 rounds
+  of 300 000 calls: 0.269 microseconds against 0.256 on the uncompressed
+  serialization, 2.326 against 2.310 on the compressed one, where the
+  field square root is what is being paid for. The docstrings quoting
+  those two numbers are re-measured with it. The other spelling was
+  measured too — `pubkey_verify` catching `parse`'s own `ValueError`
+  leaves `parse` untouched and costs 0.15 on a refusal — and it was not
+  taken: an exception is what this package answers a caller with, not
+  how it decides something it already knows
 - **the entropy argument is `aux_rand32` in all five**, BIP340's name for
   what libsecp256k1 spells `ndata` in one place and `rnd32` in another.
   What omitting it means still differs, and the difference is what the

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -71,12 +71,12 @@ def pubkey_verify(pubkey_bytes: BytesLike) -> bool:
         every other entry point taking a key raises: there is nothing to
         do with such a key either way, and a caller asking whether it has
         one has asked about the length as well.
+
+    Raises:
+        TypeError: if the value is not bytes at all, which is a malformed
+            argument and not a key to have a verdict on.
     """
-    pubkey_bytes = octets(pubkey_bytes, "public key")
-    pubkey = ffi.new("secp256k1_pubkey *")
-    return bool(
-        lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes))
-    )
+    return _parsed(pubkey_bytes, "public key") is not None
 
 
 def prvkey_negate(prvkey: BytesLike | int) -> bytes:
@@ -675,10 +675,46 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
+    pubkey = _parsed(pubkey_bytes, name)
+    if pubkey is None:
+        raise ValueError(f"invalid {name}")
+    return pubkey
+
+
+def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
+    """Parse a public key, answering None where it is not one.
+
+    `secp256k1_ec_pubkey_parse` is the proof that octets are a public key,
+    and there are two things to do with the same proof: `parse` keeps what
+    it built and raises when there is nothing to keep, `pubkey_verify`
+    keeps nothing and answers the verdict. Written twice, the two would be
+    one call each until an argument check moved in one of them.
+
+    It costs `parse` a python call, and that is the whole of what the
+    single statement is bought with: 0.269 microseconds against 0.256 on
+    the uncompressed serialization, and 2.326 against 2.310 on the
+    compressed one, where the field square root is what is being paid for
+    -- an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 7 rounds
+    of 300 000 calls.
+
+    Args:
+        pubkey_bytes: the public key, 33 or 65 bytes.
+        name: what the key is, as an exception should call it.
+
+    Returns:
+        The libsecp256k1 public key object, or None if libsecp256k1
+        refuses the octets -- a length no serialization has among them,
+        which is why neither caller checks one.
+
+    Raises:
+        TypeError: if the value is not bytes, which is a malformed
+            argument rather than a key that fails to parse: a caller with
+            no octets at all asked no question about a key.
+    """
     pubkey_bytes = octets(pubkey_bytes, name)
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
-        raise ValueError(f"invalid {name}")
+        return None
     return pubkey
 
 
@@ -697,7 +733,7 @@ def reserialize(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
     no other call to make, and one holding a compressed key and about to
     make several more calls with it has a reason to ask for the other
     form. The uncompressed serialization is the cheap one to open --
-    `parse` is 0.256 us on 65 bytes against 2.343 on 33, both coordinates
+    `parse` is 0.269 us on 65 bytes against 2.326 on 33, both coordinates
     being there to read where a compressed key is a field square root --
     so `reserialize(key, compressed=False)` pays that root once and leaves
     every later call at the price of reading it.

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -23,9 +23,9 @@ it because a caller converting a key it holds may want to know which of
 the two forms it was handed, not because the two are different keys.
 
 Which serialization to hand in is a question of cost and not of meaning:
-`keys.parse` reads the uncompressed form for 0.256 us, both coordinates
+`keys.parse` reads the uncompressed form for 0.269 us, both coordinates
 being there, where the compressed form and the 32-byte one are a field
-square root at 2.343.
+square root at 2.326.
 """
 
 from __future__ import annotations
@@ -381,8 +381,8 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
     Every entry point of this module that takes a public key reaches it,
     which is what makes them all take any of the three serializations.
     Which one costs what: the 32-byte form is `secp256k1_xonly_pubkey_parse`,
-    a field square root at 2.343 us, and so is the compressed form; the
-    uncompressed form is 0.256, both coordinates being there to read, and
+    a field square root at 2.326 us, and so is the compressed form; the
+    uncompressed form is 0.269, both coordinates being there to read, and
     the x-only conversion that follows it reads the y rather than lifting
     one.
 


### PR DESCRIPTION
Seguito di #165, sulla stessa classe di duplicazione: `keys.pubkey_verify`
(#164) è atterrata mentre #165 era aperta, ed è il parse scritto una
seconda volta — `octets`, `ffi.new`, `secp256k1_ec_pubkey_parse`. Due
scritture della stessa chiamata, giuste entrambe oggi e libere di
divergere quando un controllo si sposta in una delle due.

`_parsed` è la chiamata, e risponde la chiave o `None`; i due entry point
sono una riga di politica ciascuno — `parse` tiene l'oggetto e solleva
quando non c'è nulla da tenere, `pubkey_verify` non tiene nulla e
risponde il verdetto. Nessun comportamento si muove, e ciò che lo tiene
fermo è l'accoppiamento che `tests/test_keys.py` fa già dei due:
entrambe le serializzazioni, entrambi i modi di non parsare, tre
lunghezze sbagliate, il controllo di tipo.

**Costa a `parse` una chiamata python**, e il numero è misurato: 0.269 us
contro 0.256 sulla forma non compressa, 2.326 contro 2.310 sulla
compressa — Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimo di 7
round da 300 000 chiamate. I docstring che citano quei due numeri sono
rimisurati con questa (`keys.reserialize`, il docstring del modulo
`xonly` e quello di `xonly.parse`).

L'altra scrittura è stata misurata e scartata: `pubkey_verify` che
cattura il `ValueError` di `parse` lascia `parse` a 0.256 e costa 0.15 su
un rifiuto. Un'eccezione è quello che questo package risponde a un
chiamante, non il modo in cui decide qualcosa che già sa.

Gate: `pre-commit run --all-files` verde, 532 test, copertura 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deduplicate public key parsing by introducing a shared helper used by both pubkey verification and key parsing, updating documentation and changelog to reflect the unified behavior and measured performance costs.

Enhancements:
- Unify public key parsing logic for keys.parse and keys.pubkey_verify via a shared internal helper that returns either a parsed key or None.
- Clarify argument handling for public key parsing and verification by distinguishing malformed non-bytes inputs from invalid key data.
- Adjust keys.parse to incur a single extra Python call while preserving behavior, relying on the shared parsing helper for both verdict and object creation.

Documentation:
- Update performance figures and descriptive text in keys and xonly module docstrings to match the new shared parsing implementation and measured timings.
- Add a changelog entry documenting the unification of keys.pubkey_verify and keys.parse around a single libsecp256k1 parse call and the associated performance measurements.

Chores:
- Refresh the secrets baseline file to reflect current repository state.