### PR TITLE
Stop paying for a guard, and say what a refused object now answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,52 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### The frames between an entry point and libsecp256k1
+
+- **Five entry points are spelled out rather than composed of their
+  halves**: `keys.parse` and `xonly.parse`, which delegated to their
+  `_parsed`, `keys.pubkey_tweak_add`, which was three calls, and
+  `dsa.verify` and `ssa.verify`, which parsed through one call and
+  verified through another. What a python frame is worth was measured by
+  alternating the two spellings in one process, 7 rounds each and the
+  minimum kept for each -- an Apple M5, macOS 26.6, arm64, CPython
+  3.13.14: `keys.parse` of 65 bytes 0.010 of 0.205 and of 33 bytes 0.013
+  of 2.324, `xonly.parse` of 65 bytes 0.012 of 0.485, `ssa.verify` 0.009
+  of 14.275, `dsa.verify` 0.035 of 11.813, `keys.pubkey_tweak_add` 0.037
+  of 3.403. Small everywhere, and largest where the call is shortest.
+- **`dsa.sign` is composed still, and that is a measured result rather
+  than an omission.** Three spellings were tried -- `_sign_` inlined, the
+  DER serialization inlined, and both -- and all three land within 0.03
+  microseconds of the composed one and on the wrong side of it. A
+  signature is 11.9 microseconds of libsecp256k1; two python frames do
+  not show against it, and a body written twice for nothing is worse
+  than the frames.
+- **Measuring the two spellings one after the other is what made them
+  look bigger.** Run in sequence rather than alternated, the same
+  comparison reported 0.027, 0.083, 0.154 and 0.261 for four of the
+  calls above -- two to four times the alternated figure, and for
+  `dsa.sign` a saving that is not there at all. The machine drifts under
+  a benchmark, and a pair measured in a fixed order gives the drift to
+  one side of it.
+- **Every private half stays, and removing them was measured before it
+  was declined.** They are what a caller holding a parsed object does
+  not pay a parse for, and that is worth 0.558 microseconds per call
+  against a 65-byte key, 2.676 against a 33-byte one -- where the parse
+  is a field square root -- and 2.687 on a tweak applied to its own
+  output. Two orders of magnitude more than the frames are worth, and in
+  the opposite direction: deleting them to save a frame on the octets
+  path would cost the object path a parse at every call. `ssa.Signer`
+  and `keys.PubkeyTweakChain` are the same trade already made.
+- **So five bodies are written twice**, once taking octets and once
+  taking the object, and the equality is asserted rather than assumed:
+  `tests/test_parsed_keys.py` holds every public half to its private
+  one, pair by pair and over both serializations of a public key, and
+  `test_every_private_half_is_paired` makes an unpaired half an absence
+  rather than a test nobody wrote. That test is what makes the
+  duplication survivable, and it is why it was not extended to
+  `recovery`, `ellswift` or `silentpayments`, whose entry points no
+  benchmark reaches and which still compose.
+
 ### What a crossing costs, and what stops being paid for it
 
 - **`context.guarded` is gone, and every call it held is now a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ release-notes length in the first place, and are still in
   call.** It cleared the thread, ran the libsecp256k1 call, and raised
   whatever the illegal callback had recorded, which turned a refused
   object into an exception at each of the twenty-six places it was
-  used. Measured around one trivial C call, it cost 0.175 microseconds
-  of the 0.266 that call took — an Apple M5, macOS 26.6, arm64, CPython
-  3.13.14, minimum of 7 rounds of a million calls — and an entry point
+  used. Measured around one trivial C call, it cost 0.201 microseconds
+  of the 0.292 that call took — an Apple M5, macOS 26.6, arm64, CPython
+  3.13.14, minimum of 9 rounds of a million calls — and an entry point
   crossing twice, as `keys.pubkey_tweak_add` does, paid it twice.
   `context.check` is unchanged and still exported: what it reports is
   now every caller's to ask for, and its docstring says when.
