### PR TITLE
Stop a header on the build machine from changing what ships

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,7 +148,7 @@
         "filename": "scripts/cffi_build.py",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
         "is_verified": false,
-        "line_number": 422
+        "line_number": 453
       }
     ],
     "tests/test_keys.py": [
@@ -517,5 +517,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T19:03:44Z"
+  "generated_at": "2026-08-17T08:06:26Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1405,6 +1405,56 @@ release-notes length in the first place, and are still in
   against a 8.7 and 10.2 baseline — while the macOS images, whose default
   shell is bash, had already dropped to 1.5 and 1.2. A step that is green
   while doing nothing is why the comment above it now carries this
+- **The vendored library is no longer configured by what happens to be
+  installed on the machine that builds it** (#211).
+  `SECP256K1_VALGRIND` defaults to `AUTO`, and `AUTO` is
+  `find_package(Valgrind)` — the only `find_package` in the vendored
+  CMake. Where the header is on an include path, the library is compiled
+  with `-DVALGRIND`, which turns the `SECP256K1_CHECKMEM_*` of
+  `src/checkmem.h` from no-ops into valgrind client requests, and
+  `SECP256K1_BUILD_CTIME_TESTS` takes its default from it besides. So a
+  runner that happened to have one shipped a different library from the
+  same commit, in a wheel that says nothing about which one it is.
+  `scripts/cffi_build.py` passes `-DSECP256K1_VALGRIND=OFF` now.
+- **The defect was reproduced before it was fixed** rather than argued
+  from the CMake: configured against a directory holding a
+  `valgrind/memcheck.h`, `AUTO` reports `-- Found Valgrind`, puts
+  `Valgrind_INCLUDE_DIR` in the cache and `-DVALGRIND` in
+  `src/CMakeFiles/secp256k1.dir/flags.make`; `OFF` does none of the
+  three, `find_package` not running at all. An empty header is enough,
+  the module's compile check only rejecting `NVALGRIND`, so the trigger
+  is a header on an include path and not an installed valgrind. Every
+  wheel job's configure summary carries the answer —
+  `Valgrind .............................. OFF` — which is the audit,
+  `scripts/` being outside the coverage gate.
+- **The instrumentation in such a wheel runs rather than merely being
+  present, and the pin is still not about what it costs.**
+  `SECP256K1_CHECKMEM_RUNNING()` is itself a client request under
+  `VALGRIND` — `src/checkmem.h` defines it as
+  `(VALGRIND_MAKE_MEM_DEFINED(NULL, 0) != 0)` deliberately, memcheck
+  having to be detected specifically rather than valgrind in general —
+  and it is the left operand of the `&&` at `src/secp256k1.c:104`,
+  behind no flag and no `VERIFY`. `secp256k1_context_create` reaches
+  that line twice, so a wheel built with `-DVALGRIND` executes two of
+  them at import and none afterwards: the other call site is
+  `secp256k1_declassify` (`src/secp256k1.c:254`), behind
+  `ctx->declassify`, which line 104 refuses to set outside memcheck at
+  all. Everything else is `CHECK_VERIFY`, `MSAN_DEFINE`, or under
+  `#ifdef VERIFY`. A handful of instructions, once — and what the pin is
+  about is that the wheel be a function of the source.
+- **`SECP256K1_ASM`, `SECP256K1_ECMULT_WINDOW_SIZE` and
+  `SECP256K1_ECMULT_GEN_KB` stay at upstream's defaults, and that is now
+  written down** rather than left as three options nobody named. The two
+  table sizes (15, and 86 KiB reaching the compiler as `COMB_BLOCKS=43
+  COMB_TEETH=6`) are what upstream recommends for a desktop. `ASM` asks
+  the build machine a question too — `AUTO` is a compile check, and it
+  falls back to `OFF` in silence where that check fails, which a pinned
+  `x86_64` would turn into a build error — but it cannot be pinned in a
+  line: the macOS `universal2` cell compiles two architectures in one
+  pass and the mingw one cross-compiles, so naming an architecture there
+  would break the cells that are not it. So one machine question stays
+  open, by choice, and the headline above is scoped to the one that is
+  closed.
 - **The vendored library is compiled once per wheel job, not once per
   wheel** (#192). The six wheel jobs were 59.5 of that run's 81.8
   runner-minutes, and each of them built the whole of libsecp256k1 once

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,11 +59,17 @@ The cffi build description named in `cffi_modules`, exposing the
 **Build the vendored library.** CMake, on every platform, out of tree
 into `build/secp256k1`: the submodule is only ever read from. The
 configure line requests each module the bindings wrap
-(`ecdh`, `recovery`, `extrakeys`, `schnorrsig`, `musig`, `ellswift`)
-explicitly, rather than relying on upstream defaults, which are not part
-of upstream's API and which leave `recovery` off. Upstream's own tests,
-benchmarks and install rules are all turned off. A stale CMake cache is
-deleted first, because it remembers the previous configuration.
+(`ecdh`, `recovery`, `extrakeys`, `schnorrsig`, `musig`, `ellswift`,
+`silentpayments`) explicitly, rather than relying on upstream defaults,
+which are not part of upstream's API and which leave `recovery` off.
+One option is named for a different reason: `SECP256K1_VALGRIND` is
+pinned `OFF` because its default answers with the build machine rather
+than with a value — `AUTO` is `find_package(Valgrind)`, so a runner that
+happens to have the header ships a library compiled with `-DVALGRIND`,
+which is a wheel this repository cannot tell from any other. Upstream's
+own tests, benchmarks and install rules are all turned off. A stale
+CMake cache is deleted first, because it remembers the previous
+configuration.
 
 The build also replaces libsecp256k1's default callbacks, which
 `abort()`, with do-nothing ones, so that an illegal input can never take

--- a/scripts/cffi_build.py
+++ b/scripts/cffi_build.py
@@ -409,6 +409,37 @@ class Secp256k1CFFIExtension(FFIExtension):
             "-DSECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS=ON",
             f"-DCMAKE_PROJECT_INCLUDE={project_include}",
             f"-DBTCLIB_CALLBACKS={callbacks}",
+            # the one upstream option whose answer is what happens to be
+            # *installed* on the machine: AUTO means
+            # find_package(Valgrind), which is the only find_package in
+            # the vendored CMake, and a header on an include path is
+            # enough -- the module's compile check only rejects
+            # NVALGRIND, so valgrind itself need not be there. Where one
+            # is, the library is compiled with -DVALGRIND, which turns
+            # the SECP256K1_CHECKMEM_* of src/checkmem.h from no-ops into
+            # valgrind client requests, and SECP256K1_BUILD_CTIME_TESTS
+            # defaults to it besides (already pinned OFF below). So a
+            # runner that happens to have a header ships a different
+            # library from the same commit, in a wheel that says nothing
+            # about which one it is, and this package exists to behave
+            # identically everywhere.
+            #
+            # The instrumentation in such a wheel runs rather than merely
+            # being present: SECP256K1_CHECKMEM_RUNNING() is a client
+            # request under VALGRIND (checkmem.h, deliberately, memcheck
+            # having to be detected specifically), it is the left operand
+            # of the && that secp256k1_context_preallocated_size guards
+            # its DECLASSIFY flag with, and secp256k1_context_create
+            # reaches that function twice. So two of them at import, and
+            # none afterwards: the other call site is
+            # secp256k1_declassify, behind ctx->declassify, which that
+            # same guard refuses to set outside memcheck at all. A
+            # handful of instructions, once -- and the pin is not about
+            # the cost but about the wheel being a function of the
+            # source. Functions rather than line numbers: a vendored
+            # file's lines move with the next submodule bump and nothing
+            # here would notice, where these names survive it
+            "-DSECP256K1_VALGRIND=OFF",
             # all the modules wrapped by the bindings are requested
             # explicitly: upstream defaults are not part of its API
             # (recovery, in particular, is disabled by default)
@@ -427,6 +458,19 @@ class Secp256k1CFFIExtension(FFIExtension):
             "-DSECP256K1_INSTALL=OFF",
             *self.target_architecture_options(),
         ]
+        # not in that list, and deliberately: SECP256K1_ASM,
+        # SECP256K1_ECMULT_WINDOW_SIZE and SECP256K1_ECMULT_GEN_KB are
+        # the three options that decide how fast the result is, and all
+        # three are left at upstream's defaults. The two table sizes are
+        # what upstream recommends for a desktop. ASM asks the build
+        # machine a question too -- AUTO is a compile check, and it falls
+        # back to OFF in silence where that check fails -- but it cannot
+        # be pinned in one line: the mingw cell cross-compiles, and the
+        # macOS universal2 one compiles two architectures in a single
+        # pass, which is the `x86_64;arm64` target_architecture_options
+        # names above. Pinning an architecture here would contradict it.
+        # #211 records the values, and why they are left alone
+
         if cross_compile:
             # the toolchain file is the vendored one, upstream tested
             toolchain = self.wd / "cmake" / "x86_64-w64-mingw32.toolchain.cmake"


### PR DESCRIPTION
One line of CMake, and the reason it is one line rather than four.

## The defect

`SECP256K1_VALGRIND` defaults to `AUTO`, and `AUTO` is
`find_package(Valgrind)` — the only `find_package` in the vendored CMake.
Where the header is on an include path the library is compiled with
`-DVALGRIND`, which turns the `SECP256K1_CHECKMEM_*` of
`src/checkmem.h` from no-ops into valgrind client requests, and
`SECP256K1_BUILD_CTIME_TESTS` takes its default from it besides. So a
runner that happens to have one ships a different library from the same
commit, and the wheel says nothing about which one it is.

That is the one kind of thing this repository's premise cannot absorb —
the matrix is as large as it is precisely so that the package is the same
everywhere. `-DSECP256K1_VALGRIND=OFF` makes what a wheel is compiled
with a function of the source alone.

## Reproduced, not argued from the CMake

Configured against a directory holding a `valgrind/memcheck.h`:

```
=== SECP256K1_VALGRIND=AUTO ===
-- Found Valgrind: …/fakevalgrind
SECP256K1_VALGRIND:STRING=AUTO
Valgrind_INCLUDE_DIR:PATH=…/fakevalgrind
  -> -DVALGRIND is in src/CMakeFiles/secp256k1.dir/flags.make

=== SECP256K1_VALGRIND=OFF ===
SECP256K1_VALGRIND:STRING=OFF
  -> no -DVALGRIND: find_package never runs
```

An empty header is enough — the module's compile check only rejects
`NVALGRIND` — so the trigger is a header on an include path and not an
installed valgrind. After the change, through the real path (`uv sync
--reinstall-package btclib_secp256k1 --no-cache`), `CMakeCache.txt` reads
`SECP256K1_VALGRIND:STRING=OFF` and has no `Valgrind_INCLUDE_DIR` entry.

## What such a wheel actually executes

It runs rather than merely carrying the instrumentation, which is the one
thing the previous revision of this description got wrong.
`SECP256K1_CHECKMEM_RUNNING()` is itself a client request under
`VALGRIND` — `src/checkmem.h` defines it as
`(VALGRIND_MAKE_MEM_DEFINED(NULL, 0) != 0)`, deliberately, memcheck
having to be detected specifically — and it is the left operand of the
`&&` at `src/secp256k1.c:104`, behind no flag and no `VERIFY`.
`secp256k1_context_create` reaches that line twice, so a `-DVALGRIND`
wheel executes two of them at import and none afterwards: the other call
site is `secp256k1_declassify` (`src/secp256k1.c:254`), behind
`ctx->declassify`, which line 104 refuses to set outside memcheck at all.
Everything else is `CHECK_VERIFY`, `MSAN_DEFINE`, or under `#ifdef
VERIFY`.

A handful of instructions, once. **The pin is not about the cost** — it is
about the wheel being a function of the source, and no measurement of the
cost is claimed here.

## The three that are not pinned, and why not

`SECP256K1_ASM`, `SECP256K1_ECMULT_WINDOW_SIZE` and
`SECP256K1_ECMULT_GEN_KB` are the options that decide how fast the
library is, and all three are at upstream's desktop defaults — `AUTO`,
`15`, and `86` KiB reaching the compiler as `COMB_BLOCKS=43
COMB_TEETH=6`. Naming them would change nothing today, which is the
argument both for and against doing it, and it is a policy call rather
than a defect.

`ASM` asks the build machine a question too: `AUTO` is a compile check
that falls back to `OFF` **in silence**. It stays `AUTO` because it cannot
be pinned in a line — the mingw cell cross-compiles, and the macOS
`universal2` one compiles two architectures in a single pass, which is the
`x86_64;arm64` that `target_architecture_options` already names. That note
now sits *after* the configure list rather than inside it, for exactly
that reason: in the list it read as annotating the line it contradicts.

## Scope

`scripts/cffi_build.py`, plus `scripts/README.md` — the file CLAUDE.md
puts the build backend's documentation in, which now describes this line
and, in passing, names the seven modules the configure line requests
rather than six. CHANGELOG.md under `### CI`, where the other
vendored-library entry is. Nothing in HISTORY.md: a user acts on nothing
here and gains a wheel that is what its source says, which is the record
rather than the release note. `.secrets.baseline` moves one line number,
the reviewed entry unchanged.

The audit is the configure summary, not a test: `scripts/` is outside
`[tool.coverage.run] source`, so the coverage gate says nothing about this
line, while every wheel job's log carries
`Valgrind .............................. OFF`.

Suite green (582 tests), coverage gate at 100.00%, every hook passes.

Closes #211
