### PR TITLE
Ask whether the diff is prose before running the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # the cheapest job in the workflow, and the one that decides whether the
+  # rest of it runs at all: a pull request that edits only prose no
+  # artifact carries cannot change what any of the jobs below build, and
+  # was spending the whole matrix to prove it. Every root job takes this
+  # one as a `needs` and reads its output; the jobs downstream of those
+  # skip on their own, a job whose needs are skipped being skipped too.
+  #
+  # Three things this must not get wrong:
+  #
+  # - it runs on every trigger, and answers `true` on all but one. A
+  #   `changes` job that skipped itself off the pull_request path would
+  #   leave every dependent reading an empty output, which is not 'true',
+  #   and the whole workflow would skip on main and on a release
+  # - README.md is not prose for this purpose. It is the long description
+  #   of the package, and check-dist renders it with twine and rates it
+  #   with pyroma, so an edit to it is a change the matrix can fail on
+  # - test-passed takes this job as a `needs` as well, so a failure here
+  #   fails the gate. Without that, an error listing the files would skip
+  #   everything and be reported as a pass
+  changes:
+    name: Decide whether the matrix has anything to check
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # the file list of a pull request, which contents: read does not carry
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+
+    steps:
+      - name: Ask which files the pull request touches
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # a push to main, a release call and a dispatch build everything:
+          # only a pull request has a base to be a diff against
+          if [ "$EVENT" != pull_request ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT is not a pull request: everything runs"
+            exit 0
+          fi
+          gh api "repos/$REPO/pulls/$NUMBER/files" --paginate \
+            --jq '.[].filename' > files.txt
+          echo "files changed:"
+          cat files.txt
+          # the allowlist is what nothing built reads: the prose files of
+          # the root and of .github, and neither README.md nor a file
+          # under docs/, which the sdist carries. An empty list is not a
+          # documentation change, it is a question this could not answer,
+          # so the count is checked before the pattern
+          prose='^(CHANGELOG|CLAUDE|CONTRIBUTING|HISTORY|RELEASING|REPOSITORY|SECURITY)\.md$|^\.github/[^/]*\.md$'
+          if [ ! -s files.txt ] || grep -qvE "$prose" files.txt; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "something the matrix reads changed: everything runs"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "prose only: the matrix has nothing to check"
+          fi
+
   # coverage is a property of the python wrapper layer, not of the
   # platform: measuring it once is enough, and the fail_under ratchet in
   # pyproject.toml is what makes the number mean something
@@ -102,7 +166,7 @@ jobs:
     # should have run. A run on the merge result still happens the moment
     # the pull request is marked ready, which is why ready_for_review is a
     # trigger type above
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     # every job below caps its own runtime, this one included: the default
     # is six hours, and with tens of jobs compiling C a single hang is
@@ -112,6 +176,7 @@ jobs:
     # not a failure, while a hung one is
     timeout-minutes: 15
 
+    needs: changes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -140,7 +205,7 @@ jobs:
 
   build-cibuildwheel:
     name: Build wheels on ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # the interpreter uv runs the build tools with is the one setup-python
@@ -178,6 +243,7 @@ jobs:
           - windows-latest
           - windows-11-arm
 
+    needs: changes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -228,7 +294,7 @@ jobs:
 
   build-dynamic:
     name: Build dynamic wheel on ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     # see build-cibuildwheel; here the platform tag of the wheel is the
@@ -244,6 +310,7 @@ jobs:
         # ubuntu-24.04-arm/macos-latest are arm64
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest]
 
+    needs: changes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -304,13 +371,14 @@ jobs:
 
   build-sdist:
     name: Build sdist
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # see build-cibuildwheel
     env:
       UV_PYTHON_DOWNLOADS: never
 
+    needs: changes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -429,13 +497,14 @@ jobs:
 
   build-windows:
     name: "Build on Linux for Windows"
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # see build-cibuildwheel
     env:
       UV_PYTHON_DOWNLOADS: never
 
