### PR TITLE
Name the second force-push, the one a contributor will actually see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -783,6 +783,18 @@ release-notes length in the first place, and are still in
   paid on #930: branch deleted first, pull request Closed with its commit
   on `main` all the same. Two counts were stale besides, both saying four
   required checks where the rule has named three since `codeql` left it
+- **and CONTRIBUTING.md was the file that pass did not reach** (#200). It
+  said "the one force-push that stays right", and there are two: the
+  rebase a contributor makes when their base has moved, and the squash
+  the maintainer pushes to their branch at the end — which is the one
+  they will actually see, arriving on work they thought was finished. It
+  is now named there as the second, and the paragraph on the maintainer's
+  path carries the step it was missing: the squash reaches the branch
+  before it reaches `main`, which is what leaves the pull request naming
+  the commit that lands, so GitHub marks it Merged and the `Closes #N` in
+  the description fires. A contributor reading only this file would have
+  expected the other outcome, and the two pull requests that landed the
+  rule went the way it now describes
 
 - **The sentinel table names `windows` too** (#184). `windows.yml` became
   a workflow of its own two changes after `macos.yml` did, and the table

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -569,10 +569,14 @@ commits the review is attached to: the reviewer loses the diff they read,
 "changes since your last review" has nothing to compare against, and every
 one of those matrix jobs starts again from a commit nobody has seen. Add
 the fix on top, with a message saying what it fixes, and reply to the
-comment with the sha. The one force-push that stays right is the one
-carrying no new work — a `git rebase origin/main` on a branch whose base
-has moved — and it wants the gates re-run after it, not only before, and a
-note in the pull request saying the head moved.
+comment with the sha. Two force-pushes carry no new work, and stay right
+for that reason. One is yours: a `git rebase origin/main` on a branch
+whose base has moved, which wants the gates re-run after it, not only
+before, and a note in the pull request saying the head moved. The other
+is the maintainer's and comes at the end, your branch's own commits
+collapsed into the one about to land — the paragraph after next is where
+that is, and it is worth expecting rather than reading as a rewrite of
+the review.
 
 Nothing is lost in `main`'s history by working that way, because a pull
 request lands as one commit: a branch of several is squashed into one
@@ -585,16 +589,23 @@ branch rule, and one change is one commit there.
 **How that commit reaches `main` is a push rather than a button**, which
 is the maintainer's own path and needs the `main-self-merge` bypass no
 contributor has: REPOSITORY.md describes it, squashing the branch locally
-where it carries more than one commit and fast-forwarding it. Two things
-about it are worth knowing from here. The commit that lands is signed by
-the maintainer rather than by GitHub's web-flow key; and where your
-branch is already a single commit and needs no rebase to land, its sha
-does not change, so `main` receives the very commit the gates ran on and
-a branch stacked on it keeps applying. A rebase moves the sha like any
-other force-push, which is why the gates are asked for after one and not
-only before. Neither changes the shape of a correction: whether a branch
-is squashed or fast-forwarded is decided when it lands, and by then the
-review has its record either way.
+where it carries more than one commit, pushing that squash to the branch,
+and fast-forwarding the branch from there. Three things about it are
+worth knowing from here. The commit that lands is signed by the
+maintainer rather than by GitHub's web-flow key. Where your branch is
+already a single commit and needs no rebase to land, its sha does not
+change, so `main` receives the very commit the gates ran on and a branch
+stacked on it keeps applying — a rebase moves the sha like any other
+force-push, which is why the gates are asked for after one and not only
+before. And the squash reaches your branch before it reaches `main`,
+which is the second of those two force-pushes: that order is what leaves
+the pull request naming the commit that lands, so GitHub marks it
+**Merged** on its own and the `Closes #N` in the description closes the
+issue. Landed from a worktree instead, the pull request would name an
+object `main` never received, and would be closed by hand with the change
+in it all the same. None of the three changes the shape of a correction:
+whether a branch is squashed or fast-forwarded is decided when it lands,
+and by then the review has its record either way.
 
 Squash is the only merge *button* this repository enables, so there is no
 other to read; REPOSITORY.md has that setting, what the other two would


### PR DESCRIPTION
`CONTRIBUTING.md` was the file the pass behind
https://github.com/btclib-org/btclib-secp256k1/pull/183 did not reach, and
two sentences in it were left half-true.

**"The one force-push that stays right"** is two. The contributor's rebase is
the one the sentence had; the maintainer's landing squash carries no new work
either, and it is the one a contributor actually sees, arriving on a branch
they thought was finished. It is now named there as the second, where it is
something to expect rather than to read as a rewrite of the review.

**The maintainer's path was missing a step**: the squash reaches the branch
before it reaches `main`. That order is what leaves the pull request naming
the commit that lands, so GitHub marks it **Merged** on its own and the
`Closes #N` in the description fires; landed from a worktree instead, a pull
request names an object `main` never received and has to be closed by hand.
`REPOSITORY.md`, `RELEASING.md` and `CLAUDE.md` have carried that since
7944dce — this file is the one a contributor reads, and it would have led
them to expect the other outcome.

The evidence is the two pull requests that landed the rule:
https://github.com/btclib-org/btclib-secp256k1/pull/183 (three commits) and
https://github.com/btclib-org/btclib-secp256k1/pull/185 (one), both **Merged**
with `mergeCommit` equal to `headRefOid`.

Prose only. The suite, the coverage gate at 100%, every hook and `sphinx -W`
pass locally — and `.secrets.baseline` did not move with fourteen new lines of
`CHANGELOG.md`, which is
https://github.com/btclib-org/btclib-secp256k1/issues/198 working as intended.

Closes #200

## Summary by Sourcery

Clarify contributor and maintainer force-push workflows in CONTRIBUTING and record the correction in the changelog.

Documentation:
- Update CONTRIBUTING.md to describe both non-work-changing force-pushes (rebasing onto main and maintainer squash) and the exact landing sequence.
- Document in CHANGELOG.md that CONTRIBUTING.md was corrected to reflect the established merge workflow and automatic issue-closing behavior.