### PR TITLE
Let a caller name the buffer their secret is written to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,85 @@ release-notes length in the first place, and are still in
   None` is what says so, and two tests in `tests/test_callbacks.py` hold
   the pair, each verified against the mutant it exists to kill
 
+### The copy a caller can take back
+
+- **every producer of a secret takes `into`** (#188), a keyword-only
+  writable buffer the secret is written to instead of a `bytes`:
+  `keys.prvkey_negate`, `prvkey_tweak_add` and `prvkey_tweak_mul`,
+  `xonly.prvkey_tweak_add`, `ecdh.shared_secret` and its private half,
+  `ellswift.xdh`, `dsa.nonce_rfc6979` and `ssa.nonce_bip340`. Omitted,
+  nothing changes and the `bytes` comes back as before. Given, nothing
+  is returned, and the copy the caller ends up holding is one they can
+  overwrite — which is the entire claim, and SECURITY.md now states it
+  beside the limitation it narrows rather than instead of it. It does
+  not wipe the buffer for them; a buffer never overwritten is exactly
+  the copy `into` was reached for to avoid, and the obligation is
+  stated rather than enforced for the reason `ssa.Signer` has no
+  finalizer
+- **which is not what #87 declined.** That issue asked whether an opaque
+  secret *handle* buys assurance and answered no: a handle is a lifetime
+  someone has to own and invalidate, the same shape of requirement that
+  keeps MuSig2 out, and its entry side still starts from a `bytes` the
+  caller already made. Both halves of that stand. What is new is neither
+  a lifetime nor an entry: one keyword argument, one call, no object,
+  and it addresses the *exit* — where `_secret.take` had nowhere to put
+  the secret except an immutable object nothing can zero
+- **`into` is keyword-only, and that is not a style choice.** Passed
+  positionally to `dsa.nonce_rfc6979` it would land on `aux_rand32`,
+  which takes 32 octets and would have accepted the empty buffer as
+  entropy — a wrong nonce, silently, from a call that reads right. The
+  suite caught it on the way in; keyword-only is what keeps a caller
+  from meeting it
+- **and the buffer is proved before anything is copied, the wipe
+  happening either way.** A wrong length is refused rather than filled:
+  too short raises on the assignment anyway, but too *long* would take
+  the secret in its first octets and leave whatever was behind it, which
+  reads as a secret with a tail. A read-only view cannot be wiped, so
+  accepting one would defeat the facility silently. And a view of more
+  than one dimension passes every one of those checks and then fails the
+  copy with `NotImplementedError`, while a strided one succeeds and
+  leaves the secret scattered through an owner twice its size, so both
+  are refused as not contiguous octets. Beyond that the buffer protocol
+  decides rather than a type: `mmap` and `array.array("B")` are taken,
+  an `mlock`ed `mmap` being a plausible destination for exactly this
+  caller, and `memoryview` itself is what refuses a non-buffer. That
+  breadth is the run time's rather than the annotation's, which stays
+  the two named types until `collections.abc.Buffer` is reachable at a
+  3.12 floor: a caller under `mypy --strict` passes the rest as
+  `memoryview(x)`, and SECURITY.md says so where the mismatch is met.
+  `_secret.into_buffer` is annotated `object` and not
+  `MutableBytesLike`, that being the annotation it exists to not trust
+- **the wipe is in a `finally`, which is the defect this facility could
+  have shipped with.** `take` had no failure mode before `into`, and
+  with one on the straight line a refused buffer returned through the
+  entry point leaving a live private key in cffi memory that is freed
+  without being overwritten -- none of the eight has a `finally` of its
+  own, and `xonly.prvkey_tweak_add`'s wipes the keypair rather than the
+  key. Nothing is lost by wiping on the way out: the value never reached
+  the caller, and the call they retry recomputes it
+- **the two secrets `silentpayments` answers are left out**, each being
+  one member of a returned tuple where an argument could not say which:
+  the tweak of `label`, and the per-output tweak `scan_outputs` hands
+  back. SECURITY.md names both rather than claiming every entry point
+- **and what holds the set is a walk rather than a list.** A hardcoded
+  tuple of eight cannot notice a ninth, which is the whole point of the
+  test; `tests/test_secret.py` walks the package for functions whose
+  source calls `_secret.take` and requires `into` of each, one
+  exemption named. Its limit is written down beside it: a secret that
+  never goes through `take` is invisible to it, which is exactly how
+  `_found_output` escaped the first draft of that sentence
+- **the cost, which is in the type system rather than at run time.**
+  Three `@overload`s per entry point, so that omitting `into` still
+  types as `bytes` and a downstream `mypy --strict` sees no change; the
+  implementation signature is the union. The third is the one a caller
+  needs to *forward* an optional buffer through a wrapper of their own,
+  which is how btclib would surface this argument, and with only two it
+  is that caller who writes the two-branch version or a `cast`. Four
+  negative-typing tests moved from `type: ignore[arg-type]` to
+  `[call-overload]`, which is
+  what an overloaded call reports, and is the one way this is visible
+  to a caller who was already type-checking
+
 ### One statement of each thing
 
 - **the duplications are gone**, each of them two spellings of one

--- a/README.md
+++ b/README.md
@@ -534,6 +534,15 @@ private keys, and the x-only public key itself, from a full public key
 `hashes` provides the BIP340 tagged hash, the domain separation the
 taproot tags are built on.
 
+Wherever one of these answers a *secret* — a tweaked or negated private
+key, a shared secret, a nonce — it also takes a keyword-only `into`: a
+writable buffer of exactly 32 contiguous octets, which receives the
+secret in place of the `bytes` the call would otherwise return, so that
+the copy the caller is left holding is one they can overwrite. It is an
+addition and not a change; omit it and nothing differs. SECURITY.md is
+where what it does and does not buy is stated, and names the two
+`silentpayments` secrets it does not reach.
+
 Two of those have a second spelling for a caller doing arithmetic rather
 than holding a key. `keys.pubkey_sum` is `pubkey_combine` with the point
 at infinity answered as `None` instead of refused: `P + (-P)` is the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,43 @@ These are known and inherent, not vulnerabilities:
     and the buffer zeroed before it is dropped. That is one copy taken back,
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
+- **`into` moves that last copy somewhere the caller can overwrite,**
+    and is the whole of what it does. Eight entry points take a
+    keyword-only `into` — a writable buffer of exactly the secret's
+    length, contiguous and one octet an item, `bytearray` and
+    `memoryview` and `mmap` and `array.array("B")` alike — write the
+    secret there and return None, so no `bytes` of it is ever made.
+    That breadth is the run time's: the annotation is a `bytearray` or a
+    `memoryview`, `collections.abc.Buffer` being python 3.12 where the
+    floor here is 3.10, so a caller running `mypy --strict` passes
+    anything else as `memoryview(x)`, which copies nothing. The eight
+    are `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
+    `keys.prvkey_tweak_mul`, `xonly.prvkey_tweak_add`,
+    `ecdh.shared_secret`, `ellswift.xdh`, `dsa.nonce_rfc6979` and
+    `ssa.nonce_bip340`. **The two secrets `silentpayments` answers do
+    not**, each being one member of a returned tuple, where an argument
+    could not say which: the tweak of `label`, and the per-output tweak
+    `scan_outputs` hands back. Both are `bytes` and neither can be
+    zeroed, which is the limitation above and not this narrowing of it.
+    What the caller then does with the buffer is theirs: this does not
+    wipe it for them, and a buffer they never overwrite is exactly the
+    un-zeroizable copy `into` was reached for to avoid. Nor does it
+    touch the *entry* side, which is the half that cannot be improved
+    from inside this package: the `bytes` or `int` handed in already
+    existed before the call, and the arithmetic that produced it
+    happened where this package cannot see. The obligation is stated
+    rather than enforced, for the reason `ssa.Signer` has no finalizer:
+    a guarantee nothing keeps is worse than none
+
+    ```python
+    prvkey = bytearray(32)
+    keys.prvkey_tweak_add(parent, tweak, into=prvkey)
+    try:
+        ...                       # use it
+    finally:
+        prvkey[:] = bytes(32)     # the caller's wipe, and only theirs
+    ```
+
 - the one buffer whose zeroing is the caller's to ask for is
     `ssa.Signer`'s. Everything above is wiped inside the call that made
     it — read out and zeroed in the one operation, or wiped in a

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -61,6 +61,19 @@ CData = Any
 # idea and arrives with python 3.12, which is not yet the floor here
 BytesLike = bytes | bytearray | memoryview
 
