### PR TITLE
Spell five entry points out, and italicise the cross-reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,52 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### The frames between an entry point and libsecp256k1
+
+- **Five entry points are spelled out rather than composed of their
+  halves**: `keys.parse` and `xonly.parse`, which delegated to their
+  `_parsed`, `keys.pubkey_tweak_add`, which was three calls, and
+  `dsa.verify` and `ssa.verify`, which parsed through one call and
+  verified through another. What a python frame is worth was measured by
+  alternating the two spellings in one process, 7 rounds each and the
+  minimum kept for each -- an Apple M5, macOS 26.6, arm64, CPython
+  3.13.14: `keys.parse` of 65 bytes 0.010 of 0.205 and of 33 bytes 0.013
+  of 2.324, `xonly.parse` of 65 bytes 0.012 of 0.485, `ssa.verify` 0.009
+  of 14.275, `dsa.verify` 0.035 of 11.813, `keys.pubkey_tweak_add` 0.037
+  of 3.403. Small everywhere, and largest where the call is shortest.
+- **`dsa.sign` is composed still, and that is a measured result rather
+  than an omission.** Three spellings were tried -- `_sign_` inlined, the
+  DER serialization inlined, and both -- and all three land within 0.03
+  microseconds of the composed one and on the wrong side of it. A
+  signature is 11.9 microseconds of libsecp256k1; two python frames do
+  not show against it, and a body written twice for nothing is worse
+  than the frames.
+- **Measuring the two spellings one after the other is what made them
+  look bigger.** Run in sequence rather than alternated, the same
+  comparison reported 0.027, 0.083, 0.154 and 0.261 for four of the
+  calls above -- two to four times the alternated figure, and for
+  `dsa.sign` a saving that is not there at all. The machine drifts under
+  a benchmark, and a pair measured in a fixed order gives the drift to
+  one side of it.
+- **Every private half stays, and removing them was measured before it
+  was declined.** They are what a caller holding a parsed object does
+  not pay a parse for, and that is worth 0.558 microseconds per call
+  against a 65-byte key, 2.676 against a 33-byte one -- where the parse
+  is a field square root -- and 2.687 on a tweak applied to its own
+  output. Two orders of magnitude more than the frames are worth, and in
+  the opposite direction: deleting them to save a frame on the octets
+  path would cost the object path a parse at every call. `ssa.Signer`
+  and `keys.PubkeyTweakChain` are the same trade already made.
+- **So five bodies are written twice**, once taking octets and once
+  taking the object, and the equality is asserted rather than assumed:
+  `tests/test_parsed_keys.py` holds every public half to its private
+  one, pair by pair and over both serializations of a public key, and
+  `test_every_private_half_is_paired` makes an unpaired half an absence
+  rather than a test nobody wrote. That test is what makes the
+  duplication survivable, and it is why it was not extended to
+  `recovery`, `ellswift` or `silentpayments`, whose entry points no
+  benchmark reaches and which still compose.
+
 ### What a crossing costs, and what stops being paid for it
 
 - **`context.guarded` is gone, and every call it held is now a bare

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ That example is the one that matters: partial signing zeroes the secret
 nonce, so signing twice with it is refused, and this is how a session
 learns why. The entry points taking octets need none of it, validating
 their arguments before calling; the private halves taking an object need
-exactly it, for the reason that parsing the key once gives. Either way the
+exactly it, for the reason *Parsing the key once* gives. Either way the
 abort()ing libsecp256k1 defaults are replaced by do-nothing stubs in the
 vendored build, so no illegal argument can take the hosting process
 down.

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import overload
 
