### PR TITLE
Let the surface and the sentence agree, in both directions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 1982
+        "line_number": 2040
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -182,21 +182,21 @@
         "filename": "tests/test_properties.py",
         "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 330
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 353
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 356
       }
     ],
     "tests/test_submodule_pin.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T17:17:52Z"
+  "generated_at": "2026-08-16T06:39:36Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,10 +458,66 @@ release-notes length in the first place, and are still in
   `to_compact` name the input form the way `compact` names it on `sign`
   and `verify`, which is the coherence a third name would have broken
 
+### The surface and the sentence agree
+
+- **`mult.mult` is gone** (#170). The package docstring opens with "every
+  entry point takes octets and answers octets", and that call answered
+  `tuple[int, int]` — the one place a point of the curve left as numbers
+  rather than as a serialization, `pubkey_cmp`'s int and `prvkey_verify`'s
+  bool being verdicts and `from_pubkey`'s parity a flag beside the octets
+  it comes with. What it did is `int.from_bytes` twice over the two
+  halves of `mult_bytes`, and they cost 0.138 microseconds of a call that
+  is some 8.5 — 1.6% of it, and the whole of what the exception was
+  worth. The first spelling of this entry claimed the conversions were
+  *cheaper* inside the function, 8.549 against 8.578, which is noise read
+  as a direction: the removed function did those same two conversions
+  behind a python frame, so the ordering the code implies is the other
+  one, and three alternating rounds put the two within each other's
+  spread. What is stable is the 0.138. The module docstring carries the
+  two lines a caller writes instead
+- **and `xonly.from_keypair` stays, with the rule widened to cover it**
+  (#169). It takes a libsecp256k1 object and is not half of a
+  parse/serialize pair, which the docstring's "an object crosses only
+  where a caller already holds one" did not account for. The reason it is
+  not an exception is that a keypair *has* no serialization to make a
+  bridge out of: `secp256k1_keypair` holds a private key in
+  libsecp256k1's own layout and the C API never writes one out, so a
+  caller that built one through `lib` — a MuSig2 signer — holds something
+  no octets could have carried here. The rule now names the two kinds,
+  the parse and the keypair, and `from_keypair`'s own docstring points at
+  it rather than restating it. Making it private instead would have
+  broken the MuSig2 path the README documents, `ssa.Signer.pubkey` being
+  the same call only for a keypair this package built.
+
+  The fact #169 says the choice depends on — whether anyone outside this
+  package drives MuSig2 through `lib` today — was not established, and
+  keeping is the conservative half of that uncertainty: it costs a
+  sentence in the rule, where making it private costs a caller who may
+  exist an entry point that cannot be worked around, a keypair having no
+  serialization to reach `keys.parse` with. What would settle it is a
+  downstream search rather than an argument, and it is not on this branch
+- **the two are one question**, asked in #169 and #170 of the same
+  sentence: an exception to "octets in, octets out" is worth keeping when
+  octets cannot carry the thing, and worth removing when they can. A
+  keypair cannot be serialized; a point can
+
 ### Documentation
 
 - **`ssa.Signer` and `keys.PubkeyTweakChain` are presented as what they
-  are**, which is the one thing the README had no name for: an outpost
+  are**, and the chain's saving is now stated against the walk it is
+  actually worth measuring against. The section said five steps are 64.62
+  microseconds through `pubkey_tweak_add` and 55.14 through a chain,
+  which is true and is the compressed walk; the same path walked in the
+  *uncompressed* form, compressed in python where BIP32 wants 33 octets
+  to hash, is 54.75 — the chain within the noise. So what the chain saves
+  is real against one spelling and a rounding error against the other,
+  and what it is unambiguously worth is the line a caller does not write.
+  The README says both numbers now, and the section opens by separating
+  the two objects: a keypair is arithmetic no serialization gives back, a
+  parsed key is a parse the caller can make cheap by choosing the form it
+  carries. That is <https://github.com/btclib-org/btclib-secp256k1/issues/161>'s
+  own principle, and it is what the measurement says of the two
+- **the outpost section is what the README had no name for**: an outpost
   past the boundary. The private halves hand an object from one call to
   the next; these two hold one across many, for the caller that crosses
   again and again with the same key — a signer signing message after
@@ -471,9 +527,11 @@ release-notes length in the first place, and are still in
   compressed key, on a key it had already converted.
 
   The chain was in no section at all before this, so it now has one, with
-  the walk it is for: five steps are 65.61 microseconds through
-  `pubkey_tweak_add` and 56.58 through a chain, which is the 2.39 of a
-  compressed parse saved four times. The signer's own numbers move from
+  the walk it is for: five steps through `pubkey_tweak_add` against five
+  through a chain, which is a compressed parse saved four times. The pair
+  of timings first written here was superseded by the entry above, which
+  re-measured the walk and added the third spelling of it, so the numbers
+  live there and not in two places. The signer's own numbers move from
   the section that described the trade to the one that describes the
   saving: 15.82 against 8.27, of which the keypair is 7.55
 - **and the two answer differently under threads, which nothing said.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,12 +7,15 @@ a tag is generated from.
 
 ## v0.8.0.3 (work in progress, not released yet)
 
-**Breaking, and every break is a rename.** The public surface of these
-bindings speaks in octets; the half of each call that speaks in
-libsecp256k1 objects is now private, and spelled `_foo_` where it was
-`foo_`. Nothing was removed and no behaviour changed with the names, so
-a caller using the octets API has nothing to do; a caller holding parsed
-keys renames what it calls.
+**Breaking: one entry point is gone, and every other break is a rename.**
+The public surface of these bindings speaks in octets, and the two
+changes are that sentence made true. The half of each call that speaks in
+libsecp256k1 objects is now private, spelled `_foo_` where it was `foo_`,
+and no behaviour changed with those names: a caller holding parsed keys
+renames what it calls. `mult.mult` is the one that went rather than moved,
+answering coordinates where every other entry point answers octets, and a
+caller of it has two lines to write. Everything else in the octets API is
+what it was.
 
 | module | was | is |
 | --- | --- | --- |
@@ -33,8 +36,22 @@ keys renames what it calls.
 | `silentpayments` | `label_` | `_label_` |
 | `silentpayments` | `labeled_spend_pubkey_` | `_labeled_spend_pubkey_` |
 | `mult` | `mult_` | `mult_bytes` |
+| `mult` | `mult` | *gone: see below* |
 
-Three of them take a different argument as well, the object having
+**What the removed one costs a caller.** `mult.mult` answered the pair of
+coordinates as ints, which is the one place a point of the curve left this
+package as numbers instead of as a serialization. What it did is two
+`int.from_bytes` over the halves of `mult_bytes`, and they are 0.138
+microseconds of a call that is some 8.5 — 1.6% of it, and about what the
+python frame that used to hold them cost in the other direction:
+
+```diff
+-x, y = mult.mult(num)
++sec = mult.mult_bytes(num)
++x, y = int.from_bytes(sec[1:33], "big"), int.from_bytes(sec[33:], "big")
+```
+
+Three of the renamed take a different argument as well, the object having
 replaced the octets there too: `dsa._verify_` takes the parsed signature
 `dsa.parse_der` returns, and `recovery._recover_` the parsed pair
 `recovery.parse_compact` returns, in place of a signature and a recovery

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ and decides nothing else.
   only a value — the 32-byte width is the curve's, not a fact the caller
   supplied and got wrong. The set of valid scalars is unchanged; only the
   type spelling them is. What the door is for is the caller who already
-  holds a number: `mult(3)`, a vector, a tweak just computed.
+  holds a number: `mult_bytes(3)`, a vector, a tweak just computed.
   The cost is not in that serialization, which is a loop over nine CPython
   digits and measures as noise. It is that an `int` holding a secret was
   produced by python arithmetic, variable in time with the magnitude of
@@ -362,11 +362,18 @@ compressed key is a field square root — and pays it for a key it had
 already converted.
 
 `ssa.Signer` and `keys.PubkeyTweakChain` are the two outposts on that
-side of the boundary. Each holds the converted object across calls, so
-the conversion happens once and every crossing afterwards carries only
-what changes: a message, a tweak. There are two of them because there
-are two conversions worth not repeating, and there is nothing else in
-these bindings that holds state at all.
+side of the boundary, and the only things in these bindings that hold
+state at all. Each holds the converted object across calls, so the
+conversion happens once and every crossing afterwards carries only what
+changes: a message, a tweak.
+
+The two are not worth the same, and the numbers below say which is
+which. A keypair is *arithmetic* — a point multiplication, half of what
+a signature costs — and no serialization would give it back. A parsed
+public key is a *parse*, and the caller can make that parse cheap by
+carrying the uncompressed form instead: 0.269 microseconds against
+2.326. So the signer saves what nothing else can, and the chain saves
+what a caller free to choose its serialization could have saved itself.
 
 `ssa.Signer` holds the keypair:
 
@@ -399,12 +406,21 @@ True
 
 That is a BIP32 path walked one index at a time, and the shape of it is
 what costs: each step needs the previous step's *serialized* key to hash
-into the next tweak, so `pubkey_tweak_add` parses at every step the very
-point the step before had built and serialized. The chain parses once —
-65.61 microseconds against 56.58 for the five steps above, which is the
-2.39 of a compressed parse saved four times. Every step still answers the
-octets its caller needs, and `chain.pubkey()` is the key it has arrived
-at, with `chain._pubkey_()` the point itself for a caller handing it on.
+into the next tweak, so `pubkey_tweak_add` on the compressed form parses
+at every step the very point the step before had built and serialized —
+64.62 microseconds against the chain's 55.14, for the five steps above,
+which is the 2.326 of a compressed parse saved four times.
+
+What that comparison leaves out is the caller's other move, and it is
+worth stating because it is nearly free: walking the same path in the
+*uncompressed* form and compressing each answer in python is 54.75, which
+is the chain's 55.14 within the noise. The uncompressed parse is 0.269,
+so there is almost nothing left for holding the point to save — the
+chain's saving is real against the compressed walk and a rounding error
+against that one. What it is unambiguously worth is not having to write
+`bytes([2 + (sec[64] & 1)]) + sec[1:33]` where BIP32 wants 33 octets to
+hash. `chain.pubkey()` is the key it has arrived at, and
+`chain._pubkey_()` the point itself for a caller handing it on.
 
 What the two do not share is what they hold. A parsed public key is a
 public value a caller may keep for as long as it likes; a keypair is the

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -7,10 +7,19 @@
 
 Every entry point of these bindings takes octets and answers octets. A
 libsecp256k1 object crosses the boundary only where a caller already
-holds one: `keys.parse` and `keys.serialize`, and the pairs beside them
-in `xonly`, `dsa`, `recovery` and `silentpayments`, are that bridge, and
-a MuSig2 session driven through the raw `lib` is who is on the other
-side of it.
+holds one, and there are two ways it can. The first is a `parse`:
+`keys.parse` and `keys.serialize`, and the pairs beside them in `xonly`,
+`dsa`, `recovery` and `silentpayments`, are that bridge, and a MuSig2
+session driven through the raw `lib` is who is on the other side of it.
+
+The second is a keypair, which has no bridge because it has no
+serialization to be one: `secp256k1_keypair` holds a private key in
+libsecp256k1's own layout, and the C API creates one and never writes it
+out. A caller that built one -- through `lib`, as a MuSig2 signer does --
+holds an object nothing here could have handed it as octets, and
+`xonly.from_keypair` is what reads the public key off it.
+`ssa.Signer.pubkey` is that same call for a caller that let this package
+build the keypair instead.
 
 Under each of those entry points is the half of it that speaks in those
 objects, spelled `_foo_`. The leading underscore says private, because

--- a/btclib_secp256k1/mult.py
+++ b/btclib_secp256k1/mult.py
@@ -5,17 +5,25 @@
 
 """Secp256k1 point multiplication.
 
-The two spellings of generator multiplication for a caller who thinks of
-it as an operation on a scalar rather than as the public key of a private
-key: serialized uncompressed, and as a pair of coordinates. The C call is
-`keys.pubkey_from_prvkey`, which is the same multiplication answering in
-either serialization.
+Generator multiplication for a caller who thinks of it as an operation on
+a scalar rather than as the public key of a private key. The C call is
+`keys.pubkey_from_prvkey`, which is the same multiplication with the
+serialization flag every producer of a key takes; this is its
+`compressed=False` case under the name the operation has.
 
-`mult_bytes` used to be `mult_`, and was renamed for the trailing
-underscore rather than for anything it does: that underscore now means a
-private half speaking in parsed objects, and this is a public function
-answering octets. `_bytes` is what the rest of this package calls the
-octets of a thing.
+`mult` was here too, and answered the pair of coordinates as ints. It is
+gone: a point of the curve left this package as numbers in that one
+place, where every other answer is octets or a verdict, and reading the
+two halves of these 65 octets is `int.from_bytes` twice -- 0.138
+microseconds of a call that is some 8.5, which is 1.6% of it and the
+whole of what the exception was worth. Measured in the caller because
+that is where it now happens: the function that used to do it held the
+same two conversions inside a python frame that cost about as much
+again, so the two spellings are the same call and neither is reliably
+the faster. What a caller wanting coordinates writes is:
+
+    sec = mult.mult_bytes(num)
+    x, y = int.from_bytes(sec[1:33], "big"), int.from_bytes(sec[33:], "big")
 """
 
 from __future__ import annotations
@@ -50,27 +58,3 @@ def mult_bytes(num: BytesLike | int) -> bytes:
         '0479be667e'
     """
     return pubkey_from_prvkey(num, compressed=False)
-
-
-def mult(num: BytesLike | int) -> tuple[int, int]:
-    """Multiply the generator point, as a pair of coordinates.
-
-    Args:
-        num: the scalar to multiply the generator by, 32 bytes or an int
-            below 2**256.
-
-    Returns:
-        The affine coordinates (x, y) of the resulting point, as ints.
-        This is `mult_bytes` with the two halves of its output read as
-        big endian integers; a caller that wants bytes wants
-        `mult_bytes`, or `keys.pubkey_from_prvkey` for the compressed
-        form.
-
-    Raises:
-        ValueError: if the scalar is not 32 bytes or does not fit in
-            them, or if it is not in [1, n-1].
-        RuntimeError: if libsecp256k1 fails to serialize the point,
-            which no input can make it do.
-    """
-    result = mult_bytes(num)
-    return int.from_bytes(result[1:33], "big"), int.from_bytes(result[33:], "big")

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -163,6 +163,9 @@ def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
     holds another. `from_prvkey` is the same answer for a caller holding
     the private key and no keypair.
 
+    This is the one entry point taking a libsecp256k1 object that is not
+    half of a parse/serialize pair; the package docstring says why.
+
     Args:
         keypair_obj: the libsecp256k1 keypair object, as `ssa.Signer`
             holds and as `secp256k1_keypair_create` writes.

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -272,7 +272,6 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.pubkey_cmp", keys.pubkey_cmp, (PUBKEY, PUBKEY_LONG), {}),
     ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
     ("mult.mult_bytes", mult.mult_bytes, (PRVKEY,), {}),
-    ("mult.mult", mult.mult, (PRVKEY,), {}),
     ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),
     ("dsa.sign", dsa.sign, (MSG, PRVKEY, bytes(32)), {}),
     ("dsa.verify", dsa.verify, (MSG, PUBKEY, DER), {}),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,6 +34,8 @@ from btclib_secp256k1 import (
 )
 
 prvkey = 1
+# the field order of secp256k1, for the curve equation below
+P = 2**256 - 2**32 - 977
 pubkey_bytes = b"\x02y\xbef~\xf9\xdc\xbb\xacU\xa0b\x95\xce\x87\x0b\x07\x02\x9b\xfc\xdb-\xce(\xd9Y\xf2\x81[\x16\xf8\x17\x98"
 # the x-only form BIP340 verifies against; the key has even y, so it is
 # the same point the compressed form above encodes
@@ -142,15 +144,24 @@ def test_safe_abort() -> None:
 
 
 def test_mult() -> None:
-    """Both spellings of generator multiplication reach the same point.
+    """Generator multiplication answers the point the compressed key names.
 
-    `mult_` answers the serialized public key and `mult` the coordinates,
-    so the x of the second is the x the first carries.
+    `mult_bytes` is the uncompressed serialization, so the x it carries
+    is the x of the compressed form, and the coordinates a caller wants
+    are `int.from_bytes` of its two halves -- which is what `mult`
+    answered before it was retired.
     """
     pubkey_ = mult.mult_bytes(prvkey)
+    assert pubkey_[0] == 4
     assert pubkey_[1:33] == pubkey_bytes[1:]
-    pubkey = mult.mult(prvkey)
-    assert pubkey[0] == int.from_bytes(pubkey_bytes[1:], "big")
+    # the y, which the compressed form does not carry and which no
+    # assertion here covered while `mult` was answering it: it is the
+    # even one, `pubkey_bytes` opening with 0x02, and it satisfies the
+    # curve equation. That is what a caller reads with int.from_bytes
+    x = int.from_bytes(pubkey_[1:33], "big")
+    y = int.from_bytes(pubkey_[33:], "big")
+    assert y % 2 == 0
+    assert (y * y - x * x * x - 7) % P == 0
 
 
 def test_invalid_inputs() -> None:
@@ -201,12 +212,12 @@ def test_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="fit in 32 bytes"):
         dsa.sign(msg, 2**256)
     with pytest.raises(ValueError, match="fit in 32 bytes"):
-        mult.mult(-1)
+        mult.mult_bytes(-1)
 
     # generator multiplication is keys.pubkey_from_prvkey, so what its
     # message names is the private key the scalar of it is
     with pytest.raises(ValueError, match="private key"):
-        mult.mult(0)
+        mult.mult_bytes(0)
 
 
 def test_type_checks_refuse_what_merely_has_a_length() -> None:
@@ -237,7 +248,7 @@ def test_type_checks_refuse_what_merely_has_a_length() -> None:
     with pytest.raises(
         TypeError, match="private key must be bytes or an int, not float"
     ):
-        mult.mult(1.0)  # type: ignore[arg-type]
+        mult.mult_bytes(1.0)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="tweak must be bytes or an int, not str"):
         keys.prvkey_tweak_add(prvkey, "x" * 32)  # type: ignore[arg-type]
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -85,7 +85,7 @@ def test_pubkey_from_prvkey() -> None:
     assert keys.pubkey_from_prvkey((1).to_bytes(32, "big")) == b"\x02" + generator[1:33]
 
     # the odd y, which 1G cannot exhibit
