### PR TITLE
Assert what the octets do not already say, and give each scheme its equation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,21 +182,21 @@
         "filename": "tests/test_properties.py",
         "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
         "is_verified": false,
-        "line_number": 338
+        "line_number": 336
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
         "is_verified": false,
-        "line_number": 360
+        "line_number": 358
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
         "is_verified": false,
-        "line_number": 363
+        "line_number": 361
       }
     ],
     "tests/test_submodule_pin.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T07:26:16Z"
+  "generated_at": "2026-08-16T08:28:56Z"
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,13 +77,17 @@ These are known and inherent, not vulnerabilities:
     and the buffer zeroed before it is dropped. That is one copy taken back,
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
-- **a nonce is the private key, given the signature it made.** The two
-    nonce entry points exist so that an implementation of RFC6979 or of
-    BIP340's derivation can be checked against libsecp256k1's own, and
-    what they answer is not a value to publish, log or store beside a
-    signature: `d = (s·k − h)/r mod n` recovers the private key from one
-    of each. Reading a nonce also takes it out of constant-time code,
-    which is the limit above; this is the one that has an equation
+- a nonce is the private key, given the signature it made. The two nonce
+    entry points exist so that an implementation of RFC6979 or of BIP340's
+    derivation can be checked against libsecp256k1's own, and what they
+    answer is not a value to publish, log or store beside a signature.
+    Each scheme has its own equation: ECDSA signs `s = k⁻¹(h + r·d)`, so
+    `d = (s·k − h)/r mod n`, and BIP340 signs `s = k + e·d` with
+    `e = H(R ‖ P ‖ m)`, so `d = (s − k)/e mod n` — for the `k` and `d`
+    BIP340 negates to an even-y point, which is a parity whoever holds
+    the nonce computes rather than a step that stops them. Reading a
+    nonce also takes it out of constant-time code, which is the limit
+    above; this is the one that has the arithmetic to show for it
 - a scalar passed as an `int` leaks its magnitude. A Python integer is a
     variable-length object, so serializing one — and any arithmetic that
     produced it — takes a time that depends on the value; the argument

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -77,14 +77,12 @@ def compress(pubkey_bytes: bytes) -> bytes:
 def test_serialization_round_trips() -> None:
     """Either form parses and comes back, and negation is an involution.
 
-    The coordinates are checked against the curve equation and the parity
-    the compressed form carries,
-    and negating the private key is checked to flip the y while leaving
-    the x alone -- which is the point-level meaning of the scalar
-    operation, asserted rather than assumed. What
-    `keys.pubkey_from_prvkey` serializes in C is checked against the
-    compression composed here, over a sweep in which both parities occur:
-    a fixed key exercises one of them.
+    The coordinates are checked against the curve equation, and negating
+    the private key is checked to flip the y while leaving the x alone --
+    which is the point-level meaning of the scalar operation, asserted
+    rather than assumed. What `keys.pubkey_from_prvkey` serializes in C
+    is checked against the compression composed here, over a sweep in
+    which both parities occur: a fixed key exercises one of them.
     """
     for prvkey in derived(b"serialization"):
         uncompressed = keys.pubkey_from_prvkey(prvkey, compressed=False)
@@ -96,13 +94,13 @@ def test_serialization_round_trips() -> None:
         # and both are what pubkey_from_prvkey answers, whose compressed
         # form libsecp256k1 writes where this file composes it
         assert keys.pubkey_from_prvkey(prvkey) == compressed
-        # the coordinates a caller reads out of those octets are the ones
-        # the point has: y is even where the compressed form says 0x02,
-        # and the pair satisfies the curve equation. Read here rather
-        # than compared with the same call a second time
+        # the coordinates a caller reads out of those octets are those
+        # of a point: the pair satisfies the curve equation. Parity is
+        # not asserted beside it -- `compress` composes the prefix out of
+        # the very octet such an assertion would read, so what holds that
+        # prefix to libsecp256k1's own is the equality above
         x = int.from_bytes(uncompressed[1:33], "big")
         y = int.from_bytes(uncompressed[33:], "big")
-        assert y % 2 == compressed[0] - 2
         assert (y * y - x * x * x - 7) % P == 0
 
         # negation is an involution, on both sides


### PR DESCRIPTION
Closes #178.

Two leftovers of #174 and #175, both raised in review of those and both
left out of them because neither held anything up.

**The parity assertion could not fail.** `compress` in
`tests/test_properties.py` composes its first octet as
`2 + (pubkey_bytes[64] & 1)`, and `y % 2` of a big-endian read of the
same 32 octets is that bit: `assert y % 2 == compressed[0] - 2` compared
a parity with itself. What it meant to state — libsecp256k1's compressed
prefix agreeing with the y it wrote in the other serialization — is the
assertion three lines above, `keys.pubkey_from_prvkey(prvkey) ==
compressed`, whose right side is that composition. The curve equation
stays: it reads the octets instead of restating them, and it is what the
sweep over both parities is for.

**SECURITY.md had one equation for two schemes.** The bullet exists to
say that a nonce plus the signature it made is the private key, and it
gave `d = (s·k − h)/r mod n`, which is ECDSA's. BIP340 signs
`s = k + e·d` with `e = H(R ‖ P ‖ m)`, so there it is
`d = (s − k)/e mod n`. Both are named now, each beside the scheme it
belongs to. The bullet also opened in bold where the two around it open
in plain text.

No release note: neither the tests nor SECURITY.md's phrasing is
something a caller acts on, and the entry points they are about are
already in the notes of the two pull requests above.

Gates run locally on this commit: the suite, coverage at 100.00%,
`pre-commit run --all-files`, and sphinx with `-W`.

## Summary by Sourcery

Clarify documentation and tests around nonce-derived private keys and public key serialization, separating scheme-specific equations and removing redundant assertions.

Documentation:
- Update SECURITY.md to describe nonce-derived private key recovery with distinct equations for ECDSA and BIP340, and align formatting of the bullet with surrounding text.

Tests:
- Refine serialization round-trip property test comments and remove a redundant y-parity assertion that restated information already encoded in the compressed public key.