### PR TITLE
Name the second sentinel a pull request no longer waits for

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -706,7 +706,8 @@ jobs:
   #
   # The name carries the workflow because a context is keyed by name alone:
   # two workflows with a job named the same thing produce one ambiguous
-  # check, and macos.yml is a second workflow over the same matrix shape.
+  # check, and macos.yml and windows.yml are two more workflows over the
+  # same matrix shape.
   #
   # `if: always()` because a job with unmet `needs` is skipped, and a
   # skipped check is not a failed one: without it a failing matrix cell

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2180
+        "line_number": 2194
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T10:30:23Z"
+  "generated_at": "2026-08-16T11:12:37Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,6 +711,20 @@ release-notes length in the first place, and are still in
   serialization is 0.757 of those microseconds, and `compact=True`
   answers the 64 octets without writing it
 
+- **The sentinel table names `windows` too** (#184). `windows.yml` became
+  a workflow of its own two changes after `macos.yml` did, and the table
+  in CLAUDE.md kept listing the sentinels without it — so the paragraph
+  under the table still called `macos` "the one sentinel a pull request
+  would otherwise have waited for" when there are two, each split by a
+  measurement of a different kind: a queue for the first, an
+  organization's ceiling of concurrent jobs for the second. The
+  measurements stay where they were made, in `test.yml`'s header and
+  `windows.yml`'s. Two smaller readings of the same omission go with it:
+  the static-then-dynamic pair of steps CONTRIBUTING.md attributes to
+  `macos.yml`'s cells is `windows.yml`'s too, and `test.yml`'s aggregate
+  job explains its name by there being a second workflow over this matrix
+  shape, which is now a third
+
 ### CI
 
 - **`github-release` needed `always()` too, not just an explicit `if`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,15 +167,19 @@ both monthly on the 1st.
 | `links` | do the URLs in the prose still resolve | Mon |
 | `macos` | does the suite pass on macOS | Wed, and a release |
 | `latest` | does the tree survive every dependency at its newest | Wed |
+| `windows` | does the suite pass on Windows | Sat, and a release |
 | `mutation` | would the suite notice a wrong line | Sun |
 | `published` | can the world install what PyPI serves | 1st, a release |
 | `vendored-vectors` | do the vendored vectors still match upstream | 1st |
 
-`macos` is the one sentinel a pull request would otherwise have waited for,
-and the reason it is one is measured in `test.yml`'s header: the macOS
-runners queue for tens of minutes where every other platform queues for two.
-A release calls it, so what a merge no longer waits for a publication still
-does.
+`macos` and `windows` are the two sentinels a pull request would otherwise
+have waited for, and each left the gate on a measurement rather than a
+preference — the macOS runners queue for tens of minutes where every other
+platform queues for two, and the Windows cells were the largest family of
+jobs in a run asking for more of them at once than an organization on GitHub
+Free is given. `test.yml`'s header carries the first measurement and
+`windows.yml`'s the second. A release calls both, so what a merge no longer
+waits for a publication still does.
 
 `latest` is the one that covers a gap nothing else does. Every uv command
 elsewhere passes `--locked`, the dependency groups declare no version, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,9 +251,9 @@ command at all, for the reason above, and no longer gates.
       --reinstall-package btclib_secp256k1 pytest
   ```
 
-  the two steps of `macos.yml`'s own cells are these two, in this order and
-  for the same reason: neither the environment nor the build cache is keyed
-  on the variable that chooses the linkage
+  the two steps of `macos.yml`'s and `windows.yml`'s own cells are these
+  two, in this order and for the same reason: neither the environment nor
+  the build cache is keyed on the variable that chooses the linkage
 
 - `Build wheels on <os>`, for this platform only
 


### PR DESCRIPTION
`windows.yml` has been a workflow of its own since #142, and the table of
sentinels in `CLAUDE.md` still listed six without it — so the file that says
each sentinel is a workflow of its own named every one but the newest, and
the paragraph under the table still called `macos` "the one sentinel a pull
request would otherwise have waited for" when there are two.

Three places, one omission:

- **`CLAUDE.md`** — a `windows` row in the table (Sat, and a release), and
  the paragraph rewritten for two sentinels rather than one, each split by a
  measurement of a different kind: a queue for macOS, an organization's
  ceiling of concurrent jobs for Windows. The numbers stay where they were
  made, in `test.yml`'s header and `windows.yml`'s
- **`CONTRIBUTING.md`** — the static-then-dynamic pair of steps it
  attributes to `macos.yml`'s cells is `windows.yml`'s too, identically
- **`.github/workflows/test.yml`** — the aggregate job explains its name by
  there being a second workflow over this matrix shape, which is now a third

Documentation only; no workflow behaviour changes.

## Summary by Sourcery

Document the Windows workflow as a second sentinel alongside macOS and clarify its relationship to the test matrix.

Documentation:
- Add the Windows sentinel to the CLAUDE.md workflow table and describe macOS and Windows as the two release-triggered sentinels with their respective constraints.
- Update CONTRIBUTING.md to note that macOS.yml and windows.yml cells share the same two-step process due to linkage-dependent environments and caches.
- Clarify in test.yml documentation that both macOS.yml and windows.yml are additional workflows over the same matrix shape, explaining the aggregate job naming.