### PR TITLE
Write down the ceiling, and the column of it that money does not move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -796,6 +796,18 @@ release-notes length in the first place, and are still in
   expected the other outcome, and the two pull requests that landed the
   rule went the way it now describes
 
+- **The concurrency ceiling is written down, with the column that
+  decides it** (#194). REPOSITORY.md's plan-gated section now carries the
+  number that has moved these workflows twice, and it is an attribute of
+  the organization rather than a setting of the repository: an
+  organization on GitHub Free runs twenty jobs at once, **of which five
+  may be macOS**. Paying for Team triples the first and leaves the second
+  exactly where it is; only Enterprise moves it. So the macOS column that
+  queued for tens of minutes was thirty-five jobs asking for five slots,
+  and the split that took those cells out of the merge gate is not a
+  workaround for a plan but the answer on any plan below Enterprise —
+  which is worth having written down before someone reads the first
+  column alone and buys a seat expecting it back
 - **The sentinel table names `windows` too** (#184). `windows.yml` became
   a workflow of its own two changes after `macos.yml` did, and the table
   in CLAUDE.md kept listing the sentinels without it — so the paragraph

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -613,6 +613,42 @@ leaves them off — **do not read that 200 as success.** The
 `detect-secrets` hook is the compensating control, and CONTRIBUTING.md
 carries what maintaining its baseline costs.
 
+The other plan-gated number is not a setting at all, and it is the one
+that has moved this repository's workflows twice: how many jobs may run
+at once. It is an attribute of the organization, shared by every
+repository in it, and the plan is what sets it.
+
+```shell
+gh api orgs/btclib-org --jq .plan.name        # free
+```
+
+[GitHub's own table](https://docs.github.com/en/actions/reference/limits)
+is the authority, and two of its columns matter here:
+
+| plan | concurrent jobs | of which macOS |
+| --- | --- | --- |
+| Free | 20 | 5 |
+| Pro | 40 | 5 |
+| Team | 60 | 5 |
+| Enterprise | 500 | 50 |
+
+**Read the second column before spending anything on the first.** The
+twenty is what `windows.yml`'s header measured against, and paying for
+Team would triple it; the five is what `macos.yml`'s header measured
+against, and Team does not move it at all. A macOS column that queued for
+tens of minutes was thirty-five jobs asking for five slots, and only
+Enterprise changes that arithmetic. So the split that took those cells
+out of the merge gate is not a workaround for a plan — on this repository
+it is the answer, and the plan below Enterprise that would undo it does
+not exist.
+
+What Team would buy is the rest: the Linux and Windows crowding, and the
+contention with the other repositories of the organization, `btclib`
+asking for thirty-nine jobs a commit and `bitcoin-core-rpc` for
+forty-four. Whether that is worth three seats is a question for whoever
+pays for them, and it is recorded here so that it is asked with the
+second column in view.
+
 ## Topics
 
 The topics are `pyproject.toml`'s `keywords`, entry for entry: one list


### PR DESCRIPTION
Stacked on #193. Documentation only — the change this records is a billing
decision, which is not something a pull request can make.

The fifth of the five ways to make a pull request cheaper was "buy the
concurrency back instead of cutting the matrix". Checking the numbers before
proposing it turned it into something else:

| plan | concurrent jobs | of which macOS |
| --- | --- | --- |
| Free | 20 | 5 |
| Pro | 40 | 5 |
| Team | 60 | 5 |
| Enterprise | 500 | 50 |

([GitHub's own table](https://docs.github.com/en/actions/reference/limits);
`gh api orgs/btclib-org --jq .plan.name` answers `free`.)

**Team triples the first column and does not move the second.** The twenty
is what `windows.yml`'s header measured against; the five is what
`macos.yml`'s did — a macOS column queueing for tens of minutes was
thirty-five jobs asking for five slots, and only Enterprise changes that.
So the split that took the macOS cells out of the merge gate is not a
workaround for a cheap plan: it is the answer on every plan below
Enterprise.

What Team *would* buy is the rest — the Linux and Windows crowding, and the
contention with `btclib` (39 jobs a commit) and `bitcoin-core-rpc` (44).
Whether three seats are worth that is for whoever pays for them; this
records it in `REPOSITORY.md`'s plan-gated section, beside the two
secret-scanning settings that answer a PATCH with 200 and change nothing,
so the question gets asked with the whole table in view instead of the first
column alone.

## Summary by Sourcery

Document the GitHub Actions concurrency limits affecting this repository and record the rationale for the current macOS workflow split.

Documentation:
- Describe organization-level concurrent job and macOS slot limits across GitHub plans in REPOSITORY.md, clarifying their impact on this repo's workflows.
- Note in the changelog that the concurrency ceiling and its macOS-specific constraint are now documented as part of the plan-gated settings.