+# what a caller may hand a producer of secrets to be written into,
+# instead of taking the `bytes` it would otherwise return. `bytes` is
+# absent for the reason the whole facility exists: it cannot be
+# overwritten, so writing a secret there would buy nothing.
+#
+# The runtime is wider than this: `_secret.into_buffer` takes whatever
+# the buffer protocol offers and is writable, an `mmap` and an
+# `array.array("B")` included. These two are what a typed caller passes
+# bare -- `collections.abc.Buffer` is the alias that would say the rest
+# and arrives with python 3.12, which is not yet the floor here -- and
+# anything else is `memoryview(x)`, which copies nothing
+MutableBytesLike = bytearray | memoryview
+
 ffi = _btclib_secp256k1.ffi
 
 

--- a/btclib_secp256k1/_secret.py
+++ b/btclib_secp256k1/_secret.py
@@ -18,6 +18,15 @@ It buys one copy, not safety: the `bytes` returned to the caller holds
 the same secret and cannot be overwritten. Scalar work that must not
 leave a trace belongs where that can be promised.
 
+`into` is where that last copy stops being a `bytes`. A caller who
+hands a producer of secrets a writable buffer gets the secret written
+there and nothing returned, so the un-zeroizable object is never made
+-- and the wiping of what is left is theirs, which is the whole of the
+difference. #87 declined an opaque *handle* for a reason this does not
+disturb: a handle is a lifetime someone has to own and invalidate, and
+belongs where the signing state lives. This is one argument and one
+call, and owns nothing.
+
 The one such buffer this package builds rather than fills is the
 keypair, and `keypair` below is where it is built, so that the module
 holding the obligation to wipe one is the module that hands one out.
@@ -25,7 +34,9 @@ holding the obligation to wipe one is the module that hands one out.
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, lib
+from typing import overload
+
+from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._scalar import scalar
 from .context import ctx
 
@@ -47,21 +58,139 @@ def wipe(buffer: CData) -> None:
     memory[:] = bytes(len(memory))
 
 
