### PR TITLE
Answer the nonce each signer derives, through libsecp256k1's own pointer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2056
+        "line_number": 2111
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -382,79 +382,79 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 1032
+        "line_number": 1042
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 1035
+        "line_number": 1045
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 1036
+        "line_number": 1046
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 1043
+        "line_number": 1053
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 1044
+        "line_number": 1054
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 1077
+        "line_number": 1087
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 1078
+        "line_number": 1088
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 1102
+        "line_number": 1112
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 1103
+        "line_number": 1113
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 1119
+        "line_number": 1129
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 1120
+        "line_number": 1130
       }
     ]
   },
-  "generated_at": "2026-08-16T07:23:20Z"
+  "generated_at": "2026-08-16T07:26:16Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,61 @@ release-notes length in the first place, and are still in
   `to_compact` name the input form the way `compact` names it on `sign`
   and `verify`, which is the coherence a third name would have broken
 
+### The nonce each signer derives
+
+- **`dsa.nonce_rfc6979` and `ssa.nonce_bip340` are new** (#155).
+  libsecp256k1 exports its two nonce functions as callable pointers --
+  `secp256k1_nonce_function_rfc6979` and
+  `secp256k1_nonce_function_bip340` -- and both headers were already in
+  the parse list, so what was missing was the call through the pointer
+  and nothing else. No callback into python, which is what makes this
+  unlike the ECDH hash function `ecdh.shared_secret` declines to expose
+- **each is called with what its signer passes**, so what comes back is
+  the nonce of the signature the same arguments make, rather than a
+  derivation that resembles it. That is checked rather than asserted:
+  `tests/test_nonces.py` signs and re-derives, `r` being the x of `k`
+  times the generator reduced modulo the group order and BIP340's `R`
+  the same x without the reduction. The four points #155 lists are
+  settled that way -- the algorithm tag is fixed to the signer's (NULL
+  for ECDSA, `BIP0340/nonce` for BIP340), `attempt` is an argument
+  because RFC6979's contract has a counter even though every signature
+  takes the first candidate, `ndata` is the `aux_rand32` every other
+  entry point calls it, and the answer leaves through `_secret.take`
+- **BIP340's key enters negated where the point has odd y**, and the
+  x-only public key with it, because that is the key the signature is
+  made with: a wrapper taking the caller's key unchanged would answer a
+  nonce no signature was built on, which the odd-y parametrization of the
+  test would have caught. Both are derived here rather than asked of the
+  caller for the same reason
+- **and no auxiliary randomness is the aux of 32 zero octets**, which is
+  what libsecp256k1 substitutes and what a python implementation has to
+  choose between, BIP340 leaving the aux optional. Asserted, because it
+  is the kind of fact a reader would otherwise have to read the C for
+- **what they are not is a way to sign in python.** A nonce read out of
+  libsecp256k1 has left constant-time code, and the docstrings say so
+  where a caller meets them: they are an oracle for checking a
+  derivation, which is the gap btclib's `ecc/rfc6979_nonce.py` and
+  `ecc/bip340_nonce.py` have had
+- **and SECURITY.md gains the limit that has an equation.** Its list of
+  what libsecp256k1 writes into a cffi buffer now names the nonce, and
+  beside it the thing the other members do not have: a nonce published
+  beside the signature it made *is* the private key,
+  `d = (s·k - h)/r mod n`. The docstrings warn against signing with one;
+  what they could not say, the enumeration being elsewhere, is that it
+  must not be stored or logged beside a signature either
+- **the identity the oracle rests on is asserted, not assumed**:
+  `dsa.sign` passes NULL where the nonce function goes, which selects
+  `secp256k1_nonce_function_default`, and this wrapper calls
+  `secp256k1_nonce_function_rfc6979`. libsecp256k1's header says they are
+  "currently the same pointer", and `tests/test_nonces.py` says so too —
+  without it, a split upstream would fail the signature comparisons while
+  reporting only that a nonce does not match its signature
+- **and the published vectors are what the RFC6979 entry point answers
+  to.** `tests/test_vectors.py` already carries the RFC6979 cases with
+  their `k`, and now asserts that `nonce_rfc6979` reproduces it: the
+  signature comparison holds the wrapper to this package's own signer,
+  and this holds it to the value RFC6979 publishes
+
 ### The surface and the sentence agree
 
 - **the `mult` module is folded into `keys`** (#173). With `mult.mult`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -147,6 +147,16 @@ serializations, so that a library validating input has one shape of
 answer for all four kinds of octets rather than a verdict for two of them
 and an exception for the rest.
 
+**Two entry points answer the nonce a signature was built on.**
+`dsa.nonce_rfc6979` and `ssa.nonce_bip340` call through the function
+pointers libsecp256k1 exports, with what each signer passes them, so what
+comes back is the `k` of the signature the same arguments make -- `r`
+being the x of `k` times the generator. A python implementation of either
+derivation had published vectors and no oracle; this is the C function
+itself. The nonce is the secret the signature is built on, and reading it
+into python takes it out of constant-time code: they are for checking a
+derivation, not for driving one.
+
 **Two more entry points are for the caller doing arithmetic rather than
 holding a key.** `keys.pubkey_sum` is `pubkey_combine` answering `None`
 where the sum is the point at infinity, instead of refusing it: `P + (-P)`

--- a/README.md
+++ b/README.md
@@ -508,6 +508,18 @@ too. So the input form is named by the call, as `compact` names it on
 signs a message of any length, which BIP340 allows and which a protocol
 of its own may define.
 
+`dsa.nonce_rfc6979` and `ssa.nonce_bip340` answer the nonce each signer
+derives, which is the one part of signing these bindings used to compute
+and never show. libsecp256k1 exports both derivations as callable
+pointers, so this is the C function itself rather than a second
+implementation of it, called with what the signer passes it -- and what
+comes back is the `k` of the signature the same arguments produce, which
+is how `tests/test_nonces.py` checks it: `r` is the x of `k` times the
+generator. A python implementation of either derivation has published
+vectors and, until now, no oracle. The nonce is the secret a signature is
+built on, so reading one into python takes it out of constant-time code:
+what these are for is checking a derivation, not driving one.
+
 `ecdh.shared_secret` returns the SHA256 of the compressed shared point,
 the libsecp256k1 default. The hash function is not exposed: libsecp256k1
 takes it as a C callback, and a protocol needing another derivation has

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,10 +72,18 @@ These are known and inherent, not vulnerabilities:
     The copy in the middle is not a Python object and is overwritten: a
     private key or a shared secret libsecp256k1 writes into a cffi buffer
     — the output of a tweak or a negation, an ECDH secret, the
-    `secp256k1_keypair` a BIP340 signature is made with — is read out and
-    the buffer zeroed before it is dropped. That is one copy taken back,
+    `secp256k1_keypair` a BIP340 signature is made with, the nonce
+    `dsa.nonce_rfc6979` and `ssa.nonce_bip340` answer with — is read out
+    and the buffer zeroed before it is dropped. That is one copy taken back,
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
+- **a nonce is the private key, given the signature it made.** The two
+    nonce entry points exist so that an implementation of RFC6979 or of
+    BIP340's derivation can be checked against libsecp256k1's own, and
+    what they answer is not a value to publish, log or store beside a
+    signature: `d = (s·k − h)/r mod n` recovers the private key from one
+    of each. Reading a nonce also takes it out of constant-time code,
+    which is the limit above; this is the one that has an equation
 - a scalar passed as an `int` leaks its magnitude. A Python integer is a
     variable-length object, so serializing one — and any arithmetic that
     produced it — takes a time that depends on the value; the argument

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -19,8 +19,87 @@ serialize one of their own.
 from __future__ import annotations
 
 from . import BytesLike, CData, ffi, keys, lib
-from ._scalar import octets, optional_entropy, scalar
+from ._scalar import in_range, octets, optional_entropy, scalar
+from ._secret import take
 from .context import ctx, guarded
+
+
+def nonce_rfc6979(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    attempt: int = 0,
+) -> bytes:
+    """Return the RFC6979 nonce `sign` derives for a message and a key.
+
+    libsecp256k1 exports its nonce function as a callable pointer, and
+    this calls through it with what `secp256k1_ecdsa_sign` passes: the
+    message hash, the key, no algorithm tag, and the extra entropy. That
+    signing call selects the *default* nonce function, which libsecp256k1
+    documents as the same pointer as this one -- an identity
+    `tests/test_nonces.py` asserts rather than assumes. So what comes back
+    is the `k` of the signature `sign` makes of the same arguments: `r` is
+    the x of `k` times the generator, reduced, which is what that same
+    file holds it to.
+
+    It is here because a nonce is the one part of signing these bindings
+    compute and never show, which leaves a python implementation of
+    RFC6979 with published vectors and no oracle. `recovery.sign` derives
+    its nonce the same way and this answers for it too.
+
+    **The nonce is the secret the signature is built on.** Read into
+    python it has left constant-time code, and a caller that signs with
+    one it read here is doing the arithmetic this package delegates
+    precisely so that it is not done in python. What this is for is
+    checking a derivation, not driving one.
+
+    Args:
+        msg_bytes: the 32-byte hash of the message.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: the 32 bytes of extra entropy `sign` mixes in, or
+            None for the RFC6979 nonce alone. Whichever was given to
+            `sign` is what reproduces its nonce, `None` included.
+        attempt: which candidate to answer. RFC6979 retries when the one
+            it derives is not a scalar in [1, n-1], and libsecp256k1
+            drives that counter itself; 0 is what it takes first and what
+            every signature this package makes has used.
+
+    Returns:
+        The 32-byte nonce.
+
+    Raises:
+        TypeError: if the attempt is not an int, or an argument is not
+            bytes.
+        ValueError: if the message hash is not 32 bytes, if aux_rand32 is
+            given and is not 32 bytes, if the private key is not 32 bytes
+            or does not fit in them, or if the attempt is out of range.
+        RuntimeError: if libsecp256k1 fails to derive one, which RFC6979
+            answers for every input.
+
+    Example:
+        >>> from btclib_secp256k1 import dsa
+        >>> nonce = dsa.nonce_rfc6979(bytes(32), 1)
+        >>> len(nonce)
+        32
+    """
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    prvkey_bytes = scalar(prvkey, "private key")
+    # unsigned int, and out of range is out of domain like any other
+    # argument rather than the OverflowError cffi would answer with
+    attempt = in_range(attempt, "attempt", 2**32 - 1)
+    # the entropy has to outlive the call: cffi keeps alive what a
+    # variable points to, and this pointer is read inside it
+    ndata = optional_entropy(aux_rand32)
+
+    nonce = ffi.new("unsigned char[32]")
+    # NULL where the algorithm tag goes, which is what
+    # secp256k1_ecdsa_sign passes: a tag is what tells one derivation
+    # from another, and this is the one ECDSA signing uses
+    if not lib.secp256k1_nonce_function_rfc6979(
+        nonce, msg_bytes, prvkey_bytes, ffi.NULL, ndata, attempt
+    ):
+        raise RuntimeError("RFC6979 nonce derivation failed")
+    return take(nonce)
 
 
 def _sign_(

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -13,14 +13,96 @@ from __future__ import annotations
 
 from types import TracebackType
 
-from . import BytesLike, CData, ffi, lib, xonly
-from ._scalar import entropy, octets
-from ._secret import keypair, wipe
+from . import BytesLike, CData, ffi, keys, lib, xonly
+from ._scalar import entropy, octets, optional_entropy, scalar
+from ._secret import keypair, take, wipe
 from .context import ctx, guarded
 
 # SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC: the libsecp256k1 macros do not
 # survive the preprocessing of the headers into cffi definitions
 EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"
+
+# the tag secp256k1_schnorrsig_sign gives its nonce function, and what
+# makes the derivation BIP340's rather than another protocol's
+_NONCE_ALGO = b"BIP0340/nonce"
+
+
+def nonce_bip340(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+) -> bytes:
+    """Return the BIP340 nonce `sign` derives for a message and a key.
+
+    libsecp256k1 exports its nonce function as a callable pointer, and
+    this calls through it with what `secp256k1_schnorrsig_sign` passes:
+    the message, the key the signature is made with, the x-only public
+    key, the `BIP0340/nonce` tag and the auxiliary randomness. So what
+    comes back is the `k` of the signature `sign` makes of the same
+    arguments -- the first 32 octets of that signature are the x of `k`
+    times the generator, which is what `tests/test_nonces.py` holds it to.
+
+    The key BIP340 signs with is the one of the even-y point, so a
+    private key whose point has odd y enters the derivation negated, and
+    the x-only public key with it. Both are derived here rather than
+    asked of the caller: that is what makes the answer the nonce of the
+    signature rather than of a key nobody signs with.
+
+    It is here for the reason `dsa.nonce_rfc6979` is: a python
+    implementation of BIP340's nonce derivation has published vectors and
+    no oracle, and the aux is where implementations diverge.
+
+    **The nonce is the secret the signature is built on**, and reading it
+    into python takes it out of constant-time code: see
+    `dsa.nonce_rfc6979`, which says what that means.
+
+    Args:
+        msg_bytes: the message, of any length.
+        prvkey: the private key, 32 bytes or an int below 2**256.
+        aux_rand32: the 32 bytes of auxiliary randomness, or None for the
+            derivation libsecp256k1 makes without any -- which answers
+            what 32 zero octets answer, the tagged hash of those zeros
+            being what it substitutes. `sign` given None generates 32
+            fresh octets instead of passing none, so what reproduces a
+            signature's nonce is the aux that signature was made with.
+
+    Returns:
+        The 32-byte nonce.
+
+    Raises:
+        ValueError: if aux_rand32 is given and is not 32 bytes, or if the
+            private key is not 32 bytes, does not fit in them, or is not
+            in [1, n-1].
+        RuntimeError: if libsecp256k1 fails to derive one, which the tag
+            above keeps it from doing.
+
+    Example:
+        >>> from btclib_secp256k1 import ssa
+        >>> nonce = ssa.nonce_bip340(bytes(32), 1, bytes(32))
+        >>> len(nonce)
+        32
+    """
+    msg_bytes = octets(msg_bytes, "message")
+    xonly_pubkey, parity = xonly.from_prvkey(prvkey)
+    # the key that signs, which BIP340 negates where the point has odd y
+    prvkey_bytes = (
+        keys.prvkey_negate(prvkey) if parity else scalar(prvkey, "private key")
+    )
+    aux = optional_entropy(aux_rand32)
+
+    nonce = ffi.new("unsigned char[32]")
+    if not lib.secp256k1_nonce_function_bip340(
+        nonce,
+        msg_bytes,
+        len(msg_bytes),
+        prvkey_bytes,
+        xonly_pubkey,
+        _NONCE_ALGO,
+        len(_NONCE_ALGO),
+        aux,
+    ):
+        raise RuntimeError("BIP340 nonce derivation failed")
+    return take(nonce)
 
 
 def sign(

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -272,6 +272,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
     ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),
     ("dsa.sign", dsa.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("dsa.nonce_rfc6979", dsa.nonce_rfc6979, (MSG, PRVKEY, bytes(32)), {}),
     ("dsa.verify", dsa.verify, (MSG, PUBKEY, DER), {}),
     ("dsa._verify_", dsa._verify_, (MSG, PARSED, PARSED_DER), {}),
     ("dsa._sign_", signed_dsa, (MSG, PRVKEY, bytes(32)), {}),
@@ -281,6 +282,7 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("dsa.to_compact", dsa.to_compact, (DER,), {}),
     ("dsa.to_der", dsa.to_der, (COMPACT,), {}),
     ("ssa.sign", ssa.sign, (MSG, PRVKEY, bytes(32)), {}),
+    ("ssa.nonce_bip340", ssa.nonce_bip340, (MSG, PRVKEY, bytes(32)), {}),
     ("ssa.sign_custom", ssa.sign_custom, (b"a message", PRVKEY, bytes(32)), {}),
     # the signer's own two, which is where its three bytes-like arguments
     # are: the private key the constructor takes, and the message and aux

--- a/tests/test_nonces.py
+++ b/tests/test_nonces.py
@@ -1,0 +1,167 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The nonce each signer derives, held to the signature it produced.
+
+A nonce is checked against nothing but itself unless something else
+knows it, and here that something is the signature: `r` is the x
+coordinate of the nonce times the generator, reduced modulo the group
+order, and BIP340's `R` is the same x without the reduction. So every
+assertion below signs and then re-derives, which is what makes these
+wrappers an oracle rather than a second implementation to trust.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from btclib_secp256k1 import dsa, keys, lib, recovery, ssa
+
+# secp256k1 group order
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+msg = hashlib.sha256(b"btclib_secp256k1").digest()
+# 6 is the small scalar whose public key has odd y, which is the case
+# BIP340 signs with the negated key
+EVEN_Y, ODD_Y = 7, 6
+
+
+def x_of(nonce: bytes) -> bytes:
+    """Return the x coordinate of the nonce times the generator.
+
+    Args:
+        nonce: the 32-byte nonce.
+
+    Returns:
+        The 32 bytes of x, which is what a signature carries as r.
+    """
+    return keys.pubkey_from_prvkey(nonce, compressed=False)[1:33]
+
+
+def test_the_default_nonce_function_is_the_rfc6979_one() -> None:
+    """What `dsa.sign` selects and what `dsa.nonce_rfc6979` calls are one.
+
+    `sign` passes NULL where the nonce function goes, which is
+    `secp256k1_nonce_function_default`; this wrapper calls
+    `secp256k1_nonce_function_rfc6979`. libsecp256k1's own header says
+    they are "currently the same pointer", and every other assertion in
+    this file rests on that: were upstream to split them, the signature
+    comparisons would fail and say only that a nonce does not match its
+    signature. This one says why.
+    """
+    assert lib.secp256k1_nonce_function_default == lib.secp256k1_nonce_function_rfc6979
+
+
+@pytest.mark.parametrize("aux_rand32", [None, b"\x11" * 32], ids=["no aux", "aux"])
+def test_rfc6979_nonce_is_the_one_the_signature_was_made_with(
+    aux_rand32: bytes | None,
+) -> None:
+    """`dsa.nonce_rfc6979` answers the k of `dsa.sign` of the same arguments.
+
+    Checked through the signature rather than against a vendored value:
+    r is the x of k*G reduced modulo the group order, so a nonce that
+    gives that r is the nonce that made that signature. Both spellings of
+    the entropy are exercised, none and 32 octets, because ndata is what
+    the RFC6979 derivation mixes in and what a grinding caller drives.
+    """
+    nonce = dsa.nonce_rfc6979(msg, EVEN_Y, aux_rand32)
+    signature = dsa.sign(msg, EVEN_Y, aux_rand32, compact=True)
+
+    assert len(nonce) == 32
+    assert int.from_bytes(x_of(nonce), "big") % N == int.from_bytes(
+        signature[:32], "big"
+    )
+
+    # the recoverable signer derives its nonce the same way, so the same
+    # answer explains its r too
+    recoverable, _ = recovery.sign(msg, EVEN_Y, aux_rand32)
+    assert recoverable[:32] == signature[:32]
+
+
+def test_rfc6979_attempt_is_the_counter_the_derivation_retries_on() -> None:
+    """A later attempt is a different nonce, and 0 is what signing takes.
+
+    RFC6979 retries when the candidate it derives is not a scalar in
+    [1, n-1]; the counter is libsecp256k1's to drive and every signature
+    this package makes has taken the first candidate, which is what the
+    equality above asserts. What the argument is for is checking the rest
+    of the contract, and what it must not be is out of range.
+    """
+    first = dsa.nonce_rfc6979(msg, EVEN_Y)
+    assert dsa.nonce_rfc6979(msg, EVEN_Y, attempt=0) == first
+    assert dsa.nonce_rfc6979(msg, EVEN_Y, attempt=1) != first
+
+    with pytest.raises(ValueError, match=r"attempt must be in \[0, 4294967295\]"):
+        dsa.nonce_rfc6979(msg, EVEN_Y, attempt=2**32)
+    with pytest.raises(TypeError, match="attempt must be an int"):
+        dsa.nonce_rfc6979(msg, EVEN_Y, attempt=1.0)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("prvkey", [EVEN_Y, ODD_Y], ids=["even y", "odd y"])
+def test_bip340_nonce_is_the_one_the_signature_was_made_with(prvkey: int) -> None:
+    """`ssa.nonce_bip340` answers the k of `ssa.sign` of the same arguments.
+
+    The first 32 octets of a BIP340 signature are the x of k*G, so the
+    signature is what knows the nonce. The odd-y key is the case worth
+    parametrizing: BIP340 signs with the key of the even-y point, so both
+    the private key and the public key entering the derivation are the
+    negated ones, and a wrapper that passed the caller's key would answer
+    a nonce no signature was made with.
+    """
+    aux_rand32 = b"\x22" * 32
+    nonce = ssa.nonce_bip340(msg, prvkey, aux_rand32)
+
+    assert len(nonce) == 32
+    assert x_of(nonce) == ssa.sign(msg, prvkey, aux_rand32)[:32]
+
+
+def test_bip340_nonce_takes_a_message_of_any_length() -> None:
+    """BIP340 signs messages of any length, and so derives nonces for them.
+
+    `sign_custom` is the signer that takes one, and the nonce function
+    takes the length beside the message for the same reason.
+    """
+    aux_rand32 = b"\x33" * 32
+    for message in (b"", b"Satoshi Nakamoto" * 7):
+        nonce = ssa.nonce_bip340(message, EVEN_Y, aux_rand32)
+        assert x_of(nonce) == ssa.sign_custom(message, EVEN_Y, aux_rand32)[:32]
+
+
+def test_bip340_without_aux_is_the_aux_of_zeros() -> None:
+    """No auxiliary randomness is what 32 zero octets are, and not an error.
+
+    libsecp256k1 substitutes the tagged hash of 32 zeros where the caller
+    passes none, so the two spellings answer one nonce -- which is worth
+    asserting because a python implementation has to choose one of them
+    and BIP340's own text leaves the aux optional.
+    """
+    assert ssa.nonce_bip340(msg, EVEN_Y) == ssa.nonce_bip340(msg, EVEN_Y, bytes(32))
+    # and a different aux is a different nonce, so the argument is read
+    assert ssa.nonce_bip340(msg, EVEN_Y, b"\x01" * 32) != ssa.nonce_bip340(msg, EVEN_Y)
+
+
+def test_the_nonce_wrappers_refuse_what_the_signers_refuse() -> None:
+    """Every argument is held to what the signer holds it to.
+
+    The message hash of the ECDSA derivation is 32 octets, the auxiliary
+    randomness is 32 or nothing, and the private key is a scalar in
+    [1, n-1] -- the last one refused by the public key derivation the
+    BIP340 nonce needs, and by libsecp256k1 itself for RFC6979.
+    """
+    with pytest.raises(ValueError, match="message hash must be 32 bytes"):
+        dsa.nonce_rfc6979(msg[:-1], EVEN_Y)
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
+        dsa.nonce_rfc6979(msg, EVEN_Y, b"\x01" * 31)
+    with pytest.raises(ValueError, match="private key must be 32 bytes"):
+        dsa.nonce_rfc6979(msg, b"\x01" * 31)
+
+    with pytest.raises(ValueError, match="aux_rand32 must be 32 bytes"):
+        ssa.nonce_bip340(msg, EVEN_Y, b"\x01" * 33)
+    with pytest.raises(ValueError, match="private key"):
+        ssa.nonce_bip340(msg, 0)
+    with pytest.raises(TypeError, match="message must be bytes"):
+        ssa.nonce_bip340(11, EVEN_Y)  # type: ignore[arg-type]

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1005,10 +1005,20 @@ def test_rfc6979_ecdsa_vector(
     consistent before it is used to judge anything. libsecp256k1 always
     produces the low-s form, so the expected s is the smaller of s and
     n-s.
+
+    The published k is also what `dsa.nonce_rfc6979` has to answer, which
+    is the only assertion here that holds that entry point to something
+    other than this package: `tests/test_nonces.py` compares it with the
+    signature it made, and this compares it with the value RFC6979
+    publishes.
     """
     msg32 = hashlib.sha256(msg_text.encode()).digest()
     r = int(r_hex, 16)
     s = int(s_hex, 16)
+
+    # the derivation itself, against the published nonce rather than
+    # against a signature of ours
+    assert dsa.nonce_rfc6979(msg32, bytes.fromhex(seckey_hex)) == bytes.fromhex(k_hex)
 
     # vector self-consistency: r is the x coordinate of k*G
     assert (


### PR DESCRIPTION
Closes #155. Impilata su #174 (`fold-mult`): quella è un commit solo,
quindi il fast-forward ne conserva lo sha e questa si ritarga su `main`
senza rebase.

Un nonce è l'unica parte della firma che questi binding calcolavano senza
mai mostrarla, il che lascia un'implementazione python di RFC6979 o della
derivazione BIP340 con i vettori pubblicati e niente a cui chiedere.
Entrambe le funzioni sono esportate come puntatori chiamabili e i due
header erano già nella lista di parsing: mancava la chiamata attraverso
il puntatore, e nient'altro. Nessuna callback verso python — che è ciò
che distingue questo dalla hash function ECDH che `ecdh.shared_secret`
rifiuta di esporre.

**Ognuna è chiamata con ciò che le passa il suo firmatario**, quindi
quello che torna è il `k` della firma che gli stessi argomenti producono,
non una derivazione che le somiglia. E questo è **verificato, non
asserito**: `tests/test_nonces.py` firma e ri-deriva — `r` è la x di
`k·G` ridotta modulo l'ordine del gruppo, e la `R` di BIP340 è la stessa
x senza riduzione.

I quattro punti che #155 lasciava aperti si chiudono così:

- **il tag dell'algoritmo è quello del firmatario**, non un argomento:
  NULL per ECDSA, che è ciò che passa `secp256k1_ecdsa_sign`, e
  `BIP0340/nonce` per BIP340;
- **`attempt` è un argomento**, perché il contratto di RFC6979 ha un
  contatore anche se ogni firma prende il primo candidato;
- **`ndata` è l'`aux_rand32`** che ogni altro entry point chiama così;
- **la risposta esce da `_secret.take`**, il nonce essendo un segreto.

**La chiave BIP340 entra negata dove il punto ha y dispari**, e con lei
la chiave pubblica x-only, perché quella è la chiave con cui la firma è
fatta: un wrapper che passasse la chiave del chiamante risponderebbe un
nonce su cui nessuna firma è costruita. È la parametrizzazione y dispari
del test a tenerlo fermo.

**E l'assenza di aux è l'aux di 32 zeri**, che è ciò che libsecp256k1
sostituisce e che un'implementazione python deve scegliere, BIP340
lasciando l'aux opzionale. Asserito, perché è il tipo di fatto che
altrimenti si legge solo nel C.

Quello che **non** sono è un modo di firmare in python: un nonce letto
fuori da libsecp256k1 ha lasciato il codice a tempo costante, e i due
docstring lo dicono dove il chiamante li incontra.

Gate verde, 552 test, copertura 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose libsecp256k1’s RFC6979 and BIP340 nonce derivations as Python entry points and validate them against the signatures they produce.

New Features:
- Add dsa.nonce_rfc6979 to return the RFC6979 nonce used by ECDSA signing for a given message, key, auxiliary entropy, and attempt counter.
- Add ssa.nonce_bip340 to return the BIP340 nonce used by Schnorr signing for a given message, key, and auxiliary randomness, including the even-y key handling.

Enhancements:
- Document the new nonce oracle functions in README, CHANGELOG, and HISTORY, clarifying that they are for validation of derivations rather than for performing signatures.
- Ensure nonce wrappers share the same argument validation constraints as their corresponding signers and integrate them into the bytes-like scanning tests.

Tests:
- Add tests/test_nonces.py to verify that the exposed nonce functions reproduce the nonces implied by ECDSA, recoverable ECDSA, and BIP340 signatures, and to cover edge cases such as attempts, aux handling, and invalid inputs.