### PR TITLE
Name the one buffer this package does not zero on its own

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2111
+        "line_number": 2124
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T08:28:56Z"
+  "generated_at": "2026-08-16T08:46:04Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ release-notes length in the first place, and are still in
   What is new is a measured cost, and it is paid by every caller signing
   more than once under one key. BIP340 only: `secp256k1_ecdsa_sign`
   takes the private key directly, so `dsa.sign` has no keypair to hoist
+- **and a signer that is dropped rather than wiped is named where the
+  guarantee is made** (#177). SECURITY.md said the cffi buffer holding a
+  secret is zeroed before it is dropped, which is true of every one of
+  them except this: a signer told neither `wipe` nor `with` is collected
+  with the keypair still holding the private key, cffi freeing that
+  memory without overwriting it. The sentence now names the exception,
+  `Signer`'s own docstring says it where a caller meets the class, and
+  `tests/test_signer.py` asserts it — the keypair kept alive by a
+  reference of its own, the signer dropped and collected, the key still
+  in those octets. A `weakref.finalize` would close it in three lines and
+  is deliberately not there: it runs at a time nothing specifies, which
+  reads as a guarantee without being one, and the test is what makes
+  adding it a decision to reread rather than a silent reversal
 - **the two functions are now the signer's two calls with the keypair
   built and wiped around them**, `_sign32` and `_sign_custom` being the
   shared body, so neither side can drift into a second spelling of the

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -92,9 +92,13 @@ What a signer holds is a secret, and it is the caller's for as long as
 they hold it: use it in a `with` block, which overwrites the keypair on
 the way out whether the block ended in a signature or in an exception.
 `signer.wipe()` says the same thing by hand, and a wiped signer refuses
-to sign rather than signing with what the wipe left. The private key
-handed to the constructor is a python `bytes` or `int` and is no more
-zeroizable than before: SECURITY.md's limits are unchanged.
+to sign rather than signing with what the wipe left. Neither is a
+formality: a signer that is simply dropped is collected with the keypair
+still holding the key, cffi freeing that memory without overwriting it,
+and nothing runs behind the caller to do it — SECURITY.md now names this
+as the one buffer of the package whose zeroing is asked for rather than
+done. The private key handed to the constructor is a python `bytes` or
+`int` and is no more zeroizable than before.
 
 `xonly._tweak_add_` is the private half of `xonly.tweak_add`: it takes
 the parsed point `keys.parse` returns, rather than the x-only form, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,17 @@ These are known and inherent, not vulnerabilities:
     and the buffer zeroed before it is dropped. That is one copy taken back,
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
+- the one buffer whose zeroing is the caller's to ask for is
+    `ssa.Signer`'s. Everything above is wiped inside the call that made
+    it — read out and zeroed in the one operation, or wiped in a
+    `finally` where it is a keypair; a signer holds its
+    `secp256k1_keypair` across calls, which is what it is for, and wipes
+    it when told — `wipe`, or the `with` statement that calls it on the
+    way out of the block. A signer told neither is dropped with the
+    keypair still holding the private key, and cffi frees that memory
+    without overwriting it. There is no finalizer behind it on purpose:
+    one would run at a time nothing specifies, which reads as a guarantee
+    and is not one. `with` is the guarantee
 - a nonce is the private key, given the signature it made. The two nonce
     entry points exist so that an implementation of RFC6979 or of BIP340's
     derivation can be checked against libsecp256k1's own, and what they

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -215,6 +215,13 @@ class Signer:
     nowhere else here, which is the point -- so signing again means
     building another one.
 
+    A signer told neither way is dropped holding the key: cffi frees the
+    keypair without overwriting it, and nothing here runs behind it to
+    do so. A finalizer would, at a time nothing specifies, which is a
+    guarantee in the shape of one and not in fact -- so the instruction
+    stays the caller's to give, and SECURITY.md records this as the one
+    buffer of the package whose zeroing is asked for rather than done.
+
     What it does not change is the python side: the `bytes` or `int`
     handed in here is a python object like any other, and SECURITY.md
     records why that copy cannot be taken back.

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -17,12 +17,16 @@ What is left for this file is the half a vector cannot state: the
 lifetime the signer hands the caller. The keypair is the private key in
 libsecp256k1's layout, in memory this package owns, so what is asserted
 here is that it is still there while the signer is usable, that `wipe`
-and the `with` block each overwrite it, and that a wiped signer refuses
-to sign instead of signing with the zeros.
+and the `with` block each overwrite it, that a wiped signer refuses to
+sign instead of signing with the zeros, and that a signer told neither is
+dropped with the secret still in it -- the limit SECURITY.md names, held
+to by a test so that closing it later is a decision rather than a
+sentence quietly made false.
 """
 
 from __future__ import annotations
 
+import gc
 import hashlib
 
 import pytest
@@ -216,3 +220,27 @@ def test_a_wiped_signer_refuses_to_sign() -> None:
         signer.sign(MSG, AUX)
     with pytest.raises(ValueError, match="wiped"):
         signer.sign_custom(MSG, AUX)
+
+
+def test_a_dropped_signer_leaves_the_keypair_as_it_was() -> None:
+    """Nothing wipes behind a caller who neither wipes nor uses `with`.
+
+    SECURITY.md names this as the one buffer of the package whose
+    zeroing is asked for rather than done, and this is that sentence as
+    an assertion: the keypair is kept alive here by a reference of its
+    own, the signer is dropped and collected, and the private key is
+    still in those octets. A finalizer added later would wipe them and
+    fail this test, which is where the decision would be reread rather
+    than silently reversed.
+    """
+    signer = ssa.Signer(PRVKEY)
+    # `keypair_memory` asks a signer, and there is no signer left to ask
+    # by the time the question matters. This reference is also what keeps
+    # cffi from freeing the memory out from under the assertion
+    held = signer._keypair
+    assert held is not None
+
+    del signer
+    gc.collect()  # refcounting has dropped it already; PyPy needs asking
+
+    assert PRVKEY in bytes(ffi.buffer(held))


### PR DESCRIPTION
Closes #177.

Of the two ways that issue offers, this takes the second: SECURITY.md
names the case its sentence did not cover, and the class says it where a
caller meets it. The first — a finalizer — is the one thing this
deliberately does not add, and the reason is the issue's own: it would
run at a time nothing specifies, which reads as a guarantee without being
one.

**What was wrong.** SECURITY.md said the cffi buffer holding a secret is
read out and zeroed before it is dropped. True of every one of them but
`ssa.Signer`'s: `ssa.sign` and `ssa.sign_custom` own a keypair for the
length of a call and wipe it in a `finally`, while a signer holds one
across calls and wipes it when told. Told neither `wipe` nor `with`, it
is collected with the private key still in those 96 octets, and cffi
frees the memory without overwriting it.

**Three places say it now**, each for the reader who is there:
SECURITY.md's limitations list, `Signer`'s class docstring, and
HISTORY.md's paragraph on the lifetime — which said to use `with` and now
says why that is not a formality.

**And a test asserts it**, rather than leaving a security claim to prose:
the keypair is kept alive by a reference of its own, the signer is
dropped and collected, and the key is still in those octets.

The test was checked against the alternative rather than assumed to be
meaningful — a subclass registering
`weakref.finalize(self, wipe, self._keypair)` wipes those same octets:

```
Signer       key still in the buffer: True
Backstopped  key still in the buffer: False
```

So the assertion fails the moment a backstop exists, which is what turns
adding one later into a decision reread rather than a sentence silently
made false. Three lines is all it would take, if the answer to #177's
first option is yes after all.

Gates run locally on this commit: the suite (554), coverage at 100.00%,
`pre-commit run --all-files`, and sphinx with `-W`.

## Summary by Sourcery

Clarify the lifecycle and zeroing responsibilities of the `ssa.Signer` keypair buffer and codify that behavior in tests and documentation.

Enhancements:
- Document that `ssa.Signer` retains its keypair buffer when dropped without being wiped, and that no automatic finalizer is provided.

Documentation:
- Update SECURITY.md, HISTORY.md, and CHANGELOG.md to explicitly describe `ssa.Signer` as the one buffer whose zeroing is caller-controlled rather than automatic.

Tests:
- Add a test that verifies a dropped `Signer` leaves the underlying keypair buffer unchanged, ensuring any future automatic wiping is a deliberate, revisited decision.