### PR TITLE
Carry over the measurements main missed, and drive the two shapes the changelog claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ release-notes length in the first place, and are still in
   call.** It cleared the thread, ran the libsecp256k1 call, and raised
   whatever the illegal callback had recorded, which turned a refused
   object into an exception at each of the twenty-six places it was
-  used. Measured around one trivial C call, it cost 0.175 microseconds
-  of the 0.266 that call took — an Apple M5, macOS 26.6, arm64, CPython
-  3.13.14, minimum of 7 rounds of a million calls — and an entry point
+  used. Measured around one trivial C call, it cost 0.201 microseconds
+  of the 0.292 that call took — an Apple M5, macOS 26.6, arm64, CPython
+  3.13.14, minimum of 9 rounds of a million calls — and an entry point
   crossing twice, as `keys.pubkey_tweak_add` does, paid it twice.
   `context.check` is unchanged and still exported: what it reports is
   now every caller's to ask for, and its docstring says when.
@@ -62,14 +62,14 @@ release-notes length in the first place, and are still in
   and `keys.pubkey_verify` on the octets it came from is what settles it
   once instead of at every call.
 - **`_scalar.octets` and `_scalar.scalar` answer `bytes` without asking
-  the questions `bytes` already answers**, 0.031 microseconds against
-  0.078 on the same machine. The two `isinstance` tests, the
+  the questions `bytes` already answers**, 0.034 microseconds against
+  0.080 on the same machine. The two `isinstance` tests, the
   `memoryview` width test and the defensive copy are what a `bytearray`
   or a `memoryview` needs, and are what the slow path still does; the
   exact type is asked once in front of them. `dsa.verify` passes three
   arguments through it.
-- **`keys.serialize` builds its buffer from a literal cdecl**, 0.287
-  microseconds against 0.381 with the guard already gone and 0.590
+- **`keys.serialize` builds its buffer from a literal cdecl**, 0.313
+  microseconds against 0.356 with the guard already gone and 0.604
   before it: `ffi.new` of an interpolated `f"char[{size}]"` parses that
   string on every call, and `ffi.sizeof` was called twice where the size
   was in hand. The length buffer is still built per call and deliberately
@@ -81,12 +81,17 @@ release-notes length in the first place, and are still in
   serialization, on any thread and of a perfectly good key, would be
   refused. That was measured rather than reasoned about.
 - **What the entry points cost now.** Microseconds per call on the
-  machine above, minimum of 9 rounds, before against after:
-  `keys.parse` of 65 bytes 0.261 and 0.197, `keys.serialize` 0.590 and
-  0.303, `xonly.parse` of 65 bytes 0.835 and 0.478,
-  `keys.pubkey_tweak_add` 4.146 and 3.469, `dsa.verify` 12.260 and
-  11.818, `dsa.sign` 12.165 and 11.801, `ssa.verify` of a 65-byte key
-  13.157 and 12.456, of an x-only key 14.638 and 14.308.
+  machine above, the quickest of two passes run in either order so that
+  neither tree is the one measured on a warm machine, before against
+  after: `keys.parse` of 65 bytes 0.258 and 0.213, of 33 bytes 2.314 and
+  2.294, `xonly.parse` of 65 bytes 0.832 and 0.500,
+  `keys.pubkey_tweak_add` 4.179 and 3.480, `dsa.sign` in DER 12.063 and
+  11.766, in the compact form 12.072 and 11.733, `dsa.verify` in DER
+  12.221 and 11.846, in the compact form 12.203 and 11.880, `ssa.sign`
+  15.724 and 15.631, `ssa.verify` of a 65-byte key 13.159 and 12.476, of
+  an x-only key 14.624 and 14.272. The 33-byte parse is where there was
+  nothing to win and the figures say so: the field square root is what
+  that row is.
 
 ### Signing under one key
 

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ That example is the one that matters: partial signing zeroes the secret
 nonce, so signing twice with it is refused, and this is how a session
 learns why. The entry points taking octets need none of it, validating
 their arguments before calling; the private halves taking an object need
