### PR TITLE
Grind for a low r where a caller asks, in python and not in C

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -212,240 +212,310 @@
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
         "is_verified": false,
-        "line_number": 935
+        "line_number": 940
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
         "is_verified": false,
-        "line_number": 936
+        "line_number": 941
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
         "is_verified": false,
-        "line_number": 937
+        "line_number": 942
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
         "is_verified": false,
-        "line_number": 942
+        "line_number": 947
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
         "is_verified": false,
-        "line_number": 943
+        "line_number": 948
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
         "is_verified": false,
-        "line_number": 944
+        "line_number": 949
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
         "is_verified": false,
-        "line_number": 947
+        "line_number": 952
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
         "is_verified": false,
-        "line_number": 949
+        "line_number": 954
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
         "is_verified": false,
-        "line_number": 950
+        "line_number": 955
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
         "is_verified": false,
-        "line_number": 951
+        "line_number": 956
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
         "is_verified": false,
-        "line_number": 956
+        "line_number": 961
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
         "is_verified": false,
-        "line_number": 957
+        "line_number": 962
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
         "is_verified": false,
-        "line_number": 958
+        "line_number": 963
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
         "is_verified": false,
-        "line_number": 966
+        "line_number": 971
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
         "is_verified": false,
-        "line_number": 967
+        "line_number": 972
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
         "is_verified": false,
-        "line_number": 968
+        "line_number": 973
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
         "is_verified": false,
-        "line_number": 976
+        "line_number": 981
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
         "is_verified": false,
-        "line_number": 977
+        "line_number": 982
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
         "is_verified": false,
-        "line_number": 978
+        "line_number": 983
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
         "is_verified": false,
-        "line_number": 981
+        "line_number": 986
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 991
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
         "is_verified": false,
-        "line_number": 987
+        "line_number": 992
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
         "is_verified": false,
-        "line_number": 988
+        "line_number": 993
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
         "is_verified": false,
-        "line_number": 1042
+        "line_number": 1047
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
         "is_verified": false,
-        "line_number": 1045
+        "line_number": 1050
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
         "is_verified": false,
-        "line_number": 1046
+        "line_number": 1051
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
         "is_verified": false,
-        "line_number": 1053
+        "line_number": 1058
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
         "is_verified": false,
-        "line_number": 1054
+        "line_number": 1059
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "8f5f5625327dc73e4c9097424402189dac923ed9",
+        "is_verified": false,
+        "line_number": 1092
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "c302522e939ac8632ab8ca56a11295904cd062f3",
+        "is_verified": false,
+        "line_number": 1093
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "2945319119dbdc9bc9cbfe74e4a69a5c8cd6f959",
+        "is_verified": false,
+        "line_number": 1098
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "fdd6e3e0e2dfb37b613e876af896a0c4d4d040da",
+        "is_verified": false,
+        "line_number": 1099
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "f1bbf93d9634a52f5576abc94ab027be39f979dd",
+        "is_verified": false,
+        "line_number": 1106
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "f81513f672ebaa9ca567452ff82ec025a11f0da4",
+        "is_verified": false,
+        "line_number": 1107
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "d0def4f1524dff92a078bdc969a3cfc338caf410",
+        "is_verified": false,
+        "line_number": 1118
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "0231d195e28ec23d6f4d888b3ce2c3cdef68e59d",
+        "is_verified": false,
+        "line_number": 1119
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "6db637a61fe0acf8e143d6267a5690682148c610",
+        "is_verified": false,
+        "line_number": 1121
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_vectors.py",
+        "hashed_secret": "9b6086d959d29b4ed4e788286ebbfaf788ce5ee5",
+        "is_verified": false,
+        "line_number": 1122
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
         "is_verified": false,
-        "line_number": 1087
+        "line_number": 1219
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
         "is_verified": false,
-        "line_number": 1088
+        "line_number": 1220
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
         "is_verified": false,
-        "line_number": 1112
+        "line_number": 1244
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
         "is_verified": false,
-        "line_number": 1113
+        "line_number": 1245
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
         "is_verified": false,
-        "line_number": 1129
+        "line_number": 1261
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
         "is_verified": false,
-        "line_number": 1130
+        "line_number": 1262
       }
     ]
   },
