### PR TITLE
Say the guard with a class, the generator having cost more than the call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,19 +385,41 @@ release-notes length in the first place, and are still in
   pair. The eight failures above are eight `ValueError`s now, each
   carrying libsecp256k1's own text, and `tests/test_callbacks.py` no
   longer counts the exceptions to a rule that has none
-- **and it costs 0.48 microseconds a call**, which is worth writing down
-  because on the cheapest call it is most of the call. Measured on an
-  Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 5 rounds of
-  300 000 calls: `secp256k1_ec_pubkey_cmp` through `lib` is 0.087
-  microseconds and `keys._pubkey_cmp_` is 0.57, where a verification is
-  12.1 against 12.9 — the same 0.5 on a call that does real work. Two
-  cheaper spellings were measured and not taken: the pair written out at
-  each call site is 0.23 and a hand-written context manager class 0.30,
-  and what the second buys over `@contextmanager` is 0.27 microseconds
-  against three methods and their docstrings. The clearing and the check
-  are one thing, and the generator is the shortest way to say so; a
-  caller counting microseconds on a comparison has `lib`, which is
-  exported for exactly that
+- **and it costs 0.22 microseconds a call**, which is worth writing
+  down because on the cheapest call it is most of the call. Apple M5,
+  macOS 26.6, arm64, CPython 3.14.6, minimum of 11 rounds:
+  `secp256k1_ec_pubkey_cmp` through `lib` is 0.084 microseconds and
+  `keys._pubkey_cmp_` is 0.300, the difference being the guard and
+  nothing else. Three spellings were measured. The pair written out at
+  each call site is the cheapest, and is not taken: the clearing without
+  the check leaves a message for the next caller to be blamed for, the
+  check without the clearing raises an earlier call's message out of
+  this one, and the two belong in one place. A
+  `contextlib.contextmanager` generator is the dearest, putting the same
+  comparison at 0.567 — so the generator's guard is 0.48 a call, and the
+  0.27 between the two spellings is more than the entire C call on the
+  smallest guarded call in the package. The guard is therefore the
+  class, `__slots__` and `__enter__` and `__exit__`, which says "the
+  clearing and the check are one thing" as well as a `yield` does and
+  costs three method bodies of one line each to say
+- **and a fifth of `keys.pubkey_sort` is what settles it** (#186). A
+  guard is built once per guarded call, so a composed call builds many,
+  and a caller wanting those microseconds back through `lib` is
+  reimplementing the operation rather than making one call — where on a
+  comparison the advice to drop to `lib` costs them nothing, which is
+  why the cheap call is the wrong one to decide on. Same machine and
+  method: `keys.serialize` of a parsed point is 0.582 against a
+  generator's 0.847, and `keys.pubkey_sort` of twenty keys 21.12 against
+  26.99. Sharing one instance rather than building one per call measures
+  0.567 against 0.582, which is noise, and would have cost every
+  `with guarded():` in the package a rewrite to `with guarded:`
+- **the `__exit__` is deliberately not a `finally`,** which is the one
+  thing the spelling could get wrong. The block holds the guarded call
+  and nothing else, so an exception out of it is some other failure, and
+  checking anyway would raise the violated precondition over it —
+  reporting the wrong failure and losing the right one. `if exc_type is
+  None` is what says so, and two tests in `tests/test_callbacks.py` hold
+  the pair, each verified against the mutant it exists to kill
 
 ### One statement of each thing
 

--- a/btclib_secp256k1/context.py
+++ b/btclib_secp256k1/context.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import secrets
 import threading
-from collections.abc import Iterator
-from contextlib import contextmanager
+from types import TracebackType
 
 from . import CData, ffi, lib
 
@@ -146,8 +145,7 @@ def check() -> None:
         raise ValueError(f"libsecp256k1 illegal argument: {illegal}")
 
 
-@contextmanager
-def guarded() -> Iterator[None]:
+class guarded:
     """Run a libsecp256k1 call whose argument could not be checked first.
 
     Every argument these bindings pass as bytes is proved before the
@@ -167,17 +165,29 @@ def guarded() -> Iterator[None]:
     nothing returns 0 like any other refusal, and the reason it returns
     0 is on the thread and nowhere else.
 
-    And it is called whatever the call answered, not only on a failure,
+    And it is called whatever the call *answered*, not only on a failure,
     because a violated precondition does not always show in the return
     value: `secp256k1_ecdsa_verify` of an unreadable key answers False,
     which is a verdict a caller would believe, and
     `secp256k1_ecdh` of one answers success and 32 bytes that are a
     shared secret with nobody.
 
-    Yields:
-        None: nothing, the block being what this is for. It should hold
-        that call and nothing else -- an exception raised inside it
-        passes through with the thread left as libsecp256k1 set it.
+    A class, and lowercase, because `with guarded():` is what the call
+    sites say and the two halves above are what it has to keep together
+    -- neither of which is a reason to build a generator. A
+    `contextlib.contextmanager` generator costs more than the C call it
+    guards, and the smallest guarded *entry point* is where that shows:
+    `keys.serialize` of a parsed point is 0.582 microseconds this way
+    and 0.847 with one, `keys.pubkey_sort` of twenty keys 21.12 against
+    26.99. The sort is the shape that makes the case, building one guard
+    per key. Smaller still is `keys._pubkey_cmp_`, which is a private
+    half rather than an entry point, and is where CHANGELOG.md measures
+    the guard on its own.
+
+    A shared instance measures 0.567 against the 0.582 of building one
+    per call, which is noise and is why the call sites say `guarded()`:
+    `__slots__` leaves nothing to allocate. An Apple M5, macOS 26.6,
+    arm64, CPython 3.14.6, minimum of 11 rounds.
 
     Raises:
         ValueError: if libsecp256k1 reported a violated precondition.
@@ -189,6 +199,37 @@ def guarded() -> Iterator[None]:
         Traceback (most recent call last):
         ValueError: libsecp256k1 illegal argument: pubkey != NULL
     """
-    _reported.illegal = _reported.error = None
-    yield
-    check()
+
+    # nothing is held between the two halves: what they read and write is
+    # the thread local, so an instance needs no dictionary of its own
+    __slots__ = ()
+
+    def __enter__(self) -> None:
+        """Clear what an earlier call may have left on this thread."""
+        _reported.illegal = _reported.error = None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Raise what libsecp256k1 reported, unless the block already did.
+
+        Not a `finally`, and the difference is the whole of what this
+        method decides. The block should hold the guarded call and
+        nothing else, so an exception out of it is something other than
+        a violated precondition -- and checking anyway would replace
+        that exception with this one, reporting the precondition as the
+        failure and losing the failure that actually happened. So it
+        passes through with the thread left as libsecp256k1 set it, and
+        the next `__enter__` is what clears it.
+
+        Args:
+            exc_type: the class of the exception ending the block, if
+                one is.
+            exc_value: that exception.
+            traceback: its traceback.
+        """
+        if exc_type is None:
+            check()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -110,6 +110,42 @@ def test_from_keypair_raises_what_was_reported() -> None:
     context.check()
 
 
+def test_guarded_clears_before_the_call_it_holds() -> None:
+    """Entering the block takes an earlier call's message off the thread.
+
+    Without that, the block would raise what something else provoked,
+    which is the misattribution the guard exists to prevent -- and the
+    call it holds need not have failed, or even have happened.
+    """
+    assert not lib.secp256k1_ec_pubkey_parse(ctx, *NOWHERE_ARGS)
+    with context.guarded():
+        pass
+    # leaving raised nothing, so entering had cleared what was there
+
+
+def test_guarded_does_not_replace_the_exception_of_its_own_block() -> None:
+    """An exception out of the block passes through, and is not the guard's.
+
+    The check is deliberately not in a `finally`: the block holds the
+    guarded call and nothing else, so an exception out of it is some
+    other failure, and raising the violated precondition instead would
+    report the wrong one and lose the right one. What libsecp256k1 said
+    stays on the thread, for the next `__enter__` to clear.
+    """
+
+    def fail_after_libsecp256k1_has_reported() -> None:
+        """Provoke a precondition, then fail for an unrelated reason."""
+        with context.guarded():
+            assert not lib.secp256k1_ec_pubkey_parse(ctx, *NOWHERE_ARGS)
+            raise KeyError("what actually failed")
+
+    with pytest.raises(KeyError, match="what actually failed"):
+        fail_after_libsecp256k1_has_reported()
+    # the precondition was recorded and left, rather than raised over it
+    with pytest.raises(ValueError, match="pubkey != NULL"):
+        context.check()
+
+
 def test_internal_error() -> None:
     """An internal error reaches the caller as RuntimeError.
 


### PR DESCRIPTION
Closes #186.

## Read this first: the trade was declined once, in this repository

CHANGELOG.md already records it, in the entry that introduced the guard:

> Two cheaper spellings were measured and not taken: the pair written out
> at each call site is 0.23 and a hand-written context manager class 0.30,
> and what the second buys over `@contextmanager` is 0.27 microseconds
> against three methods and their docstrings.

That measurement is right and this branch reproduces it — 0.265 here. So
this is a decision being reopened rather than a gap being filled, and it
is worth thirty seconds of your time to close if you still think the
generator is the better sentence.

## What the earlier weighing did not look at

It priced the saving against `keys._pubkey_cmp_`, where the advice that
follows is sound: a caller counting microseconds on a comparison has
`lib`, one call away.

A guard is built **once per guarded call**, so a call composed of many
builds many, and there `lib` is not a one-line escape — it is
reimplementing the operation.

| same machine, same method, minimum of 11 rounds | before | after |
| --- | --- | --- |
| `keys.serialize` of a parsed point | 0.847 | **0.582** |
| `keys.pubkey_sort` of twenty keys | 26.99 | **21.12** |
| `keys.pubkey_from_prvkey(1)` | 8.48 | 8.14 |

A fifth of `pubkey_sort`. Apple M5, macOS 26.6, arm64, CPython 3.14.6.

## What is not being withdrawn

"The clearing and the check are one thing" is still the argument, and the
class makes it as well as the `yield` did: `__enter__`, `__exit__`, and
nothing between them to hold. `with guarded():` is unchanged at every
call site, so the diff is one module and its tests.

## The one thing the spelling could get wrong

`__exit__` is **not** a `finally`. The block holds the guarded call and
nothing else, so an exception out of it is some other failure, and
checking anyway would raise the violated precondition over it — reporting
the wrong failure and losing the right one. `if exc_type is None` is what
says that, and it is invisible in a diff, so two tests hold it:

- `test_guarded_clears_before_the_call_it_holds`
- `test_guarded_does_not_replace_the_exception_of_its_own_block`

Both were verified against the mutant each exists to kill — a bare
`check()` in place of the branch, and an `__enter__` that does not clear
— run with `PYTHONDONTWRITEBYTECODE=1`, each killing exactly its own test
and the tree restored and green after.

## Also measured and not taken

Sharing one instance instead of building one per call: 0.567 against
0.582, which is noise, and it would have cost every `with guarded():` in
the package a rewrite to `with guarded:`. `__slots__` is what leaves
nothing to allocate.

## Gate

`uvx pre-commit run --all-files` clean, 560 tests, coverage 100.00%.

## Summary by Sourcery

Replace the generator-based libsecp256k1 guard with a lightweight context manager class to reduce per-call overhead while preserving semantics.

Enhancements:
- Introduce a `guarded` context manager class with `__enter__`/`__exit__` instead of a `@contextmanager` generator to lower the cost of guarded libsecp256k1 calls.
- Document the performance trade-off and rationale for the new guard implementation in the changelog, including why instance sharing was not adopted.

Tests:
- Add tests ensuring the guard clears prior errors on entry and does not mask exceptions from within the guarded block.