### PR TITLE
Read the version when a caller asks, not when the module loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,100 @@ release-notes length in the first place, and are still in
   nothing to win and the figures say so: the field square root is what
   that row is.
 
+### What importing the package costs
+
+- **`__version__` is read on first access rather than at import** (#210).
+  The value comes from where it came from -- the installed distribution
+  metadata, so that `pyproject.toml` stays the only place a release bumps
+  -- and a module-level `__getattr__` (PEP 562) is what defers reading
+  it. `importlib.metadata` pulls `email`, `json` and `inspect` behind it,
+  among others.
+- **`pathlib` is imported where it is used**, which is the dynamic branch
+  of `_load_lib`. A static extension returns from `hasattr(module,
+  "lib")` two lines earlier, and a static extension is what every
+  platform of the matrix ships by default.
+- **It takes both, and deferring `import pathlib` alone would have bought
+  nothing.** `importlib.metadata` imports `pathlib` itself, and
+  `import pathlib` was the statement *above* the one that read the
+  version, so on the file as it was `pathlib` arrived whether that first
+  line ran or not: the row below measures it at 0.09 milliseconds, which
+  is nothing. The 2.27 that deferring it is worth here is a saving this
+  branch creates rather than one that was lying there.
+- Every figure below is one session, one build, `__init__.py` the only
+  thing that differs, minimum of 12 fresh interpreters each -- an Apple
+  M5, macOS 26.6, arm64, CPython 3.14.6. It is the only place this
+  decomposition is written down; the docstrings that quote a figure send
+  the reader here rather than repeating the split.
+
+  ```shell
+  # after each swap, run it once and throw that answer away: a changed
+  # __init__.py invalidates its .pyc, and compiling this file is about a
+  # millisecond -- most of the number being reported for the branch
+  python -c "import time, importlib
+  t = time.perf_counter(); importlib.import_module('btclib_secp256k1')
+  print((time.perf_counter() - t) * 1e3)"
+  ```
+
+  | | ms |
+  | --- | --- |
+  | as it is now, both deferred | **1.69** |
+  | with `import pathlib` back at module level | 3.96 |
+  | with the `importlib.metadata` import back instead | 10.98 |
+  | the file as it was: both, and the `version()` call | 15.85 |
+  | the file as it was, with `import pathlib` deferred alone | 15.76 |
+  | as it is now, then reading `__version__` | 15.59 |
+  | the file as it was, then reading `__version__` | 15.97 |
+  | `_btclib_secp256k1`, the extension, either way | 0.58 |
+
+  The middle rows are marginal costs over this branch, each measured by
+  putting one statement back, and they do not add up to the fourth: the
+  9.3 of the metadata import already contains `pathlib`'s 2.27, and what
+  is left of the 15.85 is the first `version()` call, 4.9 of it.
+
+  The last two rows before the extension are the same number and not a
+  saving of 0.4: a caller that reads the version pays what it paid, and
+  which of the two comes out ahead is the drift of the machine between
+  two batches.
+
+- **The value is stored into the module's namespace on the way out.**
+  `sys.modules` caches the module `importlib.metadata` is, not the answer
+  `version()` gives, so a `__getattr__` that only defers would leave
+  every read after the first walking the metadata again -- 290
+  microseconds each, where the attribute it replaced was a dict lookup at
+  0.010. Storing it is the usual shape of PEP 562 and makes the second
+  read 0.018. It is also what makes the `dir()` sentence below true: the
+  interpreter does not memoise a module `__getattr__`, so without this
+  the attribute would never appear at all.
+- **The reading of the version is outside the `TYPE_CHECKING` guard**,
+  in `_read_version`, and only the `__getattr__` is inside it. mypy does
+  not check the body of the `else` such a guard takes: with the two
+  working lines in there, `return len(version(...))` from a function
+  annotated `-> str` passes `--strict`, and `warn_unreachable` does not
+  catch it either. Out here the same error is `[return-value]`, which is
+  what `py.typed` and *a wrong annotation propagates* ask for.
+- **The `__getattr__` is behind `if TYPE_CHECKING`, and that is the
+  point of the change surviving the gate.** A module that has one is a
+  module mypy stops checking attribute names on: measured on this tree,
+  `from btclib_secp256k1 import nosuchmodule` and
+  `btclib_secp256k1.typo` both stop being errors under `--strict`, and
+  that is the front door of the package. Declaring `__version__: str` to
+  the type checker and defining the function only at run time keeps both
+  checks, and `tests/test_extension.py` needing a
+  `type: ignore[attr-defined]` to ask for a missing attribute is the
+  proof that it does.
+- **Two tests hold the saving**, `test_import_defers_the_metadata` and
+  `test_import_defers_pathlib`: each imports the package in a subprocess
+  and asserts what is *not* in `sys.modules` afterwards. Nothing else
+  would notice a module-level import added later, here or in anything
+  this package imports, which is how the 13 milliseconds arrived. The
+  second is skipped on a dynamic extension, which reaches `_load_lib`'s
+  other branch and imports `pathlib` legitimately; the matrix runs the
+  suite both ways.
+- **What it costs a caller** is that `dir(btclib_secp256k1)` does not
+  list `__version__` until something reads it, and does afterwards.
+  Nothing else changes: the attribute, the `from … import __version__`,
+  and reading the metadata directly all answer what they answered.
+
 ### Signing under one key
 
 - **`ssa.Signer` builds the BIP340 keypair once** (#153). `ssa.sign` and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -264,6 +264,22 @@ verification, which is 12.9 microseconds against 12.1, and most of the
 call on `keys._pubkey_cmp_`, which is 0.57 against a C comparison of
 0.087. `lib` is exported for a caller who counts that.
 
+**Importing the package is ten times cheaper**, 1.69 milliseconds against
+15.85 — an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 12
+fresh interpreters, CHANGELOG.md carrying the command and the table. Two
+imports did it, neither of them the compiled extension, which is 0.58 of
+those milliseconds: `importlib.metadata`, reached at import to fill
+`__version__` and pulling `email`, `json` and `inspect` behind it, and
+`pathlib`, which only the dynamic branch of `_load_lib` uses and which a
+static wheel never reaches. The version is read on first access now, and
+`pathlib` where it is used — and it takes both, `importlib.metadata`
+importing `pathlib` itself. What a caller has to know is one thing:
+`dir(btclib_secp256k1)` does not list `__version__` until something reads
+it, and does afterwards. Reading it — as the attribute, as
+`from btclib_secp256k1 import __version__`, or straight out of the
+metadata — answers what it always answered, and costs what it always
+cost, the first read and every one after it.
+
 ## v0.8.0.2
 
 Non-breaking, and two additions for a caller that verifies signatures it

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -43,15 +43,83 @@ was just serialized -- and for a compressed key that parse is a field
 square root.
 """
 
-import pathlib
-from importlib.metadata import version
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import _btclib_secp256k1
 
-# read from the installed distribution metadata, so that the version in
-# pyproject.toml stays the only place to bump at release time
-__version__ = version("btclib_secp256k1")
+
+def _read_version() -> str:
+    """Read the version out of the installed distribution metadata.
+
+    That is where it comes from so that the version in pyproject.toml
+    stays the only place to bump at release time. Where it is read is
+    the `__getattr__` below; this is only the reading of it, and it is
+    out here rather than inside that function because mypy does not
+    check the body of the `else` a `TYPE_CHECKING` guard takes -- a
+    `return len(...)` from a function annotated `-> str` passes
+    `--strict` in there, and is caught as `[return-value]` out here.
+
+    `importlib.metadata` is not a small module to reach for -- `email`,
+    `json` and `inspect` are three of the ones it pulls behind it -- so
+    the import is deferred to the one call that needs it.
+
+    Returns:
+        The version of the installed distribution.
+    """
+    from importlib.metadata import version  # noqa: PLC0415
+
+    return version("btclib_secp256k1")
+
+
+if TYPE_CHECKING:
+    # what a type checker is told, and it is told this instead of the
+    # function below rather than as well: a module with a `__getattr__`
+    # is one mypy stops checking attribute names on altogether, so
+    # `from btclib_secp256k1 import nosuchmodule` and
+    # `btclib_secp256k1.typo` both start passing --strict. That is the
+    # front door of this package, the line every caller writes, and the
+    # two checks are worth the six lines it takes to keep them
+    __version__: str
+else:
+
+    def __getattr__(name: str) -> str:
+        """Build the one attribute this module makes only when asked.
+
+        `__version__` is that attribute, and reading it at import is
+        what made that import 15.85 milliseconds where it is now 1.69 --
+        an Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 12
+        fresh interpreters. CHANGELOG.md carries the command, the rest
+        of the table and what the 14 milliseconds are made of, so that
+        the decomposition is written down once. So the caller that wants
+        the version pays for it and the one that never asks pays
+        nothing; btclib, which depends on this package, is one of
+        those.
+
+        The value is stored into the module's own namespace on the way
+        out, which is the usual shape of PEP 562 and is what keeps the
+        second read a dict lookup rather than another walk of the
+        metadata: `importlib.metadata.version` is 290 microseconds every
+        time it is called, `sys.modules` caching the module and not the
+        answer. So `dir()` does not list `__version__` until something
+        reads it, and does afterwards.
+
+        Args:
+            name: the attribute being looked up.
+
+        Returns:
+            The version of the installed distribution, for
+            `__version__`.
+
+        Raises:
+            AttributeError: for any other name, this being the fallback
+                python calls only once the module itself has none.
+        """
+        if name == "__version__":
+            globals()["__version__"] = value = _read_version()
+            return value
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
 
 # an opaque handle to a libsecp256k1 object, as returned by ffi.new: the
 # cffi cdata type is not expressible in the type system, but a named
@@ -110,7 +178,15 @@ def _load_lib(module: Any) -> Any:
         return module.lib
 
     # a dynamic one (cffi ABI mode) has to find, at run time, the shared
-    # object shipped beside it
+    # object shipped beside it. pathlib is imported here rather than at
+    # module level because the line above is where a static build
+    # returns, and a static build is what every platform of the matrix
+    # ships by default: 2.27 milliseconds of an import that is 1.69
+    # milliseconds without it, measured as `__getattr__` says. It is
+    # worth that only alongside the deferral there -- `importlib.metadata`
+    # imports pathlib itself, so this line on its own would save nothing
+    import pathlib  # noqa: PLC0415
+
     path = pathlib.Path(module.__file__).parent
     rejected: list[tuple[str, OSError]] = []
     for suffix in (".dll", ".so", ".dylib"):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -20,12 +20,15 @@ mistaken for one.
 import pathlib
 import re
 import shutil
+import subprocess
 import sys
 import types
 
+import _btclib_secp256k1
 import _cffi_backend
 import pytest
 
+import btclib_secp256k1
 from btclib_secp256k1 import __version__, _load_lib
 
 
@@ -33,16 +36,105 @@ def test_version() -> None:
     """Check that __version__ is a non-empty string.
 
     Not that the distribution is installed under the name __init__.py
-    asks for: were it not, importlib.metadata would raise at import and
-    every test in the suite would fail. What is checked is that the
-    attribute is still exposed, and with a value in it.
+    asks for: were it not, the `from` import at the top of this module
+    would raise while it is being collected, and there would be no test
+    here to fail. What is checked is that the package keeps exposing the
+    attribute, and with a value in it -- through a module-level
+    `__getattr__`, so that the attribute a caller never reads costs
+    nothing to have.
     """
-    # that the distribution is installed under the name __init__.py asks
-    # for is not what this checks: were it not, importlib.metadata would
-    # raise at import time and every test would fail. What is checked is
-    # that the package keeps exposing the attribute, and with a value
     assert isinstance(__version__, str)
     assert __version__
+
+
+def test_no_such_attribute() -> None:
+    """A name the package does not have is still an AttributeError.
+
+    The other half of the `__getattr__` that builds `__version__`, and
+    the one no other test reaches: python calls it for every name the
+    module itself has none of, so what it answers for anything but that
+    one has to be what a module without it answers on its own.
+    Answering None, or the version, would turn a typo into a value.
+
+    The `type: ignore` is the point rather than an annoyance: mypy still
+    knows this attribute does not exist, which is what the
+    `if TYPE_CHECKING` in `__init__.py` is there to preserve, and a
+    module that simply had a `__getattr__` would need no suppression
+    here because it would have stopped checking.
+    """
+    with pytest.raises(AttributeError, match="no attribute 'nonesuch'"):
+        _ = btclib_secp256k1.nonesuch  # type: ignore[attr-defined]
+
+
+def _imported_modules(name: str) -> set[str]:
+    """Return what importing this package leaves in sys.modules.
+
+    A subprocess because the answer is about a fresh interpreter: this
+    one has the package imported already, and every test module beside
+    this one has imported half the standard library into it.
+
+    Args:
+        name: the module to import in that interpreter.
+
+    Returns:
+        The names in `sys.modules` afterwards.
+    """
+    code = f"import sys, {name}; print('\\n'.join(sys.modules))"
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    return set(completed.stdout.split())
+
+
+def test_import_defers_the_metadata() -> None:
+    """Importing the package does not import `importlib.metadata`.
+
+    What the deferral in `__init__.py` bought, asserted rather than
+    measured: reading `__version__` at import time is most of what made
+    that import 15.85 milliseconds where it is now 1.69, CHANGELOG.md
+    carrying the split -- `importlib.metadata` pulls `email`, `json` and
+    `inspect` behind it. Nothing else says so, and a module level import
+    added
+    later -- here or in anything this package imports -- puts those
+    milliseconds back with every other gate green, which is how they
+    arrived in the first place.
+
+    What is asserted is what *this* import adds, the names an empty
+    interpreter already holds being subtracted first: asking for
+    absolute absence would make a future interpreter, or a stray `.pth`
+    preloading one of these, a failure of this package. Nothing is
+    subtracted today, a bare interpreter here holding none of them.
+
+    The named modules are the expensive ones rather than all of them: a
+    list of everything `importlib.metadata` reaches is a list that
+    changes with the interpreter.
+    """
+    added = _imported_modules("btclib_secp256k1") - _imported_modules("sys")
+    assert "importlib.metadata" not in added
+    for module in ("email", "json", "inspect", "zipfile"):
+        assert module not in added, f"{module} is imported again"
+
+
+@pytest.mark.skipif(
+    not hasattr(_btclib_secp256k1, "lib"),
+    reason="a dynamic extension reaches _load_lib's second branch, which uses pathlib",
+)
+def test_import_defers_pathlib() -> None:
+    """A static extension does not import `pathlib` either.
+
+    The other half of the same ratchet, and it holds for the static
+    build alone: `_load_lib` returns at `hasattr(module, "lib")` there,
+    where a dynamic one goes on to glob for the shared object and
+    imports `pathlib` legitimately. The matrix runs the suite both ways,
+    so the skip is what keeps this true rather than flaky.
+
+    It only holds alongside the test above, which is why the two are not
+    one assertion in one test: `importlib.metadata` imports `pathlib`
+    itself, so this one would fail on a tree that deferred `pathlib`
+    alone, and the deferral it is really asserting is the pair.
+    """
+    added = _imported_modules("btclib_secp256k1") - _imported_modules("sys")
+    assert "pathlib" not in added
 
 
 def test_load_lib_no_candidate(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
Importing this package was 14.83 ms and the compiled extension it exists
to load was 0.57 of them. The rest was two module-level imports, and
neither is needed by the time the import finishes.

## What moved

- **`__version__` is read on first access**, through a module-level
  `__getattr__` (PEP 562). Where the value comes from is unchanged — the
  installed distribution metadata, so `pyproject.toml` stays the only
  place a release bumps. `importlib.metadata` pulls `email`, `json` and
  `inspect` behind it, among others.
- **`pathlib` is imported where it is used**: the branch of `_load_lib`
  that globs for a shared object to `dlopen`. A static extension returns
  from `hasattr(module, "lib")` two lines above and never reaches it,
  and a static extension is what every platform of the matrix ships by
  default.

Apple M5 arm64, macOS 26.6, CPython 3.14.6, minimum of 12 fresh
interpreters:

| | import |
| --- | --- |
| before | 14.83 ms |
| with `__version__` read on first access | 3.77 ms |
| and with `pathlib` where it is used | **1.55 ms** |

A caller that reads the version pays what it paid: 15.26 ms against
14.83, the same work moved rather than removed.

## The `if TYPE_CHECKING`, which is not decoration

A module that has a `__getattr__` is a module mypy stops checking
attribute names on. Measured on this tree, with the plain spelling:

```
$ mypy --strict probe.py     # from btclib_secp256k1 import nosuchmodule
                             # btclib_secp256k1.nonesuch_typo
Found 1 error   # only the one inside a submodule
```

against three on `main`. `from btclib_secp256k1 import nosuchmodule`
passing `--strict` is not a trade worth 13 ms — that is the line every
caller of this package writes. Declaring `__version__: str` to the type
checker and defining the function only at run time keeps all three
errors, and the new test needing a `type: ignore[attr-defined]` to ask
for a missing attribute is the proof that it does.

The two deferred imports carry `# noqa: PLC0415` with the reason beside
them, deferring being the whole of what the change is.

## What a caller has to know

`dir(btclib_secp256k1)` does not list `__version__` until something
reads it, which is what PEP 562 costs wherever it is used. Nothing else
changes: the attribute, `from btclib_secp256k1 import __version__` and
reading the metadata directly all answer what they answered — the three
spellings this repository itself uses, in `tests/test_extension.py`,
`published.yml`, `test.yml` and the issue templates.

## What judges it

`test_no_such_attribute` is new and is the half no other test reached:
what the fallback answers for a name that is not `__version__`.
`test_version` keeps its two assertions, and its docstring stops
claiming that a missing distribution would fail every test in the suite
— it now fails this module's collection, which is where the `from`
import is.

Suite green (583 tests), coverage gate at 100.00%, every hook passes.
CHANGELOG.md and HISTORY.md carry the figures.

Closes #210

## Summary by Sourcery

Defer expensive imports so that the package’s import time is significantly reduced while preserving type-checking and version semantics.

Enhancements:
- Lazy-load the __version__ attribute via a module-level __getattr__ so distribution metadata is read only on demand.
- Limit the impact of __getattr__ on static analysis by guarding the runtime implementation behind an if TYPE_CHECKING block and declaring __version__ for type checkers.
- Move the pathlib import into the dynamic library-loading path so static builds avoid unnecessary import overhead.
- Add tests to validate lazy version access and correct AttributeError behavior for missing attributes.

Documentation:
- Update CHANGELOG and HISTORY to document the new import-time behavior, performance figures, and __version__ access semantics.

Tests:
- Extend the test suite with coverage for missing attributes under the new __getattr__ behavior and adjust the version test to reflect collection-time failures.