### PR TITLE
Say that a fast-forward, not a button, is how a pull request lands

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2257
+        "line_number": 2303
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T12:37:18Z"
+  "generated_at": "2026-08-16T12:41:46Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -737,6 +737,52 @@ release-notes length in the first place, and are still in
   the entry above rather than a signer that spares it: the DER
   serialization is 0.757 of those microseconds, and `compact=True`
   answers the 64 octets without writing it
+- **Four files said a button is how a pull request lands; none of them
+  is** (#176). A pull request reaches `main` as a fast-forward push from
+  the command line, squashed locally first where it carries more than one
+  commit, which is what keeps the commit signed by the maintainer rather
+  than by GitHub's web-flow key — and, where the head that lands is the
+  one the gates last ran on, keeps that sha, so a branch stacked on it
+  goes on applying instead of needing a rebase and a fresh run of the
+  matrix per level. `REPOSITORY.md`'s *Merge methods* said "squash is the only
+  method enabled", true of the setting and read as a description of the
+  landing; `CONTRIBUTING.md` said "a pull request is squashed on merge …
+  the only merge button this repository enables"; `RELEASING.md` merged
+  the release "with the squash button"; and `CLAUDE.md` said all three
+  buttons were enabled, which stopped being true when squash became the
+  only one. The twin change for btclib is
+  <https://github.com/btclib-org/btclib/pull/944>, whose merge rule
+  differs in the multi-commit case: the squash is made locally here
+  rather than pressed.
+- **and the ruleset that lets that push through had no section at all.**
+  REPOSITORY.md documented the classic branch protection and never the
+  two rulesets beside it, so the bypass the fast-forward needs was
+  reachable from the prose only through one clause of CONTRIBUTING.md.
+  It now has one: `main-integrity` carries the four rules with no bypass
+  actor, `main-self-merge` carries the pull request rule and names the
+  maintainer, and the split is what lets the review be bypassed — GitHub
+  refusing a self-approval — while a signature stays required of
+  everybody — though not the whole of the permission either, a push to
+  `main` needing `enforce_admins` to stay `false` and the pusher to hold
+  `admin` before the bypass is reached at all.
+
+  The sequence is there with it, and so is what GitHub does afterwards,
+  which is two different things and was written as one. A pull request is
+  marked merged when its head becomes reachable from the base branch, so
+  what decides is whether the commit pushed to `main` is the sha the pull
+  request names at that moment — not whether a rebase happened, a rebase
+  force-pushed to the branch leaving it naming the new one. Push the
+  squash to the branch before landing it and the squashed branch is the
+  reconciled case too, with the matrix running on the object that lands:
+  #185 did that and was marked **Merged**, its head branch deleted by
+  `delete_branch_on_merge` a second later. Land the squash straight from
+  a worktree and nothing is reconciled and nothing is deleted — btclib's
+  #953 is **Closed** with `mergedAt: null`, its issue closed by the
+  keyword in the *commit message*, which is the reason for putting it
+  there. Getting ahead of the reconciliation costs the same thing btclib
+  paid on #930: branch deleted first, pull request Closed with its commit
+  on `main` all the same. Two counts were stale besides, both saying four
+  required checks where the rule has named three since `codeql` left it
 
 - **The sentinel table names `windows` too** (#184). `windows.yml` became
   a workflow of its own two changes after `macos.yml` did, and the table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,10 +226,19 @@ kill rate, which is the one failure mode that looks like good news.
   version named in `README.md` and `HISTORY.md` moved with it
 - **`main` is the only long-lived branch**, so a pull request targets it
   and a tag on it is a release; it is protected, and every change gets
-  there through a pull request. Which button GitHub has selected is worth
-  reading before it is pressed: all three are enabled, and it remembers
-  the last one used — a merge commit is refused whichever is showing,
-  `main` requiring linear history. The `dev` this repository used to
+  there through a pull request. No button is what lands it: a branch of
+  more than one commit is squashed locally, and the result is
+  fast-forwarded onto `main` from the command line, which is what keeps
+  the signature the maintainer's and, where what lands is the head the
+  gates ran on, that sha with it. Push the squash to the branch before
+  landing it: GitHub reconciles a push whose commit the pull request
+  names — Merged, and `Closes #N` in the description fires — and
+  reconciles nothing when the object is one it has never seen, which
+  leaves the pull request to be closed by hand and the issue to the
+  keyword in the commit message. REPOSITORY.md has the sequence, the
+  `main-self-merge` bypass it needs, and both outcomes. Squash is the
+  only button enabled, and auto-merge is what would press it — GitHub
+  signing what that produces. The `dev` this repository used to
   develop on, and the release merge into `master` that went with it, are
   gone; RELEASING.md is the file that describes what replaced them
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -575,20 +575,40 @@ has moved — and it wants the gates re-run after it, not only before, and a
 note in the pull request saying the head moved.
 
 Nothing is lost in `main`'s history by working that way, because a pull
-request is squashed on merge: the branch lands as one commit whose subject
-is the pull request title with its number, so the review's commits are the
-record of the review and `main` keeps one commit per landed change. It is
-the only merge button this repository enables, so which one is used is a
-setting rather than a choice made at the merge; REPOSITORY.md has that
-setting and what the other two would have cost.
+request lands as one commit: a branch of several is squashed into one
+whose subject is the pull request title with its number, so the review's
+commits are the record of the review and `main` keeps one commit per
+landed change. A merge commit would put the branch's steps into `main`
+and a rebase merge would replay them one by one — `main` is linear by
+branch rule, and one change is one commit there.
 
-Auto-merge had that choice to make earlier and no longer does, the dialog
-that switches it on carrying one method: what a pull request set to merge
-itself once the checks go green is holding is still
+**How that commit reaches `main` is a push rather than a button**, which
+is the maintainer's own path and needs the `main-self-merge` bypass no
+contributor has: REPOSITORY.md describes it, squashing the branch locally
+where it carries more than one commit and fast-forwarding it. Two things
+about it are worth knowing from here. The commit that lands is signed by
+the maintainer rather than by GitHub's web-flow key; and where your
+branch is already a single commit and needs no rebase to land, its sha
+does not change, so `main` receives the very commit the gates ran on and
+a branch stacked on it keeps applying. A rebase moves the sha like any
+other force-push, which is why the gates are asked for after one and not
+only before. Neither changes the shape of a correction: whether a branch
+is squashed or fast-forwarded is decided when it lands, and by then the
+review has its record either way.
+
+Squash is the only merge *button* this repository enables, so there is no
+other to read; REPOSITORY.md has that setting, what the other two would
+have cost, and the fast-forward that is not a button at all. Auto-merge is
+what presses it, the dialog that switches it on carrying one method: what
+a pull request set to merge itself once the checks go green is holding is
+still
 `gh pr view <n> --json autoMergeRequest`. Enabling it is the way to not
-wait for a matrix that compiles C on every platform; GitHub only offers it
-while something is still pending, and it merges nothing the branch rule
-would not have let through by hand.
+wait for a matrix that compiles C on every platform, and what it costs is
+the paragraph above: GitHub signs what it composes, so a pull request
+left to merge itself lands a commit signed by the web-flow key rather
+than by the maintainer, and one whose sha the branch never carried.
+GitHub only offers it while something is still pending, and it merges
+nothing the branch rule would not have let through by hand.
 
 Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -148,13 +148,26 @@ Then:
    accurate without an edit.
 
    Then merge it into `main` with a green CI. It is an ordinary pull
-   request against the only branch there is, and it merges the way every
-   other one here does: with the squash button, which is the only one the
-   repository enables — a merge commit was refused by `main`'s required
-   linear history anyway, and REPOSITORY.md has what the rebase merge
-   would have cost.
+   request against the only branch there is, and it lands the way every
+   other one here does: squashed locally into one signed commit where it
+   carries more than one — a version bump and two retitles, not a cycle
+   of work — and fast-forwarded onto `main` from the command line,
+   REPOSITORY.md having the sequence and the bypass it needs.
 
-   What that button cannot cost any more is the history of a cycle. It
+   The button is the wrong landing on this pull request in particular,
+   and not merely a second-best one: it is the release commit that gets
+   tagged, and a squash composed by GitHub would leave the tag over a
+   commit signed by the web-flow key rather than by the maintainer.
+
+   This branch is the squashed case every time — a version bump and two
+   retitles is never one commit — so push the squash to the branch before
+   fast-forwarding it, and the gates below run on the object that lands
+   and GitHub still marks the pull request Merged. Land the squash
+   straight from a worktree instead and nothing is reconciled: the pull
+   request has to be closed by hand, which is a surprise worth not having
+   between here and the tag. REPOSITORY.md has both outcomes.
+
+   What no landing here can cost any more is the history of a cycle. It
    could once: 0.7.1 was *Squash and merge* on a release pull request
    carrying ninety-two commits from a development branch, and it left one
    commit where ninety-two records of a decision had been. The trees were

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -270,7 +270,7 @@ would change the answer.
 
 ## Branch protection
 
-`main`, all of it read from the endpoint above: `strict` with the four
+`main`, all of it read from the endpoint above: `strict` with the three
 checks already described, one approving review with
 `dismiss_stale_reviews`, **required signatures**, linear history, no force
 pushes, no deletions, `required_conversation_resolution`, and
@@ -309,6 +309,101 @@ branch it protected. Nothing was weakened by that: what it guarded was a
 trunk a pull request did not have to pass through, and every change now
 reaches `main` through the rules above.
 
+## The rulesets, and the push their bypass is for
+
+Two rulesets sit on `main` beside that protection, and what separates
+them is who may bypass:
+
+```shell
+gh api repos/btclib-org/btclib-secp256k1/rulesets \
+  --jq '.[] | "\(.name) \(.enforcement) bypass=\(.bypass_actors | length)"'
+```
+
+`main-integrity` is the four CONTRIBUTING.md names — a verified
+signature, linear history, no force push, no branch deletion — with **no
+bypass actor at all**, which is what makes "on every commit, not at
+review time" true of an administrator too, `enforce_admins` above being
+off. `main-self-merge` is the pull request rule, and names the maintainer
+as one; the listing above answers each ruleset's id, and the rules and
+the bypass of either are read from it:
+
+```shell
+gh api repos/btclib-org/btclib-secp256k1/rulesets/<id> \
+  --jq '{rules: [.rules[].type], bypass: [.bypass_actors[].actor_type]}'
+```
+
+The split is the point of there being two. The review is the rule a solo
+maintainer cannot satisfy, GitHub refusing a self-approval; the integrity
+four are the rules nobody should be able to. One ruleset each is what
+lets the first be bypassed without the second going with it.
+
+**What the bypass is for is a push, not a button.** A reviewed branch
+reaches `main` from the command line:
+
+```shell
+git fetch origin && git rebase origin/main   # replayed on the tip
+git log --format='%h %G?' origin/main..      # every commit G, none N
+git push origin HEAD:main                    # a fast-forward, nothing rewritten
+```
+
+Where the branch carries more than one commit it is squashed into a
+single signed commit first — `git reset --soft origin/main && git
+commit`, with `--author` where the branch is somebody else's, GitHub's
+button being what would otherwise have kept their name on it — and that
+commit is what the push fast-forwards.
+
+**The bypass is not the whole of the permission.** The protection above
+still carries `required_pull_request_reviews` and its `strict` required
+checks, and what a push to `main` clears those with is `enforce_admins`
+being `false` and the pusher holding `admin`; the ruleset bypass alone
+would not be enough. So the path depends on two settings and not one,
+and the fragile one is that: turning `enforce_admins` on closes the
+fast-forward whatever the ruleset says, and moving the review
+requirement onto a ruleset of its own is what would leave the bypass
+answering for all of it.
+
+What this buys is what no button can give. GitHub composes a squash
+server-side and signs it with its own web-flow key, so the commit that
+lands is `verified` with GitHub as the signer; a push signs nothing and
+has nothing to sign, the commit arriving with the signature it already
+carried. And where the branch was a single commit and the rebase moved
+nothing, its sha does not change either, so `main` receives the very
+commit the gates ran on and a branch stacked on that one keeps applying
+instead of needing a rebase and a fresh run of the matrix per level.
+Where the rebase did move it, re-running the gates after it is what buys
+that back — and it is discipline on this path rather than a rule, the
+`strict` above being one of the things the push clears. What `strict`
+holds is the merge nobody performs here.
+
+**Whether GitHub reconciles the push depends on one thing: whether what
+lands is the sha the pull request names at that moment**, a pull request
+being marked merged when its head becomes reachable from the base
+branch.
+
+- **it names what lands** — the branch's own head is fast-forwarded,
+  whether it reached that shape as one commit or as a squash **pushed to
+  the branch first**, and a rebase force-pushed to the branch is this
+  case too. GitHub marks the pull request **Merged** on its own, and the
+  `Closes #N` in its description closes the issue.
+- **it names something else** — the squash or the rebase was made
+  locally and pushed straight to `main`. What lands is an object no pull
+  request names, so nothing is reconciled: close it by hand, and let the
+  issue close from the `Closes #N` in the *commit message*, which is the
+  reason for the keyword to be there and not only in the description.
+
+Which is an argument for pushing the squash to the branch before landing
+it, where the branch is one whose head may move: the matrix then runs on
+the very object that will land rather than on a head that never will,
+and the reconciliation does the closing. Measured in btclib the other
+way, on the day this was written:
+<https://github.com/btclib-org/btclib/pull/953> was squashed locally and
+pushed straight to `main`, landing as `7f7a269b` — signed by the
+maintainer, so both halves of the rule worked — and is **Closed** with
+`mergedAt: null`, its issue having closed twenty-two seconds earlier
+from the commit message. Which of the two happened is also what decides
+when the head branch goes, and "Head branches after a merge" below is
+where that is.
+
 ## Head branches after a merge
 
 `delete_branch_on_merge` is on, since 7 August 2026:
@@ -331,10 +426,26 @@ branch is never deleted, protection winning over it — which used to reach
 the release pull request, whose head branch was protected. No head branch
 is protected now.
 
+**It reaches one of the two landings above**, and which one is the
+reconciliation again — the setting hangs on the merge GitHub records, so
+it fires wherever GitHub records one:
+
+- **the pull request named what landed**: nothing to do. Measured on
+  <https://github.com/btclib-org/btclib-secp256k1/pull/185>, whose
+  squash was pushed to the branch and then fast-forwarded: marked Merged
+  at 12:39:19 and `head_ref_deleted` at 12:39:20, with nobody asking.
+  What is left is not to get ahead of it — deleting the branch before
+  the reconciliation is what leaves a pull request Closed with its
+  commit on `main` all the same, as btclib's
+  <https://github.com/btclib-org/btclib/pull/930> came out.
+- **it named something else** — the squash or the rebase went straight
+  to `main`: nothing is reconciled, so nothing is deleted either. Close
+  the pull request by hand and delete the branch with it.
+
 ## Merge methods
 
-**Squash is the only method enabled**, so it is a setting and not only the
-convention CONTRIBUTING.md states:
+**Squash is the only *button* enabled**, so it is a setting and not only
+the convention CONTRIBUTING.md states:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1 \
@@ -342,6 +453,13 @@ gh api repos/btclib-org/btclib-secp256k1 \
 ```
 
 answers `true` for the first and `false` for the other two.
+
+A button is not how a pull request lands here, and this section named one
+as if it were: every merge is the fast-forward above, and the squash the
+branch may need first is made locally. What that leaves the setting doing
+is bounding the damage of a landing nobody drove from a shell — auto-merge
+below is the one that reaches the button, and GitHub's key is what signs
+what it presses.
 
 The merge commit was refused by `main`'s required linear history already,
 so turning it off takes away a button that could not have worked. The
@@ -366,7 +484,7 @@ gh api repos/btclib-org/btclib-secp256k1 --jq '.allow_auto_merge'
 It bypasses nothing, and it is not the admin escape hatch above: GitHub
 offers the button **only on a pull request that cannot be merged
 immediately**, and then merges it when the last thing blocking it clears —
-one of the four required checks, the approving review, an unresolved
+one of the three required checks, the approving review, an unresolved
 conversation. Where nothing is pending there is nothing to wait for and the
 button is not offered at all, so this setting does something here precisely
 because the rule on `main` is what it is: the matrix is tens of jobs
@@ -374,21 +492,29 @@ compiling C, and `test.yml`'s header measures what waiting for it costs.
 
 **Required signatures survive it**, measured rather than assumed, because
 GitHub composes the squash commit server-side and signs it with its own key
-exactly as the merge button does. A merge from the CLI is where that stops
-being true — `--rebase --admin` replays the author's commits as they were,
-unsigned — so the check is worth making on whatever landed:
+exactly as the merge button does — its own key and not the author's, which
+is the trade this setting makes and the fast-forward above is what does
+not make it. Nor does every landing from a shell keep a signature:
+`gh pr merge --rebase --admin` replays the author's commits as they were,
+unsigned, where a fast-forward moves commits that were signed before it
+was run. So the check is worth making on whatever landed, whichever way it
+got there:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1/commits/<sha> \
   --jq '.commit.verification | {verified, reason}'
 ```
 
-**The merge method was chosen here, when auto-merge was switched on rather
-than when the merge happened.** That dropdown carries one entry now, squash
-being the only method enabled — "Merge methods" above is the setting and
+**What auto-merge will press was chosen when it was switched on, rather
+than when the merge happened.** That dropdown carries one entry, squash
+being the only button enabled — "Merge methods" above is the setting and
 the reason — so switching auto-merge on answers nothing a reviewer has to
-catch before it lands. What a pull request is holding is still worth
-reading, the wait itself being what this bypasses:
+catch before it lands. The fast-forward is not in the dropdown at all,
+being a push: a pull request left to merge itself is one that will not
+land that way, and what it costs is the signature on the commit. Not
+waiting for a matrix that compiles C on every platform is what is bought
+with it. What a pull request is holding is still worth reading, the wait
+itself being what this bypasses:
 
 ```shell
 gh pr view <n> --json autoMergeRequest


### PR DESCRIPTION
Four files described the squash button as the merge. It is a setting —
`allow_squash_merge` alone is `true` — and it is not what lands a pull
request here: a branch of more than one commit is squashed **locally**
into a single signed commit, and the result is fast-forwarded onto
`main` from the command line, through the `main-self-merge` bypass.

What that buys is the signature. GitHub composes a squash server-side
and signs it with its web-flow key, so the commit on `main` is verified
with GitHub as its signer; a push carries the commit as it was signed.
And where the branch was already one commit its sha survives, so `main`
receives the very commit the matrix tested and a branch stacked on it
keeps applying rather than needing a rebase and a fresh run per level.

`REPOSITORY.md` had **no section for the rulesets at all**, which is
where this differs from the twin: the bypass the sequence needs was
documented in one clause of `CONTRIBUTING.md`. It has a section now —
`main-integrity` with no bypass actor, `main-self-merge` naming the
maintainer, and the split between them being what lets the review be
bypassed, GitHub refusing a self-approval, while a signature stays
required of everybody. The sequence sits with it, and so does the
ordering btclib paid for: `delete_branch_on_merge` does not fire on a
push GitHub did not perform, so a head branch deleted before the
reconciliation leaves its pull request *Closed* rather than Merged.

`CONTRIBUTING.md` says the fast-forward needs a bypass no contributor
has, which is why it is described there rather than instructed.
`RELEASING.md` gains the case where the landing matters most: it is the
release commit that gets tagged, so a squash composed by GitHub would
leave the tag over a commit the maintainer did not sign. `CLAUDE.md`
said all three buttons were enabled, which the commit that made squash
the only one made untrue.

Two stale counts went with it, both naming four required checks where
the rule has named three since `codeql` left it.

The twin is btclib-org/btclib#944, and the two differ in the
multi-commit case: the squash is made locally here rather than pressed.

Closes #176

## Summary by Sourcery

Document that pull requests land via a locally created, signed squash commit fast-forwarded to main, not via GitHub’s merge buttons, and describe the associated rulesets and behaviors.

Documentation:
- Clarify in REPOSITORY.md that merges are performed as fast-forward pushes after local squashes, and add a new section documenting the main-integrity and main-self-merge rulesets, their bypass behavior, and head-branch deletion ordering.
- Update CONTRIBUTING.md, RELEASING.md, and CLAUDE.md to consistently describe the fast-forward-based landing process, the maintainer-signed nature of landed commits, and the implications for stacked branches and release tags.
- Correct stale references to four required checks to reflect the current three-check protection rule in relevant documentation.
- Add a CHANGELOG entry explaining the shift from button-based merges to fast-forward pushes and the new ruleset documentation.