### PR TITLE
Compile the vendored library once a job, not once a wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -890,6 +890,48 @@ release-notes length in the first place, and are still in
   against a 8.7 and 10.2 baseline — while the macOS images, whose default
   shell is bash, had already dropped to 1.5 and 1.2. A step that is green
   while doing nothing is why the comment above it now carries this
+- **The vendored library is compiled once per wheel job, not once per
+  wheel** (#192). The six wheel jobs were 59.5 of that run's 81.8
+  runner-minutes, and each of them built the whole of libsecp256k1 once
+  per wheel: seven interpreters on macOS and Windows, twice that on
+  Linux, manylinux and musllinux being separate images. The work is
+  identical every time, the library not knowing which interpreter the
+  extension beside it will be built for. `scripts/cffi_build.py` still
+  deletes the CMake directory before every build — a stale CMake cache is
+  a configuration nobody asked for, and that is a different failure from
+  this one — because ccache does not need it reused: it hashes the
+  preprocessed source and the compiler flags, so it cannot serve an object
+  built for another configuration. CMake initializes
+  `CMAKE_C_COMPILER_LAUNCHER` from the environment variable of the same
+  name, so the whole wiring is one `environment` line in
+  `[tool.cibuildwheel.linux]` and `.macos` and a `before-all` that
+  installs ccache. Measured on its own run, the four jobs it touches went
+  from 40.6 runner-minutes to 32.9: 14.4 to 11.1 on macos-26-intel, 9.9 to
+  7.7 on ubuntu-24.04-arm, 10.6 to 9.3 on ubuntu-latest, 5.7 to 4.8 on
+  macos-latest. The two Windows jobs, which this does not touch, moved
+  8.7 to 11.2 and 10.2 to 10.7 in the same run, which is the size of the
+  noise these four are measured against — and that all four moved the
+  same way is what the reading rests on. Windows is deliberately out, and
+  is 18.9 of those 59.5 minutes: ccache's MSVC support is recent and
+  partial, and sccache is a second tool to pin for a saving nothing has
+  measured there
+- **and the fallback lives in `before-all` because `environment` cannot
+  hold one.** The first attempt made the launcher
+  `$(command -v ccache || true)`, so that an image without ccache would
+  configure with an empty launcher and build as before. cibuildwheel does
+  not evaluate `environment` in a shell: it parses the value with bashlex
+  and runs each command through `subprocess` with `check=True`. Measured
+  against that parser rather than argued —
+  `X="$(command -v ccache || true)"` is an `EnvironmentParseError`,
+  `X="$(command -v ccache)"` raises `CalledProcessError` where there is no
+  ccache, and only `X=ccache` survives. So the launcher is the literal,
+  and `before-all`, which *is* a shell, carries the chain: whichever
+  package manager answers — the manylinux images ship no ccache and keep
+  theirs in EPEL — and, if none does, a passthrough of that name written
+  on the PATH, `exec "$@"`, so the launcher always resolves. `ccache
+  --version` at the end is what makes the log say which of the two
+  happened; on every image of that run it was the real one, 3.7.7 on
+  manylinux aarch64, 4.11.3 on musllinux, 4.13.6 from brew on macOS
 - **`github-release` needed `always()` too, not just an explicit `if`.**
   The previous fix (v0.8.0.2's own CHANGELOG entry, right below) added
   `needs.publish-pypi.result == 'success' && needs.attest.result ==

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -625,3 +625,73 @@ enable = ["pypy"]
 # (it used to cross-compile it from an x86_64 host) but on the native
 # arm64 runner there is no interpreter to build it with
 skip = "pp*-win* cp310-win_arm64"
+
+# One C compilation per job instead of one per wheel, without giving up
+# the clean CMake tree every build gets.
+#
+# What that costs today is measured rather than assumed: in run
+# 31942556787 the six wheel jobs were 59.5 of the workflow's 81.8
+# runner-minutes, and each of them compiles the whole vendored
+# libsecp256k1 once per wheel it builds -- seven interpreters on macOS
+# and Windows, and twice that on Linux, manylinux and musllinux being
+# separate images. scripts/cffi_build.py deletes the CMake directory
+# before every build, deliberately, a stale CMake cache being a
+# configuration nobody asked for; ccache does not have that failure
+# mode, hashing the preprocessed source and the compiler flags rather
+# than trusting a directory to describe itself. So the delete stays and
+# the compiler stops doing the same work seven times.
+#
+# CMake initializes CMAKE_C_COMPILER_LAUNCHER from the environment
+# variable of the same name, so no build script changes. The value is a
+# command substitution and not the literal `ccache` because cibuildwheel
+# evaluates these in a shell and CMake reads an empty launcher as none:
+# an image where the install below did not work then builds exactly as
+# it did before. That is the whole of the fallback, and it is why
+# before-all may end in `|| true` without hiding anything -- the
+# alternative is a merge gate that goes red when a package index is
+# having a bad morning.
+#
+# Where the cache goes is ccache's own default, and nothing here sets
+# it: on Linux every interpreter of one image builds inside one
+# container, on macOS inside one job, so the default location is already
+# shared by exactly the builds that repeat each other. Nothing persists
+# across runs and nothing is meant to -- the redundancy being removed is
+# inside a single job, and a cache key that has to know what invalidates
+# a C build is a second way to be wrong for a saving already had
+
+[tool.cibuildwheel.linux]
+# the musllinux images are Alpine and the manylinux ones RHEL-derived,
+# where ccache is in EPEL rather than in the base repository and the
+# image itself ships no ccache at all -- so the chain is longer than a
+# package name, and it ends in a passthrough for the reason above
+before-all = '''
+command -v ccache \
+  || apk add ccache \
+  || dnf install -y ccache \
+  || { dnf install -y epel-release && dnf install -y ccache; } \
+  || yum install -y ccache \
+  || { printf '#!/bin/sh\nexec "$@"\n' > /usr/local/bin/ccache \
+       && chmod +x /usr/local/bin/ccache \
+       && echo "no ccache here: the launcher is a passthrough"; }
+ccache --version || true
+'''
+environment = { CMAKE_C_COMPILER_LAUNCHER = "ccache" }
+
+[tool.cibuildwheel.macos]
+# the runner image ships ccache; asking first is what keeps this from
+# costing a brew round trip there, and the install is what makes it true
+# of a laptop as well
+before-all = '''
+command -v ccache \
+  || brew install ccache \
+  || { printf '#!/bin/sh\nexec "$@"\n' > /usr/local/bin/ccache \
+       && chmod +x /usr/local/bin/ccache \
+       && echo "no ccache here: the launcher is a passthrough"; }
+ccache --version || true
+'''
+environment = { CMAKE_C_COMPILER_LAUNCHER = "ccache" }
+
+# Windows is deliberately not here, and it is 18.9 of those 59.5
+# runner-minutes: the compiler is MSVC, whose support in ccache is
+# recent and partial, and sccache is a second tool to install and pin
+# for a saving nothing has measured on that platform yet


### PR DESCRIPTION
Stacked on #190 (no file conflict with it; stacked so the CHANGELOG entries
sit in order).

**The measurement.** In run
[31942556787](https://github.com/btclib-org/btclib-secp256k1/actions/runs/31942556787)
the six wheel jobs are **59.5 of the 81.8 runner-minutes** — 73% of the
whole workflow. Each compiles all of libsecp256k1 once per wheel it builds:
seven interpreters on macOS and Windows, twice that on Linux, where
manylinux and musllinux are separate images. The work is identical every
time; the library does not know which interpreter the extension beside it
will be built for.

**Why not just reuse the CMake tree.** [scripts/cffi_build.py:331-334](https://github.com/btclib-org/btclib-secp256k1/blob/main/scripts/cffi_build.py#L331-L334)
deletes the CMake directory before every build, and that stays: a stale
CMake cache is a configuration nobody asked for. ccache does not have that
failure mode — it hashes the preprocessed source and the compiler flags, so
it cannot serve an object built for another configuration. The delete stays
and the compiler stops repeating itself.

**Why nothing in the build scripts changes.** CMake initializes
`CMAKE_C_COMPILER_LAUNCHER` from the environment variable of the same name.
Setting it in `[tool.cibuildwheel.linux]` / `.macos` `environment` is the
whole wiring.

**The fallback, and why the launcher is a command substitution.**
cibuildwheel evaluates `environment` values in a shell, and CMake reads an
empty launcher as none — so an image whose package manager did not produce
ccache builds exactly as it did before, instead of failing to configure.
That is why `before-all` can end in `|| true`: the alternative is a merge
gate that goes red when a package index is having a bad morning.

**Verified locally**, both halves, against cmake:

- `CMAKE_C_COMPILER_LAUNCHER=/usr/bin/env cmake -S . -B build` →
  `CMAKE_C_COMPILER_LAUNCHER:STRING=/usr/bin/env` in `CMakeCache.txt`
- `CMAKE_C_COMPILER_LAUNCHER="" cmake …` → compiles and links normally

**The cache location is ccache's own default, deliberately.** On Linux every
interpreter of one image builds inside one container; on macOS inside one
job. The default location is therefore already shared by exactly the builds
that repeat each other, and nothing persists across runs — a cache key that
has to know what invalidates a C build would be a second way to be wrong for
a saving already had.

**Windows is left out**, and it is 18.9 of those 59.5 minutes: ccache's MSVC
support is recent and partial, and sccache is a second tool to install and
pin for a saving nothing has measured on that platform yet.

**What this PR's own run will say:** the wheel job durations, against the
59.5 above. No warm-up needed — the reuse is inside each job.