### PR TITLE
Walk the interpreters in one job per image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -633,10 +633,33 @@ jobs:
     # no rule names it today
     name: >-
       Run the suite on the dynamic wheel,
-      ${{ matrix.python-version }}, ${{ matrix.os }}
+      every interpreter, ${{ matrix.os }}
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # one job now walks what eight did, so the cap is the sum of theirs
+    # rather than one of them: eight installs and eight suites in
+    # sequence, where each cell was under two minutes
+    timeout-minutes: 30
+    env:
+      # one statement of which interpreters are tested, read twice in this
+      # job: setup-python installs the list, and the loop below walks it.
+      # A version added to one and not the other is either an interpreter
+      # installed and never run or a run that fails on a missing
+      # executable, and both say so immediately.
+      # 3.14t, the free-threaded interpreter, matters here in particular:
+      # the dynamic wheel is tagged py3-none, so it is what a
+      # free-threaded interpreter installs, and unlike the static wheels
+      # nothing else exercises it (cibuildwheel tests every wheel it
+      # builds, including cp314t; this job has no such counterpart)
+      PYTHONS: |
+        3.10
+        3.11
+        3.12
+        3.13
+        3.14
+        3.14t
+        pypy-3.10
+        pypy-3.11
     strategy:
       fail-fast: false
       matrix:
@@ -645,20 +668,6 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-        # 3.14t, the free-threaded interpreter, matters here in particular:
-        # the dynamic wheel is tagged py3-none, so it is what a
-        # free-threaded interpreter installs, and unlike the static wheels
-        # nothing else exercises it (cibuildwheel tests every wheel it
-        # builds, including cp314t; this job has no such counterpart)
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-          - "3.14t"
-          - "pypy-3.10"
-          - "pypy-3.11"
     needs: [build-windows, build-dynamic]
 
     steps:
@@ -666,20 +675,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }}
+      # every interpreter of PYTHONS at once: setup-python takes a list and
+      # puts each on the PATH under its own name, which is what lets one
+      # job do what one cell per version did
+      - name: Set up every interpreter
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.python-version }}
-
-      # unpinned, and for the reason spelled out in test-sdist: a user's
-      # environment rather than the locked one
-      - name: Upgrade Python packaging tools
-        run: python -m pip install -U pip pytest
-
-      - name: Show runner information
-        run: |
-          python --version
-          pip --version
+          python-version: ${{ env.PYTHONS }}
 
       # only the wheel built for this platform: downloading all of them
       # meant every job in the matrix listing and fetching four
@@ -691,22 +693,65 @@ jobs:
           name: dynamic-wheels-${{ matrix.os == 'windows-latest' && 'windows' || matrix.os }}
           path: dist
 
-      - name: Install lib
+      # pip and pytest unpinned, and for the reason spelled out in
+      # suite-sdist: a user's environment rather than the locked one.
+      #
+      # What a red check says is what this trades away, and the loop is
+      # written to give it back: a matrix cell named the interpreter in the
+      # check itself, where this job names the image and leaves the
+      # interpreter to the log. So every version runs even after one has
+      # failed -- `fail-fast: false` between cells, kept between iterations
+      # -- each inside a fold of its own, and the failures are named
+      # together at the end rather than being the first one to abort
+      - name: Install the wheel and run the suite under each interpreter
         run: |
-          python -m pip install cffi
-          python -m pip install --verbose --no-index --find-links dist/ btclib_secp256k1
-
-      - name: Test
-        run: pytest
+          failed=""
+          for version in $PYTHONS; do
+            case $version in
+              pypy-*) python=pypy${version#pypy-} ;;
+              *) python=python$version ;;
+            esac
+            echo "::group::$version ($python)"
+            if "$python" --version \
+              && "$python" -m pip install -U pip pytest cffi \
+              && "$python" -m pip install --verbose --no-index \
+                --find-links dist/ btclib_secp256k1 \
+              && "$python" -m pytest; then
+              echo "$version passed"
+            else
+              failed="$failed $version"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::the suite failed under:$failed"
+            exit 1
+          fi
 
   suite-static:
     # the linkage is in the name: see suite-dynamic
     name: >-
       Run the suite on the static wheel,