-    assert mult.mult(6)[1] & 1
+    assert mult.mult_bytes(6)[64] & 1
     assert keys.pubkey_from_prvkey(6) == b"\x03" + mult.mult_bytes(6)[1:33]
 
     # mult_ is this function with the compressed flag off

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -95,8 +95,13 @@ def test_serialization_round_trips() -> None:
         # form libsecp256k1 writes where this file composes it
         assert keys.pubkey_from_prvkey(prvkey) == compressed
         assert keys.pubkey_from_prvkey(prvkey, False) == uncompressed
-        # mult agrees with the serialization it is derived from
-        assert mult.mult(prvkey) == (
+        # the coordinates agree with the serialization they are read
+        # out of, which is the whole of what `mult.mult` used to do
+        multiplied = mult.mult_bytes(prvkey)
+        assert (
+            int.from_bytes(multiplied[1:33], "big"),
+            int.from_bytes(multiplied[33:], "big"),
+        ) == (
             int.from_bytes(uncompressed[1:33], "big"),
             int.from_bytes(uncompressed[33:], "big"),
         )
@@ -330,7 +335,7 @@ def test_pinned_zero_leading_x() -> None:
     assert keys.serialize(keys.parse(uncompressed)) == compress(uncompressed)
     assert keys.serialize(keys.parse(compress(uncompressed)), False) == uncompressed
     assert xonly.from_pubkey(uncompressed)[0] == uncompressed[1:33]
-    assert mult.mult(prvkey)[0] == int.from_bytes(uncompressed[1:33], "big")
+    assert mult.mult_bytes(prvkey)[1:33] == uncompressed[1:33]
 
 
 def test_pinned_short_der_signature() -> None:

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1012,7 +1012,7 @@ def test_rfc6979_ecdsa_vector(
     s = int(s_hex, 16)
 
     # vector self-consistency: r is the x coordinate of k*G
-    assert mult.mult(bytes.fromhex(k_hex))[0] == r
+    assert int.from_bytes(mult.mult_bytes(bytes.fromhex(k_hex))[1:33], "big") == r
 
     # libsecp256k1 always produces low-s signatures
     der = dsa.sign(msg32, bytes.fromhex(seckey_hex))
@@ -1164,7 +1164,7 @@ def test_secp256k1py_custom_nonce_vectors() -> None:
 
         r, s = der_decode(der)
         assert s <= N // 2, "not a low-s signature"
-        assert r == mult.mult(k)[0] % N
+        assert r == int.from_bytes(mult.mult_bytes(k)[1:33], "big") % N
         pubkey = mult.mult_bytes(prvkey)
         assert dsa.verify(msg32, pubkey, der)
 


### PR DESCRIPTION
Closes #170, closes #169. Le due fanno la stessa domanda alla frase di
apertura del docstring di package — *every entry point takes octets and
answers octets* — e la risposta è diversa perché è diverso quello che
l'eccezione costa.

**`mult.mult` se ne va.** Rispondeva `tuple[int, int]`: l'unico posto in
cui un punto della curva usciva da questo package come numeri invece che
come serializzazione — l'int di `pubkey_cmp` e il bool di `prvkey_verify`
sono verdetti, la parità di `from_pubkey` è un flag accanto agli ottetti
con cui arriva. Quello che faceva sono due `int.from_bytes` sulle metà di
`mult_bytes`, e farli fuori costa 8.578 us contro 8.549 — tutto quello
che l'eccezione valeva. Il docstring del modulo porta le due righe che un
chiamante scrive al suo posto.

**`xonly.from_keypair` resta, e la regola si allarga a coprirla.** Prende
un oggetto e non è metà di una coppia parse/serialize, ma non è
un'eccezione: un keypair *non ha* una serializzazione con cui fare un
ponte. `secp256k1_keypair` tiene una chiave privata nel layout di
libsecp256k1 e l'API C ne crea uno senza mai scriverlo fuori, quindi chi
se n'è costruito uno attraverso `lib` — un firmatario MuSig2, che è il
percorso documentato dal README — ha in mano qualcosa che nessun ottetto
avrebbe potuto portare qui. La regola ora nomina i due modi in cui un
oggetto arriva, e `from_keypair` lo dice dove la domanda si pone.
Renderla privata avrebbe rotto quel percorso per una comodità che
`Signer.pubkey` già copre quando il keypair è nostro.

Quindi la regola non è "niente oggetti": **un'eccezione vale quando gli
ottetti non possono portare la cosa, e va tolta quando possono.** Un
keypair non si serializza; un punto sì.

**E un numero di #167 è corretto qui.** Quella sezione misurava
`PubkeyTweakChain` contro il cammino compresso, 64.62 us contro 55.14 su
cinque passi: vero, e non è il confronto che decide. Lo stesso cammino in
forma non compressa, compresso in python dove BIP32 vuole 33 ottetti da
hashare, è **54.75** — la catena entro il rumore. Quello che la catena
risparmia è reale contro una scrittura e un arrotondamento contro
l'altra; quello che vale senza ambiguità è la riga che il chiamante non
scrive. Ora la sezione dice entrambi i numeri, e separa i due oggetti per
quello che tengono: un keypair è aritmetica che nessuna serializzazione
restituisce, una chiave parsata è un parse che il chiamante può rendere
economico scegliendo la forma che porta. È il principio di #161, applicato
alla misura invece che all'intenzione.

Gate verde, 544 test, copertura 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align public API and docs with the "octets in, octets out" rule while adding verdict-style validators and arithmetic helpers.

New Features:
- Add keys.pubkey_sum to sum public keys and expose the point at infinity as a None result instead of raising.
- Introduce xonly.pubkey_verify and xonly.to_pubkey to validate x-only public keys and lift them back to full points.
- Introduce dsa.signature_verify to validate DER and compact signatures without raising, and share a common internal parser for both forms.

Enhancements:
- Refine xonly.parse to share a non-raising _parsed helper with xonly.pubkey_verify and adjust lifting semantics to prefer even-y points.
- Refactor DSA signature parsing to a shared _parsed helper, unifying error handling and enabling length-based verdicts.
- Split keys._pubkey_combine_ into a lower-level _pubkey_sum_ that distinguishes invalid inputs from sums at infinity, and build pubkey_combine/pubkey_sum on top of it.
- Remove the mult.mult coordinate-returning helper in favor of using mult.mult_bytes plus explicit int.from_bytes in tests and docs.
- Clarify and extend package, README, changelog, and history documentation around entry-point surface, keypairs, verdict APIs, and tweak chain performance.
- Update tests to cover new pubkey_sum, x-only helpers, signature_verify behaviour, and the removal of mult.mult while preserving property and vector coverage.

Documentation:
- Document new verdict-style APIs (pubkey_verify family and signature_verify), arithmetic helpers, and the rationale for when objects cross the boundary versus octet APIs in README, CHANGELOG, HISTORY, and module docstrings.

Tests:
- Add tests ensuring pubkey_sum matches pubkey_combine except at infinity, and that infinity is represented as None.
- Add tests for xonly.pubkey_verify and xonly.to_pubkey round-trips, invalid inputs, and parity handling.
- Add tests for dsa.signature_verify across DER and compact encodings, malformed encodings, high-s signatures, and type errors.
- Adjust existing tests and property-based checks to use mult.mult_bytes instead of the removed mult.mult and to validate coordinate/serialization consistency.