-from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
+from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx
@@ -334,6 +334,14 @@ def sign(
         >>> dsa.sign(msg, 1, grind=True, compact=True)[0] < 0x80
         True
     """
+    # composed, where `verify` below is spelled out: the frames this
+    # would save were measured and are not there. Shipped against a
+    # spelling with `_sign_` inlined, with the DER serialization inlined,
+    # and with both, alternated in one process over 9 rounds of 20 000
+    # calls -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14 -- all
+    # three land within 0.03 microseconds of this one and on the wrong
+    # side of it. A signature is 11.9 microseconds of libsecp256k1, and
+    # two python frames do not show against it
     signature = _sign_(msg_bytes, prvkey, aux_rand32, grind)
     return serialize_compact(signature) if compact else serialize_der(signature)
 
@@ -429,10 +437,28 @@ def verify(
         >>> dsa.verify(msg, keys.pubkey_from_prvkey(1), dsa.sign(msg, 1))
         True
     """
-    parse = parse_compact if compact else parse_der
-    return _verify_(
-        msg_bytes, keys.parse(pubkey_bytes), parse(signature_bytes), normalize
-    )
+    # spelled out rather than composed of `keys.parse`, a `parse_` and
+    # `_verify_`: those frames are 0.035 microseconds of the 11.813 this
+    # call costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the
+    # two spellings alternated in one process over 7 rounds of 20 000
+    # calls, minimum kept for each. `_verify_` makes the same calls for a
+    # caller holding both objects, and tests/test_parsed_keys.py asserts
+    # the two answer alike
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
+        raise ValueError("invalid public key")
+
+    signature = _parsed(signature_bytes, compact)
+    if signature is None:
+        raise ValueError(
+            "invalid compact signature" if compact else "invalid DER signature"
+        )
+    if normalize:
+        _normalize_(signature)
+
+    msg_bytes = octets(msg_bytes, "message hash", 32)
+    return bool(lib.secp256k1_ecdsa_verify(ctx, signature, msg_bytes, pubkey))
 
 
 def _normalize_(signature: CData) -> CData:

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -367,7 +367,20 @@ def pubkey_tweak_add(
         RuntimeError: if libsecp256k1 fails to serialize the result,
             which no valid input can make it do.
     """
-    return serialize(_pubkey_tweak_add_(parse(pubkey_bytes), tweak), compressed)
+    # spelled out rather than composed of `parse`, `_pubkey_tweak_add_`
+    # and `serialize`: those three frames are 0.037 microseconds of the
+    # 3.403 this call costs -- an Apple M5, macOS 26.6, arm64, CPython
+    # 3.13.14, the two spellings alternated in one process over 7 rounds
+    # of 20 000 calls, minimum kept for each. The private half makes the
+    # same calls for a caller holding the point, and
+    # tests/test_parsed_keys.py asserts the two answer alike
+    pubkey_bytes = octets(pubkey_bytes, "public key")
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
+        raise ValueError("invalid public key")
+    if not lib.secp256k1_ec_pubkey_tweak_add(ctx, pubkey, scalar(tweak, "tweak")):
+        raise ValueError("invalid tweak or resulting public key")
+    return serialize(pubkey, compressed)
 
 
 class PubkeyTweakChain:
@@ -918,8 +931,16 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         ValueError: if the bytes are not a valid point in either
             serialization.
     """
-    pubkey = _parsed(pubkey_bytes, name)
-    if pubkey is None:
+    # spelled out rather than delegated to `_parsed`: the one python
+    # frame between them is 0.010 microseconds of the 0.205 this call
+    # costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the two
+    # spellings alternated in one process over 7 rounds of 400 000 calls,
+    # minimum kept for each. Small, and it is the parse every wrapper
+    # taking a public key begins with. `_parsed` answers None where this
+    # raises, and `pubkey_verify` is what wants that
+    pubkey_bytes = octets(pubkey_bytes, name)
+    pubkey = ffi.new("secp256k1_pubkey *")
+    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, pubkey_bytes, len(pubkey_bytes)):
         raise ValueError(f"invalid {name}")
     return pubkey
 
@@ -930,15 +951,17 @@ def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
     `secp256k1_ec_pubkey_parse` is the proof that octets are a public key,
     and there are two things to do with the same proof: `parse` keeps what
     it built and raises when there is nothing to keep, `pubkey_verify`
-    keeps nothing and answers the verdict. Written twice, the two would be
-    one call each until an argument check moved in one of them.
+    keeps nothing and answers the verdict.
 
-    It costs `parse` a python call, and that is the whole of what the
-    single statement is bought with: 0.269 microseconds against 0.256 on
-    the uncompressed serialization, and 2.326 against 2.310 on the
-    compressed one, where the field square root is what is being paid for
-    -- an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 7 rounds
-    of 300 000 calls.
+    `pubkey_verify` is the only caller. `parse` spells the same three
+    statements out rather than delegating, the frame between them being
+    0.027 microseconds of the 0.218 it costs -- an Apple M5, macOS 26.6,
+    arm64, CPython 3.13.14, minimum of 9 rounds of 400 000 calls -- which
+    is a tenth of the call, on the parse every wrapper taking a public key
+    begins with. Two spellings of one parse is what that buys, and what
+    holds them together is that either one refusing these octets is the
+    other one refusing them: `tests/test_keys.py` asserts the pair over
+    both serializations and over what is neither.
 
     Args:
         pubkey_bytes: the public key, 33 or 65 bytes.

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -482,7 +482,22 @@ def verify(
             A well-formed signature that simply does not verify is False,
             not an exception.
     """
-    return _verify_(msg_bytes, xonly.parse(pubkey_bytes), signature_bytes)
+    # spelled out rather than composed of `xonly.parse` and `_verify_`:
+    # the frame between them is 0.009 microseconds of the 14.275 this
+    # call costs -- an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the
+    # two spellings alternated in one process over 7 rounds of 20 000
+    # calls, minimum kept for each. That is the smallest of these and is
+    # kept for consistency with the rest rather than on its own account.
+    # `_verify_` makes the same calls for a caller holding the x-only
+    # key, and tests/test_parsed_keys.py asserts the two answer alike
+    xonly_pubkey = xonly.parse(pubkey_bytes)
+    msg_bytes = octets(msg_bytes, "message")
+    signature_bytes = octets(signature_bytes, "signature", 64)
+    return bool(
+        lib.secp256k1_schnorrsig_verify(
+            ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
+        )
+    )
 
 
 def _sign32(

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -427,8 +427,19 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         ValueError: if it is not a valid point, or is not 32, 33 or 65
             bytes.
     """
-    xonly_pubkey = _parsed(pubkey_bytes, name)
-    if xonly_pubkey is None:
+    # spelled out rather than delegated to `_parsed`, for the reason
+    # `keys.parse` is: this is the parse BIP340 verification begins with.
+    # `_parsed` answers None where this raises, and `pubkey_verify` is
+    # what wants that
+    pubkey_bytes = octets(pubkey_bytes, name)
+    if len(pubkey_bytes) != _XONLY_SIZE:
+        pubkey = keys._parsed(pubkey_bytes, name)
+        if pubkey is None:
+            raise ValueError(f"invalid {name}")
+        return _drop_y(pubkey)[0]
+
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
         raise ValueError(f"invalid {name}")
     return xonly_pubkey
 
@@ -437,8 +448,9 @@ def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
     """Parse a public key into its x, answering None where it is not one.
 
     What `keys._parsed` is to a full public key, and for the same reason:
-    `parse` raises where this answers None and `pubkey_verify` answers
-    the verdict, and one call is what both are.
+    this answers the verdict `pubkey_verify` wants where `parse` raises.
+    `parse` spells the same statements out rather than delegating, for the
+    reason `keys.parse` does.
 
     Args:
         pubkey_bytes: the public key, 32, 33 or 65 bytes.


### PR DESCRIPTION
The `cheaper-crossings` work, rebased onto main. Two commits, and the first
is one line.

## Five entry points spelled out

`keys.parse` and `xonly.parse` delegated to their `_parsed` halves,
`keys.pubkey_tweak_add` was three calls, and `dsa.verify` and `ssa.verify`
parsed through one call and verified through another. The python frames
between them are worth something on calls this short, and now they are not
paid.

Measured by **alternating the two spellings in one process**, 7 rounds each,
minimum kept for each — an Apple M5, macOS 26.6, arm64, CPython 3.13.14:
`keys.parse` of 65 bytes 0.010 microseconds of 0.205 and of 33 bytes 0.013 of
2.324, `xonly.parse` of 65 bytes 0.012 of 0.485, `ssa.verify` 0.009 of
14.275, `dsa.verify` 0.035 of 11.813, `keys.pubkey_tweak_add` 0.037 of 3.403.

`dsa.sign` stays composed, and that is a result rather than an omission:
three spellings were tried — `_sign_` inlined, the DER serialization inlined,
and both — and all three land within 0.03 microseconds of the composed one
and on the wrong side of it.

Measuring the two spellings one after the other rather than alternating them
is what made all of these look bigger: in a fixed order the same comparison
reported 0.027, 0.083, 0.154 and 0.261 for four of the calls above, two to
four times the alternated figure and, for `dsa.sign`, a saving that is not
there. The machine drifts under a benchmark, and a fixed order gives the
drift to one side.

Every private half stays. They are what a caller holding a parsed object does
not pay a parse for — 0.558 microseconds against a 65-byte key, 2.676 against
a 33-byte one, 2.687 on a tweak applied to its own output — two orders of
magnitude more than the frames, in the opposite direction. So five bodies are
now written twice, and `tests/test_parsed_keys.py` is what holds each pair to
one answer.

## The cross-reference

`Parsing the key once` is a section of README.md, and the context-callback
passage named it mid-sentence. Italics are how that section and *What the
boundary checks* are referred to at lines 78 and 140.

That commit carried the remeasurement of the boundary figures with it before
the rebase. **That part is already on main** —
[`06bb46c`](https://github.com/btclib-org/btclib-secp256k1/commit/06bb46c1156dd474139048be2e99574efd123e6a)
took it there, #205's fast-forward having landed the earlier of two heads and
#206 having carried the difference over — so the rebase left this commit the
sentence alone, and its message now says that rather than the old story.

## Gate

`uv run --locked --no-default-groups --group test pytest --cov` — 578 passed,
coverage 100.00%. `uvx pre-commit run --all-files` — exit 0.

## Summary by Sourcery

Inline several libsecp256k1 entry-point wrappers for measured micro-optimizations and align documentation with the new structure.

Enhancements:
- Inline public-key parsing and tweak-add logic in `keys.parse`, `xonly.parse`, `keys.pubkey_tweak_add`, `dsa.verify`, and `ssa.verify` instead of delegating through helper functions, reducing Python call overhead at entry points.
- Keep `dsa.sign` as a composed wrapper with added commentary explaining benchmarked trade-offs versus inlining.
- Adjust internal pubkey parsing helpers to reflect that they are now only used by verification-style helpers and document their relationship to the public entry points.
- Remove unused `keys` import from the DSA module after inlining verification logic.

Documentation:
- Extend the unreleased changelog with a section describing the entry-point inlining, benchmark methodology, and the role of private helper halves and their tests.
- Update README wording to italicize and correctly reference the *Parsing the key once* section for consistency with other cross-references.

Tests:
- Document in the changelog the new `tests/test_parsed_keys.py` coverage of public/private half equivalence and pairing, ensuring duplicated entry-point bodies stay in sync.