### PR TITLE
Stop every commit from rewriting the secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,15 +133,6 @@
     }
   ],
   "results": {
-    "CHANGELOG.md": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "CHANGELOG.md",
-        "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
-        "is_verified": false,
-        "line_number": 2303
-      }
-    ],
     "btclib_secp256k1/hashes.py": [
       {
         "type": "Hex High Entropy String",
@@ -456,5 +447,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T12:41:46Z"
+  "generated_at": "2026-08-16T12:45:53Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -855,6 +855,27 @@ release-notes length in the first place, and are still in
   v0.8.0.2 all published clean and none produced a GitHub release,
   recreated by hand from each run's own `sdist` and `attestation`
   artifacts every time
+- **A change to prose no longer rewrites `.secrets.baseline`** (#198). The
+  baseline recorded one finding in `CHANGELOG.md`, and this file grows
+  above it: of the forty commits before this one, forty rewrote the
+  baseline and thirty-three moved nothing in it but that finding's
+  `line_number`. What the rewrite costs is not the command that makes it
+  — it is that every open pull request then conflicts there with every
+  other and with `main`, whatever either of them touches, which is what
+  happened to #183 and #185 within the hour they were both open. The
+  finding is a false positive this file's own entry above records: the
+  `-DSECP256K1_BUILD_BENCHMARK=OFF` it names is quoted there as
+  `cffi_build.py` writes it, and a string in straight quotes is what the
+  base64 detector reads. A
+  `pragma: allowlist secret` beside it takes it out of the baseline
+  without taking the quotes out of the sentence, they being why the
+  detector fires and so what the sentence is about. Measured against the
+  alternatives: dropping the quotes also clears it and says less; the
+  pragma on the previous line does *not* clear it, `is_line_allowlisted`
+  reading `context.previous_line` notwithstanding; and excluding the file
+  from the hook would take the keyword and provider-token detectors off
+  it too. The baseline is now written when a file that has a finding
+  changes, which was 7 of those 40 rather than all of them
 
 ## v0.8.0.2
 
@@ -2300,10 +2321,11 @@ branch has to edit.
   the baseline `--baseline` points at. The newly recorded findings were
   reviewed one by one: hex constants written inline in
   `tests/test_vectors.py` and `tests/test_properties.py`, and
-  `"-DSECP256K1_BUILD_BENCHMARK=OFF"` in `scripts/cffi_build.py`, which
-  the base64 detector reads as a secret. Verified by planting a
-  64-character hex constant in a test module and an AWS access key in a
-  vector file, and watching each hook name its own.
+  `"-DSECP256K1_BUILD_BENCHMARK=OFF"` <!-- pragma: allowlist secret -->
+  in `scripts/cffi_build.py`, which the base64 detector reads as a
+  secret. Verified by planting a 64-character hex constant in a test
+  module and an AWS access key in a vector file, and watching each hook
+  name its own.
 - **The copyright-notice hook reads files at all.** Without
   `--enforce-all` the tool intersects the filenames pre-commit hands it
   with `git diff --staged --name-only --diff-filter=A`: newly *added*


### PR DESCRIPTION
Of the forty commits before this one, forty rewrote `.secrets.baseline`
and thirty-three moved nothing in it but one `line_number`: the finding
recorded against `CHANGELOG.md`, which every change pushes further down
the file by appending above it. Re-measured after
https://github.com/btclib-org/btclib-secp256k1/pull/183 and
https://github.com/btclib-org/btclib-secp256k1/pull/185 landed, and the
pair is the same.

The rewrite itself is one command. What it costs is that two open pull
requests then conflict there with each other and with `main` whatever
else they touch — those two did, within the hour they were both open,
with `CHANGELOG.md` itself auto-merging cleanly, and 183 lost its whole
matrix to it.

The finding is a false positive that this very file's entry recorded:
the build flag it quotes is a string in straight quotes, which is what
the base64 detector reads. A `pragma: allowlist secret` beside it takes
the finding out of the baseline without taking the quotes out of the
sentence — they are why the detector fires, so they are what the
sentence is about. The paragraph is reflowed so the flag and the pragma
share a line of 71 columns, and an HTML comment renders as nothing.

Three alternatives, measured with `detect-secrets 1.5.0` against a copy
rather than argued: dropping the straight quotes also clears it and says
less; the pragma on the *previous* line does **not** clear it, whatever
`is_line_allowlisted` reading `context.previous_line` suggests; and
excluding the file from the hook would take the keyword and
provider-token detectors off it too.

What is left is a baseline written when a file that has a finding
changes, which was seven of those forty rather than all of them.

The suite, the coverage gate at 100%, every hook and `sphinx -W` pass
locally, re-run after the rebase.

Closes #198

## Summary by Sourcery

Reduce unnecessary updates to the secrets baseline when changelog prose changes, avoiding frequent merge conflicts across pull requests.

Bug Fixes:
- Treat the benchmark build-flag string in cffi_build.py as an allowlisted value to prevent a false-positive secret from forcing baseline rewrites.

Enhancements:
- Adjust secrets baseline behavior so it is rewritten only when files with actual findings change instead of on every commit touching the changelog.

Documentation:
- Document the new secrets-baseline behavior and the rationale for the allowlist pragma in the changelog.