### PR TITLE
Ask where the walk starts, which is what the three numbers leave out

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2230
+        "line_number": 2257
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T11:35:38Z"
+  "generated_at": "2026-08-16T12:37:18Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -657,6 +657,33 @@ release-notes length in the first place, and are still in
   parsed key is a parse the caller can make cheap by choosing the form it
   carries. That is <https://github.com/btclib-org/btclib-secp256k1/issues/161>'s
   own principle, and it is what the measurement says of the two
+- **and what the three numbers leave unasked is where the walk starts**
+  (#161). The two moves the section describes — hold the point, carry the
+  uncompressed form — look as though they compose into a fourth and
+  faster spelling, `chain.tweak_add(compressed=False)`, and they do not.
+  A chain re-parses nothing in either serialization, the point being what
+  it holds, so asking it for 65 octets saves no parse and pays a
+  serialization and the caller's own compression line at every step.
+  Measured on an Apple M5, macOS 26.6, arm64, CPython 3.14.6, five steps,
+  medians of nine alternating rounds with a sha256 control and absolutes
+  about 5% above this section's: the composition is 59.27 against the
+  chain's 58.62 and the uncompressed walk's 58.26 — a loss of 1.01 where
+  the section's own numbers predict 0.98, one compressed parse in against
+  five uncompressed parses out.
+
+  The comparison that does decide something is the one nothing here
+  asked: the uncompressed walk's 54.75 begins from 65 octets a BIP32
+  caller does not have. An xpub carries the 33, so reaching that form
+  costs `keys.reserialize` once — a compressed parse and a serialization,
+  more than the 0.39 that separated the two walks — and counted, the same
+  run puts the walk at 61.55 against the chain's 58.62. So the chain is
+  ahead of the spelling this section had called it a rounding error
+  behind, on the key its caller actually holds. The README says both now:
+  the composition is not worth reaching for, and the parse the chain pays
+  at construction is the one the caller could not have avoided. What the
+  issue left open is unchanged and rests on that rather than on the cost
+  of breaking a released caller — the chain shipped in v0.8.0.1 and
+  `btclib`'s `bip32.py` adopted it
 - **the outpost section is what the README had no name for**: an outpost
   past the boundary. The private halves hand an object from one call to
   the next; these two hold one across many, for the caller that crosses

--- a/README.md
+++ b/README.md
@@ -442,10 +442,33 @@ worth stating because it is nearly free: walking the same path in the
 is the chain's 55.14 within the noise. The uncompressed parse is 0.269,
 so there is almost nothing left for holding the point to save — the
 chain's saving is real against the compressed walk and a rounding error
-against that one. What it is unambiguously worth is not having to write
+against that one, where the caller already holds the 65 octets — which
+two paragraphs below is the assumption that turns out to decide it. What
+it is unambiguously worth is not having to write
 `bytes([2 + (sec[64] & 1)]) + sec[1:33]` where BIP32 wants 33 octets to
 hash. `chain.pubkey()` is the key it has arrived at, and
 `chain._pubkey_()` the point itself for a caller handing it on.
+
+The two moves do not compose into a third saving, which is worth saying
+because the shape of them invites it. A chain answers whichever
+serialization it is asked for, but it re-parses nothing in either: the
+point is what it holds. So `chain.tweak_add(compressed=False)` saves no
+parse that `chain.tweak_add()` had been paying, and gives back the line
+above to be written at every step — it measures slightly slower, for the
+serialization and that line, and it is not the spelling to reach for.
+
+What the three numbers do leave unasked is where the walk *starts*. An
+xpub carries the 33 octets, so a caller taking the uncompressed path
+reaches its starting form through `keys.reserialize` — a compressed
+parse, the 2.326 above, and a serialization — before the first step,
+and that is rather more than the 0.39 separating the two walks. Counted
+from the key a BIP32 caller actually holds, the chain is *ahead* of the
+uncompressed walk rather than a rounding error behind it: the parse it
+pays at construction is the one that caller could not have avoided, and
+it pays it once where the compressed walk pays it five times. Which
+does not make the chain's saving arithmetic — this section's distinction
+stands — but it is the parse the caller could not make cheap, which is
+the case the class is for.
 
 What the two do not share is what they hold. A parsed public key is a
 public value a caller may keep for as long as it likes; a keypair is the


### PR DESCRIPTION
The outpost section measures three spellings of a five-step BIP32 walk.
This asks the question none of them does — **where the walk starts** —
and drops a claim that does not survive being measured.

## What the branch first said, and why it was wrong

That `chain.tweak_add(compressed=False)` is the fast spelling of four.
It is the slowest of three. A chain re-parses nothing in either
serialization, the point being what it holds, so asking it for 65 octets
saves no parse and pays a serialization and the caller's own compression
line at every step. Measured here — five steps, medians of nine
alternating rounds, sha256 control, absolutes about 5% above the
section's — 59.27 for the composition against 58.62 for
`chain.tweak_add()` and 58.26 for the uncompressed walk. The section's
own numbers predicted a loss of 0.98, one compressed parse in against
five uncompressed parses out; the measured one is 1.01.

## What replaces it

The uncompressed walk's 54.75 starts from 65 octets a BIP32 caller does
not have. An xpub carries the 33, so reaching that form costs
`keys.reserialize` once — a compressed parse and a serialization, more
than the 0.39 that separated the two walks. Counted, the same run puts
that walk at 61.55 against the chain's 58.62.

| five steps, from the 33 octets an xpub carries | µs |
| --- | --- |
| compressed walk | 68.15 |
| uncompressed walk, `reserialize` counted | 61.55 |
| `chain.tweak_add()` | **58.62** |
| `chain.tweak_add(compressed=False)` | 59.27 |

So the chain is *ahead* of the spelling the section calls it a rounding
error behind, on the key its caller actually holds — the parse it pays
at construction being the one that caller could not have avoided.

That is a better answer to #161 than the claim was: the class rests on a
measurement rather than on the cost of breaking a released caller.
Documentation only; the API is untouched.

Closes #161