+    needs: changes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -720,6 +789,7 @@ jobs:
     # skips uniformly rather than tripping the skip check below
     if: ${{ always() && !github.event.pull_request.draft }}
     needs:
+      - changes
       - coverage
       - build-cibuildwheel
       - build-dynamic

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2194
+        "line_number": 2213
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T11:12:37Z"
+  "generated_at": "2026-08-16T11:32:21Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,6 +727,25 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **A pull request that changes only prose no longer runs the matrix**
+  (#189). Measured on the last full run before this, 48 jobs and 81.8
+  runner-minutes, of which the change that added `windows.yml` to the
+  table of sentinels — four markdown files and one workflow comment —
+  asked for all of them. `changes` is one ubuntu job that lists the pull
+  request's files through the API and answers whether anything the matrix
+  reads changed; the five root jobs read it in their `if`, and what hangs
+  off them skips on its own. `test: every job passed` already carried
+  `always()`, so it still runs and reads `skipped`, which it does not
+  treat as a failure, and the branch rule keeps naming the same context.
+  Three things the job cannot get wrong, all in the comment above it: it
+  runs on every trigger and answers `true` on all but `pull_request`,
+  because a `changes` that skipped itself would leave every dependent
+  reading an empty output and skip the release path too; `README.md` is
+  not prose here, being the long description `check-dist` renders with
+  twine and rates with pyroma, which is why the allowlist is written out
+  rather than inverted from `*.md`; and `test-passed` takes `changes` as
+  a `needs`, so an error listing the files fails the gate instead of
+  skipping everything and reporting a pass
 - **`github-release` needed `always()` too, not just an explicit `if`.**
   The previous fix (v0.8.0.2's own CHANGELOG entry, right below) added
   `needs.publish-pypi.result == 'success' && needs.attest.result ==


### PR DESCRIPTION
Stacked on #184, which it needs only to avoid a conflict in `test.yml`.

**The measurement.** Last full run of `test.yml` on a pull request
([31942556787](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31942556787)):
48 jobs, 81.8 runner-minutes. #184 itself — four markdown files and one
workflow comment — asked for every one of them.

**What this adds.** One ubuntu job, `changes`, that lists the pull request's
files through the API and answers whether anything the matrix reads changed.
The five root jobs (`coverage`, `build-cibuildwheel`, `build-dynamic`,
`build-sdist`, `build-windows`) take it as a `needs` and read the output in
their `if`; everything downstream skips on its own, a job whose needs are
skipped being skipped too. `test: every job passed` still runs — it already
carries `always()` — and reads `skipped`, which it does not treat as a
failure. The branch rule keeps naming the same context.

**Three traps, all in the comment above the job.**

1. It runs on *every* trigger and answers `true` on all but `pull_request`.
   A `changes` job that skipped itself on a push to `main` would leave every
   dependent reading an empty output — not `'true'` — and the whole workflow,
   release path included, would skip.
2. `README.md` is not prose here: it is the long description, which
   `check-dist` renders with twine and rates with pyroma. Nor is anything
   under `docs/`, which the sdist carries. The allowlist is written out for
   that reason rather than inverted from `*.md`.
3. `test-passed` takes `changes` as a `needs`, so a failure listing the
   files fails the gate instead of skipping everything and reporting a pass.

The job declares `pull-requests: read` for itself; the workflow default
stays `contents: read`.

**How to see it work:** this pull request is not prose (it edits a workflow),
so it runs the full matrix. A follow-up that touches only CHANGELOG.md will
show `changes` alone, green in about five seconds.

## Summary by Sourcery

Gate the main test matrix behind a preliminary job that checks whether a pull request changes anything the matrix validates, so prose-only PRs skip expensive builds while still reporting status correctly.

CI:
- Add a `changes` job that inspects pull request file paths to decide if the test matrix needs to run, treating non-PR events as always requiring a full run.
- Wire root build and coverage jobs to depend on `changes` and conditionally run based on its output, ensuring downstream jobs are skipped when only allowed prose files change.
- Include the `changes` job in the `test-passed` gate to fail the workflow if change detection itself fails, rather than silently skipping the matrix.