### PR TITLE
Multiply each key by its scalar and add the products, in one crossing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2124
+        "line_number": 2180
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T08:46:04Z"
+  "generated_at": "2026-08-16T10:30:23Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,62 @@ release-notes length in the first place, and are still in
   and operates in octets, and the parsed key stops being something an API
   has to hand around.
 
+- **`keys.pubkey_tweak_mul_sum` is the multi-scalar multiplication, with
+  no product crossing the boundary.** A term per key and one sum over
+  them is the shape of a verification equation, of a MuSig2 aggregate
+  key and of BIP352's tweak data, and written with the public halves
+  every product is serialized as 65 octets only for `pubkey_sum` to
+  parse them back — the one composition above whose crossing is *per
+  term*, where sorting-then-adding pays per key and the others pay once.
+  Handed over whole, the products stay `secp256k1_pubkey` objects and
+  the boundary is one parse per input and one serialization for the
+  answer. Measured on this tree, on an Apple M5, macOS 26.6, arm64,
+  CPython 3.14.6, best of seven alternating rounds, uncompressed
+  throughout, with `pubkey_from_prvkey` as the noise detector (9.2 µs
+  across every round):
+
+  | terms | `tweak_mul` each, then `pubkey_sum` | `pubkey_tweak_mul_sum` |
+  | --- | --- | --- |
+  | 2 | 19.53 µs | 16.90 µs |
+  | 3 | 27.63 µs | 23.76 µs |
+  | 5 | 43.87 µs | 37.59 µs |
+  | 8 | 68.46 µs | 57.90 µs |
+  | 20 | 166.22 µs | 142.37 µs |
+  | 64 | 536.50 µs | 459.27 µs |
+
+  So about a seventh of the call from three terms up, a little less at
+  two, and it does not shrink with the term count the way the per-term
+  combine `pubkey_sum` replaced did. That flatness is what it is: the
+  naive form, a term at a time and one sum, with none of the shared
+  precomputation of Strauss or Pippenger.
+  `secp256k1_ecmult_multi_var` exists upstream and is internal, declared
+  in `src/ecmult.h` and not in `include/secp256k1.h`, so the public API
+  composes to this shape and no other -- what is saved here is the
+  crossing rather than the arithmetic, which matters most where the
+  caller is BIP340 batch verification and the asymptotic win is the
+  point of the exercise. btclib is that caller
+  (<https://github.com/btclib-org/btclib/issues/917>), whose
+  `curves.curve._libsecp256k1_multi_mult_` is that composition written
+  out and is reached by `mult`, `double_mult_var` and `multi_mult_var`
+  with one, two and many terms, by MuSig2's `key_agg`, and by BIP340
+  batch verification with two terms a signature.
+
+  **It is the second function here that is more than one libsecp256k1
+  decision**, `xonly.from_prvkey` being the first, and the README's
+  Design section states the rule the two answer to rather than leaving
+  them as exceptions: a composition belongs here when what it saves is
+  the crossing between its halves, which is the caller's cost and not
+  its own choice, and it is named after the calls it makes. Nothing is
+  computed here that libsecp256k1 does not: the terms are
+  `secp256k1_ec_pubkey_tweak_mul` and the sum is
+  `secp256k1_ec_pubkey_combine`, in the order the equation names them.
+
+  The sum at infinity is `pubkey_sum`'s None, and is likelier here than
+  there: a verification equation is written to land on it. The two
+  sequences must be of one length, which is the one refusal this
+  function raises itself — `zip` would otherwise stop at the shorter and
+  answer the sum of whatever paired up.
+
 ### The half that speaks in objects is private, and is spelled `_foo_`
 
 - **`foo_` is now `_foo_`, everywhere, and the API break is the point.**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -211,6 +211,22 @@ not a multiplication — 0.4 microseconds, where deriving it again is
 10.5. `xonly.from_keypair` is that read for a caller holding a keypair
 of its own, a MuSig2 session through `lib` being one.
 
+**`keys.pubkey_tweak_mul_sum` multiplies each key by its scalar and adds
+the products**, which is a verification equation, a MuSig2 aggregate key
+and BIP352's tweak data, and which written with the public halves
+serializes every product as 65 octets only for `pubkey_sum` to parse
+them back. Handed over whole, no product crosses: about a seventh of the
+call from three terms up, 64 terms 459.3 microseconds against 536.5, and
+the saving does not shrink with the count -- it is the naive form, one
+term at a time and one sum, libsecp256k1 exporting no batched
+multi-multiplication, so what it saves is the crossing and not the
+arithmetic. Like `xonly.from_prvkey` it
+is a composition rather than one libsecp256k1 call, and for the same
+reason — what it saves is the crossing between its halves, which is the
+caller's cost and not its own choice. The sum at infinity is
+`pubkey_sum`'s `None`, which a verification equation is written to land
+on.
+
 **And a wrong object is now told to the caller, wherever one is taken.**
 `keys.serialize` and `xonly.from_keypair` raised what libsecp256k1
 reported of an argument no python check can prove; every other call

--- a/README.md
+++ b/README.md
@@ -126,7 +126,19 @@ bytes, no libsecp256k1 call producing them directly.
 `keys.pubkey_from_prvkey` is `secp256k1_ec_pubkey_create` followed by
 `secp256k1_ec_pubkey_serialize`; every other function returning a key or
 a signature has the same shape, the second call being the serialization
-the first cannot do rather than a second decision. The cryptography —
+the first cannot do rather than a second decision.
+
+A function that does make a second decision is named after both of them
+and is here for one reason: what the composition saves is the crossing
+between its halves, which is the caller's cost and not its own choice.
+`xonly.from_prvkey` is the private key's public key and then the x of
+it; `keys.pubkey_tweak_mul_sum` is a `pubkey_tweak_mul` per term and one
+`pubkey_sum` over them, which is the multi-scalar multiplication a
+verification equation is written as, with no product serialized on its
+way into the sum. Neither computes anything libsecp256k1 does not: the
+arithmetic is upstream's calls in the order the equation names them, and
+*Parsing the key once* below is where the crossing they save is
+measured. The cryptography —
 the algorithms, the constant-time
 implementation, the side-channel hardening — is upstream's, and none of
 it is reimplemented, extended or second-guessed here. Wrappers of the
@@ -343,13 +355,26 @@ pays it per transaction, which is why `silentpayments` has a private
 half for each of its three entry points, the summary of a transaction's
 inputs included.
 
-Two entry points are there instead of two halves. `xonly.from_prvkey` is
-the x-only public key of a private key — the two halves above composed,
+Some compositions are an entry point instead of two halves, where what
+the caller wanted was the composition. `xonly.from_prvkey` is the
+x-only public key of a private key — the two halves above composed,
 which is what BIP340 and BIP341 ask for and what this package used to
 make every caller spell in two steps, with a full public key in the
-middle that nothing wanted. `ssa.Signer.pubkey` reads that same key off
-the keypair the signer already holds, which is a read rather than a
-multiplication, and so is cheaper than any composition could be.
+middle that nothing wanted. `keys.pubkey_tweak_mul_sum` is the other:
+a term per scalar and one sum over them, which is a verification
+equation, a MuSig2 aggregate key and BIP352's tweak data, and where the
+crossing is per term — every product serialized as 65 octets only for
+the sum to parse them again. Handed over whole it is about a seventh of
+the call from three terms up and stays there, 64 terms 459.3 µs against
+536.5; the CHANGELOG entry that added it has the count-by-count table
+and the conditions. It is the naive form and not a batched algorithm:
+`secp256k1_ecmult_multi_var` is internal to libsecp256k1 and not
+declared in its public header, so what is saved here is the crossing,
+which is flat in the number of terms.
+
+`ssa.Signer.pubkey` reads that same key off the keypair the signer
+already holds, which is a read rather than a multiplication, and so is
+cheaper than any composition could be.
 
 ## Two outposts past the boundary
 
@@ -476,7 +501,8 @@ declarations are available through the `lib` and `ffi` cffi objects:
 `keys` provides the public key of a private key (`pubkey_from_prvkey`,
 compressed by default, `compressed=False` for the uncompressed form)
 and the scalar and point algebra (tweaking, negation,
-combination, arbitrary point multiplication) underlying BIP32 key
+combination, arbitrary point multiplication, and the multi-scalar
+multiplication of `pubkey_tweak_mul_sum`) underlying BIP32 key
 derivation, plus the lexicographic ordering of public keys (`pubkey_cmp`,
 `pubkey_sort`) that BIP67 and MuSig2 key aggregation call for; `xonly`
 provides the BIP341 taproot tweaking of x-only public keys and of their

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -365,7 +365,13 @@ class PubkeyTweakChain:
 
         Raises:
             ValueError: if the tweak is not 32 bytes or does not fit in