-def take(buffer: CData) -> bytes:
+def into_buffer(into: object, size: int) -> memoryview:
+    """Hold a caller's buffer to what a secret is about to be written to.
+
+    What is required is a buffer of exactly `size` writable, contiguous
+    octets, and anything else is refused rather than adapted. The length
+    is the one that matters: `into[:] = ...` of a short buffer raises
+    anyway, but a caller who sized it by hand should be told what it
+    should have been, and a *longer* one would take the secret in its
+    first octets and leave whatever was in the rest -- which reads as a
+    secret with a tail. A read-only view cannot be written and cannot be
+    wiped either, so it would defeat the facility silently. Items wider
+    than an octet are refused for the reason `_scalar.octets` refuses
+    them: the view states a width this would not be honouring.
+
+    Contiguity is two refusals rather than one, and neither is
+    fastidious. A view of more than one dimension passes every other
+    check -- `memoryview(bytearray(32)).cast("B", (4, 8))` is writable,
+    octet-wide and 32 octets long -- and then fails the copy itself with
+    `NotImplementedError`, which is neither of the two exceptions a
+    caller was told to expect. A strided one *works*, and is refused all
+    the same: `memoryview(bytearray(64))[::2]` would leave the secret
+    scattered through 64 octets of an owner whose other 32 the caller
+    has no reason to think are involved, and a wipe through the view
+    would be right while a wipe of the owner would look right and not
+    be.
+
+    Anything the buffer protocol offers is otherwise accepted, an
+    `mmap` and an `array.array("B")` included -- the first of those
+    being a plausible destination, `mlock`ed, for exactly the caller
+    this exists for. What refuses a non-buffer is `memoryview` itself.
+
+    Typed `object` rather than `MutableBytesLike`, that being the
+    annotation this exists to not trust: a caller is not obliged to run
+    a type checker, and the whole job here is to answer what happens
+    when they did not.
+
+    Args:
+        into: the buffer, as the caller passed it.
+        size: the number of octets the secret is.
+
+    Returns:
+        A `memoryview` of the buffer, one octet per item, which is what
+        the copy is made through.
+
+    Raises:
+        TypeError: if it is not a writable buffer of contiguous
+            one-dimensional octets.
+        ValueError: if it is not exactly `size` octets long.
+    """
+    try:
+        # the annotation is `object` on purpose, and mypy is right that
+        # `memoryview` wants a Buffer: asking whether this one is a
+        # buffer is what the call is for, and the answer is the
+        # TypeError below
+        view = memoryview(into)  # type: ignore[arg-type]
+    except TypeError:
+        msg = (
+            "the buffer to write into must be a writable buffer, "
+            f"not {type(into).__name__}"
+        )
+        raise TypeError(msg) from None
+    if view.readonly:
+        raise TypeError("the buffer to write into must be writable")
+    if view.itemsize != 1:
+        msg = (
+            "the buffer to write into must be a buffer of bytes, "
+            f"not of {view.itemsize}-byte items"
+        )
+        raise TypeError(msg)
+    if view.ndim != 1 or not view.c_contiguous:
+        raise TypeError("the buffer to write into must be contiguous octets")
+    if view.nbytes != size:
+        raise ValueError(f"the buffer to write into must be {size} bytes")
+    return view
+
+
+@overload
+def take(buffer: CData) -> bytes: ...
+@overload
+def take(buffer: CData, *, into: MutableBytesLike) -> None: ...
+@overload
+def take(buffer: CData, *, into: MutableBytesLike | None) -> bytes | None: ...
+def take(buffer: CData, *, into: MutableBytesLike | None = None) -> bytes | None:
     """Read a secret out of the buffer holding it, and overwrite that.
 
     The pair of operations every wrapper producing a secret ends with,
     so that neither is done without the other.
 
+    With `into`, the secret is copied there instead of into a `bytes`,
+    and nothing is returned. That is the whole of what the argument
+    buys, and it is worth being exact about: this package's own buffer
+    is wiped either way, and what changes is only whether the copy the
+    caller ends up holding is one they can overwrite. It does not
+    overwrite it for them, and the argument that produced the secret is
+    still whatever they made it out of. See SECURITY.md.
+
+    Either way this package's buffer is left zeroed, a refused `into`
+    included: the pair is the point, and a failure is no reason to keep
+    a secret the caller cannot reach.
+
     Args:
         buffer: the cffi buffer holding the secret.
+        into: a writable buffer of exactly the secret's length, to
+            receive it instead of a `bytes`.
 
     Returns:
-        Its contents, as bytes, the buffer itself left zeroed.
+        Its contents as bytes, the buffer itself left zeroed -- or None
+        where `into` was given and has been written to.
+
+    Raises:
+        TypeError: if `into` is not a writable buffer of contiguous
+            one-dimensional octets.
+        ValueError: if `into` is not the secret's length.
     """
-    secret = bytes(ffi.buffer(buffer))
-    wipe(buffer)
-    return secret
+    memory = ffi.buffer(buffer)
+    if into is None:
+        secret = bytes(memory)
+        wipe(buffer)
+        return secret
+    # the wipe is in a `finally` because `into_buffer` can refuse, and
+    # this is the one call here with a failure path: without it a
+    # rejected buffer returns through the entry point leaving a live
+    # private key in cffi memory that is freed without being
+    # overwritten, in the one facility whose whole claim is about where
+    # copies of secrets live. Nothing is lost by wiping on the way out:
+    # the value never reached the caller, and the operation they retry
+    # recomputes it
+    try:
+        view = into_buffer(into, len(memory))
+        view[:] = memory
+    finally:
+        wipe(buffer)
+    return None
 
 
 def keypair(prvkey: BytesLike | int) -> CData:

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -18,18 +18,47 @@ serialize one of their own.
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, keys, lib
+from typing import overload
+
+from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
 from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx, guarded
 
 