-      ${{ matrix.python-version }}, ${{ matrix.os }}
+      every interpreter, ${{ matrix.os }}
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # see suite-dynamic, one interpreter fewer
+    timeout-minutes: 30
+    env:
+      # one statement of the interpreters, as in suite-dynamic, and one
+      # shorter by pypy-3.10: no static wheel is built for it.
+      # cibuildwheel already runs the suite against every wheel it builds,
+      # cp314t included: what this job adds is that pip, given a directory
+      # holding all of them, selects the right one, which for the
+      # free-threaded interpreter nothing checked
+      PYTHONS: |
+        3.10
+        3.11
+        3.12
+        3.13
+        3.14
+        3.14t
+        pypy-3.11
     strategy:
       fail-fast: false
       matrix:
@@ -723,12 +768,6 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-        python-version:
-          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
-        # cibuildwheel already runs the suite against every wheel it
-        # builds, cp314t included: what this job adds is that pip, given a
-        # directory holding all of them, selects the right one, which for
-        # the free-threaded interpreter nothing checked
     needs: build-cibuildwheel
 
     steps:
@@ -736,19 +775,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }}
+      # see suite-dynamic
+      - name: Set up every interpreter
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ matrix.python-version }}
-
-      # unpinned, as in test-dynamic
-      - name: Upgrade Python packaging tools
-        run: python -m pip install -U pip pytest
-
-      - name: Show runner information
-        run: |
-          python --version
-          pip --version
+          python-version: ${{ env.PYTHONS }}
 
       # only the wheels built for this platform, as above
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -756,13 +787,34 @@ jobs:
           name: static-wheels-${{ matrix.os }}
           path: dist
 
-      - name: Install lib
+      # the loop, the folds and the failures named together: see
+      # suite-dynamic. The install is the point of this job rather than a
+      # step before it -- pip choosing among a directory of wheels tagged
+      # for seven interpreters -- so it stays inside the loop with the run
+      - name: Install the wheel and run the suite under each interpreter
         run: |
-          python -m pip install cffi
-          python -m pip install --verbose --no-index --find-links dist/ btclib_secp256k1
-
-      - name: Test
-        run: pytest
+          failed=""
+          for version in $PYTHONS; do
+            case $version in
+              pypy-*) python=pypy${version#pypy-} ;;
+              *) python=python$version ;;
+            esac
+            echo "::group::$version ($python)"
+            if "$python" --version \
+              && "$python" -m pip install -U pip pytest cffi \
+              && "$python" -m pip install --verbose --no-index \
+                --find-links dist/ btclib_secp256k1 \
+              && "$python" -m pytest; then
+              echo "$version passed"
+            else
+              failed="$failed $version"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::the suite failed under:$failed"
+            exit 1
+          fi
 
   # one context for the branch rule, instead of the matrix's own. A rule
   # naming `Run the suite on the static wheel, 3.10, ubuntu-latest` names a

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 2213
+        "line_number": 2230
       }
     ],
     "btclib_secp256k1/hashes.py": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T11:32:21Z"
+  "generated_at": "2026-08-16T11:35:38Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -746,6 +746,23 @@ release-notes length in the first place, and are still in
   rather than inverted from `*.md`; and `test-passed` takes `changes` as
   a `needs`, so an error listing the files fails the gate instead of
   skipping everything and reporting a pass
