### PR TITLE
Work out at import what a wrapper was working out per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,18 +190,19 @@ release-notes length in the first place, and are still in
   or a `memoryview` needs, and are what the slow path still does; the
   exact type is asked once in front of them. `dsa.verify` passes three
   arguments through it.
-- **`keys.serialize` builds its buffer from a literal cdecl**, 0.313
-  microseconds against 0.356 with the guard already gone and 0.604
-  before it: `ffi.new` of an interpolated `f"char[{size}]"` parses that
+- **`keys.serialize` stopped building its buffer from an interpolated
+  cdecl**, 0.313 microseconds against 0.356 with the guard already gone
+  and 0.604 before it: `ffi.new` of an `f"char[{size}]"` parses that
   string on every call, and `ffi.sizeof` was called twice where the size
-  was in hand. The length buffer is still built per call and deliberately
-  not hoisted, though it holds the same number every time — libsecp256k1
-  writes 0 into it before it does anything and restores it only on
-  success, and it holds what it finds there against 33 or 65 on the way
-  in, so one
-  failed call would leave a shared buffer at zero and every later
-  serialization, on any thread and of a perfectly good key, would be
-  refused. That was measured rather than reasoned about.
+  was in hand. It went to a literal here and then to a hoisted type, for
+  the reason and at the price the entry below states; what follows is
+  what did not change. The length buffer is still built per call and
+  deliberately not hoisted, though it holds the same number every time —
+  libsecp256k1 writes 0 into it before it does anything and restores it
+  only on success, and it holds what it finds there against 33 or 65 on
+  the way in, so one failed call would leave a shared buffer at zero and
+  every later serialization, on any thread and of a perfectly good key,
+  would be refused. That was measured rather than reasoned about.
 - **What the entry points cost now.** Microseconds per call on the
   machine above, the quickest of two passes run in either order so that
   neither tree is the one measured on a warm machine, before against
@@ -308,6 +309,104 @@ release-notes length in the first place, and are still in
   list `__version__` until something reads it, and does afterwards.
   Nothing else changes: the attribute, the `from … import __version__`,
   and reading the metadata directly all answer what they answered.
