### PR TITLE
State the test a third outpost would have to pass, where the two are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,6 +500,48 @@ release-notes length in the first place, and are still in
   what an overloaded call reports, and is the one way this is visible
   to a caller who was already type-checking
 
+### The test a stateful object has to pass
+
+- **the rule the outpost section applies is now stated there** (#191),
+  rather than only in <https://github.com/btclib-org/btclib-secp256k1/issues/161>
+  where it was reached. That section explained the two objects that
+  exist and separated them correctly — a keypair is arithmetic, a parsed
+  point is a parse — but the reader who needs it is the one proposing a
+  *third*, and what they needed was the test, not the two instances of
+  it. It is written as one sentence: what an object saves is the cost of
+  rebuilding, from octets, whatever it holds
+- **and the saving is that cost by construction, not by measurement,**
+  which is the stronger form of the same claim and the one the section
+  now makes. `ssa.sign` builds the keypair, signs with it and wipes it;
+  `signer.sign` is that middle term with the first already paid, so the
+  difference between them is `secp256k1_keypair_create` on any machine,
+  and the numbers only add that nothing else of consequence sits in it.
+  They are the section's own — 15.82 against the signer's 8.27, of which
+  the keypair is 7.55, and 15.82 − 8.27 is that 7.55 — rather than a set
+  of its own. The chain gets the same treatment: what it saves is the
+  parse it holds, and which parse that is depends on the serialization
+  its caller carries — the pair the section states four paragraphs
+  above, pointed at rather than restated. That is the sharper form of
+  the distinction, because it says why this saving is the one a caller
+  can make cheap and the keypair's is not
+- **and which figures survive a different machine is said**, because a
+  section arguing from microseconds should say which of them it is
+  arguing from: the identity, and it carries because it is structural,
+  not because a ratio travels better than an absolute. The counts are
+  one laptop's
+- **two objections are answered before they are raised.** What recovers
+  a parse is `keys.parse`, not a cheaper serialization: the
+  uncompressed-form argument reaches neither an x-only key, which has no
+  second serialization, nor a walk starting from the 33 octets an xpub
+  carries, where reaching the uncompressed form costs a `reserialize`
+  the chain does not pay — which is the finding of
+  <https://github.com/btclib-org/btclib-secp256k1/pull/185>, now in the
+  same section and pointed at from here. And statelessness is the other
+  side of the ledger, the same argument that keeps MuSig2 out, so the
+  two paragraphs point at each other. Ergonomics is weighed by neither,
+  deliberately: the line a caller does not write belongs in btclib with
+  the lifetimes
+
 ### One statement of each thing
 
 - **the duplications are gone**, each of them two spellings of one

--- a/README.md
+++ b/README.md
@@ -400,6 +400,60 @@ carrying the uncompressed form instead: 0.269 microseconds against
 2.326. So the signer saves what nothing else can, and the chain saves
 what a caller free to choose its serialization could have saved itself.
 
+**The rule that separates them is the test a third outpost would have to
+pass**, and it is worth stating on its own, because the answer to every
+proposal of one — a held public key for verifying, for ECDH, for
+combining — is here rather than in the proposal:
+
+> what an object saves is the cost of *rebuilding, from octets, whatever
+> it holds*. It earns its state when that cost is arithmetic, and does
+> not when it is a parse.
+
+The saving is not merely bounded by that cost; it *is* that cost, and by
+construction rather than by measurement. `ssa.sign` builds the keypair,
+signs with it and wipes it; `signer.sign` is that middle term with the
+first already paid — so the difference between them is
+`secp256k1_keypair_create` on any machine, and what the numbers below
+add is that nothing else of consequence sits in it. They are the ones
+this section already states: 15.82 microseconds against the signer's
+8.27, of which the keypair is 7.55, and 15.82 − 8.27 is that 7.55.
+
+The chain reads the same way and answers differently, which is the
+distinction of the paragraph above arrived at from the other end. What
+it saves is the parse it holds, so *which* parse decides the figure —
+and that is the pair the paragraph above states, the caller's to choose
+by the serialization they carry. A keypair offers its caller no such
+choice.
+
+Two things the rule needs said, or it reads as narrower than it is. The
+first is what recovers a parse, and it is **`keys.parse` itself, not a
+cheaper serialization**. The argument through the uncompressed form does
+not reach an x-only key, which is a field square root to rebuild and has
+no second serialization to escape to — and it does not always reach a
+full one either, which is what the walk below measures: from the 33
+octets an xpub carries, reaching the uncompressed form costs a
+`reserialize` that the chain does not pay. A caller who wants the parse
+held holds it — `keys.parse` hands back the object and the private
+halves take it, which is what "the private halves above hand one object
+from a call to the next" already promised. What a class would add there
+is a name, not a saving. The second is the other side of the ledger:
+this package is [stateless by construction](#design), which is also why
+MuSig2 is not
+wrapped, so an object is an exception to that, with an owner and an
+invalidation and a threading story, and the rule is what the exception
+has to be paid for with. What it does not weigh is ergonomics — the line
+a caller does not have to write is real, and belongs in btclib along
+with the lifetimes.
+
+So the numbers **confirm** the rule rather than establish it, and it is
+worth being clear which of them would survive a different machine. Not
+the microsecond counts, which are one laptop's; the identity is what
+carries, and it carries because it is structural rather than because a
+ratio travels better than an absolute. A rule resting instead on which
+of two measurements is larger would invert on the first machine that
+measured them differently — and one such pair is a rounding error apart,
+which the walk below is about.
+
 `ssa.Signer` holds the keypair:
 
 ```python


### PR DESCRIPTION
Closes #191. Documentation only; the API is untouched.

"Two outposts past the boundary" explains the two objects that exist and
separates them by the right thing. The reader who needs that distinction
is the one proposing a **third** — a held public key for `verify`, for
`ecdh`, for `combine` — and what they need is the *test*, not the two
instances of it. The test lived in #161.

## What is added

The rule, as one sentence:

> what an object saves is the cost of **rebuilding, from octets,
> whatever it holds**. It earns its state when that cost is arithmetic,
> and does not when it is a parse.

And the reason it can be checked rather than argued: the saving is not
merely bounded by that cost, it **is** that cost.

| Apple M5, macOS 26.6, arm64, CPython 3.14.6, min of 11 rounds | µs |
| --- | --- |
| `ssa.sign(msg, prvkey)` | 16.67 |
| `ssa.Signer(prvkey).sign(msg)` | 9.01 |
| the difference | **7.66** |
| `secp256k1_keypair_create` alone | **7.65** |

The same subtraction on a parsed point gives 0.27. The section already
carried every number it needed except that keypair rebuild, which is
what turns the distinction into an identity.

## Two objections answered before they are raised

**What recovers a parse is `keys.parse`, not a cheaper serialization.**
The section argues through the uncompressed form, 0.269 against 2.326 —
an argument that does not reach an x-only key, 2.42 microseconds to
rebuild with no second serialization to escape to. Unsaid, that number
reads as a counterexample. The rule holds on the other leg: the public
parse/serialize bridge is the escape, and needs no class beside it.

**Statelessness is the other side of the ledger**, and it is the same
argument that keeps MuSig2 out. The two paragraphs now point at each
other; before, only the MuSig2 one existed.

Also said, because the difference matters: the numbers **confirm** the
rule, they do not establish it. A rule resting on which of two
measurements is larger inverts on the first machine that measures them
differently — and one of the pair #161 weighed was 55.14 against 54.75.

## Overlap with #185

#185 is open on this same section and refines the chain's case from the
other direction. The hunks do not touch: this inserts at the rule
paragraph, #185 after the chain example. Whichever lands second may want
one cross-reference — #185's finding, that the chain is *ahead* when the
walk starts from the 33 octets an xpub carries, is a sharper instance of
"what recovers a parse is not always cheap" than the x-only case used
here, and the two paragraphs would read well together.

## Gate

`uvx pre-commit run --all-files` clean, 558 tests pass (README doctests
included).

## Summary by Sourcery

Document the rule that determines when a stateful object is justified and integrate its explanation and supporting benchmarks into the README and changelog.

Documentation:
- Clarify the distinction between stateful keypair holders and parsed points by stating a general rule and test for proposed third stateful outposts in the README, supported by performance measurements and examples.

Chores:
- Record the new rule and its rationale in the changelog, including how it applies to stateful objects, parses, stateless design, and the role of benchmarks in confirming rather than establishing the rule.