-exactly it, for the reason Parsing the key once gives. Either way the
+exactly it, for the reason that parsing the key once gives. Either way the
 abort()ing libsecp256k1 defaults are replaced by do-nothing stubs in the
 vendored build, so no illegal argument can take the hosting process
 down.

--- a/btclib_secp256k1/_scalar.py
+++ b/btclib_secp256k1/_scalar.py
@@ -53,8 +53,8 @@ def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
     # the block below asks is already answered for it: it is one of the
     # three types, its items are octets, and the copy it would take is the
     # object itself. Asking the type once and skipping the rest measures
-    # 0.031 microseconds against 0.078 -- an Apple M5, macOS 26.6, arm64,
-    # CPython 3.13.14, minimum of 7 rounds of a million calls -- and every
+    # 0.034 microseconds against 0.080 -- an Apple M5, macOS 26.6, arm64,
+    # CPython 3.13.14, minimum of 9 rounds of a million calls -- and every
     # entry point here pays it at least once, several of them three times.
     # `type(...) is` rather than `isinstance`, deliberately: a subclass of
     # bytes may override `__len__`, so what the fast path is allowed to

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -1033,9 +1033,9 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     """
     # the buffer is declared by a literal and the size read back off it,
     # so the two cannot say different numbers: `ffi.new` of an
-    # interpolated cdecl parses that string on every call, which is 0.045
-    # microseconds of the 0.287 this costs -- an Apple M5, macOS 26.6,
-    # arm64, CPython 3.13.14, minimum of 7 rounds of 500 000 calls.
+    # interpolated cdecl parses that string on every call, which is 0.043
+    # microseconds of the 0.313 this costs -- an Apple M5, macOS 26.6,
+    # arm64, CPython 3.13.14, minimum of 9 rounds of 500 000 calls.
     #
     # What is unpacked is the buffer, not the length libsecp256k1 reports
     # back: this serialization has one length per flag, so a buffer of

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -804,8 +804,6 @@ def serialize_label(label_obj: CData) -> bytes:
             cannot read -- or fails to serialize for any other reason,
             which a label it produced cannot make it do.
             `context.check` is what tells the two apart.
-        RuntimeError: if libsecp256k1 fails for any other reason, which
-            a label it produced cannot make it do.
     """
     output = ffi.new(f"char[{LABEL_SIZE}]")
     serialized = lib.secp256k1_silentpayments_recipient_label_serialize(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -145,6 +145,40 @@ def test_verification_of_an_unreadable_key_is_false_not_a_verdict() -> None:
         context.check()
 
 
+def test_schnorr_verification_of_an_unreadable_key_is_false_too() -> None:
+    """`ssa._verify_` answers False for the same reason `dsa._verify_` does.
+
+    Two entry points and one contract, and the second is driven rather
+    than inferred from the first: they read different libsecp256k1 calls
+    of different key types, so which of them leaves a reason on the
+    thread is a fact about each rather than about the shape they share.
+    """
+    msg = bytes(range(32))
+    signature = ssa.sign(msg, 7)
+
+    assert ssa._verify_(msg, ffi.new("secp256k1_xonly_pubkey *"), signature) is False
+    with pytest.raises(ValueError, match="illegal argument"):
+        context.check()
+
+
+def test_a_signature_libsecp256k1_cannot_read_is_low_s_like_any_other() -> None:
+    """`dsa._is_low_s_` answers True for a signature it was never shown.
+
+    Which is the True an already-normalized signature gets: the call
+    reports the input as unchanged either way, and nothing in the answer
+    separates the two.
+
+    NULL is what reaches that shape, and the zeroed object the tests
+    above prefer would not: an r and an s of zero are a signature
+    libsecp256k1 reads and normalizes -- answering True with the thread
+    left clean -- where a zeroed `secp256k1_pubkey` is a point it
+    refuses. The reachable mistake is not the same object twice.
+    """
+    assert dsa._is_low_s_(ffi.NULL) is True
+    with pytest.raises(ValueError, match="illegal argument: sigin != NULL"):
+        context.check()
+
+
 def test_ecdh_with_an_unreadable_key_answers_a_secret_with_nobody() -> None:
     """`ecdh._shared_secret_` answers 32 bytes, and they are worth nothing.
 


### PR DESCRIPTION
Two commits, and the first is the more important: **main is holding a
superseded version of #205.**

## What happened

#205's head was fast-forwarded onto main as `681ace1`. The branch was then
rewritten — `fd77af0` replaced that commit, and `a9e7c2d` followed it — so
main has a version of that work that the branch itself moved past. The code
is identical on both sides. What differs is every number in it, and one line
of prose.

The measurements were taken again by a better method: **the quickest of two
passes run in either order**, so that neither tree is the one measured on a
warm machine. That moves the guard from 0.175 microseconds of 0.266 to 0.201
of 0.292, `_scalar.octets` from 0.031 against 0.078 to 0.034 against 0.080,
`keys.serialize` from 0.287 to 0.313, and it adds the rows a single pass had
left out — `keys.parse` of 33 bytes among them, which is where there was
nothing to win and now says so.

The prose is the README line the review flagged; `a9e7c2d` lowercased it, and
that is what lands here.

The first commit is therefore content **already reviewed on #205**. It is not
on main only because the fast-forward named the earlier of two heads. Diffed
against `a9e7c2d`, this branch adds nothing but the second commit's two files.

## The second commit: a claim that was not true of the tree

CHANGELOG.md and #205 both say each shape a refused object answers with is
driven in `tests/test_callbacks.py` rather than described. Five shapes, three
tests: `ssa._verify_` answering `False` and `dsa._is_low_s_` answering `True`
had a docstring apiece and nothing running.

Neither is the covered case restated:

- **`ssa._verify_`** reads `secp256k1_schnorrsig_verify` on a
  `secp256k1_xonly_pubkey`, where the covered `dsa._verify_` reads
  `secp256k1_ecdsa_verify` on a `secp256k1_pubkey`. Which of them leaves a
  reason on the thread is a fact about each call, not about the shape they
  share.
- **`dsa._is_low_s_`** will not take the zeroed object every other test in
  the file prefers. An r and an s of zero are a signature libsecp256k1
  *reads* and normalizes — `True`, thread left clean — where a zeroed
  `secp256k1_pubkey` is a point it refuses. `ffi.NULL` is what reaches the
  documented shape, and the test says why it had to be, so the next reader
  does not "simplify" it back to a blank object and quietly stop testing
  anything.

That second point is why this was worth a commit: the contract holds, but the
reachable mistake is not the same object twice, and nothing in the tree said
so until now.

Also from the review: `silentpayments.serialize_label` listed `RuntimeError`
twice in its `Raises:`, the second entry saying half of what the first said.

## Not taken from the review

- **A `*_checked` helper, or a `(value, illegal_reason)` return.** That is
  `context.guarded` under another name, and #205 measured what it cost and
  removed it deliberately. The review's premise is right — the private halves
  are easy to misuse — and #205's answer stands: `keys.pubkey_verify` on the
  octets the object came from settles it once instead of at every call, and
  README.md and SECURITY.md say who is in that position.
- **Relaxing `type(value) is bytes` to `isinstance`.** A `bytes` subclass is
  not rejected by the fast path: it falls to the general branch, passes the
  `isinstance` check there, and is copied by `bytes(value)`. There is no
  breakage to avoid, and the comment in `_scalar.octets` already gives the
  reason the exact type is what the fast path may trust — a subclass can
  override `__len__`.

## Gate

`uv run --locked --no-default-groups --group test pytest --cov` — 573 passed,
coverage 100.00%. `uvx pre-commit run --all-files` — exit 0.