-  "generated_at": "2026-08-16T12:45:53Z"
+  "generated_at": "2026-08-16T18:08:59Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,56 @@ release-notes length in the first place, and are still in
   used to name the message. Each on its own is refused as before, and
   every wipe that happened still happens
 
+### Grinding for a low r
+
+- **`dsa.sign(grind=True)` signs again until `r` is the low one** (#204).
+  Bitcoin Core's `CKey::Sign` scheme and not a rephrasing of it: the
+  first attempt is the plain RFC6979 signature, and each retry mixes a
+  `uint32` counter, little endian in the first 4 of 32 octets, into the
+  nonce, until the high bit of `r` is clear and DER therefore spends no
+  leading zero octet on it. One octet shorter, about half the time, for
+  two signatures' work — measured on this tree, on an Apple M5, macOS
+  26.6, arm64, CPython 3.14.6, 2000 distinct keys signed once each,
+  microseconds per call: `dsa.sign` 12.62 against `dsa.sign(grind=True)`
+  25.23, at 2.09 attempts on the mean and 14 for the worst of those keys.
+  Off by default for that reason, and asked for by a caller who wants the
+  octet. `dsa._sign_` takes it too; `s` has no counterpart, libsecp256k1
+  having already returned the lower of the two, and `recovery.sign` does
+  not get one, a recoverable signature being 65 fixed octets with nothing
+  to shorten
+- **the loop is python, and no C was written** — which was measured
+  rather than assumed. In the compact form, which is what the retry
+  tests: 25.90 for a loop calling the wrappers once per attempt, 24.82
+  for what landed, with the key checked once and the two scratch buffers
+  allocated once per call, and 23.82 for the same loop with those buffers
+  held at module level — which one shared context and a documented
+  thread-safety story rule out. A loop compiled in C would have started
+  from that last figure, so the crossing is worth about a microsecond of
+  twenty-five, and it would have been bought with the one property these
+  bindings do not trade: a dynamic build compiles no C at all, so a C
+  helper would be a feature the static wheels have and the dynamic ones
+  do not
+- **the retry reads the compact serialization, not the DER length**,
+  which is not the same question: DER is `6 + lenR + lenS`, so a high `r`
+  of 33 octets with an `s` that needs only 31 encodes to 70 octets too —
+  about one signature in 500, measured over 200 000 — and a length test
+  would take those for low-r ones. The first octet of the compact form is
+  the top of `r`, which is what Core's `SigHasLowR` reads
+- **`aux_rand32` and `grind` are refused together**, with a `ValueError`.
+  Grinding writes the very 32 octets that argument is, so a caller asking
+  for both is asking for two values of one argument; ignoring one of
+  them, as Core does with its `test_case`, would make an argument vanish
+  where every other one here is checked
+- **what judges it is Core's vectors and rust-secp256k1's**, in
+  `tests/test_vectors.py`: the two deterministic signatures of Core's
+  `key_test1`, which are already low-r at the first attempt and so pin
+  that asking for grinding changes nothing; the property
+  `key_signature_tests` asserts over 256 messages, together with the
+  high-r half of that same test, which says the loop has something to
+  find; and rust-secp256k1's `test_low_r`, whose vector takes five
+  attempts and so pins the counter itself, in an implementation sharing
+  no line with Core's
+
 ### The parsed public key
 
 - **`xonly.tweak_add_` tweaks the point, where `tweak_add` tweaks its

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -73,8 +73,9 @@ them `ndata` and `ellswift.encode` called them `rnd32`, and
 unaffected.
 
 What the rest of the release adds: one for a caller that signs more than
-once under one key, one for a caller computing a taproot output key from
-a public key it has validated, a set for a caller composing two of these
+once under one key, one for a caller whose ECDSA signatures go into a
+transaction, one for a caller computing a taproot output key from a
+public key it has validated, a set for a caller composing two of these
 calls where the second used to parse what the first had just serialized,
 and one for a caller that would rather hold octets than a parsed key at
 all.
@@ -99,6 +100,18 @@ and nothing runs behind the caller to do it — SECURITY.md now names this
 as the one buffer of the package whose zeroing is asked for rather than
 done. The private key handed to the constructor is a python `bytes` or
 `int` and is no more zeroizable than before.
+
+`dsa.sign` takes `grind=True`, which answers the signature of the same
+key and message whose `r` has its high bit clear — one octet shorter in
+DER, and the reason Bitcoin Core's `CKey::Sign` does it. It is Core's
+scheme rather than a rephrasing: a `uint32` counter mixed into the nonce,
+so what comes back is what Core and rust-secp256k1 answer for the same
+inputs, held to their own vectors here. It costs two signatures on
+average — 12.62 microseconds against 25.23, on the machine and with the
+method CHANGELOG.md states — which is why it is asked for and never done
+by default. `aux_rand32` is refused alongside it, being the same 32
+octets, and `s` needs nothing of the kind: libsecp256k1 has always
+returned the lower of the two.
 
 `xonly._tweak_add_` is the private half of `xonly.tweak_add`: it takes
 the parsed point `keys.parse` returns, rather than the x-only form, and

--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ verification equation is written as, with no product serialized on its
 way into the sum. Neither computes anything libsecp256k1 does not: the
 arithmetic is upstream's calls in the order the equation names them, and
 *Parsing the key once* below is where the crossing they save is
-measured. The cryptography —
+measured. One entry point is more than a composition, and it is
+`dsa.sign(grind=True)`: a loop that signs again, with a counter mixed
+into the nonce, until `r` is the low one. That is Bitcoin Core's
+`CKey::Sign` and not a scheme of this package's — a signer's size policy,
+which is why it is asked for and never done by default — and *Grinding
+for a low r* below is where its cost, and the reason the loop is python
+rather than C, are measured. The cryptography —
 the algorithms, the constant-time
 implementation, the side-channel hardening — is upstream's, and none of
 it is reimplemented, extended or second-guessed here. Wrappers of the
@@ -570,6 +576,56 @@ What does cost in `dsa.sign` is the DER serialization, 0.757
 microseconds, and a caller who wanted the other form never has to pay it:
 `compact=True` answers the 64 octets of `r ‖ s` directly, where reaching
 them through `to_compact` writes the DER and parses it straight back.
+
+## Grinding for a low r
+
+`dsa.sign(grind=True)` answers the signature of the same key and message
+whose `r` has its high bit clear. DER spends a leading zero octet on an
+integer whose top bit is set, so that signature encodes one octet
+shorter — which is what Bitcoin Core's `CKey::Sign` grinds for, and this
+is Core's scheme rather than a rephrasing of it: the first attempt is the
+plain RFC6979 signature, and each retry mixes a `uint32` counter, little
+endian in the first 4 of 32 octets, into the nonce. Written any other
+way it would answer octets nobody else answers; written this way,
+`tests/test_vectors.py` holds it to Core's own vectors and to
+rust-secp256k1's.
+
+It costs a signature and then some: 25.23 microseconds against the 12.62
+of a plain one, measured beside it over 2000 keys, because half the
+attempts are wasted and the tail is longer than the average — 2.09
+attempts on the mean, and the worst of those 2000 keys took 14. That is
+why it is a parameter and not the default, and why `s` is not mentioned
+in the same breath: libsecp256k1 has already returned the lower of the
+two, so there is nothing there to grind for.
+
+Where the loop is written was measured, not assumed. In the compact form,
+which is what the retry tests: 25.90 microseconds for a loop calling the
+wrappers once per attempt, 24.82 for what is implemented — the key
+checked once, the two scratch buffers allocated once per call — and 23.82
+for the same loop with those buffers held at module level, which a
+package with one shared context and a
+[thread safety](#thread-safety) story does not get to do. A loop compiled
+in C would have started from that last number, so what crossing the
+boundary twice on average actually costs is about a microsecond of
+twenty-five. It buys nothing here, and it would have cost the one thing
+these bindings do not trade: a
+[dynamic build](#the-vendored-library-is-not-optional) compiles no C at
+all, so a C helper would be a feature the static wheels have and the
+dynamic ones do not.
+
+What the loop tests is the compact serialization, and not the DER
+length, which is not the same question: DER is `6 + lenR + lenS`, so a
+high `r` of 33 octets with an `s` that happens to need only 31 encodes to
+70 octets too — about one signature in 500 — and a length test would
+take those for low-r ones. The first octet of the compact form is the top
+of `r`, which is exactly what Core's `SigHasLowR` reads.
+
+The entropy argument is refused together with it. Grinding writes the
+very 32 octets `aux_rand32` is, so `dsa.sign(msg, key, aux, grind=True)`
+raises rather than resolving silently in favour of one of them.
+`recovery.sign` has no `grind`, and the reason is that there is nothing
+to shorten: a recoverable signature is 65 fixed octets, so grinding one
+would buy the caller two signatures' worth of nothing.
 
 ## Wrapped modules
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -136,8 +136,99 @@ def nonce_rfc6979(
     return take(nonce, into=into)
 
 
+def _signed(
+    signature: CData, msg_bytes: bytes, prvkey_bytes: bytes, ndata: bytes | CData
+) -> None:
+    """Sign into a signature object the caller owns.
+
+    The one signing call of this module, written once because `_sign_`
+    makes it and `_grind` makes it again for every attempt after the
+    first. Every argument is checked before it gets here, so what this
+    is for is the call itself and the one failure of it: two spellings of
+    it would be two chances to pass a different nonce function.
+
+    Args:
+        signature: the signature object to sign into, overwritten.
+        msg_bytes: the 32-byte hash of the message, already checked.
+        prvkey_bytes: the 32-byte private key, already checked.
+        ndata: the extra entropy to mix into the nonce, or NULL for none,
+            as `optional_entropy` returns it.
+
+    Raises:
+        ValueError: if the private key is not in [1, n-1], which is the
+            one thing about it libsecp256k1 answers for and `scalar`
+            cannot.
+    """
+    # secp256k1_ecdsa_sign takes the nonce function and its data: NULL
+    # for the first selects the RFC6979 default, and it is the only one
+    # these bindings pass -- a python nonce function would be called from
+    # inside the signature, with the secret passing through a python
+    # object on every call. The contribution beside it is 32 bytes of
+    # entropy, and `optional_entropy` says what omitting it means here
+    noncefp = ffi.NULL
+    if not lib.secp256k1_ecdsa_sign(
+        ctx, signature, msg_bytes, prvkey_bytes, noncefp, ndata
+    ):
+        raise ValueError("invalid private key: not in [1, n-1]")
+
+
+def _grind(signature: CData, msg_bytes: bytes, prvkey_bytes: bytes) -> None:
+    """Sign again into the same object until r is the low one.
+
+    Bitcoin Core's `CKey::Sign` scheme, and it has to be that one octet
+    for octet: what makes a ground signature reproducible by anybody else
+    is the counter, not the idea. The first attempt is the plain RFC6979
+    signature the caller already holds; each retry mixes a `uint32`
+    counter, little endian in the first 4 of 32 octets, into the nonce
+    that derives the next one. Where the high bit of r is clear, DER
+    spends no leading zero octet on it and the encoding is one octet
+    shorter -- which is the whole of the benefit, and why this is a
+    signer's policy rather than an operation of the curve.
+
+    The test is on the compact serialization rather than on the DER
+    length, and they are not the same question: DER is 6 + lenR + lenS,
+    so a high r of 33 octets with an s that happens to need only 31
+    encodes to 70 octets too -- about one signature in 500 -- and a
+    length test would take those for low-r. The first octet of the
+    compact form is the top of r, which is what Core's `SigHasLowR`
+    reads.
+
+    Both buffers are allocated here and reused across attempts: once per
+    call rather than once per attempt, which is most of what a loop
+    written in C would have saved, and per call rather than at module
+    level, which a package holding one shared context and documenting
+    thread safety cannot do.
+
+    Args:
+        signature: the signature of the first attempt, signed over in
+            place until its r is the low one.
+        msg_bytes: the 32-byte hash of the message, already checked.
+        prvkey_bytes: the 32-byte private key, already checked.
+
+    Raises:
+        RuntimeError: if libsecp256k1 fails to serialize an attempt,
+            which a signature it has just made cannot do.
+    """
+    compact = ffi.new("unsigned char[64]")
+    # the counter goes in the first 4 octets and the other 28 stay zero,
+    # so the buffer is written once per attempt and not rebuilt
+    entropy = ffi.new("unsigned char[32]")
+    counter = 0
+    while True:
+        if not lib.secp256k1_ecdsa_signature_serialize_compact(ctx, compact, signature):
+            raise RuntimeError("signature serialization failed")
+        if compact[0] < 0x80:
+            return
+        counter += 1
+        entropy[0:4] = counter.to_bytes(4, "little")
+        _signed(signature, msg_bytes, prvkey_bytes, entropy)
+
+
 def _sign_(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    grind: bool = False,
 ) -> CData:
     """Create an ECDSA signature, as the parsed signature.
 
@@ -152,6 +243,10 @@ def _sign_(
         prvkey: the private key, 32 bytes or an int below 2**256.
         aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
             None for the RFC6979 nonce alone.
+        grind: whether to sign again until r is the low one, as `sign`
+            documents. Not with aux_rand32: the two write the same 32
+            octets, so asking for both is refused rather than resolved
+            here.
 
     Returns:
         The libsecp256k1 signature object, in the lower-s form
@@ -159,30 +254,19 @@ def _sign_(
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
-            given and is not 32 bytes, or if the private key is not 32
-            bytes, does not fit in them, or is not in [1, n-1].
+            given and is not 32 bytes, if aux_rand32 and grind are given
+            together, or if the private key is not 32 bytes, does not fit
+            in them, or is not in [1, n-1].
     """
     prvkey_bytes = scalar(prvkey, "private key")
     msg_bytes = octets(msg_bytes, "message hash", 32)
+    if grind and aux_rand32 is not None:
+        raise ValueError("aux_rand32 and grind are the same 32 octets")
 
     signature = ffi.new("secp256k1_ecdsa_signature *")
-
-    # secp256k1_ecdsa_sign takes the nonce function and its data: NULL
-    # for the first selects the RFC6979 default, and it is the only one
-    # these bindings pass -- a python nonce function would be called from
-    # inside the signature, with the secret passing through a python
-    # object on every call. The contribution beside it is 32 bytes of
-    # entropy, and `optional_entropy` says what omitting it means here
-    noncefp = ffi.NULL
-    if not lib.secp256k1_ecdsa_sign(
-        ctx,
-        signature,
-        msg_bytes,
-        prvkey_bytes,
-        noncefp,
-        optional_entropy(aux_rand32),
-    ):
-        raise ValueError("invalid private key: not in [1, n-1]")
+    _signed(signature, msg_bytes, prvkey_bytes, optional_entropy(aux_rand32))
+    if grind:
+        _grind(signature, msg_bytes, prvkey_bytes)
     return signature
 
 
@@ -191,6 +275,7 @@ def sign(
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
     compact: bool = False,
+    grind: bool = False,
 ) -> bytes:
     """Create an ECDSA signature.
 
@@ -204,6 +289,15 @@ def sign(
     reaching it through `to_compact` is that DER encoding parsed straight
     back apart.
 
+    `grind` is the one thing here that is more than a libsecp256k1 call,
+    and it is Bitcoin Core's `CKey::Sign` scheme rather than an invention
+    of this package: signing again, with a counter mixed into the nonce,
+    until r has its high bit clear and DER therefore spends no leading
+    zero octet on it. It costs what the octet is worth -- two signatures
+    on average, and the tail is longer than that -- so it is asked for
+    and never done by default. `s` is not ground for and could not be:
+    libsecp256k1 has already returned the lower of the two.
+
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -212,15 +306,22 @@ def sign(
             entropy is not a serialization, and padding one would make a
             caller mistake a valid argument.
         compact: whether to answer the 64-byte `r || s` rather than DER.
+        grind: whether to sign again until r is the low one. Refused
+            together with aux_rand32: grinding is written into those very
+            32 octets, so a caller asking for both is asking for two
+            different values of one argument, and Core's counter is what
+            makes the result reproducible by anyone else.
 
     Returns:
         The signature, in the lower-s form libsecp256k1 always produces:
         DER, or the 64 octets of `r || s` where `compact` asks for them.
+        Where `grind` asks for it, of the low r as well.
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
-            given and is not 32 bytes, or if the private key is not 32
-            bytes, does not fit in them, or is not in [1, n-1].
+            given and is not 32 bytes, if aux_rand32 and grind are given
+            together, or if the private key is not 32 bytes, does not fit
+            in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to serialize the signature,
             which no input can make it do.
 
@@ -230,8 +331,10 @@ def sign(
         >>> msg = hashlib.sha256(b"hello").digest()
         >>> dsa.is_low_s(dsa.sign(msg, 1))
         True
+        >>> dsa.sign(msg, 1, grind=True, compact=True)[0] < 0x80
+        True
     """
-    signature = _sign_(msg_bytes, prvkey, aux_rand32)
+    signature = _sign_(msg_bytes, prvkey, aux_rand32, grind)
     return serialize_compact(signature) if compact else serialize_der(signature)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -75,6 +75,44 @@ def test_sign_and_verify() -> None:
     assert ssa.verify(msg, keys.reserialize(pubkey_bytes), ssa_sig)
 
 
+def test_grinding_is_the_signature_the_boundary_would_have_returned() -> None:
+    """Grinding changes which signature is answered, and nothing else.
+
+    What the vendored vectors pin is the octets, against Core and against
+    rust-secp256k1; what is left for here is the boundary around them.
+    Both halves grind -- `_sign_` for a caller holding the object and
+    `sign` for one wanting the encoding -- and both serializations carry
+    the same signature out, so the compact form and the DER form of one
+    ground signature are each other's. It still verifies, and it is still
+    low-s: grinding chooses among the signatures libsecp256k1 makes
+    rather than making one of its own.
+
+    The refusal is the entropy argument: grinding writes those same 32
+    octets, so asking for both at once is refused rather than silently
+    resolved in favour of one of them.
+    """
+    msg = b"\x03" * 32
+
+    ground = dsa.sign(msg, prvkey, grind=True)
+    assert dsa.verify(msg, pubkey_bytes, ground)
+    assert dsa.is_low_s(ground)
+    # the high bit of r is what was ground for, and r is the first 32
+    # octets of the compact form
+    assert dsa.to_compact(ground)[0] < 0x80
+    assert dsa.sign(msg, prvkey, compact=True, grind=True) == dsa.to_compact(ground)
+    # the private half answers with the object the public one encodes
+    assert dsa.serialize_der(dsa._sign_(msg, prvkey, grind=True)) == ground
+
+    # deterministic, like the signature it grinds from: the counter is a
+    # function of the message and the key too
+    assert dsa.sign(msg, prvkey, grind=True) == ground
+
+    with pytest.raises(ValueError, match="aux_rand32 and grind"):
+        dsa.sign(msg, prvkey, b"\x01" * 32, grind=True)
+    with pytest.raises(ValueError, match="aux_rand32 and grind"):
+        dsa._sign_(msg, prvkey, b"\x01" * 32, grind=True)
+
+
 def test_ssa_sign_custom() -> None:
     """Sign a BIP340 message of any length, which only sign_custom takes.
 

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -29,6 +29,11 @@
 - deterministic ECDSA and DER encodings from trezor-firmware
   (crypto/tests/test_check.c, test_ecdsa_sign_digest_deterministic
   and test_ecdsa_der)
+- low-r grinding, from the two implementations of the scheme this
+  package copies: bitcoin/bitcoin src/test/key_tests.cpp, both the
+  fixed signatures of `key_test1` and the property `key_signature_tests`
+  asserts over 256 messages, and rust-bitcoin/rust-secp256k1 src/lib.rs
+  `test_low_r`, whose vector is the one that takes more than one attempt
 - ecdsa_sig.json and ecdsa_custom_nonce_sig.json, the ECDSA vectors
   used by btclib, vendored from
   https://github.com/rustyrussell/secp256k1-py (tests/data);
@@ -1075,6 +1080,133 @@ def test_trezor_ecdsa_vector(seckey_hex: str, digest_hex: str, sig_hex: str) -> 
 
     pubkey = keys.pubkey_from_prvkey(bytes.fromhex(seckey_hex), compressed=False)
     assert dsa.verify(digest, pubkey, der)
+
+
+# Bitcoin Core's src/test/key_tests.cpp, key_test1: the scalars of the
+# WIFs strSecret1 and strSecret2, signing Hash("Very deterministic
+# message") through CKey::Sign, which grinds unless told otherwise. Core
+# asserts the same octets for the compressed and the uncompressed
+# spelling of each key, so the scalar is all there is to carry over --
+# and it is the scalar this package takes anyway, a private key having
+# no compression flag on this side of the boundary
+CORE_PRVKEY1 = "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747"
+CORE_PRVKEY2 = "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117"
+CORE_DETERMINISTIC_VECTORS = [
+    (
+        CORE_PRVKEY1,
+        (
+            "304402205dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe5"
+            "9d31d022014ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd"
+            "4582f6"
+        ),
+    ),
+    (
+        CORE_PRVKEY2,
+        (
+            "3044022052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9d"
+            "c1cd5022061d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771"
+            "b5944d"
+        ),
+    ),
+]
+
+# rust-bitcoin/rust-secp256k1, src/lib.rs, test_low_r: the same counter
+# scheme in an implementation that shares no line of code with Core's,
+# and a case that needs five attempts to reach a low r -- so the counter
+# is in the answer here, where Core's own vectors are settled by the
+# first attempt
+RUST_LOW_R_MSG = "887d04bb1cf1b1554f1b268dfe62d13064ca67ae45348d50d1392ce2d13418ac"
+RUST_LOW_R_PRVKEY = "57f0148f94d13095cfda539d0da0d1541304b678d8b36e243980aab4e1b7cead"
+RUST_LOW_R_SIG = (
+    "047dd4d049db02b430d24c41c7925b2725bcd5a85393513bdec04b4dc363632b"
+    "1054d0180094122b380f4cfa391e6296244da773173e78fc745c1b9c79f7b713"
+)
+
+
+def hash256(msg: bytes) -> bytes:
+    """Return Bitcoin Core's Hash(), which is the SHA256 of the SHA256."""
+    return hashlib.sha256(hashlib.sha256(msg).digest()).digest()
+
+
+@pytest.mark.parametrize("prvkey_hex, der_hex", CORE_DETERMINISTIC_VECTORS)
+def test_bitcoin_core_deterministic_vector(prvkey_hex: str, der_hex: str) -> None:
+    """Reproduce the deterministic signatures of Core's `key_test1`.
+
+    Both are low-r at the first attempt, which is the half of grinding a
+    fixed vector pins without looking as though it pins anything: asking
+    for it has to change nothing, and a loop that ground one attempt too
+    many, or that read the wrong octet of the compact form, would answer
+    something else here.
+    """
+    msg = hash256(b"Very deterministic message")
+    prvkey = bytes.fromhex(prvkey_hex)
+
+    assert dsa.sign(msg, prvkey).hex() == der_hex
+    assert dsa.sign(msg, prvkey, grind=True).hex() == der_hex
+    assert dsa.verify(msg, keys.pubkey_from_prvkey(prvkey), bytes.fromhex(der_hex))
+
+
+def test_rust_secp256k1_low_r_vector() -> None:
+    """Reproduce rust-secp256k1's `test_low_r`, which grinds five times.
+
+    The vector that says the counter is written the way both other
+    implementations write it: little endian, in the first 4 of 32 octets,
+    starting at 1 for the attempt after the deterministic one. Any other
+    reading of those octets diverges by the second attempt, and this one
+    needs five -- the first is the signature asserted below to be the one
+    with the high r.
+    """
+    msg = bytes.fromhex(RUST_LOW_R_MSG)
+    prvkey = bytes.fromhex(RUST_LOW_R_PRVKEY)
+
+    assert dsa.sign(msg, prvkey, compact=True, grind=True).hex() == RUST_LOW_R_SIG
+    # what grinding was for: the deterministic signature of this key and
+    # message is the high-r one, so the vector above is not it
+    assert dsa.sign(msg, prvkey, compact=True)[0] >= 0x80
+    assert dsa.verify(
+        msg,
+        keys.pubkey_from_prvkey(prvkey),
+        bytes.fromhex(RUST_LOW_R_SIG),
+        compact=True,
+    )
+
+
+def test_bitcoin_core_low_r_property() -> None:
+    """Reproduce `key_signature_tests` of Core's src/test/key_tests.cpp.
+
+    Core's own property, over its own inputs: 256 messages signed with
+    grinding, none of them encoding to more than 70 octets and none with
+    an r of more than 32, at least one shorter than 70 -- and, before
+    that, the other half of the same test, that specifying the entropy
+    without grinding does reach a high r within 20 tries. That last one
+    is what makes the rest mean something: it is the same 32 octets the
+    grinding counter writes, so it says the loop has something to find
+    rather than a predicate that is always true.
+    """
+    prvkey = bytes.fromhex(CORE_PRVKEY1)
+
+    # a high r within 20 tries, the counter as Core's test_case writes it
+    high_r = [
+        dsa.sign(
+            hash256(b"A message to be signed"),
+            prvkey,
+            attempt.to_bytes(4, "little") + bytes(28),
+        )
+        for attempt in range(1, 21)
+    ]
+    assert any(der[3:5] == b"\x21\x00" for der in high_r)
+
+    lengths = set()
+    for i in range(256):
+        der = dsa.sign(
+            hash256(b"A message to be signed" + str(i).encode()), prvkey, grind=True
+        )
+        # der[3] is the length of r, which grinding holds to 32 octets:
+        # the leading zero DER spends on a high one is what it is for
+        assert der[3] <= 32
+        lengths.add(len(der))
+    assert max(lengths) <= 70
+    assert min(lengths) < 70
 
 
 # encodings accepted by secp256k1_ecdsa_signature_parse_der: they parse


### PR DESCRIPTION
Closes #204.

`dsa.sign(grind=True)` signs again, with a counter mixed into the nonce,
until `r` has its high bit clear — one octet less of DER, which is what
Bitcoin Core's `CKey::Sign` grinds for. Core's scheme octet for octet,
because the counter is what makes the answer reproducible anywhere else:
the first attempt is the plain RFC6979 signature, each retry a `uint32`
little endian in the first 4 of 32 octets.

## The decision the issue left open, measured

The issue closed on a C-side loop looking 7% cheaper. It is not: what
that bought was the allocation, not the crossing, and python can stop
allocating too. Compact form, 2000 keys, one message, Apple M5 / CPython
3.14.6:

| | per signature |
| --- | --- |
| a loop calling the wrappers once per attempt | 25.90 µs |
| **what this implements** — key checked once, both scratch buffers allocated once per call | 24.82 µs |
| the same with those buffers at module level, which thread safety rules out | 23.82 µs |

So a C helper would have started half a microsecond below what landed,
and would have cost the property these bindings do not trade: `create_cffi`
compiles no C in ABI mode, so it would have existed in the static wheels
and not the dynamic ones. Through the public API, `dsa.sign` is 12.62 µs
and `dsa.sign(grind=True)` 25.23 — 2.09 attempts on the mean, 14 for the
worst of those 2000 keys, which is why it is asked for and never default.

## What the implementation is careful about

- **the retry reads the compact serialization, not the DER length.** DER
  is `6 + lenR + lenS`, so a high `r` of 33 octets beside an `s` needing
  only 31 encodes to 70 too — one signature in about 500, measured over
  200000 — and a length test takes those for low-r ones. `compact[0] <
  0x80` is what Core's `SigHasLowR` reads.
- **`aux_rand32` and `grind` are refused together**, rather than one
  ignored as Core ignores its `test_case`: they write the same 32 octets,
  and an argument that silently vanishes is not what this boundary does
  with one.
- **`recovery.sign` gets no `grind`**: 65 fixed octets have nothing to
  shorten.
- **`s` gets none either**, and could not: libsecp256k1 has always
  returned the lower of the two.

## What judges it

External vectors from both implementations of the scheme, in
`tests/test_vectors.py`:

- Core's `key_test1` deterministic signatures — low-r at the first
  attempt, so they pin that asking for grinding changes nothing;
- the property `key_signature_tests` asserts over 256 messages, with the
  high-r half of that same test, which says the loop has something to
  find;
- rust-secp256k1's `test_low_r`, whose vector takes five attempts and so
  pins the counter itself, in an implementation sharing no line with
  Core's.

Suite green, coverage gate at 100.00%, every hook passes.

## Summary by Sourcery

Add optional low-r grinding to ECDSA signing to match Bitcoin Core’s behavior and document, test, and release-note the new capability.

New Features:
- Introduce a grind parameter to dsa.sign and _sign_ to repeatedly sign until r has its high bit clear, producing low-r signatures identical to Bitcoin Core’s CKey::Sign scheme.

Enhancements:
- Factor shared signing logic into a reusable helper and add an internal grinding loop that reuses buffers per call for better performance.
- Validate that aux_rand32 and grind are not used together, keeping API behavior explicit and consistent.

Documentation:
- Document the new dsa.sign(grind=True) option, its semantics, performance characteristics, and rationale in README, CHANGELOG, and HISTORY.

Tests:
- Add vector-based tests against Bitcoin Core and rust-secp256k1 low-r signatures, plus property tests to validate grinding behavior, determinism, and boundary handling.