+
+### What a wrapper works out per call, and now works out once
+
+- **An interpolated cdecl is resolved at import, not at every call**
+  (#212). `xonly.serialize` and `silentpayments.serialize_label` declared
+  their buffer with `ffi.new(f"char[{_XONLY_SIZE}]")`, which states the
+  width once — the reason it is an f-string — and costs twice what a
+  literal does, cffi having to hash a string built afresh each time:
+  0.1219 microseconds against 0.0681. `ffi.typeof` of the same f-string,
+  evaluated once at module level, is the literal's price with the width
+  still stated once.
+- **A literal cdecl is left exactly as it was**, and that is the measured
+  half of the same rule. cffi already caches the parse of one, so
+  hoisting a literal saves 0.003 microseconds — real, 4.3% on a noise row
+  of 0.5%, and an order below the 0.054 an interpolated cdecl gives back.
+  That is the size a hoist has to be worth to justify spelling a width
+  twice, or naming every cdecl in the package at module level, so every
+  `ffi.new` here still spells its cdecl in full — including the two
+  beside the hoisted types.
+- **`ffi.sizeof` of a buffer whose size is a constant is not asked per
+  call**, and that is what asked `keys.serialize` for a type at module
+  level: each size is `ffi.sizeof` of the very type beside it, so the
+  buffer and the length cannot say different numbers, and the 0.0175
+  microseconds is not paid at every call. `keys.serialize` also decides
+  its flag in the branch that picks its buffer, so the one condition is
+  asked once. The length *object* is still built per call, for the
+  thread-safety reason its comment gives.
+- **`_secret.take` zeroes through the view it already holds.** It built
+  an `ffi.buffer` to read the secret and then called `wipe`, which built
+  a second one over the same cdata. The statement that writes the zeros
+  is now `_zero`, which `wipe` calls too, so it is written once — and
+  that frame is paid for deliberately: `wipe` twice is 0.1826
+  microseconds, `_zero` is 0.1439 and the same statement inlined in both
+  places is 0.1314. A quarter of what was on the table, for one copy of
+  the line that overwrites a secret rather than two.
+- **The parity nobody reads is not allocated.**
+  `secp256k1_xonly_pubkey_from_pubkey` documents `pk_parity` as "can be
+  NULL", and the callers that want the object alone — `parse`, `_parsed`
+  and `_tweak_add_` — are why NULL is the default. `_drop_y` takes the
+  pointer as an argument now: 0.1747 microseconds against 0.2425 on the
+  conversion alone. `_from_pubkey_` and `to_pubkey` read a parity and go
+  through `_drop_y_with_parity`, which is that allocation written once,
+  and no saving lands on them — what it adds is some hundredths of a
+  microsecond, measurable against both. One figure rather than one per
+  caller: it is the same frame at each, and two harnesses put a different
+  one of the two ahead, which is the spread of a number this small and
+  not a structure. What they get out of this is the C call still written
+  once and the call site they had.
+- **Two sessions, and each is named where a figure comes from.** Every
+  wrapper figure this change quotes — in CHANGELOG.md, HISTORY.md and in
+  the comments of `keys.py`, `xonly.py`, `silentpayments.py` and
+  `_secret.py` alike — is the one below; every cffi-primitive figure is
+  the one after it. An Apple M5, macOS 26.6, arm64, CPython 3.14.6.
+
+  `main`'s spelling of each call written out and alternated against this
+  one in a single process over one build, minimum of 15 rounds of
+  200 000 calls, a noise row running `main`'s spelling twice, and every
+  pair asserted to answer alike before it is timed:
+
+  | | main | now |
+  | --- | --- | --- |
+  | `_drop_y`, the conversion alone | 0.2425 | 0.1747 |
+  | `xonly.serialize` | 0.2569 | 0.1969 |
+  | `silentpayments.serialize_label` | 0.2621 | 0.2023 |
+  | `_secret.take` | 0.1826 | 0.1439 |
+  | `xonly.parse`, 65 bytes | 0.5021 | 0.4295 |
+  | `xonly._from_pubkey_`, 65 bytes | 0.5127 | 0.4711 |
+  | `keys.prvkey_negate` | 0.3790 | 0.3380 |
+  | `keys.serialize`, compressed | 0.3106 | 0.2906 |
+  | `keys.serialize`, uncompressed | 0.3101 | 0.2903 |
+  | *noise* | 0.2578 | 0.2577 |
+
+  and the primitives, minimum of 15 rounds of 300 000 calls:
+
+  | | first | second |
+  | --- | --- | --- |
+  | `ffi.new` of an f-string, then of a literal `char[32]` | 0.1219 | 0.0681 |
+  | `ffi.new` of a literal, then of a hoisted `char[33]` | 0.0685 | 0.0656 |
+  | `ffi.new` of a literal, then of a hoisted `size_t *` | 0.0809 | 0.0774 |
+  | `ffi.unpack` with `ffi.sizeof`, then with the constant | 0.0764 | 0.0589 |
+  | *noise* | 0.0676 | 0.0680 |
+
+- **`_scalar.scalar` was measured and left alone**, which is the one
+  declined here. Asking `type(num) is int` instead of
+  `isinstance(num, int) and not isinstance(num, bool)` is one check where
+  those are two and excludes `bool` on its own, and it is 0.141
+  microseconds against 0.157 — but it needs the range check and the
+  serialization written twice, once for the exact type and once for the
+  subclass, and the int path is the one this module's own docstring says
+  is not the common one: a scalar handed to these bindings in a loop is
+  bytes, and that path does not reach the test at all.
+- **The stub gains an opaque `_CType`**, which is what `typeof` answers
+  and what `new` takes beside a string. Typing that argument `Any`
+  instead would be the vacuous type-checking
+  `stubs/_btclib_secp256k1.pyi` exists to prevent: `ffi.new(_XONLY_SIZE)`
+  — an int where a cdecl belongs, and the size and the type built from
+  it now sit a dozen lines apart in the same module — passes `--strict`
+  with `Any` and is an `[arg-type]` error with `_CType`.
 
 ### Signing under one key
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -310,6 +310,21 @@ it, and does afterwards. Reading it — as the attribute, as
 metadata — answers what it always answered, and costs what it always
 cost, the first read and every one after it.
 
+**Serializing and parsing cost a little less, and nothing changed about
+what they answer.** Four things a wrapper used to work out at every call
+are worked out once: the cffi type of a buffer whose declaration was
+built by an f-string, the size of a buffer whose size is a constant, the
+second view of memory `_secret.take` was already looking at, and the
+parity `xonly._drop_y` allocated for `parse`, `_parsed` and
+`_tweak_add_`, which throw it away.
+What that is worth, against the same calls as they were and with a noise
+row beside each: `xonly.serialize` 0.197 microseconds against 0.257,
+`silentpayments.serialize_label` 0.202 against 0.262, `xonly.parse` of a
+65-byte key 0.430 against 0.502, `keys.serialize` 0.291 against 0.311.
+Nothing on a signature or a verification, which are twelve microseconds
+of libsecp256k1; something on a caller doing point arithmetic in a loop,
+which is who these calls are short for.
+
 ## v0.8.0.2
 
 Non-breaking, and two additions for a caller that verifies signatures it

--- a/btclib_secp256k1/_secret.py
+++ b/btclib_secp256k1/_secret.py
@@ -41,6 +41,37 @@ from ._scalar import scalar
 from .context import ctx
 
 
+def _zero(memory: memoryview) -> None:
+    """Overwrite what a cffi buffer views.
+
+    The statement that writes the zeros, written once: `wipe` builds the
+    view over a cdata, and `take` is already holding one it read the
+    secret through, so calling `wipe` from there would build a second
+    over the same memory.
+
+    That it is a function and not the statement inlined in both places
+    is a trade made deliberately and against the faster spelling.
+    Measured over the same session as every other figure of this change,
+    which CHANGELOG.md names: calling `wipe` a second time is 0.1826
+    microseconds, this is 0.1439, and the inlined statement is 0.1314.
+    So the frame gives up about a quarter of what is on the table, and
+    what it buys is that the line which overwrites a secret exists once:
+    two copies are two things to keep true, in the one facility whose
+    whole claim is about what is left in memory.
+
+    Args:
+        memory: the `ffi.buffer` to overwrite, and a view of the whole
+            cdata rather than a slice of one -- `wipe` builds it from
+            the cdata for the reason its own docstring gives, and
+            `_zero(ffi.buffer(buffer, 8))` would zero a quarter of the
+            private key inside a keypair and report success, which is
+            the failure that docstring records. Typed as the stub
+            declares `ffi.buffer` to answer, this being the module that
+            reads both a slice and a length off one.
+    """
+    memory[:] = bytes(len(memory))
+
+
 def wipe(buffer: CData) -> None:
     """Overwrite a buffer that held a secret.
 
@@ -54,8 +85,7 @@ def wipe(buffer: CData) -> None:
     Args:
         buffer: the cffi buffer to overwrite, as `ffi.new` returned it.
     """
-    memory = ffi.buffer(buffer)
-    memory[:] = bytes(len(memory))
+    _zero(ffi.buffer(buffer))
 
 
 def into_buffer(into: object, size: int) -> memoryview:
@@ -172,12 +202,15 @@ def take(buffer: CData, *, into: MutableBytesLike | None = None) -> bytes | None
             one-dimensional octets.
         ValueError: if `into` is not the secret's length.
     """
+    # the zeroing goes through this view rather than through `wipe`,
+    # which would build a second one over the same cdata: what `wipe`
+    # writes is `_zero`, and it is that statement both paths reach
     memory = ffi.buffer(buffer)
     if into is None:
         secret = bytes(memory)
-        wipe(buffer)
+        _zero(memory)
         return secret
-    # the wipe is in a `finally` because `into_buffer` can refuse, and
+    # the zeroing is in a `finally` because `into_buffer` can refuse, and
     # this is the one call here with a failure path: without it a
     # rejected buffer returns through the entry point leaving a live
     # private key in cffi memory that is freed without being
@@ -189,7 +222,7 @@ def take(buffer: CData, *, into: MutableBytesLike | None = None) -> bytes | None
         view = into_buffer(into, len(memory))
         view[:] = memory
     finally:
-        wipe(buffer)
+        _zero(memory)
     return None
 
 

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -30,6 +30,25 @@ from .context import ctx
 COMPRESSED = 258
 UNCOMPRESSED = 2
 
+# the two buffers `serialize` writes into, and the lengths it declares
+# them with. The pairing is what these are for: each size is
+# `ffi.sizeof` of the very type beside it, so the buffer and the length
+# cannot say different numbers, and stating the width once is what asked
+# for a type at module level in the first place. What it saves is the
+# `ffi.sizeof` per call, 0.0175 microseconds.
+#
+# It is not hoisted for the `ffi.new`. cffi already caches the parse of
+# a literal cdecl, so a hoisted type beats one by 0.003 microseconds --
+# real, 4.3% on a noise row of 0.5%, and an order below the 0.054 an
+# interpolated cdecl gives back, which is the figure a hoist has to earn
+# to be worth spelling a width twice or naming every cdecl in the
+# package. So the length pointer below stays spelled in full, like every
+# other `ffi.new` here. `xonly.py` carries the session
+_COMPRESSED_BUFFER_TYPE = ffi.typeof("char[33]")
+_COMPRESSED_SIZE = ffi.sizeof(_COMPRESSED_BUFFER_TYPE)
+_UNCOMPRESSED_BUFFER_TYPE = ffi.typeof("char[65]")
+_UNCOMPRESSED_SIZE = ffi.sizeof(_UNCOMPRESSED_BUFFER_TYPE)
+
 
 def prvkey_verify(prvkey: BytesLike | int) -> bool:
     """Return True if the private key is a valid scalar, i.e. in [1, n-1].
@@ -1054,11 +1073,11 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
         >>> keys.serialize(keys.parse(uncompressed)).hex()[:10]
         '0279be667e'
     """
-    # the buffer is declared by a literal and the size read back off it,
-    # so the two cannot say different numbers: `ffi.new` of an
-    # interpolated cdecl parses that string on every call, which is 0.043
-    # microseconds of the 0.313 this costs -- an Apple M5, macOS 26.6,
-    # arm64, CPython 3.13.14, minimum of 9 rounds of 500 000 calls.
+    # the buffer's type and the size are declared together at the top of
+    # this module, each size being `ffi.sizeof` of the type beside it, so
+    # the two cannot say different numbers and neither is worked out
+    # again here. The flag is decided in the branch that picks the
+    # buffer, so the one condition is asked once.
     #
     # What is unpacked is the buffer, not the length libsecp256k1 reports
     # back: this serialization has one length per flag, so a buffer of
@@ -1068,17 +1087,26 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
     # that spelling, and dies in this one). The DER serialization is the
     # other case, and reads `length[0]` for the reason given there.
     #
-    # The length is built per call and not hoisted, though it is the same
-    # number every time: libsecp256k1 writes 0 into it before it does
-    # anything (`*outputlen = 0` in secp256k1.c) and restores it only on
-    # success, and it holds the value it finds there against 33 or 65 on
-    # the way in. One failed call would leave a shared buffer at
-    # zero, and every later serialization -- on any thread, of a
-    # perfectly good key -- would be refused
-    output = ffi.new("char[33]" if compressed else "char[65]")
-    size = ffi.sizeof(output)
+    # The length *object* is built per call and not hoisted, though it
+    # holds the same number every time: libsecp256k1 writes 0 into it
+    # before it does anything (`*outputlen = 0` in secp256k1.c) and
+    # restores it only on success, and it holds the value it finds there
+    # against 33 or 65 on the way in. One failed call would leave a
+    # shared buffer at zero, and every later serialization -- on any
+    # thread, of a perfectly good key -- would be refused
+    if compressed:
+        output, size, flags = (
+            ffi.new(_COMPRESSED_BUFFER_TYPE),
+            _COMPRESSED_SIZE,
+            COMPRESSED,
+        )
+    else:
+        output, size, flags = (
+            ffi.new(_UNCOMPRESSED_BUFFER_TYPE),
+            _UNCOMPRESSED_SIZE,
+            UNCOMPRESSED,
+        )
     length = ffi.new("size_t *", size)
-    flags = COMPRESSED if compressed else UNCOMPRESSED
     serialized = lib.secp256k1_ec_pubkey_serialize(ctx, output, length, pubkey, flags)
     if not serialized:
         raise RuntimeError("point serialization failed")

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -43,6 +43,16 @@ from .context import ctx
 SUMMARY_SIZE = ffi.sizeof("secp256k1_silentpayments_prevouts_summary")
 LABEL_SIZE = 33
 
+# the buffer `serialize_label` writes into, resolved here rather than at
+# every call: `ffi.new` of an f-string formats it and leaves cffi to
+# hash the result, where `ffi.typeof` of the same string, evaluated
+# once, costs what a literal cdecl does and still states the width once.
+# 0.2023 microseconds against 0.2621 on this serialization -- one
+# session with every other figure of this change, which CHANGELOG.md
+# names. `xonly.py` says the rest, the reason a literal cdecl is left
+# alone included
+_LABEL_BUFFER_TYPE = ffi.typeof(f"char[{LABEL_SIZE}]")
+
 
 def _create_outputs_(
     recipients: Sequence[tuple[CData, CData]],
@@ -805,10 +815,12 @@ def serialize_label(label_obj: CData) -> bytes:
             which a label it produced cannot make it do.
             `context.check` is what tells the two apart.
     """
-    output = ffi.new(f"char[{LABEL_SIZE}]")
+    output = ffi.new(_LABEL_BUFFER_TYPE)
     serialized = lib.secp256k1_silentpayments_recipient_label_serialize(
         ctx, output, label_obj
     )
     if not serialized:
         raise RuntimeError("label serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
+    # the length is the constant the buffer's type was built from, so the
+    # two still cannot say different numbers
+    return ffi.unpack(output, LABEL_SIZE)

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -41,13 +41,75 @@ from .context import ctx
 # two lengths this module takes are a full public key, whose x it is
 _XONLY_SIZE = 32
 
+# the buffer `serialize` writes into, resolved here rather than at every
+# call. `ffi.new` of an f-string formats it and leaves cffi to hash the
+# result: 0.1219 microseconds against 0.0681 for a literal cdecl -- an
+# Apple M5, macOS 26.6, arm64, CPython 3.14.6, minimum of 15 rounds of
+# 300 000 calls, on a noise row that moved 0.5%. A literal here would
+# state the width a second time; `ffi.typeof` of the same f-string,
+# evaluated once, is the literal's price with the width still stated
+# once.
+#
+# A *literal* cdecl is already cached by cffi, and hoisting one saves
+# 0.003 -- 0.0656 against 0.0685, real at 4.3% and an order below the
+# 0.054 above. Too small to be worth a module-level name for every
+# cdecl in the package, so this is done where the string is built and
+# every other `ffi.new` here is spelled in full
+_XONLY_BUFFER_TYPE = ffi.typeof(f"char[{_XONLY_SIZE}]")
 
-def _drop_y(pubkey: CData) -> tuple[CData, int]:
-    """Convert a parsed public key into a parsed x-only key and the parity.
+
+def _drop_y(pubkey: CData, parity: CData = ffi.NULL) -> CData:
+    """Convert a parsed public key into a parsed x-only key.
 
     The conversion itself, which is where the y is dropped, without the
     serialization that follows it in `_from_pubkey_`: `_tweak_add_` wants
     the object and not the 32 bytes, having a tweak to add to it.
+
+    Args:
+        pubkey: the already-parsed public key, as `keys.parse` returns.
+        parity: an `int *` to receive the parity of the y being dropped,
+            0 for even and 1 for odd -- or the NULL that says nobody is
+            reading it, which is the default because the callers that
+            want the object alone are why it exists: `parse`, `_parsed`
+            and `_tweak_add_`. libsecp256k1 documents `pk_parity` as
+            "can be NULL", so the allocation is the caller's to make
+            rather than this function's, and skipping it is 0.4295
+            microseconds against 0.5021 on `xonly.parse` of a 65-byte
+            key -- CHANGELOG.md names the session every figure in this
+            module comes from. `_drop_y_with_parity` is the allocation,
+            written once, for the callers that read one.
+
+    Returns:
+        The libsecp256k1 x-only public key object.
+
+    Raises:
+        RuntimeError: if libsecp256k1 refuses the object -- one it
+            cannot read -- or fails to convert for any other reason,
+            which a key it produced cannot make it do. `context.check`
+            is what tells the two apart.
+    """
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    converted = lib.secp256k1_xonly_pubkey_from_pubkey(
+        ctx, xonly_pubkey, parity, pubkey
+    )
+    if not converted:
+        raise RuntimeError("x-only public key conversion failed")
+    return xonly_pubkey
+
+
+def _drop_y_with_parity(pubkey: CData) -> tuple[CData, int]:
+    """Convert a parsed public key, and read the parity of the y dropped.
+
+    `_drop_y` for the callers that want the parity, so that the
+    allocation is written once rather than at each of their call sites.
+    The NULL default above is where the saving is -- 0.1747 microseconds
+    against 0.2425 on the conversion alone -- and it lands on the callers
+    that discard the parity, not on these: no saving lands here, and what
+    this adds is some hundredths of a microsecond, measurable against
+    both. One figure and not one per caller: the same frame is added at
+    each, and two harnesses put a different one of the two ahead, which
+    is the spread and not a structure. What it buys is the C call written
+    once and these two call sites left as they read.
 
     Args:
         pubkey: the already-parsed public key, as `keys.parse` returns.
@@ -57,21 +119,11 @@ def _drop_y(pubkey: CData) -> tuple[CData, int]:
         y that was dropped: 0 for even, 1 for odd.
 
     Raises:
-        RuntimeError: if libsecp256k1 refuses the object -- one it
-            cannot read -- or fails to convert for any other reason,
-            which a key it produced cannot make it do. `context.check`
-            is what tells the two apart.
-        RuntimeError: if libsecp256k1 fails for any other reason, which
-            no valid key can make it do.
+        RuntimeError: if libsecp256k1 refuses the object or fails to
+            convert it, as `_drop_y` says.
     """
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     parity = ffi.new("int *")
-    converted = lib.secp256k1_xonly_pubkey_from_pubkey(
-        ctx, xonly_pubkey, parity, pubkey
-    )
-    if not converted:
-        raise RuntimeError("x-only public key conversion failed")
-    return xonly_pubkey, parity[0]
+    return _drop_y(pubkey, parity), parity[0]
 
 
 def _from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
@@ -92,7 +144,7 @@ def _from_pubkey_(pubkey: CData) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize it,
             which no valid key can make it do.
     """
-    xonly_pubkey, parity = _drop_y(pubkey)
+    xonly_pubkey, parity = _drop_y_with_parity(pubkey)
     return serialize(xonly_pubkey), parity
 
 
@@ -258,7 +310,7 @@ def _tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails to convert or serialize the
             result, which no valid input can make it do.
     """
-    return _tweak_xonly(_drop_y(pubkey)[0], tweak)
+    return _tweak_xonly(_drop_y(pubkey), tweak)
 
 
 def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, int]:
@@ -467,7 +519,7 @@ def parse(pubkey_bytes: BytesLike, name: str = "public key") -> CData:
         pubkey = keys._parsed(pubkey_bytes, name)
         if pubkey is None:
             raise ValueError(f"invalid {name}")
-        return _drop_y(pubkey)[0]
+        return _drop_y(pubkey)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
@@ -499,7 +551,7 @@ def _parsed(pubkey_bytes: BytesLike, name: str) -> CData | None:
     pubkey_bytes = octets(pubkey_bytes, name)
     if len(pubkey_bytes) != _XONLY_SIZE:
         pubkey = keys._parsed(pubkey_bytes, name)
-        return None if pubkey is None else _drop_y(pubkey)[0]
+        return None if pubkey is None else _drop_y(pubkey)
 
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
     if not lib.secp256k1_xonly_pubkey_parse(ctx, xonly_pubkey, pubkey_bytes):
@@ -583,9 +635,11 @@ def to_pubkey(pubkey_bytes: BytesLike, compressed: bool = True) -> bytes:
 
     # the point is already lifted, so the y is read rather than found:
     # an odd one is negated in the field, where reaching the even-y point
-    # through the 32 octets would be a square root of an x in hand
+    # through the 32 octets would be a square root of an x in hand. The
+    # x-only key the conversion builds is what is thrown away here, the
+    # parity being the whole of what this asks for
     pubkey = keys.parse(pubkey_bytes)
-    if _drop_y(pubkey)[1]:
+    if _drop_y_with_parity(pubkey)[1]:
         keys._pubkey_negate_(pubkey)
     return keys.serialize(pubkey, compressed)
 
@@ -613,8 +667,12 @@ def serialize(xonly_pubkey: CData) -> bytes:
         RuntimeError: if libsecp256k1 fails for any other reason, which
             a key it produced cannot make it do.
     """
-    output = ffi.new(f"char[{_XONLY_SIZE}]")
+    output = ffi.new(_XONLY_BUFFER_TYPE)
     serialized = lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey)
     if not serialized:
         raise RuntimeError("x-only public key serialization failed")
-    return ffi.unpack(output, ffi.sizeof(output))
+    # the length is the constant the buffer's type was built from, so
+    # the two cannot say different numbers, and `ffi.sizeof` of the
+    # cdata would be 0.0175 microseconds nothing reads, measured as the
+    # comment above says
+    return ffi.unpack(output, _XONLY_SIZE)

--- a/stubs/_btclib_secp256k1.pyi
+++ b/stubs/_btclib_secp256k1.pyi
@@ -27,13 +27,25 @@ measured -- so that is what it is declared to return.
 `addressof` is how a field of a struct is passed where libsecp256k1 wants
 a pointer to it: the found outputs of `silentpayments` carry an x-only
 public key and a label by value, and each has to reach its own serializer.
+
+`typeof` resolves a cdecl once, at import, for the buffers whose
+declaration is built by an f-string, and `new` takes what it answers as
+well as a string. `_CType` is what says so: with `Any` there instead,
+`new` accepts anything at all -- `ffi.new(_XONLY_SIZE)`, an int where a
+cdecl belongs, and the size and the type it was built from now sit a
+dozen lines apart in the same module -- which is the vacuous
+type-checking this file exists to prevent. It is opaque because nothing
+here reads what cffi answers; only where it may be passed matters.
 """
 
 from typing import Any
 
+class _CType: ...
+
 class _FFI:
     NULL: Any
-    def new(self, cdecl: str, init: Any = ...) -> Any: ...
+    def new(self, cdecl: str | _CType, init: Any = ...) -> Any: ...
+    def typeof(self, cdecl: str) -> _CType: ...
     def addressof(self, cdata: Any, field: str) -> Any: ...
     def sizeof(self, cdecl_or_cdata: Any) -> int: ...
     def buffer(self, cdata: Any, size: int = ...) -> memoryview: ...


### PR DESCRIPTION
Four things a wrapper worked out at every call and now works out once.
No answer changes, no signature a caller uses changes.

## What moved

- **An interpolated cdecl.** `xonly.serialize` and
  `silentpayments.serialize_label` declared their buffer with
  `ffi.new(f"char[{_XONLY_SIZE}]")` — which states the width once, the
  reason it is an f-string, and costs twice what a literal does, cffi
  having to hash a string built afresh each time. `ffi.typeof` of the
  same f-string, evaluated at import, is the literal's price with the
  width still stated once.
- **`ffi.sizeof` of a buffer whose size is a constant.** Each hoisted
  type has its size taken from that very type beside it, so buffer and
  length still cannot say different numbers. `keys.serialize` decides its
  flag in the branch that picks its buffer, instead of asking
  `compressed` twice. The length *object* stays per call, for the
  thread-safety reason its comment gives; only its type is hoisted.
- **The second view of memory already in hand.** `_secret.take` built an
  `ffi.buffer` to read the secret and then called `wipe`, which built
  another over the same cdata. `_zero` is now the statement that writes
  the zeros, and `wipe` calls it too, so it is written once.
- **The parity nobody reads.**
  `secp256k1_xonly_pubkey_from_pubkey` documents `pk_parity` as "can be
  NULL", and three of the five callers of `xonly._drop_y` discard it:
  `parse`, `_parsed`, `_tweak_add_`. It takes the pointer as an argument
  now, defaulting to NULL, and the two callers that read a parity
  allocate one.

## The figures, re-measured against the branch as implemented

Each `main` spelling written out and alternated against this one in a
single process over one build, minimum of 9 rounds, with a noise row
running `main`'s spelling twice under two names — an Apple M5, macOS
26.6, arm64, CPython 3.14.6. Every pair is asserted to answer alike
before it is timed.

| | main | now | delta | noise |
| --- | --- | --- | --- | --- |
| `xonly.serialize` | 0.2499 µs | 0.1858 µs | −25.6% | 0.2% |
| `silentpayments.serialize_label` | 0.2583 µs | 0.1912 µs | −26.0% | 0.5% |
| `xonly.parse`, 65 bytes | 0.5071 µs | 0.4168 µs | −17.8% | 0.2% |
| `_secret.take` | 0.1561 µs | 0.1366 µs | −12.5% | 0.2% |
| `keys.serialize`, compressed | 0.3055 µs | 0.2809 µs | −8.1% | 0.1% |
| `keys.serialize`, uncompressed | 0.3057 µs | 0.2785 µs | −8.9% | 0.1% |
| `xonly.from_pubkey`, 65 bytes | 0.7571 µs | 0.6976 µs | −7.9% | 0.3% |
| `keys.prvkey_negate` | 0.3418 µs | 0.3211 µs | −6.1% | 0.2% |

**Two of #212's numbers were wrong and are corrected here.** `take` is
−12.5%, not −29%: the figure in the issue came from a variant with the
zeroing inlined, and `_zero` costs the frame that variant did not pay —
kept anyway, because the alternative is writing the statement that
overwrites a secret in two places. And `prvkey_negate` is −6.1%, not
−21%: that row's `main` variant skipped `_scalar.scalar` altogether, so
the two spellings differed in more than the change being measured. Both
rows above are the honest comparison.

## What was measured and not done

- **Hoisting `ffi.typeof` for *literal* cdecls: nothing.** 0.0800 µs
  against 0.0811, on a noise row that moved 0.0798 — cffi already caches
  the parse of a literal. Which is why this PR hoists only where the
  string is built by an f-string, and leaves
  `ffi.new("secp256k1_pubkey *")` and the rest exactly as they are.
- **`_scalar.scalar`.** `type(num) is int` is one check where
  `isinstance(num, int) and not isinstance(num, bool)` is two, and
  excludes `bool` on its own: 0.141 µs against 0.157. It needs the range
  check and the serialization written twice, once for the exact type and
  once for the subclass, and the int path is the one the module's own
  docstring says is not the common one — a scalar handed to these
  bindings in a loop is bytes, and bytes never reach that test. Declined.
- The rest of #212's "measured and left alone" table stands: the
  `ffi.callback` per scan, the `_cdata.array` list copy, the
  `found_output` block, and the GIL, which cffi releases already.

## Scope

`stubs/_btclib_secp256k1.pyi` gains `typeof`, and `new` takes what it
answers as well as a string — without that mypy fails, which is the stub
doing its job. CHANGELOG.md carries the table and the two declined
results; HISTORY.md carries the four figures a caller sees.

Suite green (582 tests), coverage gate at 100.00%, every hook passes.

Closes #212

## Summary by Sourcery

Hoist several cffi-related computations from hot call paths to module import time to reduce overhead without changing public behavior or results.

Enhancements:
- Optimize x-only key handling by reusing parity buffers only where needed and simplifying `_drop_y` to return just the x-only pubkey.
- Precompute and reuse cffi buffer types and sizes for key and label serialization, avoiding repeated cdecl parsing and sizeof calls.
- Refactor secret wiping to share a single zeroing implementation, removing redundant buffer view creation while preserving safety semantics.

Documentation:
- Extend CHANGELOG and HISTORY with performance notes and rationale for hoisting wrapper work from per-call to import-time.

Chores:
- Update type stubs to expose `ffi.typeof` and accept precomputed cdecl types in `ffi.new`, keeping static type checking accurate with the new usage.