-                them, or if the tweak or the resulting key is invalid.
+                them, or if the tweak or the resulting key is invalid --
+                which ends the chain. libsecp256k1 says of
+                `secp256k1_ec_pubkey_tweak_add` that "pubkey will be set
+                to an invalid value if this function returns 0", and the
+                point this holds is that pubkey: there is nothing left
+                to step from, so a caller catching this builds a chain
+                afresh rather than asking again.
             RuntimeError: if libsecp256k1 fails to serialize the result,
                 which no valid input can make it do.
         """
@@ -596,6 +602,105 @@ def pubkey_sum(
         True
     """
     summed = _pubkey_sum_([parse(pubkey_bytes) for pubkey_bytes in pubkeys_bytes])
+    return None if summed is None else serialize(summed, compressed)
+
+
+def pubkey_tweak_mul_sum(
+    pubkeys_bytes: Sequence[BytesLike],
+    tweaks: Sequence[BytesLike | int],
+    compressed: bool = True,
+) -> bytes | None:
+    """Multiply each public key by its tweak and add the products.
+
+    The two names it is spelled with, in that order: a
+    `pubkey_tweak_mul` per pair and one `pubkey_sum` over the products.
+    That is the multi-scalar multiplication a caller writes as a
+    verification equation -- u*H + v*Q of ECDSA and BIP340, MuSig2's
+    aggregate of a key per signer, BIP352's tweak data -- and the whole
+    of what it adds is that no product is serialized: written with the
+    public halves, each `pubkey_tweak_mul` serializes 65 octets that the
+    sum then parses again, and the terms are the only place a caller has
+    to put them.
+
+    The naive form of it, deliberately: a term at a time and one sum,
+    with none of the shared precomputation of Strauss or Pippenger.
+    libsecp256k1 has `secp256k1_ecmult_multi_var`, which is internal and
+    not declared in `include/secp256k1.h`, so this is the only
+    multi-scalar multiplication the public API can be composed of -- and
+    the saving here is the crossing rather than the arithmetic, flat in
+    the number of terms where a batched algorithm would grow with it.
+
+    **This is the second function here that is more than one
+    libsecp256k1 decision**, `xonly.from_prvkey` being the first, and
+    the README's Design section says why the rule is what it is: the
+    boundary computes nothing of its own. Neither does this -- the terms
+    are `secp256k1_ec_pubkey_tweak_mul` and the sum is
+    `secp256k1_ec_pubkey_combine`, in the one order that spells the
+    equation -- and what is saved is a serialization and a parse per
+    term, about a seventh of the call from three terms up and a little
+    less at two.
+    `PubkeyTweakChain` is an exception of the other kind and not of
+    this one: its `tweak_add` is one decision and a serialization like
+    every other, and what it holds is a parsed key across calls the
+    caller makes one at a time.
+
+    The infinity is `pubkey_sum`'s None, for the reason it is there and
+    is more likely here: a verification equation is written to land on
+    it, u*H + v*Q with v*Q the negation of u*H being the accepting case
+    of a check spelled as a difference.
+
+    Args:
+        pubkeys_bytes: the public keys, each 33 or 65 bytes. At least
+            one is required, as the sum requires it.
+        tweaks: the scalar each key is multiplied by, one per key, 32
+            bytes or an int below 2**256.
+        compressed: whether to return 33 bytes rather than 65.
+
+    Returns:
+        The serialized sum of the products, or None where they sum to
+        the point at infinity.
+
+    Raises:
+        ValueError: if the two sequences are of different lengths, if
+            the sequence of keys is empty, if any key is not a valid
+            point, or if any tweak is not 32 bytes, does not fit in
+            them, or multiplies its key to something invalid -- zero and
+            the group order being the two scalars there is no product
+            for.
+        RuntimeError: if libsecp256k1 fails to serialize the result,
+            which no valid input can make it do.
+
+    Example:
+        >>> from btclib_secp256k1 import keys
+        >>> generator = keys.pubkey_from_prvkey(1)
+        >>> pubkey = keys.pubkey_from_prvkey(7)
+        >>> # 2*G + 3*(7*G) is 23*G
+        >>> total = keys.pubkey_tweak_mul_sum([generator, pubkey], [2, 3])
+        >>> total == keys.pubkey_from_prvkey(23)
+        True
+        >>> # and a sum landing on the identity is None, not a refusal
+        >>> negated = keys.pubkey_negate(pubkey)
+        >>> keys.pubkey_tweak_mul_sum([pubkey, negated], [3, 3]) is None
+        True
+    """
+    if len(pubkeys_bytes) != len(tweaks):
+        msg = (
+            f"as many tweaks as public keys are required: "
+            f"{len(tweaks)} tweaks, {len(pubkeys_bytes)} public keys"
+        )
+        raise ValueError(msg)
+
+    # `strict=False` and the check above rather than `strict=True` and
+    # no check: a sequence has a length, so the two are the same guard,
+    # and the one that raises here says which sequence was short and by
+    # how much where zip says only that they differed. A guard no input
+    # can reach is one no test can drive, which this package does not
+    # leave behind
+    products = [
+        _pubkey_tweak_mul_(parse(pubkey_bytes), tweak)
+        for pubkey_bytes, tweak in zip(pubkeys_bytes, tweaks, strict=False)
+    ]
+    summed = _pubkey_sum_(products)
     return None if summed is None else serialize(summed, compressed)
 
 

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -268,6 +268,12 @@ CALLS: list[tuple[str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
     ("keys.pubkey_combine", keys.pubkey_combine, ([PUBKEY, PUBKEY_LONG],), {}),
     ("keys.reserialize", keys.reserialize, (PUBKEY,), {}),
     ("keys.pubkey_sum", keys.pubkey_sum, ([PUBKEY, PUBKEY_LONG],), {}),
+    (
+        "keys.pubkey_tweak_mul_sum",
+        keys.pubkey_tweak_mul_sum,
+        ([PUBKEY, PUBKEY_LONG], [TWEAK, TWEAK]),
+        {},
+    ),
     ("keys.pubkey_cmp", keys.pubkey_cmp, (PUBKEY, PUBKEY_LONG), {}),
     ("keys.pubkey_sort", keys.pubkey_sort, ([PUBKEY, PUBKEY_LONG],), {}),
     ("hashes.tagged_sha256", hashes.tagged_sha256, (b"TapLeaf", MSG), {}),

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -674,6 +674,106 @@ def test_pubkey_sum_answers_the_infinity_combine_refuses() -> None:
         keys.pubkey_sum([pubkey_a, b"\x02" + bytes(32)])
 
 
+def test_pubkey_tweak_mul_sum_is_the_arithmetic_it_names() -> None:
+    """The multi-scalar multiplication, against the scalar it comes to.
+
+    Every key here is a known multiple of the generator, so the sum of
+    the products is the generator times the sum of the products of the
+    scalars, modulo the group order. That is an algebraic invariant over
+    derived inputs and not an external vector: the scalar arithmetic is
+    python's, the point either side of the comparison is these bindings'
+    -- it catches a key paired with the wrong scalar, a wrong order
+    and a wrong reduction,
+    and it would not catch a curve that is not secp256k1. The anchor is
+    below and is the one value the equality can be pinned to without
+    computing a point here: the generator SEC 2 v.2 section 2.4.1
+    publishes, which `test_pubkey_from_prvkey` also holds this package
+    to.
+
+    The composition the entry point replaces is asserted too, and
+    separately: it is what the entry point promises to be, and both
+    serializations of it.
+    """
+    # the published generator, written out rather than derived: the sum
+    # of a term and its negation-by-scalar is 1*G, and this is what 1*G
+    # is according to SEC 2 v.2 rather than according to these bindings
+    generator = bytes.fromhex(
+        "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    )
+    assert keys.pubkey_tweak_mul_sum([generator, generator], [N - 1, 2], False) == (
+        generator
+    )
+
+    prvkeys = (3, 5, 7, 11)
+    tweaks = (2, 13, N - 1, 0x123456789ABCDEF)
+    pubkeys = [keys.pubkey_from_prvkey(k, compressed=False) for k in prvkeys]
+
+    total = sum(k * t for k, t in zip(prvkeys, tweaks, strict=True)) % N
+    for compressed in (True, False):
+        assert keys.pubkey_tweak_mul_sum(
+            pubkeys, tweaks, compressed
+        ) == keys.pubkey_from_prvkey(total, compressed)
+        # and the composition it stands for, term by term
+        products = [
+            keys.pubkey_tweak_mul(pubkey, tweak, False)
+            for pubkey, tweak in zip(pubkeys, tweaks, strict=True)
+        ]
+        assert keys.pubkey_tweak_mul_sum(
+            pubkeys, tweaks, compressed
+        ) == keys.pubkey_sum(products, compressed)
+
+    # one term is that term multiplied, the sum having nothing to add
+    assert keys.pubkey_tweak_mul_sum(pubkeys[:1], tweaks[:1]) == keys.pubkey_tweak_mul(
+        pubkeys[0], tweaks[0]
+    )
+
+    # a key given compressed is the same key: what the entry point does
+    # with the octets is parse them, as every other one here does
+    assert keys.pubkey_tweak_mul_sum(
+        [compress(pubkey) for pubkey in pubkeys], tweaks
+    ) == keys.pubkey_tweak_mul_sum(pubkeys, tweaks)
+
+
+def test_pubkey_tweak_mul_sum_answers_infinity_and_refuses_the_rest() -> None:
+    """The identity is a value; a wrong argument is not.
+
+    A verification equation is written to land on infinity, so the sum
+    that has no public key is `pubkey_sum`'s None here too. Everything
+    else the two sequences can be wrong about is a refusal, and the
+    lengths are the one this function has to raise itself: zip would
+    otherwise stop at the shorter of the two and answer a sum of the
+    terms that happened to pair up.
+    """
+    pubkey = keys.pubkey_from_prvkey(7, compressed=False)
+    negated = keys.pubkey_negate(pubkey, compressed=False)
+
+    # None whichever serialization was asked for: the flag is what the
+    # answer would have been written in, and there is no answer
+    for compressed in (True, False):
+        assert keys.pubkey_tweak_mul_sum([pubkey, negated], [3, 3], compressed) is None
+    # an intermediate at infinity is not a total at infinity: the terms
+    # are added by libsecp256k1, not into a running total this side
+    assert keys.pubkey_tweak_mul_sum(
+        [pubkey, negated, pubkey], [3, 3, 3]
+    ) == keys.pubkey_tweak_mul(pubkey, 3)
+
+    with pytest.raises(ValueError, match="as many tweaks as public keys"):
+        keys.pubkey_tweak_mul_sum([pubkey, negated], [3])
+    with pytest.raises(ValueError, match="at least one public key"):
+        keys.pubkey_tweak_mul_sum([], [])
+    with pytest.raises(ValueError, match="invalid public key"):
+        keys.pubkey_tweak_mul_sum([pubkey, b"\x02" + bytes(32)], [3, 3])
+    # zero and the group order are the two scalars with no product, and
+    # a tweak of the wrong width is refused before either is asked
+    with pytest.raises(ValueError, match="invalid tweak"):
+        keys.pubkey_tweak_mul_sum([pubkey, negated], [3, 0])
+    with pytest.raises(ValueError, match="invalid tweak"):
+        keys.pubkey_tweak_mul_sum([pubkey, negated], [3, N])
+    with pytest.raises(ValueError, match="tweak must be 32 bytes"):
+        keys.pubkey_tweak_mul_sum([pubkey, negated], [3, b"\x01"])
+
+
 def test_xonly_pubkey_verify_and_to_pubkey_are_the_two_x_only_twins() -> None:
     """The x-only twins of `keys.pubkey_verify` and of a lift.
 


### PR DESCRIPTION
The bindings half of
https://github.com/btclib-org/btclib/issues/917, which is where that
issue says the remaining work belongs: "the composition belongs on the
other side, and it is a decision for that repository". This is that
decision proposed as a diff.

## What it adds

`keys.pubkey_tweak_mul_sum(pubkeys_bytes, tweaks, compressed=True)` — a
`pubkey_tweak_mul` per pair and one `pubkey_sum` over the products, with
no product serialized in between. That shape is a verification equation,
a MuSig2 aggregate key and BIP352's tweak data; written with the public
halves, each product crosses as 65 octets that the sum parses again. It
is the one composition in this package whose crossing is *per term* —
sorting-then-adding pays per key, the others pay once.

| terms | `tweak_mul` each, then `pubkey_sum` | `pubkey_tweak_mul_sum` |
| --- | --- | --- |
| 2 | 20.98 µs | 18.96 µs |
| 3 | 30.85 µs | 25.25 µs |
| 5 | 47.81 µs | 41.29 µs |
| 8 | 74.69 µs | 63.90 µs |
| 20 | 183.09 µs | 154.09 µs |
| 64 | 593.72 µs | 499.89 µs |

About a sixth of the call from three terms up, flat in the term count —
unlike the per-term combine `pubkey_sum` replaced, whose saving grew.
Measured on this tree, on an Apple M5, macOS 26.6, arm64, CPython
3.14.6, best of seven alternating rounds, uncompressed throughout, with
`pubkey_from_prvkey` as the noise detector (9.2 µs across every round).

## The design question it answers

This is the second function here that is more than one libsecp256k1
decision. `xonly.from_prvkey` was the first, and the README already
described it under *Parsing the key once* as "an entry point instead of
two halves" — so the rule the Design section states ("every function is
one libsecp256k1 call") had an exception it did not name. Rather than
adding a second unnamed one, both sections now state the rule the two
answer to: **a composition belongs here when what it saves is the
crossing between its halves, which is the caller's cost and not its own
choice, and it is named after the calls it makes.** Nothing is computed
here that libsecp256k1 does not — the terms are
`secp256k1_ec_pubkey_tweak_mul`, the sum is
`secp256k1_ec_pubkey_combine`, in the order the equation names them.

If that rule is the wrong one, this is the diff to say so on: the
function is additive and nothing else changes behaviour.

## Details

- the sum at infinity is `pubkey_sum`'s `None`, and is likelier here
  than there: a verification equation is written to land on it
- the two sequences must be of one length, which is the one refusal this
  function raises itself — `zip(strict=True)` would report it in its own
  words, and a non-strict zip would answer the sum of whatever paired up
- `tests/test_keys.py` holds the answer to the integer arithmetic on
  this side, every key being a known multiple of the generator, rather
  than only to the composition it replaces; the composition, both
  serializations, the one-term case, infinity and every refusal are
  driven too, and `tests/test_bytes_like.py` sweeps the new entry point
  like every other

Gates: `uvx pre-commit run --all-files` green, `uv run --locked
--no-default-groups --group test pytest --cov` green at 100%, the docs
build green with `-W`.

The btclib side follows once this is released — its `uv.lock` tracks
this repository's `main`, so `_libsecp256k1_multi_mult_` becomes one
call there and https://github.com/btclib-org/btclib/issues/917 closes
with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a multi-scalar public key operation that multiplies each key by its tweak and sums the products, and document this as a deliberate multi-call libsecp256k1 composition.

New Features:
- Introduce keys.pubkey_tweak_mul_sum to perform multi-scalar public key multiplication and aggregation in a single entry point.

Enhancements:
- Clarify the design rule around when multi-call compositions belong in this package, documenting pubkey_tweak_mul_sum and xonly.from_prvkey as explicit exceptions that avoid redundant parse/serialize crossings.
- Update README, CHANGELOG, and HISTORY to describe the new multi-scalar operation, its performance characteristics, and its role in verification equations, MuSig2 key aggregation, and BIP352 tweak data.

Tests:
- Add unit tests validating pubkey_tweak_mul_sum against integer arithmetic, its equivalence to the tweak-multiply-then-sum composition, its handling of infinity, and its argument validation.
- Extend bytes-like entry point scanning tests to cover keys.pubkey_tweak_mul_sum.