+- **The suite cells are one job per image, not one per interpreter**
+  (#190). In the same run, 30 of the 48 jobs were suite cells and they
+  were 11.8 of its 81.8 runner-minutes: what they cost is slots, of which
+  an organization on GitHub Free has twenty shared across every
+  repository in it, and not time. `suite-dynamic` (eight interpreters on
+  two images) and `suite-static` (seven on two) are two jobs each now,
+  walking their whole list. Per cell the marginal work is an install and
+  a suite, both under half a minute, against a checkout, a setup-python
+  and an artifact download paid once per job — so the collapse costs
+  little wall clock and pays back twenty-six slots. What it trades away
+  is that a cell named the interpreter in the check itself, and the loop
+  gives that back where it can: every version runs even after one has
+  failed, each inside a fold of its own, and the failures are named
+  together at the end rather than the first one aborting the job. The
+  list is stated once per job and read twice, by setup-python and by the
+  loop, so a version in one and not the other is either an interpreter
+  installed and never run or a run that fails on a missing executable
 - **`github-release` needed `always()` too, not just an explicit `if`.**
   The previous fix (v0.8.0.2's own CHANGELOG entry, right below) added
   `needs.publish-pypi.result == 'success' && needs.attest.result ==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,11 @@ command at all, for the reason above, and no longer gates.
   ```
 
 - `Run the suite on the static wheel, <version>, <os>`, and its dynamic
-  counterpart, one row of either matrix
+  counterpart, one row of either matrix. In `test.yml` those two jobs read
+  `every interpreter` where the version would be, one job per image
+  walking the whole list, so the version a failure names is in the log
+  rather than in the name of the check; `macos.yml` and `windows.yml`
+  still have a cell per version
 
   ```shell
   uv run --python 3.10 --no-cache pytest


### PR DESCRIPTION
Stacked on #189.

**The measurement.** In run
[31942556787](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31942556787):
30 of the 48 jobs are suite cells, and they are **11.8 of the 81.8
runner-minutes**. What they cost is not time, it is slots — and the
organization has twenty, shared across every repository in it.

**What this does.** `suite-dynamic` (8 interpreters × 2 images) and
`suite-static` (7 × 2) become two jobs each, one per image, walking the
whole list. Per cell the marginal work is one install and one suite, both
under half a minute, against a checkout, a `setup-python` and an artifact
download paid once per job — so the collapse costs little wall clock and
pays back 26 slots.

**What it trades away, and what gives it back.** A matrix cell named the
interpreter in the check itself; these jobs name the image and leave the
interpreter to the log. So the loop keeps what `fail-fast: false` gave
between cells: every version runs even after one has failed, each inside a
`::group::` fold of its own, and the failures are named together in one
`::error::` at the end rather than the first one aborting the job.

The interpreter list is stated once per job, in `env.PYTHONS`, and read
twice — `setup-python` installs it, the loop walks it. A version in one and
not the other is either an interpreter installed and never run or a run that
fails on a missing executable, and both say so immediately.

`CONTRIBUTING.md` gains the sentence that says where the version went, and
that `macos.yml` and `windows.yml` still have a cell per version.

**Verified locally**: the `pypy-3.11` → `pypy3.11` and `3.14t` →
`python3.14t` mapping under bash, which is the runners' shell.

## Summary by Sourcery

Collapse the Linux dynamic and static wheel test matrices into one job per image that runs the full interpreter list sequentially, while preserving per-interpreter coverage and clearer failure reporting.

Enhancements:
- Run dynamic and static wheel suites under all configured interpreters within a single job per OS image instead of separate matrix cells per interpreter.
- Add grouped, per-interpreter execution and consolidated error reporting to make it clear which versions fail while keeping all versions running despite failures.
- Define the tested interpreter set once per job via an environment variable that is shared between setup and the execution loop, including free-threaded and PyPy variants.

CI:
- Increase CI timeout for consolidated Linux wheel suite jobs to account for running all interpreters sequentially and adjust workflow configuration to use multi-interpreter setup via actions/setup-python.

Documentation:
- Update CONTRIBUTING.md to explain that Linux wheel suite jobs now walk all interpreters per image, with individual failure versions identified in logs, while macOS and Windows remain one cell per version.