### PR TITLE
Let an ECDSA signature cross in either of its serializations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1850
+        "line_number": 1877
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T15:42:44Z"
+  "generated_at": "2026-08-15T16:17:50Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,33 @@ release-notes length in the first place, and are still in
   in [1, n-1]" wherever that is the whole of what was wrong, and "the
   {name} must be in [0, {upper}]" for the four small numbers
 
+### The signature's two serializations
+
+- **`dsa.sign` and `dsa.verify` take a `compact` flag**, false by
+  default. A signature is `r` and `s`; DER is what the wire carries, and
+  a caller holding the two scalars had to write an ASN.1 structure around
+  them for a call whose first act is to take it apart again — and read
+  one back the same way on the answer. `parse_compact` and
+  `serialize_compact` have been public since the halves were separated,
+  but they speak in the parsed signature, which is exactly what a caller
+  doing one thing with it does not want to hold.
+
+  btclib is the caller, and pays it at both ends
+  (<https://github.com/btclib-org/btclib/issues/922>): building the DER
+  is 0.712 us against the 0.077 of `r.to_bytes() + s.to_bytes()`, and
+  reading it back 1.250 against 0.320 — the second of those *per grind
+  attempt* under low-r grinding, where the loop parses what it may
+  discard. Its recoverable path never had the problem:
+  `recovery.sign` answers the compact form, and the comment there says
+  why.
+
+- **Which form it is has to be said, and cannot be read off the length.**
+  A DER signature of 64 octets exists — `r` and `s` of 29 bytes each —
+  and it begins with the 0x30 a compact `r` may begin with too. So the
+  flag, rather than a dispatch; and each form is refused as the other,
+  which `tests/test_core.py` asserts along with the round trip through
+  `to_der` and `to_compact` and the `normalize` flag on either form.
+
 ### CI
 
 - **`github-release` needed `always()` too, not just an explicit `if`.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -132,6 +132,17 @@ whatever form the x arrived in, so `ssa.verify`, `xonly.tweak_add` and
 that refusal cost was a lift, and a tweak from the uncompressed form is
 4.11 microseconds against the 5.92 of the 32-byte one.
 
+**`dsa.sign` and `dsa.verify` take a `compact` flag**, false by default,
+so an ECDSA signature crosses in either of its two serializations. A
+signature is `r` and `s`, and DER is what the wire carries: a caller
+holding the two scalars was writing an ASN.1 structure around them for a
+call that takes it apart again, and reading one back on the answer — 0.7
+and 1.3 microseconds of the caller's own time, the second of them per
+attempt where low-r grinding discards what it has just parsed. Which form
+is being handed in has to be said and cannot be read off the length: a
+DER signature of 64 octets exists. Nothing about the default moves, and
+`to_der` and `to_compact` are unchanged.
+
 **`xonly.from_prvkey` and `ssa.Signer.pubkey` are two entry points
 rather than two halves**, and they save different things. The first is
 the x-only public key of a private key: it is `_pubkey_from_prvkey_` and

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -74,12 +74,22 @@ def _sign_(
 
 
 def sign(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    compact: bool = False,
 ) -> bytes:
     """Create an ECDSA signature.
 
     The nonce is the deterministic RFC6979 one, so the signature is a
     function of the message and the key alone unless aux_rand32 is given.
+
+    Which serialization to answer with is the caller's, as it is
+    everywhere a key is answered: a signature is `r` and `s`, and DER is
+    what the wire carries rather than what a caller holds. Asking for the
+    compact form is `serialize_compact` in place of `serialize_der`, where
+    reaching it through `to_compact` is that DER encoding parsed straight
+    back apart.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
@@ -88,10 +98,11 @@ def sign(
             None for the RFC6979 nonce alone. Never a shorter value:
             entropy is not a serialization, and padding one would make a
             caller mistake a valid argument.
+        compact: whether to answer the 64-byte `r || s` rather than DER.
 
     Returns:
-        The signature in DER encoding, in the lower-s form libsecp256k1
-        always produces.
+        The signature, in the lower-s form libsecp256k1 always produces:
+        DER, or the 64 octets of `r || s` where `compact` asks for them.
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
@@ -107,7 +118,8 @@ def sign(
         >>> dsa.is_low_s(dsa.sign(msg, 1))
         True
     """
-    return serialize_der(_sign_(msg_bytes, prvkey, aux_rand32))
+    signature = _sign_(msg_bytes, prvkey, aux_rand32)
+    return serialize_compact(signature) if compact else serialize_der(signature)
 
 
 def _verify_(
@@ -157,6 +169,7 @@ def verify(
     pubkey_bytes: BytesLike,
     signature_bytes: BytesLike,
     normalize: bool = False,
+    compact: bool = False,
 ) -> bool:
     """Verify a ECDSA signature.
 
@@ -171,18 +184,24 @@ def verify(
     Args:
         msg_bytes: the 32-byte hash of the message.
         pubkey_bytes: the public key, 33 or 65 bytes.
-        signature_bytes: the signature in DER encoding.
+        signature_bytes: the signature, DER encoded or the 64 octets of
+            `r || s`, as `compact` says.
         normalize: whether to verify the lower-s form of the signature
             rather than reject a signature that is not in it.
+        compact: whether the signature is the 64-byte `r || s` rather
+            than DER. Which of the two it is has to be said and cannot be
+            read off the length: a DER signature of 64 octets exists,
+            `r` and `s` of 29 bytes each, and it begins with the 0x30 a
+            compact `r` may begin with too.
 
     Returns:
         True if the signature is valid for that key and message.
 
     Raises:
-        ValueError: if the message hash is not 32 bytes, if the DER
-            signature is malformed, or if the public key is not a valid
-            point. A well-formed signature that simply does not verify
-            is False, not an exception.
+        ValueError: if the message hash is not 32 bytes, if the signature
+            is malformed in the serialization it was said to be in, or if
+            the public key is not a valid point. A well-formed signature
+            that simply does not verify is False, not an exception.
 
     Example:
         >>> import hashlib
@@ -191,8 +210,9 @@ def verify(
         >>> dsa.verify(msg, mult.mult_bytes(1), dsa.sign(msg, 1))
         True
     """
+    parse = parse_compact if compact else parse_der
     return _verify_(
-        msg_bytes, keys.parse(pubkey_bytes), parse_der(signature_bytes), normalize
+        msg_bytes, keys.parse(pubkey_bytes), parse(signature_bytes), normalize
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,6 +12,7 @@ that would take the hosting Python process down with them.
 """
 
 import array
+import hashlib
 import secrets
 
 import pytest
@@ -471,3 +472,46 @@ def test_generated_randomness_is_always_32_octets(
     ellswift.encode(pubkey_bytes)
 
     assert requested == [32, 32, 32, 32]
+
+
+def test_a_signature_crosses_in_either_serialization() -> None:
+    """`compact` decides the form, and the two forms are one signature.
+
+    A signature is `r` and `s`; DER is what the wire carries, and a
+    caller holding the two scalars has no reason to write a structure
+    around them for a call that takes it straight apart again. So `sign`
+    answers either form and `verify` takes either, and what says which is
+    the flag rather than the length: a DER signature of 64 octets exists,
+    and begins with an 0x30 a compact `r` may begin with too.
+    """
+    msg = hashlib.sha256(b"btclib_secp256k1").digest()
+    prvkey = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+    pubkey = keys.pubkey_from_prvkey(prvkey)
+
+    der = dsa.sign(msg, prvkey)
+    compact = dsa.sign(msg, prvkey, compact=True)
+    assert len(compact) == 64
+    assert compact == dsa.to_compact(der)
+    assert der == dsa.to_der(compact)
+
+    assert dsa.verify(msg, pubkey, der)
+    assert dsa.verify(msg, pubkey, compact, compact=True)
+    # the aux_rand32 argument keeps its place before the flag
+    assert dsa.sign(msg, prvkey, bytes(32), compact=True) == dsa.to_compact(
+        dsa.sign(msg, prvkey, bytes(32))
+    )
+
+    # each form is refused as the other: DER read as compact is the wrong
+    # length, and 64 octets read as DER are no structure
+    with pytest.raises(ValueError, match="compact signature"):
+        dsa.verify(msg, pubkey, der, compact=True)
+    with pytest.raises(ValueError, match="DER"):
+        dsa.verify(msg, pubkey, compact)
+
+    # and normalize is the flag it always was, on either form
+    high_s = dsa.to_compact(der)
+    s = int.from_bytes(high_s[32:], "big")
+    order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    malleated = high_s[:32] + (order - s).to_bytes(32, "big")
+    assert not dsa.verify(msg, pubkey, malleated, compact=True)
+    assert dsa.verify(msg, pubkey, malleated, normalize=True, compact=True)


### PR DESCRIPTION
A signature is `r` and `s`. DER is what the wire carries, and `sign` and
`verify` took nothing else — so a caller holding the two scalars wrote an
ASN.1 structure around them for a call whose first act is to take it
apart again, and read one back the same way on the answer.

`parse_compact` and `serialize_compact` have been public since the halves
were separated, but they speak in the parsed signature, which is exactly
what a caller doing *one* thing with it does not want to hold. So the
form becomes a flag on the two outer halves, as `compressed` is on
everything that serializes a key.

### The caller

btclib, at both ends
([btclib#922](https://github.com/btclib-org/btclib/issues/922)): building
the DER is **0.712 us against the 0.077** of `r.to_bytes() +
s.to_bytes()`, and reading it back **1.250 against 0.320** — the second
of those *per grind attempt* under low-r grinding, where the loop parses
what it may discard. Its recoverable path never had the problem:
`recovery.sign` answers the compact form already, and the comment in
btclib says why.

### Which form it is has to be said

It cannot be read off the length: a DER signature of 64 octets exists —
`r` and `s` of 29 bytes each — and it begins with the 0x30 a compact `r`
may begin with too. So a flag rather than a dispatch, and each form is
refused as the other.

`tests/test_core.py` asserts the round trip through `to_der` and
`to_compact`, both refusals, the `aux_rand32` argument keeping its place
before the flag, and `normalize` working on either form.

`pytest --cov` at 100.00%, `pre-commit run --all-files` clean, `-W`
sphinx build. Branch is on `main`'s tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for using ECDSA signatures in either DER or compact r||s form via an explicit flag on signing and verification, with tests and documentation updated accordingly.

New Features:
- Allow dsa.sign to return either DER or compact 64-byte r||s signatures based on a compact flag.
- Allow dsa.verify to accept either DER or compact 64-byte r||s signatures based on a compact flag.

Enhancements:
- Document the dual serialization support and compact flag behavior for ECDSA signatures in CHANGELOG and HISTORY.

Tests:
- Add tests ensuring round-trip conversion between DER and compact signatures, correct handling of the compact flag, and normalization behavior for both forms.