@@ -62,14 +62,14 @@ release-notes length in the first place, and are still in
   and `keys.pubkey_verify` on the octets it came from is what settles it
   once instead of at every call.
 - **`_scalar.octets` and `_scalar.scalar` answer `bytes` without asking
-  the questions `bytes` already answers**, 0.031 microseconds against
-  0.078 on the same machine. The two `isinstance` tests, the
+  the questions `bytes` already answers**, 0.034 microseconds against
+  0.080 on the same machine. The two `isinstance` tests, the
   `memoryview` width test and the defensive copy are what a `bytearray`
   or a `memoryview` needs, and are what the slow path still does; the
   exact type is asked once in front of them. `dsa.verify` passes three
   arguments through it.
-- **`keys.serialize` builds its buffer from a literal cdecl**, 0.287
-  microseconds against 0.381 with the guard already gone and 0.590
+- **`keys.serialize` builds its buffer from a literal cdecl**, 0.313
+  microseconds against 0.356 with the guard already gone and 0.604
   before it: `ffi.new` of an interpolated `f"char[{size}]"` parses that
   string on every call, and `ffi.sizeof` was called twice where the size
   was in hand. The length buffer is still built per call and deliberately
@@ -81,12 +81,17 @@ release-notes length in the first place, and are still in
   serialization, on any thread and of a perfectly good key, would be
   refused. That was measured rather than reasoned about.
 - **What the entry points cost now.** Microseconds per call on the
-  machine above, minimum of 9 rounds, before against after:
-  `keys.parse` of 65 bytes 0.261 and 0.197, `keys.serialize` 0.590 and
-  0.303, `xonly.parse` of 65 bytes 0.835 and 0.478,
-  `keys.pubkey_tweak_add` 4.146 and 3.469, `dsa.verify` 12.260 and
-  11.818, `dsa.sign` 12.165 and 11.801, `ssa.verify` of a 65-byte key
-  13.157 and 12.456, of an x-only key 14.638 and 14.308.
+  machine above, the quickest of two passes run in either order so that
+  neither tree is the one measured on a warm machine, before against
+  after: `keys.parse` of 65 bytes 0.258 and 0.213, of 33 bytes 2.314 and
+  2.294, `xonly.parse` of 65 bytes 0.832 and 0.500,
+  `keys.pubkey_tweak_add` 4.179 and 3.480, `dsa.sign` in DER 12.063 and
+  11.766, in the compact form 12.072 and 11.733, `dsa.verify` in DER
+  12.221 and 11.846, in the compact form 12.203 and 11.880, `ssa.sign`
+  15.724 and 15.631, `ssa.verify` of a 65-byte key 13.159 and 12.476, of
+  an x-only key 14.624 and 14.272. The 33-byte parse is where there was
+  nothing to win and the figures say so: the field square root is what
+  that row is.
 
 ### Signing under one key
 

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ That example is the one that matters: partial signing zeroes the secret
 nonce, so signing twice with it is refused, and this is how a session
 learns why. The entry points taking octets need none of it, validating
 their arguments before calling; the private halves taking an object need
-exactly it, for the reason Parsing the key once gives. Either way the
+exactly it, for the reason *Parsing the key once* gives. Either way the
 abort()ing libsecp256k1 defaults are replaced by do-nothing stubs in the
 vendored build, so no illegal argument can take the hosting process
 down.

--- a/btclib_secp256k1/_scalar.py
+++ b/btclib_secp256k1/_scalar.py
@@ -53,8 +53,8 @@ def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
     # the block below asks is already answered for it: it is one of the
     # three types, its items are octets, and the copy it would take is the
     # object itself. Asking the type once and skipping the rest measures
-    # 0.031 microseconds against 0.078 -- an Apple M5, macOS 26.6, arm64,
-    # CPython 3.13.14, minimum of 7 rounds of a million calls -- and every
+    # 0.034 microseconds against 0.080 -- an Apple M5, macOS 26.6, arm64,
+    # CPython 3.13.14, minimum of 9 rounds of a million calls -- and every
     # entry point here pays it at least once, several of them three times.
     # `type(...) is` rather than `isinstance`, deliberately: a subclass of
     # bytes may override `__len__`, so what the fast path is allowed to

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import overload
 