+@overload
 def nonce_rfc6979(
     msg_bytes: BytesLike,
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
     attempt: int = 0,
-) -> bytes:
+) -> bytes: ...
+@overload
+def nonce_rfc6979(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    attempt: int = 0,
+    *,
+    into: MutableBytesLike,
+) -> None: ...
+@overload
+def nonce_rfc6979(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    attempt: int = 0,
+    *,
+    into: MutableBytesLike | None,
+) -> bytes | None: ...
+def nonce_rfc6979(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    attempt: int = 0,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Return the RFC6979 nonce `sign` derives for a message and a key.
 
     libsecp256k1 exports its nonce function as a callable pointer, and
@@ -64,12 +93,17 @@ def nonce_rfc6979(
             drives that counter itself; 0 is what it takes first and what
             every signature this package makes has used.
 
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
+
     Returns:
-        The 32-byte nonce.
+        The 32-byte nonce -- or None where `into` was given and holds it.
 
     Raises:
-        TypeError: if the attempt is not an int, or an argument is not
-            bytes.
+        TypeError: if the attempt is not an int, if an argument is not
+            bytes, or if `into` is not a writable bytearray or
+            memoryview of octets.
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, if the private key is not 32 bytes
             or does not fit in them, or if the attempt is out of range.
@@ -99,7 +133,7 @@ def nonce_rfc6979(
         nonce, msg_bytes, prvkey_bytes, ffi.NULL, ndata, attempt
     ):
         raise RuntimeError("RFC6979 nonce derivation failed")
-    return take(nonce)
+    return take(nonce, into=into)
 
 
 def _sign_(

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -7,13 +7,27 @@
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, keys, lib
+from typing import overload
+
+from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
 from ._scalar import scalar
 from ._secret import take
 from .context import ctx, guarded
 
 
-def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
+@overload
+def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes: ...
+@overload
+def _shared_secret_(
+    pubkey: CData, prvkey: BytesLike | int, *, into: MutableBytesLike
+) -> None: ...
+@overload
+def _shared_secret_(
+    pubkey: CData, prvkey: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def _shared_secret_(
+    pubkey: CData, prvkey: BytesLike | int, *, into: MutableBytesLike | None = None
+) -> bytes | None:
     """Compute the ECDH shared secret from an already-parsed public key.
 
     The private half of `shared_secret`, for a caller who already holds
@@ -27,12 +41,18 @@ def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
             `keys.parse` returns.
         prvkey: this party's private key, 32 bytes or an int below
             2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
         The 32-byte shared secret, the SHA256 of the compressed shared
-        point as `shared_secret` documents it.
+        point as `shared_secret` documents it -- or None where `into`
+        was given and holds it.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if the private key is not 32 bytes, does not fit in
             them, is not a valid scalar, or if the object is not a public
             key libsecp256k1 will read; see `context.guarded`, without
@@ -50,10 +70,25 @@ def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes:
         )
     if not computed:
         raise ValueError("invalid private key")
-    return take(output)
+    return take(output, into=into)
 
 
-def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
+@overload
+def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes: ...
+@overload
+def shared_secret(
+    pubkey_bytes: BytesLike, prvkey: BytesLike | int, *, into: MutableBytesLike
+) -> None: ...
+@overload
+def shared_secret(
+    pubkey_bytes: BytesLike, prvkey: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def shared_secret(
+    pubkey_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Compute the ECDH shared secret.
 
     The result is the SHA256 of the compressed shared point, i.e. the
@@ -74,13 +109,19 @@ def shared_secret(pubkey_bytes: BytesLike, prvkey: BytesLike | int) -> bytes:
         pubkey_bytes: the other party's public key, 33 or 65 bytes.
         prvkey: this party's private key, 32 bytes or an int below
             2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32-byte shared secret.
+        The 32-byte shared secret -- or None where `into` was given and
+        holds it.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if the public key is not a valid point, if the
             private key is not 32 bytes or does not fit in them, or if
             it is not a valid scalar.
     """
-    return _shared_secret_(keys.parse(pubkey_bytes), prvkey)
+    return _shared_secret_(keys.parse(pubkey_bytes), prvkey, into=into)

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -10,7 +10,9 @@ https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, lib
+from typing import overload
+
+from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._scalar import entropy, in_range, octets, scalar
 from ._secret import take
 from .context import ctx, guarded
@@ -156,9 +158,36 @@ def decode(ell_bytes: BytesLike, compressed: bool = True) -> bytes:
     return serialize(_decode_(ell_bytes), compressed)
 
 
+@overload
 def xdh(
     ell_a_bytes: BytesLike, ell_b_bytes: BytesLike, prvkey: BytesLike | int, party: int
-) -> bytes:
+) -> bytes: ...
+@overload
+def xdh(
+    ell_a_bytes: BytesLike,
+    ell_b_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    party: int,
+    *,
+    into: MutableBytesLike,
+) -> None: ...
+@overload
+def xdh(
+    ell_a_bytes: BytesLike,
+    ell_b_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    party: int,
+    *,
+    into: MutableBytesLike | None,
+) -> bytes | None: ...
+def xdh(
+    ell_a_bytes: BytesLike,
+    ell_b_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    party: int,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Compute the x-only ECDH shared secret of two ElligatorSwift keys.
 
     The private key must be the one of the given party: 0 for party A,
@@ -171,14 +200,19 @@ def xdh(
         prvkey: the private key of the party below, 32 bytes or an int
             below 2**256.
         party: 0 if the private key is A's, 1 if it is B's.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32-byte shared secret, which both parties compute alike. The
-        two encodings enter the hash in the order they are given here,
-        so BIP324's initiator goes first.
+        The 32-byte shared secret, which both parties compute alike --
+        or None where `into` was given and holds it. The two encodings
+        enter the hash in the order they are given here, so BIP324's
+        initiator goes first.
 
     Raises:
-        TypeError: if the party is not an int.
+        TypeError: if the party is not an int, or if `into` is not a
+            writable bytearray or memoryview of octets.
         ValueError: if either encoding is not 64 bytes, if party is not
             0 or 1, or if the private key is not 32 bytes, does not fit
             in them, or is not a valid scalar.
@@ -202,4 +236,4 @@ def xdh(
         ffi.NULL,
     ):
         raise ValueError("invalid private key")
-    return take(output)
+    return take(output, into=into)

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -16,8 +16,9 @@ Public keys are returned in compressed form, unless otherwise required.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import overload
 
-from . import BytesLike, CData, ffi, lib
+from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._cdata import array
 from ._scalar import octets, scalar
 from ._secret import take
@@ -79,26 +80,57 @@ def pubkey_verify(pubkey_bytes: BytesLike) -> bool:
     return _parsed(pubkey_bytes, "public key") is not None
 
 
-def prvkey_negate(prvkey: BytesLike | int) -> bytes:
+@overload
+def prvkey_negate(prvkey: BytesLike | int) -> bytes: ...
+@overload
+def prvkey_negate(prvkey: BytesLike | int, *, into: MutableBytesLike) -> None: ...
+@overload
+def prvkey_negate(
+    prvkey: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def prvkey_negate(
+    prvkey: BytesLike | int, *, into: MutableBytesLike | None = None
+) -> bytes | None:
     """Negate a private key.
 
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32 bytes of n - k, the key of the negated public key.
+        The 32 bytes of n - k, the key of the negated public key -- or
+        None where `into` was given and holds them.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if it is not 32 bytes, does not fit in them, or is
-            not in [1, n-1].
+            not in [1, n-1]; or if `into` is not 32 bytes.
     """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     if not lib.secp256k1_ec_seckey_negate(ctx, prvkey_buffer):
         raise ValueError("invalid private key: not in [1, n-1]")
-    return take(prvkey_buffer)
+    return take(prvkey_buffer, into=into)
 
 
-def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
+@overload
+def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes: ...
+@overload
+def prvkey_tweak_add(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike
+) -> None: ...
+@overload
+def prvkey_tweak_add(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def prvkey_tweak_add(
+    prvkey: BytesLike | int,
+    tweak: BytesLike | int,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Add a tweak to a private key.
 
     This is the private-key side of BIP32 derivation, and of any other
@@ -108,42 +140,71 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
         tweak: the tweak, 32 bytes or an int below 2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32 bytes of (k + t) mod n.
+        The 32 bytes of (k + t) mod n -- or None where `into` was given
+        and holds them.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if either value is not 32 bytes or does not fit in
-            them, if the private key is not in [1, n-1], or if the sum
-            is zero, which is the one tweak with no valid result.
+            them, if the private key is not in [1, n-1], if the sum
+            is zero, which is the one tweak with no valid result, or if
+            `into` is not 32 bytes.
     """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_add(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")
-    return take(prvkey_buffer)
+    return take(prvkey_buffer, into=into)
 
 
-def prvkey_tweak_mul(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
+@overload
+def prvkey_tweak_mul(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes: ...
+@overload
+def prvkey_tweak_mul(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike
+) -> None: ...
+@overload
+def prvkey_tweak_mul(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def prvkey_tweak_mul(
+    prvkey: BytesLike | int,
+    tweak: BytesLike | int,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Multiply a private key by a tweak.
 
     Args:
         prvkey: the private key, 32 bytes or an int below 2**256.
         tweak: the tweak, 32 bytes or an int below 2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32 bytes of (k * t) mod n.
+        The 32 bytes of (k * t) mod n -- or None where `into` was given
+        and holds them.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if either value is not 32 bytes or does not fit in
-            them, if the private key is not in [1, n-1], or if the tweak
-            is zero or at or above the group order.
+            them, if the private key is not in [1, n-1], if the tweak
+            is zero or at or above the group order, or if `into` is not
+            32 bytes.
     """
     prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_mul(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")
-    return take(prvkey_buffer)
+    return take(prvkey_buffer, into=into)
 
 
 def _pubkey_from_prvkey_(prvkey: BytesLike | int) -> CData:

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -12,8 +12,9 @@ https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 from __future__ import annotations
 
 from types import TracebackType
+from typing import overload
 
-from . import BytesLike, CData, ffi, keys, lib, xonly
+from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib, xonly
 from ._scalar import entropy, octets, optional_entropy, scalar
 from ._secret import keypair, take, wipe
 from .context import ctx, guarded
@@ -27,11 +28,35 @@ EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"
 _NONCE_ALGO = b"BIP0340/nonce"
 
 
+@overload
 def nonce_bip340(
     msg_bytes: BytesLike,
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
-) -> bytes:
+) -> bytes: ...
+@overload
+def nonce_bip340(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    into: MutableBytesLike,
+) -> None: ...
+@overload
+def nonce_bip340(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    into: MutableBytesLike | None,
+) -> bytes | None: ...
+def nonce_bip340(
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Return the BIP340 nonce `sign` derives for a message and a key.
 
     libsecp256k1 exports its nonce function as a callable pointer, and
@@ -65,11 +90,16 @@ def nonce_bip340(
             being what it substitutes. `sign` given None generates 32
             fresh octets instead of passing none, so what reproduces a
             signature's nonce is the aux that signature was made with.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32-byte nonce.
+        The 32-byte nonce -- or None where `into` was given and holds it.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if aux_rand32 is given and is not 32 bytes, or if the
             private key is not 32 bytes, does not fit in them, or is not
             in [1, n-1].
@@ -102,7 +132,7 @@ def nonce_bip340(
         aux,
     ):
         raise RuntimeError("BIP340 nonce derivation failed")
-    return take(nonce)
+    return take(nonce, into=into)
 
 
 def sign(

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -30,7 +30,9 @@ square root at 2.326.
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, keys, lib
+from typing import overload
+
+from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
 from ._scalar import in_range, octets, scalar
 from ._secret import keypair, take, wipe
 from .context import ctx, guarded
@@ -333,7 +335,22 @@ def tweak_add_check(
     )
 
 
-def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
+@overload
+def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes: ...
+@overload
+def prvkey_tweak_add(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike
+) -> None: ...
+@overload
+def prvkey_tweak_add(
+    prvkey: BytesLike | int, tweak: BytesLike | int, *, into: MutableBytesLike | None
+) -> bytes | None: ...
+def prvkey_tweak_add(
+    prvkey: BytesLike | int,
+    tweak: BytesLike | int,
+    *,
+    into: MutableBytesLike | None = None,
+) -> bytes | None:
     """Add a tweak to the private key of an x-only public key.
 
     The private key is first negated, if needed, to be the one of the
@@ -345,14 +362,21 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
         prvkey: the internal private key, 32 bytes or an int below
             2**256.
         tweak: the tweak, 32 bytes or an int below 2**256.
+        into: a writable 32-byte buffer to receive the result, instead
+            of the `bytes` this otherwise returns. See `_secret.take`
+            and SECURITY.md for what that does and does not buy.
 
     Returns:
-        The 32-byte tweaked private key.
+        The 32-byte tweaked private key -- or None where `into` was
+        given and holds it.
 
     Raises:
+        TypeError: if `into` is not a writable bytearray or memoryview
+            of octets.
         ValueError: if either value is not 32 bytes or does not fit in
-            them, if the private key is not in [1, n-1], or if the tweak
-            or the resulting key is invalid.
+            them, if the private key is not in [1, n-1], if the tweak
+            or the resulting key is invalid, or if `into` is not 32
+            bytes.
         RuntimeError: if libsecp256k1 fails to extract the key, which no
             valid input can make it do.
     """
@@ -365,7 +389,7 @@ def prvkey_tweak_add(prvkey: BytesLike | int, tweak: BytesLike | int) -> bytes:
 
         if not lib.secp256k1_keypair_sec(ctx, prvkey_buffer, keypair_obj):
             raise RuntimeError("private key extraction failed")
-        return take(prvkey_buffer)
+        return take(prvkey_buffer, into=into)
     finally:
         # a keypair carries the private key -- the tweaked one here,
         # which is the one that signs -- so it is overwritten on the way

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -248,7 +248,7 @@ def test_type_checks_refuse_what_merely_has_a_length() -> None:
     ):
         keys.pubkey_from_prvkey(1.0, compressed=False)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="tweak must be bytes or an int, not str"):
-        keys.prvkey_tweak_add(prvkey, "x" * 32)  # type: ignore[arg-type]
+        keys.prvkey_tweak_add(prvkey, "x" * 32)  # type: ignore[call-overload]
 
     # a sequence of public keys handed one public key: bytes is itself a
     # sequence, so what reaches parse is an int, and saying so is the
@@ -311,7 +311,7 @@ def test_a_flag_that_is_not_an_int_is_refused_by_name() -> None:
     with pytest.raises(TypeError, match="parity must be an int, not float"):
         xonly.tweak_add_check(tweaked, float(tweaked_parity), xonly_bytes, 11)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="party must be an int, not float"):
-        ellswift.xdh(ell, ell, 7, 0.0)  # type: ignore[arg-type]
+        ellswift.xdh(ell, ell, 7, 0.0)  # type: ignore[call-overload]
     with pytest.raises(TypeError, match="label m must be an int, not float"):
         silentpayments.label(7, 0.0)  # type: ignore[arg-type]
 

--- a/tests/test_nonces.py
+++ b/tests/test_nonces.py
@@ -98,7 +98,7 @@ def test_rfc6979_attempt_is_the_counter_the_derivation_retries_on() -> None:
     with pytest.raises(ValueError, match=r"attempt must be in \[0, 4294967295\]"):
         dsa.nonce_rfc6979(msg, EVEN_Y, attempt=2**32)
     with pytest.raises(TypeError, match="attempt must be an int"):
-        dsa.nonce_rfc6979(msg, EVEN_Y, attempt=1.0)  # type: ignore[arg-type]
+        dsa.nonce_rfc6979(msg, EVEN_Y, attempt=1.0)  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize("prvkey", [EVEN_Y, ODD_Y], ids=["even y", "odd y"])
@@ -164,4 +164,4 @@ def test_the_nonce_wrappers_refuse_what_the_signers_refuse() -> None:
     with pytest.raises(ValueError, match="private key"):
         ssa.nonce_bip340(msg, 0)
     with pytest.raises(TypeError, match="message must be bytes"):
-        ssa.nonce_bip340(11, EVEN_Y)  # type: ignore[arg-type]
+        ssa.nonce_bip340(11, EVEN_Y)  # type: ignore[call-overload]

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -14,7 +14,26 @@ given: the `char[32]` a tweaked private key comes back in, and the
 
 from __future__ import annotations
 
-from btclib_secp256k1 import _secret, ffi, lib
+import array
+import importlib
+import inspect
+import mmap
+import pkgutil
+
+import pytest
+
+import btclib_secp256k1
+from btclib_secp256k1 import (
+    _secret,
+    dsa,
+    ecdh,
+    ellswift,
+    ffi,
+    keys,
+    lib,
+    ssa,
+    xonly,
+)
 from btclib_secp256k1.context import ctx
 
 SECRET = b"\x07" * 32
@@ -48,3 +67,196 @@ def test_wipe_asks_the_buffer_for_its_own_size() -> None:
 
     _secret.wipe(keypair)
     assert bytes(memory) == bytes(len(memory))
+
+
+def test_take_writes_into_the_caller_s_buffer_and_returns_nothing() -> None:
+    """With `into` the secret lands where the caller can overwrite it.
+
+    Which is the whole of what the argument is for: a `bytes` holds the
+    same secret and cannot be zeroed, so the copy this package has to
+    make is made somewhere the caller owns.
+    """
+    buffer = ffi.new("char[32]", SECRET)
+    into = bytearray(32)
+
+    assert _secret.take(buffer, into=into) is None
+    assert bytes(into) == SECRET
+    # this package's own buffer is wiped either way
+    assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+    # and the caller can do what a bytes would not have let them
+    into[:] = bytes(32)
+    assert bytes(into) == bytes(32)
+
+
+def test_take_into_a_writable_memoryview() -> None:
+    """A memoryview of a bytearray is the other spelling, and writes through."""
+    buffer = ffi.new("char[32]", SECRET)
+    owner = bytearray(32)
+
+    assert _secret.take(buffer, into=memoryview(owner)) is None
+    assert bytes(owner) == SECRET
+
+
+def test_take_refuses_a_buffer_of_the_wrong_length() -> None:
+    """And wipes its own buffer anyway, the refusal being no reason not to.
+
+    A longer buffer is the one worth refusing rather than filling: the
+    secret would sit in its first octets with whatever was already there
+    behind it, which reads as a secret that is not this one.
+
+    What the second assertion holds is the finding this test was written
+    the wrong way round for: the value never reached the caller, so
+    keeping it costs them nothing and leaves a live private key in cffi
+    memory that is freed without being overwritten.
+    """
+    for wrong in (bytearray(31), bytearray(33)):
+        buffer = ffi.new("char[32]", SECRET)
+        with pytest.raises(ValueError, match="must be 32 bytes"):
+            _secret.take(buffer, into=wrong)
+        assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+        assert bytes(wrong) == bytes(len(wrong))
+
+
+def test_take_refuses_a_buffer_it_cannot_write() -> None:
+    """A read-only view would defeat the facility silently, so it is refused.
+
+    `bytes` is the same mistake spelled shorter, and reaches the same
+    refusal through `readonly` rather than through a type check. An
+    `int` is not a buffer at all, and `memoryview` is what says so.
+    """
+    wrong: list[tuple[object, str]] = [
+        (memoryview(bytes(32)), "must be writable"),
+        (b"\x00" * 32, "must be writable"),
+        (7, "must be a writable buffer, not int"),
+    ]
+    for value, message in wrong:
+        buffer = ffi.new("char[32]", SECRET)
+        with pytest.raises(TypeError, match=message):
+            _secret.take(buffer, into=value)  # type: ignore[call-overload]
+        assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+
+
+def test_take_accepts_any_writable_contiguous_buffer() -> None:
+    """An mmap and an array of octets are destinations too, and are taken.
+
+    The refusals are about what a buffer *is*, not about which class
+    produced it: an `mlock`ed `mmap` is a plausible place for the caller
+    this argument exists for to want a secret. `MutableBytesLike` names
+    the two a typed caller passes bare, `collections.abc.Buffer` being
+    3.12 where the floor here is 3.10; anything else is wrapped in a
+    `memoryview`, which costs nothing and is what these two do.
+    """
+    with mmap.mmap(-1, 32) as anonymous:
+        buffer = ffi.new("char[32]", SECRET)
+        assert _secret.take(buffer, into=memoryview(anonymous)) is None
+        assert anonymous[:] == SECRET
+
+    octets = array.array("B", bytes(32))
+    buffer = ffi.new("char[32]", SECRET)
+    assert _secret.take(buffer, into=memoryview(octets)) is None
+    assert octets.tobytes() == SECRET
+
+
+def test_take_refuses_a_buffer_that_is_not_contiguous_octets() -> None:
+    """Two shapes that pass every other check, one of which used to crash.
+
+    A two-dimensional view is writable, octet-wide and 32 octets long,
+    and the copy through it raises `NotImplementedError` -- neither of
+    the exceptions the caller was told to expect. A strided one works,
+    and is refused all the same: the secret would land scattered through
+    64 octets of an owner whose other 32 nothing says are involved.
+    """
+    for wrong in (
+        memoryview(bytearray(32)).cast("B", (4, 8)),
+        memoryview(bytearray(64))[::2],
+    ):
+        buffer = ffi.new("char[32]", SECRET)
+        with pytest.raises(TypeError, match="must be contiguous octets"):
+            _secret.take(buffer, into=wrong)
+        assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+
+
+def test_take_refuses_a_view_of_wider_items() -> None:
+    """Eight uint32 are 32 octets of nobody's byte order.
+
+    `memoryview.cast("B")` is how a caller says the octets are what they
+    meant, which is the rule `_scalar.octets` states on the way in.
+    """
+    buffer = ffi.new("char[32]", SECRET)
+    wide = memoryview(bytearray(32)).cast("I")
+    with pytest.raises(TypeError, match="not of 4-byte items"):
+        _secret.take(buffer, into=wide)
+    assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+
+
+def test_every_function_that_takes_a_secret_out_offers_into() -> None:
+    """Found by walking the package, so that a ninth producer is caught.
+
+    A hardcoded list of the eight cannot notice a ninth, which is what
+    this test is for; `_secret.take` is the one thing every producer of
+    a secret has in common, so its call sites are the population. One
+    of them is exempt and named, and naming it here is what keeps
+    SECURITY.md's sentence honest.
+
+    What the walk does *not* see is either of two shapes, and writing
+    them down here is what keeps the check from being read as more than
+    it is. A secret that never goes through `take`:
+    `silentpayments._found_output` reads the per-output tweak out of the
+    struct as a `bytes` of its own, so no population defined this way
+    can contain it, and SECURITY.md names it for that reason. And a
+    public entry point that delegates to a private producer rather than
+    calling `take` itself: `ecdh.shared_secret` is that shape, caught
+    here only because `_shared_secret_` is, and a ninth producer written
+    that way would need its public half checked by hand.
+    """
+    # the tweak of a label is one member of a returned tuple, where an
+    # argument could not say which half it names; SECURITY.md says so too
+    exempt = {"_label_"}
+    found: dict[str, set[str]] = {}
+    for info in pkgutil.iter_modules(btclib_secp256k1.__path__):
+        module = importlib.import_module(f"btclib_secp256k1.{info.name}")
+        for name, function in vars(module).items():
+            if (
+                not inspect.isfunction(function)
+                or function.__module__ != module.__name__
+            ):
+                continue
+            try:
+                source = inspect.getsource(function)
+            except OSError:  # pragma: no cover - source ships with the wheel
+                continue
+            if "take(" in source and "def take(" not in source:
+                found.setdefault(info.name, set()).add(name)
+
+    callers = {name for names in found.values() for name in names}
+    assert callers, "no call site of _secret.take was found: the walk is broken"
+    for module_name, names in sorted(found.items()):
+        for name in sorted(names - exempt):
+            signature = inspect.signature(
+                getattr(
+                    importlib.import_module(f"btclib_secp256k1.{module_name}"), name
+                )
+            )
+            assert "into" in signature.parameters, f"{module_name}.{name} has no into"
+    assert exempt <= callers, (
+        "an exemption names a function that no longer takes a secret"
+    )
+
+
+def test_the_two_spellings_of_a_producer_agree() -> None:
+    """Each entry point answers through `into` what it answers as bytes."""
+    ell = ellswift.create(2, bytes(32))
+    calls = (
+        (keys.prvkey_negate, (7,)),
+        (keys.prvkey_tweak_add, (7, 3)),
+        (keys.prvkey_tweak_mul, (7, 3)),
+        (xonly.prvkey_tweak_add, (7, 3)),
+        (ecdh.shared_secret, (keys.pubkey_from_prvkey(3), 7)),
+        (ellswift.xdh, (ell, ell, 2, 0)),
+        (dsa.nonce_rfc6979, (bytes(32), 7)),
+        (ssa.nonce_bip340, (bytes(32), 7, bytes(32))),
+    )
+    for call, args in calls:
+        into = bytearray(32)
+        assert call(*args, into=into) is None, call.__name__
+        assert bytes(into) == call(*args), call.__name__


### PR DESCRIPTION
Closes #188.

`_secret.take` reads a secret out of the cffi buffer this package owns,
wipes that buffer, and returns a `bytes`. SECURITY.md calls that last
copy inherent, and it is — as a `bytes`. `into` makes it not be one.

```python
prvkey = bytearray(32)
keys.prvkey_tweak_add(parent, tweak, into=prvkey)
try:
    ...
finally:
    prvkey[:] = bytes(32)     # the caller's wipe, and only theirs
```

Omit `into` and nothing changes. Give it and nothing is returned, so no
`bytes` of the secret is ever made.

## This is not what #87 declined

#87 assessed an opaque secret-key **handle** and declined it, twice
correctly: a handle is a lifetime someone has to own and invalidate —
the shape of requirement that keeps MuSig2 out of this package — and its
entry side still starts from a `bytes` the caller already made. Both
halves stand and neither is reopened here.

What this is instead: one keyword argument, one call, no object, nothing
to invalidate. And it addresses the half #87 named but did not price —
the **exit**, where `take` had nowhere to put the secret except an
immutable object nothing can zero.

## Three things the implementation had to decide

**Keyword-only, and not for style.** Passed positionally to
`dsa.nonce_rfc6979(msg, prvkey, buf)` it lands on `aux_rand32`, which
takes 32 octets and accepts the empty buffer as entropy — a wrong nonce,
silently, from a call that reads right. The suite caught it while this
branch was being written; `*` is what keeps a caller from meeting it.

**The buffer is proved before anything is copied.** Too short raises on
the assignment anyway; too **long** would take the secret in its first
octets and leave whatever was behind it, which reads as a secret with a
tail. A read-only `memoryview` cannot be wiped, so accepting one defeats
the facility silently. On any refusal this package's buffer is left
holding the secret, so its wipe stays the one operation that empties it.
`_secret.into_buffer` is annotated `object`, that being the annotation it
exists to not trust.

**The obligation is stated, not enforced.** A buffer the caller never
overwrites is exactly the copy `into` was reached for to avoid. No
finalizer, for the reason `ssa.Signer` has none: a guarantee nothing
keeps is worse than none. SECURITY.md says so beside the limitation it
narrows, rather than instead of it.

## Scope

Taken: `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
`keys.prvkey_tweak_mul`, `xonly.prvkey_tweak_add`, `ecdh.shared_secret`
and its private half, `ellswift.xdh`, `dsa.nonce_rfc6979`,
`ssa.nonce_bip340`.

**Left out: `silentpayments.label`**, whose secret is one half of a
returned pair — `into` there would name which half in the argument list
and nowhere else. Stated rather than guessed at; say the word and it
goes in.

## The cost, which is in the type system

Two `@overload`s per entry point, so omitting `into` still types as
`bytes` and a downstream `mypy --strict` sees no change. The one visible
consequence: four negative-typing tests moved from
`type: ignore[arg-type]` to `[call-overload]`, which is what an
overloaded call reports. No coverage configuration change was needed —
overload stubs are already not counted.

## Gate

`uvx pre-commit run --all-files` clean, 564 tests, coverage 100.00%.

## Summary by Sourcery

Add an optional keyword-only `into` buffer parameter to secret-producing APIs so callers can receive secrets in mutable memory instead of new bytes objects, and update internals, typing, tests, and documentation accordingly.

New Features:
- Allow `_secret.take` and all public secret-producing functions to write secrets into a caller-provided mutable buffer via a keyword-only `into` parameter that suppresses the bytes return value.

Enhancements:
- Introduce a `MutableBytesLike` type alias and a shared `_secret.into_buffer` helper to validate and normalize caller-provided secret buffers before writing.
- Extend type hints with overloads so existing call sites still type as returning `bytes` when `into` is omitted, while supporting `None` returns when `into` is used.

Documentation:
- Document the new `into` mechanism and its security properties in SECURITY.md and CHANGELOG, clarifying caller responsibilities for wiping buffers.

Tests:
- Add and adjust tests to cover `_secret.take` buffer semantics, the new `into` parameter across all secret-producing functions, and updated typing expectations.