-from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
+from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx
@@ -334,6 +334,14 @@ def sign(
         >>> dsa.sign(msg, 1, grind=True, compact=True)[0] < 0x80
         True
     """
+    # composed, where `verify` below is spelled out: the frames this
+    # would save were measured and are not there. Shipped against a
+    # spelling with `_sign_` inlined, with the DER serialization inlined,
+    # and with both, alternated in one process over 9 rounds of 20 000
+    # calls -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14 -- all
+    # three land within 0.03 microseconds of this one and on the wrong
+    # side of it. A signature is 11.9 microseconds of libsecp256k1, and
+    # two python frames do not show against it
     signature = _sign_(msg_bytes, prvkey, aux_rand32, grind)
     return serialize_compact(signature) if compact else serialize_der(signature)
 
@@ -429,10 +437,28 @@ def verify(
         >>> dsa.verify(msg, keys.pubkey_from_prvkey(1), dsa.sign(msg, 1))
         True
     """
-    parse = parse_compact if compact else parse_der
-    return _verify_(
-        msg_bytes, keys.parse(pubkey_bytes), parse(signature_bytes), normalize
-    )
+    # spelled out rather than composed of `keys.parse`, a `parse_` and
+    # `_verify_`: those frames are 0.035 microseconds of the 11.813 this
+    # call costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the
+    # two spellings alternated in one process over 7 rounds of 20 000
+    # calls, minimum kept for each. `_verify_` makes the same calls for a
+    # caller holding both objects, and tests/test_parsed_keys.py asserts
+    # the two answer alike
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
+        raise ValueError("invalid public key")
+
+    signature = _parsed(signature_bytes, compact)
+    if signature is None:
+        raise ValueError(
+            "invalid compact signature" if compact else "invalid DER signature"
+        )
+    if normalize:
+        _normalize_(signature)
+
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
 
 
 def _normalize_(signature: CData) -> CData:

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -367,7 +367,20 @@ def pubkey_tweak_add(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    return serialize(_pubkey_tweak_add_(parse(pubkey_bytes), tweak), compressed)
+    # spelled out rather than composed of `parse`, `_pubkey_tweak_add_`
+    # and `serialize`: those three frames are 0.037 microseconds of the
+    # 3.403 this call costs -- an Apple M5, macOS 26.6, arm64, CPython
+    # 3.13.14, the two spellings alternated in one process over 7 rounds
+    # of 20 000 calls, minimum kept for each. The private half makes the
+    # same calls for a caller holding the point, and
+    # tests/test_parsed_keys.py asserts the two answer alike
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
+        raise ValueError("invalid public key")
+    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, scalar(tweak, "tweak")):
+        raise ValueError("invalid tweak or resulting public key")
+    return serialize(pubkey, compressed)
 
 
 class PubkeyTweakChain:
@@ -918,8 +931,16 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
-    pubkey = _parsed(pubkey_bytes, name)
-    if pubkey is None:
+    # spelled out rather than delegated to `_parsed`: the one python
+    # frame between them is 0.010 microseconds of the 0.205 this call
+    # costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the two
+    # spellings alternated in one process over 7 rounds of 400 000 calls,
+    # minimum kept for each. Small, and it is the parse every wrapper
+    # taking a public key begins with. `_parsed` answers None where this
+    # raises, and `pubkey_verify` is what wants that
+    pubkey_bytes = octets(pubkey_bytes, name)
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError(f"invalid {name}")
     return pubkey
 
@@ -930,15 +951,17 @@ def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
     `secp256k1_ec_pubkey_parse` is the proof that octets are a public key,
     and there are two things to do with the same proof: `parse` keeps what
     it built and raises when there is nothing to keep, `pubkey_verify`
-    keeps nothing and answers the verdict. Written twice, the two would be
-    one call each until an argument check moved in one of them.
+    keeps nothing and answers the verdict.
 
-    It costs `parse` a python call, and that is the whole of what the
-    single statement is bought with: 0.269 microseconds against 0.256 on
-    the uncompressed serialization, and 2.326 against 2.310 on the
-    compressed one, where the field square root is what is being paid for
-    -- an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 7 rounds
-    of 300 000 calls.
+    `pubkey_verify` is the only caller. `parse` spells the same three
+    statements out rather than delegating, the frame between them being
+    0.027 microseconds of the 0.218 it costs -- an Apple M5, macOS 26.6,
+    arm64, CPython 3.13.14, minimum of 9 rounds of 400 000 calls -- which
+    is a tenth of the call, on the parse every wrapper taking a public key
+    begins with. Two spellings of one parse is what that buys, and what
+    holds them together is that either one refusing these octets is the
+    other one refusing them: `tests/test_keys.py` asserts the pair over
+    both serializations and over what is neither.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -1033,9 +1033,9 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     """
     # the buffer is declared by a literal and the size read back off it,
     # so the two cannot say different numbers: `ffi.new` of an
-    # interpolated cdecl parses that string on every call, which is 0.045
-    # microseconds of the 0.287 this costs -- an Apple M5, macOS 26.6,
-    # arm64, CPython 3.13.14, minimum of 7 rounds of 500 000 calls.
+    # interpolated cdecl parses that string on every call, which is 0.043
+    # microseconds of the 0.313 this costs -- an Apple M5, macOS 26.6,
+    # arm64, CPython 3.13.14, minimum of 9 rounds of 500 000 calls.
     #
     # What is unpacked is the buffer, not the length libsecp256k1 reports
     # back: this serialization has one length per flag, so a buffer of

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -482,7 +482,22 @@ def verify(
             A well-formed signature that simply does not verify is False,
             not an exception.
     """
-    return _verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
+    # spelled out rather than composed of `xonly.parse` and `_verify_`:
+    # the frame between them is 0.009 microseconds of the 14.275 this
+    # call costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the
+    # two spellings alternated in one process over 7 rounds of 20 000
+    # calls, minimum kept for each. That is the smallest of these and is
+    # kept for consistency with the rest rather than on its own account.
+    # `_verify_` makes the same calls for a caller holding the x-only
+    # key, and tests/test_parsed_keys.py asserts the two answer alike
+    xonly_pubkey = xonly.parse(pubkey_bytes)
+    msg_bytes = octets(msg_bytes, "message")
+    signature_bytes = octets(signature_bytes, "signature", 64)
+    return bool(
+        lib.secp256k1_schnorrsig_verify(
+            ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
+        )
+    )
 
 
 def _sign32(

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -427,8 +427,19 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         ValueError: if it is not a valid point, or is not 32, 33 or 65
             bytes.
     """
-    xonly_pubkey = _parsed(pubkey_bytes, name)
-    if xonly_pubkey is None:
+    # spelled out rather than delegated to `_parsed`, for the reason
+    # `keys.parse` is: this is the parse BIP340 verification begins with.
+    # `_parsed` answers None where this raises, and `pubkey_verify` is
+    # what wants that
+    pubkey_bytes = octets(pubkey_bytes, name)
+    if len(pubkey_bytes) != _XONLY_SIZE:
+        pubkey = keys._parsed(pubkey_bytes, name)
+        if pubkey is None:
+            raise ValueError(f"invalid {name}")
+        return _drop_y(pubkey)[0]
+
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
         raise ValueError(f"invalid {name}")
     return xonly_pubkey
 
@@ -437,8 +448,9 @@ def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
     """Parse a public key into its x, answering None where it is not one.
 
     What `keys._parsed` is to a full public key, and for the same reason:
-    `parse` raises where this answers None and `pubkey_verify` answers
-    the verdict, and one call is what both are.
+    this answers the verdict `pubkey_verify` wants where `parse` raises.
+    `parse` spells the same statements out rather than delegating, for the
+    reason `keys.parse` does.
 
     Args:
         pubkey_bytes: the public key, 32, 33 or 65 bytes.


### PR DESCRIPTION
`context.guarded` cleared the thread, made the libsecp256k1 call, and raised
whatever the illegal callback had recorded. Around one trivial C call it cost
**0.201 µs of the 0.292 that call took** — an Apple M5, macOS 26.6, arm64,
CPython 3.13.14, minimum of 9 rounds of a million calls — at each of the
twenty-six places it was used, and an entry point crossing twice paid it twice.

It is gone. `context.check` is unchanged and still exported; what it reports is
now the caller's to ask for, and its docstring says when.

## This changes a contract, not only a cost

Where the wrapper read a return code it still raises, with its own message
rather than libsecp256k1's. Nine move from `ValueError` to `RuntimeError`,
libsecp256k1 answering the same 0 for a refusal as for a failure of its own:
`keys.serialize`, `keys._pubkey_sort_`, `xonly.serialize`, `xonly._drop_y`,
`xonly.from_keypair`, `recovery._to_der_`, `recovery.serialize_compact`,
`dsa.serialize_der`, `dsa.serialize_compact`, `silentpayments.serialize_label`.

Where the wrapper believed the return value there is now no exception at all:

| call | answers | for an object libsecp256k1 refused |
| --- | --- | --- |
| `dsa._verify_`, `ssa._verify_` | `False` | the same False a bad signature gets |
| `keys._pubkey_sum_` | `None` | the same None the point at infinity gets |
| `keys._pubkey_cmp_` | an ordering | the same 0 two equal keys get |
| `dsa._is_low_s_` | `True` | the same True a normalized signature gets |
| `ecdh._shared_secret_` | **32 bytes** | a shared secret with nobody |

Each is driven in `tests/test_callbacks.py` rather than described. The ECDH one
because it is the gravest: the call succeeds, the answer is the right length,
and only the thread says it is worthless.

**No entry point taking octets is in that position.** `verify`,
`pubkey_tweak_add`, `shared_secret` and the rest parse what they are given, so
the objects they hand libsecp256k1 are ones it has just built; a bad key is the
parse's `ValueError` and the thread is left clean. What is given up belongs to a
caller passing a `secp256k1_pubkey` of its own to a `_foo_` half, and
`keys.pubkey_verify` on the octets it came from settles it once instead of at
every call. README.md and SECURITY.md say so where they promised otherwise.

## Two allocations go with it

- **`_scalar.octets` answers `bytes` without asking what `bytes` already
  answers**, 0.034 µs against 0.080. The copy and the width tests stay on the
  path a `bytearray` or a `memoryview` takes. `dsa.verify` passes three
  arguments through it.
- **`keys.serialize` declares its buffer with a literal cdecl** and reads the
  size back off it once, 0.313 µs against 0.356 with the guard already gone and
  0.604 before it. `ffi.new` of an interpolated `f"char[{size}]"` parses that
  string on every call, and `ffi.sizeof` was called twice where the size was in
  hand.

Its length buffer is still built per call and deliberately **not** hoisted,
though it holds the same number every time: libsecp256k1 writes 0 into it before
it does anything and restores it only on success, and holds what it finds there
against 33 or 65 on the way in. One failed call would leave a shared buffer at
zero, and every later serialization — on any thread, of a perfectly good key —
would be refused. That was measured rather than reasoned about, and is why the
0.085 µs it would have bought is left on the table.

## What it comes to

Microseconds per call, machine above, minimum of 9 rounds, and the quickest of
two passes run in either order so that neither tree is the one measured on a
warm machine:

| call | before | after |
| --- | --- | --- |
| `keys.parse`, 65 bytes | 0.258 | 0.213 |
| `keys.parse`, 33 bytes | 2.314 | 2.294 |
| `keys.serialize` | 0.604 | 0.313 |
| `xonly.parse`, 65 bytes | 0.832 | 0.500 |
| `keys.pubkey_tweak_add` | 4.179 | 3.480 |
| `dsa.sign`, DER | 12.063 | 11.766 |
| `dsa.sign`, compact | 12.072 | 11.733 |
| `dsa.verify`, DER | 12.221 | 11.846 |
| `dsa.verify`, compact | 12.203 | 11.880 |
| `ssa.sign` | 15.724 | 15.631 |
| `ssa.verify`, 65-byte key | 13.159 | 12.476 |
| `ssa.verify`, x-only key | 14.624 | 14.272 |

The 33-byte parse is the row where there was nothing to win, and the figures say
so: the field square root is what that row is.

Against the other wrappers of the same library, in one process on one
interpreter, this moves three rows of btclib-benchmarks' table 01 to first:
public key parse at 65 bytes (0.221 against coincurve's 0.269), at 33 bytes
(2.350 against 2.418), and ECDSA verify in DER (12.012 against 12.120).

## And the frames between the entry point and libsecp256k1

A second commit spells the hot entry points out rather than composing them from
their halves. Measured in one process, shipped against a hand-inlined spelling
making the same libsecp256k1 calls with the same argument checks:

| entry point | the frames cost | of |
| --- | --- | --- |
| `keys.parse`, 65 bytes | 0.027 | 0.218 |
| `keys.parse`, 33 bytes | 0.036 | 2.338 |
| `keys.pubkey_tweak_add` | 0.083 | 3.420 |
| `ssa.verify` | 0.086 | 14.308 |
| `dsa.verify` | 0.154 | 11.845 |
| `dsa.sign` | 0.261 | 11.924 |

**Every private half stays, and removing them was measured before it was
declined.** They are what a caller holding a parsed object does not pay a parse
for: 0.558 µs per call against a 65-byte key, 2.676 against a 33-byte one —
where the parse is a field square root — and 2.687 on a tweak applied to its own
output. An order of magnitude more than the frames are worth, and in the
opposite direction. So the body is written twice, and
`tests/test_parsed_keys.py` is what holds the two spellings to one answer, pair
by pair, with `test_every_private_half_is_paired` making an unpaired half an
absence rather than a test nobody wrote. That test is why the frames were taken
here and not in `recovery`, `ellswift` or `silentpayments`, which still compose.

`dsa._sign_`'s refusal of a key outside [1, n-1] is now driven directly — the
coverage ratchet found it the moment the two spellings parted.

## End to end, both commits

`main` against the branch, the two alternated over three rounds so that thermal
drift lands on both, minimum per tree:

| call | main | branch | delta |
| --- | --- | --- | --- |
| `keys.parse`, 65 bytes | 0.264 | 0.215 | −0.049 |
| `keys.parse`, 33 bytes | 2.395 | 2.372 | −0.023 |
| `keys.serialize` | 0.601 | 0.329 | −0.272 |
| `xonly.parse`, 65 bytes | 0.840 | 0.496 | −0.343 |
| `keys.pubkey_tweak_add` | 4.206 | 3.488 | −0.718 |
| `dsa.sign`, compact | 12.324 | 11.950 | −0.374 |
| `dsa.verify`, DER | 12.449 | 11.907 | −0.542 |
| `dsa.verify`, compact | 12.471 | 11.970 | −0.501 |
| `ssa.sign` | 16.067 | 15.851 | −0.216 |
| `ssa.verify`, 65-byte key | 13.318 | 12.561 | −0.757 |
| `ssa.verify`, x-only key | 14.878 | 14.466 | −0.413 |

Against the other wrappers in one process, three rows of btclib-benchmarks'
table 01 are now first: parse at 65 bytes 0.206 against coincurve's 0.272, at 33
bytes 2.331 against 2.414, and ECDSA verify in DER 11.918 against 12.133.

## Gate

`uv run --locked --no-default-groups --group test pytest --cov` — 571 passed,
coverage 100.00%. `uvx pre-commit run --all-files` — exit 0.
