### PR TITLE
Check a signature before answering with it, in both signing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,82 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### A signer checks its own signature
+
+- **`dsa.sign` and `ssa.sign` verify what they made before answering
+  with it**, under the public key of the very key that made it, and take
+  a keyword-only `verify` that defaults to `True` to say so.
+  `ssa.sign_custom`, `ssa.Signer.sign`, `ssa.Signer.sign_custom` and the
+  private `dsa._sign_`, `ssa._sign32` and `ssa._sign_custom` take the
+  same argument with the same default, so no path reaches libsecp256k1
+  with a weaker policy than the one above it. A signature that fails is
+  a `RuntimeError` and is never returned.
+- **The two halves of that arrived by different routes.** For BIP340 it
+  is a step of the algorithm rather than a practice around it: *Default
+  Signing* ends with "If Verify(bytes(P), m, sig) returns failure,
+  abort", and the BIP's own note gives the reason and the escape --
+  computation errors, random or provoked, yield a signature that "may
+  leak information about the secret key", and the step "can be omitted
+  if the computation cost is prohibitive". For ECDSA no standard asks,
+  and Bitcoin Core does it anyway at the end of `CKey::Sign`, with no
+  way to decline; declining is what `verify=False` is here.
+- **What it costs was measured rather than reasoned about**, the
+  variants alternated in one process over 7 rounds of 20 000 calls with
+  the minimum kept for each -- an Apple M5, macOS 26.6, arm64, CPython
+  3.13.14, and a noise row of ±0.04. `dsa.sign` 12.15 against 31.67,
+  `ssa.sign` 15.87 against 28.57, `ssa.Signer.sign` 8.18 against 20.82.
+  The finding is the gap between the two increments: 19.5 for ECDSA
+  against 12.7 for BIP340, the 6.8 between them being the point
+  multiplication `secp256k1_ec_pubkey_create` does and
+  `secp256k1_keypair_xonly_pub` does not. The step the specification
+  prescribes is the cheaper of the two, which is why neither is opt-in.
+- **A caller that signs and does not publish pays for a guarantee it may
+  not want**, and `verify=False` is the whole of the remedy: the
+  signature is the same bytes either way, which
+  `tests/test_verified_signing.py` asserts for each of the eight entry
+  points rather than for one of them.
+- **`recovery.sign` is not in it, and the shipped documentation says so
+  rather than leaving it to a pull request description.** It answers a
+  signature nothing here has checked, and the reason is that the check
+  is a different one: Core closes the same hole in `CKey::SignCompact`
+  by recovering the public key and comparing it with
+  `secp256k1_ec_pubkey_cmp`, which is the question a recovery id invites
+  and is its own design, tests and measurement -- #217 carries it, and
+  names the three files to correct when it closes. README.md carries
+  the asymmetry beside the one it already carries for `grind`.
+- **The two halves do not check quite the same region**, which is worth
+  a sentence and not a change. `ssa` verifies the 64 octets it answers
+  with; `dsa` verifies the signature object and serializes it after, so
+  the encoding is outside what was checked -- as it is in Core, for the
+  same reason, the serializers being memcpy-shaped where the signing is
+  arithmetic.
+- **`xonly._from_keypair_` is new**, and is what makes the BIP340 half
+  cheap: `xonly.from_keypair` is now that call with a serialize behind
+  it, where reaching the key through the public half would have written
+  a point out only to lift it back, and a lift is a field square root.
+  It is the one private half whose object is a keypair, so
+  `test_every_private_half_is_paired` excuses it from the parametrized
+  tables the way it already excuses `ssa._verify_` and
+  `xonly._tweak_add_`, and a test of its own holds the equality.
+- **The fault itself is not tested, because no input produces one.** The
+  `raise RuntimeError` is excluded from coverage for the reason every
+  other one is. What is tested is the wiring around it: the verification
+  is substituted for one that refuses, and each entry point is held to
+  raising rather than returning -- and, in the other direction, to *not*
+  raising where `verify=False` was passed, which is the only assertion
+  that sees the flag at all: the signature is the same bytes whether or
+  not it was honoured, so a `verify` ignored altogether answers exactly
+  what it should. Replacing every `if verify:` with `if True:` leaves
+  the rest of the suite passing, which is how that hole was found rather
+  than argued for. The keys of both y parities are signed
+  with as well, both parities asserted to occur, because a check read
+  off the wrong half of the negation BIP340 prescribes would pass for
+  the wrong reason.
+- **`dsa.sign` carries a `noqa: PLR0913`** and the reason above it: six
+  arguments where the rule allows five, and the alternative is an
+  options object for one function whose four questions group with
+  nothing.
+
 ### The frames between an entry point and libsecp256k1
 
 - **Five entry points are spelled out rather than composed of their

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -72,6 +72,36 @@ them `ndata` and `ellswift.encode` called them `rnd32`, and
 `pubkeys_bytes`. All four are keyword names; a positional call is
 unaffected.
 
+**Signing now verifies, and that is the one change to act on that is not
+a rename.** `dsa.sign`, `ssa.sign`, `ssa.sign_custom` and both methods of
+`ssa.Signer` check the signature they just made under the public key of
+the key that made it, and raise instead of returning one that fails. It
+is BIP340's own last step — *Default Signing* ends with it — and the end
+of Bitcoin Core's `CKey::Sign` for ECDSA, and what it protects against is
+a computation gone wrong, by bad memory or by an induced fault,
+publishing a signature that is invalid and may say something about the
+key.
+
+The signature is the same bytes it always was; what changed is the price
+and the guarantee. On the machine and with the method CHANGELOG.md
+states: `dsa.sign` 12.15 microseconds against 31.67, `ssa.sign` 15.87
+against 28.57, `ssa.Signer.sign` 8.18 against 20.82. ECDSA pays more than
+BIP340 because it has to derive the public key, which a BIP340 keypair
+already holds. A caller that measured the old cost, or that signs
+without publishing, passes the new keyword-only `verify=False` and is
+back where it was:
+
+```diff
+-sig = dsa.sign(msg, prvkey)
++sig = dsa.sign(msg, prvkey, verify=False)
+```
+
+`recovery.sign` is the one signing call this does not cover: it answers a
+signature nothing here has checked, and it takes no `verify`. The check a
+recoverable signature wants is a different one — recover the key from the
+signature and compare it, which is what Bitcoin Core's `CKey::SignCompact`
+does — so it is a change of its own rather than this one applied twice.
+
 What the rest of the release adds: one for a caller that signs more than
 once under one key, one for a caller whose ECDSA signatures go into a
 transaction, one for a caller computing a taproot output key from a

--- a/README.md
+++ b/README.md
@@ -577,6 +577,79 @@ microseconds, and a caller who wanted the other form never has to pay it:
 `compact=True` answers the 64 octets of `r ‖ s` directly, where reaching
 them through `to_compact` writes the DER and parses it straight back.
 
+## Checking the signature before answering with it
+
+`dsa.sign` and `ssa.sign` verify what they just made, under the public
+key of the very key that made it, and a signature that fails is raised
+on rather than returned. It is the one argument here that defaults to
+on, and `verify=False` is how a caller declines it.
+
+The two have the same reasoning behind them and did not arrive by the
+same route. For BIP340 it is a step of the algorithm: *Default Signing*
+ends with "If Verify(bytes(P), m, sig) returns failure, abort", and the
+note beside it says why — "Verifying the signature before leaving the
+signer prevents random or attacker provoked computation errors. This
+prevents publishing invalid signatures which may leak information about
+the secret key. It is recommended, but can be omitted if the computation
+cost is prohibitive." Schnorr is linear, so what leaks is not vague: two
+signatures over one nonce and two challenges give up `d` by subtraction.
+For ECDSA no standard asks for it and Bitcoin Core does it anyway, at the
+end of `CKey::Sign`, under a comment reading "Additional verification
+step to prevent using a potentially corrupted signature" — and Core
+offers no way to turn it off, where this does.
+
+What it catches is not a bad argument: those have all raised by the time
+it runs. It catches the computation itself going wrong, whether by bad
+memory or by a fault induced on purpose, and the whole of the protection
+is not publishing the result.
+
+It costs what a verification costs, and in ECDSA a point multiplication
+besides — the public key, which BIP340 needs to sign at all and ECDSA
+needs for neither of the two things `sign` does. Measured with the
+variants alternated in one process, an Apple M5, macOS 26.6, arm64,
+CPython 3.13.14, seven rounds of 20 000 calls with the minimum of each
+kept, and a last row running one of them a second time so that the noise
+has a figure of its own:
+
+| the call | `verify=False` | `verify=True` |
+| --- | --- | --- |
+| `dsa.sign` | 12.15 | 31.67 |
+| `ssa.sign` | 15.87 | 28.57 |
+| `ssa.Signer.sign` | 8.18 | 20.82 |
+| `ssa.sign` again (the noise) | | ±0.04 |
+
+Microseconds per signature. The finding is the gap between the two
+increments: 19.5 for ECDSA against 12.7 for BIP340, and the 6.8 between
+them is the multiplication `secp256k1_ec_pubkey_create` does and
+`secp256k1_keypair_xonly_pub` does not — the keypair holds the point
+already, which is the same 7.55 the [signer](#two-outposts-past-the-boundary)
+hoists. So the step the specification prescribes is also the cheaper of
+the two, and a `Signer` pays it at the same price as a bare `ssa.sign`.
+
+**`recovery.sign` has no `verify`, and answers a signature nothing here
+has checked.** It is the one signing entry point this does not cover, and
+saying so is the point: the two sections above read as a policy of the
+package, and a caller reaching for a recoverable signature would
+otherwise conclude it was checked. The reason is that the check is a
+different one. Core closes the same hole in `CKey::SignCompact`, and not
+with a verification: it recovers the public key from the signature and
+compares it with `secp256k1_ec_pubkey_cmp`, which is the natural question
+to ask of a signature carrying a recovery id, and it is its own design,
+its own tests and its own measurement rather than this argument applied
+twice.
+
+What each half checks is not quite the same region either. `ssa` verifies
+the very 64 octets it answers with; `dsa` verifies the signature *object*
+and serializes it afterwards, so the DER or compact encoding is outside
+what was checked — as it is in Core, whose `CKey::Sign` verifies the
+`secp256k1_ecdsa_signature` and serializes after. Both are defensible,
+the serializers being memcpy-shaped where the signing is arithmetic, and
+the difference is worth a sentence rather than a change.
+
+Every other microsecond figure in this file was measured before this
+argument existed and is therefore the signature without the check:
+`verify=False` is the column they are in.
+
 ## Grinding for a low r
 
 `dsa.sign(grind=True)` answers the signature of the same key and message

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import overload
 
-from . import BytesLike, CData, MutableBytesLike, ffi, lib
+from . import BytesLike, CData, MutableBytesLike, ffi, keys, lib
 from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx
@@ -226,6 +226,8 @@ def _sign_(
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
     grind: bool = False,
+    *,
+    verify: bool = True,
 ) -> CData:
     """Create an ECDSA signature, as the parsed signature.
 
@@ -244,6 +246,12 @@ def _sign_(
             documents. Not with aux_rand32: the two write the same 32
             octets, so asking for both is refused rather than resolved
             here.
+        verify: whether to check the signature under the public key of
+            the key that made it before answering with it, as `sign`
+            documents. Where `grind` asks too, what is checked is the
+            signature the grinding settled on: the attempts it discarded
+            are never answered with, so a fault in one of them is a
+            wasted attempt rather than a published signature.
 
     Returns:
         The libsecp256k1 signature object, in the lower-s form
@@ -255,7 +263,8 @@ def _sign_(
             together, or if the private key is not 32 bytes, does not fit
             in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to serialize an attempt while
-            grinding, which a signature it has just made cannot do.
+            grinding, which a signature it has just made cannot do, or if
+            `verify` asks and the signature does not verify.
     """
     prvkey_bytes = scalar(prvkey, "private key")
     msg_bytes = octets(msg_bytes, "message hash", 32)
@@ -266,15 +275,33 @@ def _sign_(
     _signed(signature, msg_bytes, prvkey_bytes, optional_entropy(aux_rand32))
     if grind:
         _grind(signature, msg_bytes, prvkey_bytes)
+    if verify:
+        # through `_verify_` and `keys._pubkey_from_prvkey_` rather than
+        # through the two public halves, which would serialize this
+        # signature into DER and the point into octets only to parse both
+        # straight back -- and for a compressed key that parse is a field
+        # square root. `normalize` is not passed: libsecp256k1 has just
+        # answered the lower-s form, so there is nothing to normalize
+        pubkey = keys._pubkey_from_prvkey_(prvkey_bytes)
+        if not _verify_(msg_bytes, pubkey, signature):
+            raise RuntimeError("signing produced a signature that does not verify")
     return signature
 
 
-def sign(
+# six arguments, where PLR0913 allows five. The alternative is an options
+# object, and it would be one for this function alone: `aux_rand32`,
+# `compact` and `grind` are ECDSA's own three questions, `verify` is the
+# fourth these bindings add, and none of the four is a group with either
+# of the others. `verify` is keyword-only, as the two before it should
+# have been, so what a call site actually carries is named
+def sign(  # noqa: PLR0913
     msg_bytes: BytesLike,
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
     compact: bool = False,
     grind: bool = False,
+    *,
+    verify: bool = True,
 ) -> bytes:
     """Create an ECDSA signature.
 
@@ -297,6 +324,23 @@ def sign(
     and never done by default. `s` is not ground for and could not be:
     libsecp256k1 has already returned the lower of the two.
 
+    `verify` is the second thing beyond a libsecp256k1 call, and it is
+    the other half of that same `CKey::Sign`: the signature is checked
+    under the public key of the very key that made it, and one that
+    fails is never answered with. What it catches is not a bad argument
+    -- those have all raised by then -- but a computation that went
+    wrong, a bit flipped in memory or a fault induced on purpose, whose
+    cost is a published signature that is invalid and may say something
+    about the key. It is the one argument here that is on by default,
+    and the asymmetry with `grind` is the point: grinding buys an octet
+    of DER, this buys the guarantee that what was answered is a
+    signature. Core pays it on every signature and offers no way not to;
+    here there is one, because the check is a point multiplication and a
+    verification and the caller who has measured that against its own
+    threat model is the one entitled to refuse it -- `ssa.sign` refuses
+    it more cheaply, BIP340 needing the public key to sign at all where
+    ECDSA needs it for neither of the two things `sign` does.
+
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -310,6 +354,11 @@ def sign(
             32 octets, so a caller asking for both is asking for two
             different values of one argument, and Core's counter is what
             makes the result reproducible by anyone else.
+        verify: whether to check the signature under the public key of
+            the key that made it before returning it. It costs a point
+            multiplication and a verification, and False is what a
+            caller that has measured those against its own threat model
+            passes.
 
     Returns:
         The signature, in the lower-s form libsecp256k1 always produces:
@@ -341,7 +390,7 @@ def sign(
     # three land within 0.03 microseconds of this one and on the wrong
     # side of it. A signature is 11.9 microseconds of libsecp256k1, and
     # two python frames do not show against it
-    signature = _sign_(msg_bytes, prvkey, aux_rand32, grind)
+    signature = _sign_(msg_bytes, prvkey, aux_rand32, grind, verify=verify)
     return serialize_compact(signature) if compact else serialize_der(signature)
 
 

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -136,7 +136,11 @@ def nonce_bip340(
 
 
 def sign(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    verify: bool = True,
 ) -> bytes:
     """Create a Schnorr signature of a 32-byte message hash.
 
@@ -144,6 +148,17 @@ def sign(
     before returning, which is the right cost for one signature and
     half the cost of each of several: signing more than once under one
     key is `Signer`, which builds it once.
+
+    `verify` is BIP340's own last step -- "If Verify(bytes(P), m, sig)
+    returns failure, abort" -- and the one thing here that is more than a
+    libsecp256k1 call. A computation gone wrong, memory gone bad or a
+    fault induced on purpose, yields a signature that is invalid and may
+    leak something about the secret key, and not answering with one is
+    the whole of the protection. It is on by default because the BIP
+    puts it inside the algorithm rather than beside it, and it can be
+    turned off because the BIP says that too, "if the computation cost
+    is prohibitive" -- which here is one verification and no
+    multiplication. `_abort_unless_verified` carries the rest of the reasoning.
 
     Args:
         msg_bytes: the 32-byte message hash.
@@ -154,6 +169,11 @@ def sign(
             or None for fresh randomness. Never a shorter value: BIP340
             defines a 32-byte a, and padding a short one would make a
             caller mistake a valid argument.
+        verify: whether to check the signature under its own public key
+            before returning it. It costs a verification and no point
+            multiplication, the keypair already holding the point, and
+            False is what a caller that has measured that against its
+            own threat model passes.
 
     Returns:
         The 64-byte signature.
@@ -163,18 +183,22 @@ def sign(
             is given and is not 32 bytes, or if the private key is not
             32 bytes, does not fit in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to sign, which no input can
-            make it do.
+            make it do, or if `verify` asks and the signature does not
+            verify.
 
     Example:
         >>> from btclib_secp256k1 import keys, ssa, xonly
         >>> msg, prvkey = bytes(32), 1
         >>> pubkey, _ = xonly.from_pubkey(keys.pubkey_from_prvkey(prvkey))
-        >>> ssa.verify(msg, pubkey, ssa.sign(msg, prvkey, bytes(32)))
+        >>> sig = ssa.sign(msg, prvkey, bytes(32))
+        >>> ssa.verify(msg, pubkey, sig)
+        True
+        >>> ssa.sign(msg, prvkey, bytes(32), verify=False) == sig
         True
     """
     keypair_obj = keypair(prvkey)
     try:
-        return _sign32(msg_bytes, keypair_obj, aux_rand32)
+        return _sign32(msg_bytes, keypair_obj, aux_rand32, verify=verify)
     finally:
         # a keypair carries the private key: overwrite it whether the
         # signature was made, refused, or never attempted, the argument
@@ -183,7 +207,11 @@ def sign(
 
 
 def sign_custom(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    verify: bool = True,
 ) -> bytes:
     """Create a Schnorr signature of a message of any length.
 
@@ -200,6 +228,9 @@ def sign_custom(
         prvkey: the private key, 32 bytes or an int below 2**256.
         aux_rand32: the 32 bytes of auxiliary randomness, or None for
             fresh randomness.
+        verify: whether to check the signature under its own public key
+            before returning it, as `sign` documents and BIP340
+            prescribes.
 
     Returns:
         The 64-byte signature.
@@ -209,11 +240,12 @@ def sign_custom(
             the private key is not 32 bytes, does not fit in them, or is
             not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to sign, which no input can
-            make it do.
+            make it do, or if `verify` asks and the signature does not
+            verify.
     """
     keypair_obj = keypair(prvkey)
     try:
-        return _sign_custom(msg_bytes, keypair_obj, aux_rand32)
+        return _sign_custom(msg_bytes, keypair_obj, aux_rand32, verify=verify)
     finally:
         # the keypair carries the private key: see sign
         wipe(keypair_obj)
@@ -285,7 +317,13 @@ class Signer:
         # wiped keypair is 96 zero octets and looks like any other
         self._keypair: CData | None = keypair(prvkey)
 
-    def sign(self, msg_bytes: BytesLike, aux_rand32: BytesLike | None = None) -> bytes:
+    def sign(
+        self,
+        msg_bytes: BytesLike,
+        aux_rand32: BytesLike | None = None,
+        *,
+        verify: bool = True,
+    ) -> bytes:
         """Create a Schnorr signature of a 32-byte message hash.
 
         The signature `ssa.sign` makes of the same arguments, over the
@@ -295,6 +333,11 @@ class Signer:
             msg_bytes: the 32-byte message hash.
             aux_rand32: the 32 bytes of auxiliary randomness BIP340
                 defines, or None for fresh randomness.
+            verify: whether to check the signature under this signer's
+                own public key before returning it, as `ssa.sign`
+                documents and BIP340 prescribes. It is the same cost
+                here as there, the point being read off the keypair
+                either way.
 
         Returns:
             The 64-byte signature.
@@ -304,12 +347,17 @@ class Signer:
                 aux_rand32 is given and is not 32 bytes, or if this
                 signer has been wiped.
             RuntimeError: if libsecp256k1 fails to sign, which no input
-                can make it do.
+                can make it do, or if `verify` asks and the signature
+                does not verify.
         """
-        return _sign32(msg_bytes, self._held(), aux_rand32)
+        return _sign32(msg_bytes, self._held(), aux_rand32, verify=verify)
 
     def sign_custom(
-        self, msg_bytes: BytesLike, aux_rand32: BytesLike | None = None
+        self,
+        msg_bytes: BytesLike,
+        aux_rand32: BytesLike | None = None,
+        *,
+        verify: bool = True,
     ) -> bytes:
         """Create a Schnorr signature of a message of any length.
 
@@ -321,6 +369,9 @@ class Signer:
             msg_bytes: the message, of any length.
             aux_rand32: the 32 bytes of auxiliary randomness, or None
                 for fresh randomness.
+            verify: whether to check the signature under this signer's
+                own public key before returning it, as `ssa.sign`
+                documents and BIP340 prescribes.
 
         Returns:
             The 64-byte signature.
@@ -329,9 +380,10 @@ class Signer:
             ValueError: if aux_rand32 is given and is not 32 bytes, or
                 if this signer has been wiped.
             RuntimeError: if libsecp256k1 fails to sign, which no input
-                can make it do.
+                can make it do, or if `verify` asks and the signature
+                does not verify.
         """
-        return _sign_custom(msg_bytes, self._held(), aux_rand32)
+        return _sign_custom(msg_bytes, self._held(), aux_rand32, verify=verify)
 
     def pubkey(self) -> tuple[bytes, int]:
         """Return the x-only public key this signer signs under.
@@ -500,8 +552,60 @@ def verify(
     )
 
 
+def _abort_unless_verified(
+    keypair_obj: CData, msg_bytes: BytesLike, signature_bytes: bytes
+) -> None:
+    """Check a signature just made, under the keypair that made it.
+
+    Named for what it does rather than for what it asks: `_verify_` is
+    thirty lines up, answers `bool` and is what a caller composes with,
+    where this one raises and answers nothing. Two neighbours told apart
+    by tense would invite `if _abort_unless_verified(...)`, which is
+    syntactically fine and means nothing at all. The verb is BIP340's
+    own -- "returns failure, abort".
+
+    BIP340's *Default Signing* ends with this step -- "If Verify(bytes(P),
+    m, sig) returns failure, abort" -- and says what it is for: a random
+    or attacker provoked computation error yields a signature that is
+    invalid and may leak something about the secret key, and not
+    publishing one is the whole of the protection. Schnorr is linear, so
+    what leaks is not vague: two signatures over one nonce and two
+    challenges give up `d` by subtraction. The BIP puts the step inside
+    the algorithm and allows omitting it where the cost is prohibitive,
+    which is why `sign` does it unless told not to rather than the other
+    way round.
+
+    Written once because `_sign32` and `_sign_custom` both end in it, and
+    because the key has to be the one that signed: two spellings would be
+    two chances for it to be some other key, and a check against the
+    wrong key proves nothing while looking like proof.
+
+    The key is read off the keypair rather than derived, which is what
+    makes this cheaper than the same step is in `dsa`: BIP340 needs the
+    public key to sign at all, so the multiplication is already paid and
+    what is left is the verification.
+
+    Args:
+        keypair_obj: the keypair that made the signature.
+        msg_bytes: the message it was made of, already checked.
+        signature_bytes: the 64-byte signature just made.
+
+    Raises:
+        RuntimeError: if the signature does not verify, which no input
+            can make happen: what it reports is the computation itself
+            having gone wrong.
+    """
+    xonly_pubkey, _ = xonly._from_keypair_(keypair_obj)
+    if not _verify_(msg_bytes, xonly_pubkey, signature_bytes):
+        raise RuntimeError("signing produced a signature that does not verify")
+
+
 def _sign32(
-    msg_bytes: BytesLike, keypair_obj: CData, aux_rand32: BytesLike | None
+    msg_bytes: BytesLike,
+    keypair_obj: CData,
+    aux_rand32: BytesLike | None,
+    *,
+    verify: bool = True,
 ) -> bytes:
     """Sign a 32-byte message hash with a keypair somebody else owns.
 
@@ -517,6 +621,8 @@ def _sign32(
             whoever built it and not here.
         aux_rand32: the 32 bytes of auxiliary randomness, or None for
             fresh randomness.
+        verify: whether to check the signature before answering with it,
+            as `_abort_unless_verified` documents and BIP340 prescribes.
 
     Returns:
         The 64-byte signature.
@@ -525,7 +631,8 @@ def _sign32(
         ValueError: if the message hash is not 32 bytes, or if
             aux_rand32 is given and is not 32 bytes.
         RuntimeError: if libsecp256k1 fails to sign, which no input can
-            make it do.
+            make it do, or if `verify` asks and the signature does not
+            verify.
     """
     msg_bytes = octets(msg_bytes, "message hash", 32)
 
@@ -534,11 +641,18 @@ def _sign32(
         ctx, sig, msg_bytes, keypair_obj, entropy(aux_rand32)
     ):
         raise RuntimeError("schnorr signing failed")
-    return ffi.unpack(sig, ffi.sizeof(sig))
+    signature_bytes = ffi.unpack(sig, ffi.sizeof(sig))
+    if verify:
+        _abort_unless_verified(keypair_obj, msg_bytes, signature_bytes)
+    return signature_bytes
 
 
 def _sign_custom(
-    msg_bytes: BytesLike, keypair_obj: CData, aux_rand32: BytesLike | None
+    msg_bytes: BytesLike,
+    keypair_obj: CData,
+    aux_rand32: BytesLike | None,
+    *,
+    verify: bool = True,
 ) -> bytes:
     """Sign a message of any length with a keypair somebody else owns.
 
@@ -550,6 +664,8 @@ def _sign_custom(
             whoever built it and not here.
         aux_rand32: the 32 bytes of auxiliary randomness, or None for
             fresh randomness.
+        verify: whether to check the signature before answering with it,
+            as `_abort_unless_verified` documents and BIP340 prescribes.
 
     Returns:
         The 64-byte signature.
@@ -557,7 +673,8 @@ def _sign_custom(
     Raises:
         ValueError: if aux_rand32 is given and is not 32 bytes.
         RuntimeError: if libsecp256k1 fails to sign, which no input can
-            make it do.
+            make it do, or if `verify` asks and the signature does not
+            verify.
     """
     msg_bytes = octets(msg_bytes, "message")
 
@@ -574,4 +691,7 @@ def _sign_custom(
         ctx, sig, msg_bytes, len(msg_bytes), keypair_obj, extraparams
     ):
         raise RuntimeError("schnorr signing failed")
-    return ffi.unpack(sig, ffi.sizeof(sig))
+    signature_bytes = ffi.unpack(sig, ffi.sizeof(sig))
+    if verify:
+        _abort_unless_verified(keypair_obj, msg_bytes, signature_bytes)
+    return signature_bytes

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -155,6 +155,41 @@ def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
     return _from_pubkey_(keys._pubkey_from_prvkey_(prvkey))
 
 
+def _from_keypair_(keypair_obj: CData) -> tuple[CData, int]:
+    """Return the x-only public key of a keypair, as the parsed point.
+
+    The private half of `from_keypair`, for a caller about to hand the
+    key to another wrapper rather than to hold its bytes: see the package
+    docstring for what the two underscores mean throughout. The one this
+    package makes is `ssa`, verifying a signature it has just made, where
+    reaching the key through `from_keypair` would serialize a point only
+    to lift it straight back -- and that lift is a field square root,
+    where this is a read of what the keypair already holds.
+
+    Args:
+        keypair_obj: the libsecp256k1 keypair object, as `ssa.Signer`
+            holds and as `secp256k1_keypair_create` writes.
+
+    Returns:
+        The libsecp256k1 x-only public key object, and the parity of y:
+        0 for even, 1 for odd. The parity is of the point the private
+        key gives, the keypair being the negated key where that y is odd.
+
+    Raises:
+        RuntimeError: if libsecp256k1 will not read the object -- a NULL
+            pointer, or one that has been wiped -- or fails for any other
+            reason. It answers the same 0 for both, so this is a
+            RuntimeError rather than the ValueError a wiped keypair
+            deserves, and `context.check` is what tells the two apart.
+    """
+    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+    parity = ffi.new("int *")
+    converted = lib.secp256k1_keypair_xonly_pub(ctx, xonly_pubkey, parity, keypair_obj)
+    if not converted:
+        raise RuntimeError("x-only public key conversion failed")
+    return xonly_pubkey, parity[0]
+
+
 def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
     """Return the x-only public key of a keypair, and the y parity.
 
@@ -187,12 +222,8 @@ def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
             fails to serialize the result, which a keypair it built
             cannot make it do.
     """
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    parity = ffi.new("int *")
-    converted = lib.secp256k1_keypair_xonly_pub(ctx, xonly_pubkey, parity, keypair_obj)
-    if not converted:
-        raise RuntimeError("x-only public key conversion failed")
-    return serialize(xonly_pubkey), parity[0]
+    xonly_pubkey, parity = _from_keypair_(keypair_obj)
+    return serialize(xonly_pubkey), parity
 
 
 def _tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -436,6 +436,7 @@ NOT_SWEPT = {
     "xonly.from_keypair",
     "xonly.parse",
     "xonly.serialize",
+    "xonly._from_keypair_",
     "xonly._from_pubkey_",
 }
 

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -37,6 +37,7 @@ from btclib_secp256k1 import (
     ssa,
     xonly,
 )
+from btclib_secp256k1._secret import keypair, wipe
 
 # secp256k1 group order
 N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
@@ -345,6 +346,25 @@ def test_the_schnorr_pair_parses_the_x_only_key() -> None:
     assert not ssa._verify_(MSG, xonly.parse(XONLY), tampered)
 
 
+def test_the_keypair_pair_reads_the_point_it_already_holds() -> None:
+    """`xonly.from_keypair` is `xonly._from_keypair_` behind a serialize.
+
+    The one pair whose object is a keypair rather than a parsed key, so
+    the equality is over one this test builds and not over octets a
+    caller could have handed in. What the private half saves is that
+    serialize and the lift back that reading it again would cost, which
+    is what `ssa.sign(verify=True)` takes it for.
+    """
+    keypair_obj = keypair(PRVKEY)
+    try:
+        xonly_pubkey, parity = xonly._from_keypair_(keypair_obj)
+        assert (xonly.serialize(xonly_pubkey), parity) == xonly.from_keypair(
+            keypair_obj
+        )
+    finally:
+        wipe(keypair_obj)
+
+
 def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:
     """`xonly._tweak_add_` is `xonly.tweak_add` of the key's own x.
 
@@ -512,11 +532,12 @@ def test_every_private_half_is_paired() -> None:
     the tables are checked against what the modules carry rather than
     trusted to have been kept up to date.
 
-    `ssa._verify_` and `xonly._tweak_add_` are paired in tests of their
-    own rather than in a table: the parsed key of the first is
-    `xonly.parse`'s and not `keys.parse`'s, and the second takes the
-    point whose x its public half is given, so neither equality is the
-    one parametrized above.
+    `ssa._verify_`, `xonly._tweak_add_` and `xonly._from_keypair_` are
+    paired in tests of their own rather than in a table: the parsed key
+    of the first is `xonly.parse`'s and not `keys.parse`'s, the second
+    takes the point whose x its public half is given, and the third
+    takes a keypair, which is the one object with no serialization to
+    parametrize over. None of the three is the equality above.
     """
     modules = {
         "dsa": dsa,
@@ -531,7 +552,7 @@ def test_every_private_half_is_paired() -> None:
     paired = (
         {name for name, *_ in PAIRS}
         | {name for name, *_ in EQUALITIES}
-        | {"ssa._verify_", "xonly._tweak_add_"}
+        | {"ssa._verify_", "xonly._tweak_add_", "xonly._from_keypair_"}
     )
     private_halves = {
         f"{module_name}.{name}"

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -1,0 +1,225 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A signer checks its own signature before answering with it.
+
+BIP340 puts the check inside *Default Signing* -- "If Verify(bytes(P), m,
+sig) returns failure, abort" -- and Bitcoin Core's `CKey::Sign` does the
+same for ECDSA without offering a way out, both for the same reason: a
+computation that went wrong, whether by bad memory or by an induced
+fault, yields a signature that is invalid and may say something about the
+key, and the protection is not publishing one.
+
+What can be tested about it is not the fault, which no input produces.
+It is the four things around it: that the check changes no signature,
+that it is on where nothing asks, that a refusal is wired to the raise
+rather than merely written near it, and that `verify=False` does not
+reach the check at all.
+
+The last two are one substituted verification read in both directions,
+and the last is the one nothing else covers: the signature is the same
+bytes whether or not the flag was honoured, so a `verify` ignored
+altogether would answer exactly what it should. Replacing every
+`if verify:` in the package with `if True:` leaves every other test here
+passing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from btclib_secp256k1 import dsa, ssa, xonly
+
+MSG = hashlib.sha256(b"a message to sign twice").digest()
+PRVKEY = 7
+AUX = bytes(32)
+
+# every entry point that took a `verify`, as a call of one key and one
+# message: the pair is the same signature asked for with the check and
+# without it, which is the equality every test here is built on
+SIGNERS: list[tuple[str, Callable[..., bytes]]] = [
+    ("dsa.sign", lambda **kw: dsa.sign(MSG, PRVKEY, **kw)),
+    ("dsa.sign compact", lambda **kw: dsa.sign(MSG, PRVKEY, compact=True, **kw)),
+    ("dsa.sign grind", lambda **kw: dsa.sign(MSG, PRVKEY, grind=True, **kw)),
+    ("dsa._sign_", lambda **kw: dsa.serialize_der(dsa._sign_(MSG, PRVKEY, **kw))),
+    ("ssa.sign", lambda **kw: ssa.sign(MSG, PRVKEY, AUX, **kw)),
+    ("ssa.sign_custom", lambda **kw: ssa.sign_custom(MSG, PRVKEY, AUX, **kw)),
+    ("Signer.sign", lambda **kw: _through_signer("sign", **kw)),
+    ("Signer.sign_custom", lambda **kw: _through_signer("sign_custom", **kw)),
+]
+
+
+def _refusing(*_args: Any, **_kwargs: Any) -> bool:
+    """Stand in for a verification, and refuse whatever it is handed.
+
+    Substituted for `dsa._verify_` and `ssa._verify_` in the two tests
+    that ask what the signing path does with each answer: no input makes
+    a real verification of a fresh signature fail, so a stand-in is the
+    only way to reach either branch.
+
+    Args:
+        _args: whatever the verification would have taken.
+        _kwargs: the same.
+
+    Returns:
+        False, always.
+    """
+    return False
+
+
+def _through_signer(method: str, **kwargs: Any) -> bytes:
+    """Sign through a `Signer` built and wiped for the one call.
+
+    Args:
+        method: `sign` or `sign_custom`.
+        kwargs: what to pass it beyond the message and the aux.
+
+    Returns:
+        The 64-byte signature.
+    """
+    with ssa.Signer(PRVKEY) as signer:
+        signed: bytes = getattr(signer, method)(MSG, AUX, **kwargs)
+    return signed
+
+
+@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+def test_the_check_changes_no_signature(
+    name: str, signer: Callable[..., bytes]
+) -> None:
+    """Checking a signature is a question, so it answers the same bytes.
+
+    The point of the parametrization is the entry points rather than the
+    signatures: each of them grew an argument, and an argument passed to
+    the wrong half of a call -- or not passed on at all -- is what this
+    would catch. Deterministic on both sides, RFC6979 for ECDSA and a
+    fixed aux for BIP340, so the equality is of one signature and not of
+    two that happen to verify.
+
+    Args:
+        name: the entry point, for the test id.
+        signer: it, as a call taking the keyword under test.
+    """
+    assert signer(verify=True) == signer(verify=False)
+
+
+@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+def test_the_check_is_on_where_nothing_asks(
+    name: str, signer: Callable[..., bytes]
+) -> None:
+    """Not passing the argument is passing True, which is the default.
+
+    Stated in five docstrings and checked here, because the difference
+    between the two defaults is invisible in every other test in this
+    suite: the signature is the same either way, and only the cost and
+    the guarantee differ.
+
+    Args:
+        name: the entry point, for the test id.
+        signer: it, as a call taking the keyword under test.
+    """
+    assert signer() == signer(verify=True)
+
+
+@pytest.mark.parametrize(
+    "name,function",
+    [
+        ("dsa.sign", dsa.sign),
+        ("dsa._sign_", dsa._sign_),
+        ("ssa.sign", ssa.sign),
+        ("ssa.sign_custom", ssa.sign_custom),
+        ("ssa._sign32", ssa._sign32),
+        ("ssa._sign_custom", ssa._sign_custom),
+        ("Signer.sign", ssa.Signer.sign),
+        ("Signer.sign_custom", ssa.Signer.sign_custom),
+    ],
+)
+def test_every_signer_defaults_to_checking(
+    name: str, function: Callable[..., Any]
+) -> None:
+    """The default is True everywhere it exists, private halves included.
+
+    A private half left at False would be the hole the public ones
+    closed: `Signer.sign` reaches `_sign32` and passes what it was given,
+    so a default that disagreed would be a second policy nobody stated.
+
+    Args:
+        name: the entry point, for the test id.
+        function: it, to read the signature of.
+    """
+    assert inspect.signature(function).parameters["verify"].default is True
+
+
+@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+def test_a_signature_that_does_not_verify_is_not_answered_with(
+    name: str, signer: Callable[..., bytes]
+) -> None:
+    """The raise is wired to the check, and not merely written near it.
+
+    No input makes a verification of a fresh signature fail -- that is
+    why the `raise RuntimeError` is excluded from coverage -- so the
+    verification is substituted for one that refuses. What this holds is
+    the wiring: that a False there stops the signature from being
+    returned, at every entry point rather than at one of them.
+
+    Args:
+        name: the entry point, for the test id.
+        signer: it, as a call taking the keyword under test.
+    """
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(dsa, "_verify_", _refusing)
+        patch.setattr(ssa, "_verify_", _refusing)
+        with pytest.raises(RuntimeError, match="does not verify"):
+            signer()
+
+
+@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+def test_the_refused_check_is_not_made_at_all(
+    name: str, signer: Callable[..., bytes]
+) -> None:
+    """`verify=False` does not reach the check, which nothing else sees.
+
+    The other direction, and the one no assertion above can stand in for:
+    the signature is the same bytes whether or not the flag was honoured,
+    so a `verify` ignored altogether would answer exactly what it should.
+    Replacing every `if verify:` with `if True:` leaves the whole suite
+    passing without this test, and fails it with it.
+
+    The refusing verification is what makes the difference visible: if
+    the check were made in spite of the False it would raise here, and
+    what this asserts is that a signature comes back instead.
+
+    Args:
+        name: the entry point, for the test id.
+        signer: it, as a call taking the keyword under test.
+    """
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(dsa, "_verify_", _refusing)
+        patch.setattr(ssa, "_verify_", _refusing)
+        assert signer(verify=False)
+
+
+def test_the_keypair_is_checked_against_the_key_that_signed() -> None:
+    """BIP340 negates an odd-y key, and the check follows it there.
+
+    The failure this rules out is a check that passes for the wrong
+    reason: `_verified` reads the x-only key off the keypair, which is
+    the negated one where the point has odd y, and a signature verifies
+    against those 32 bytes whichever the parity was. Signing with keys of
+    both parities is what exercises the two sides, so both are asserted
+    to occur rather than assumed to.
+    """
+    parities = set()
+    for prvkey in range(1, 8):
+        pubkey, parity = xonly.from_prvkey(prvkey)
+        parities.add(parity)
+        # verify=True is the default: what this asserts is that it did
+        # not raise, and the signature is held to the key besides
+        assert ssa.verify(MSG, pubkey, ssa.sign(MSG, prvkey, AUX))
+    assert parities == {0, 1}


### PR DESCRIPTION
BIP340 ends *Default Signing* with "If Verify(bytes(P), m, sig) returns
failure, abort", and Bitcoin Core ends `CKey::Sign` with the same step for
ECDSA, under a comment naming what it is for. Neither was done here.

What the step catches is not a bad argument — those have all raised by the
time it runs — but the computation itself going wrong, by bad memory or by
an induced fault, whose cost is a published signature that is invalid and
may say something about the key. In Schnorr what leaks is not vague:
two signatures over one nonce and two challenges give up `d` by subtraction.

## What changes

`dsa.sign` and `ssa.sign` verify what they made, under the public key of the
key that made it, and take a **keyword-only `verify` defaulting to `True`**.
`ssa.sign_custom`, both `Signer` methods and the three private halves
(`dsa._sign_`, `ssa._sign32`, `ssa._sign_custom`) take it with the same
default, so no path reaches libsecp256k1 with a weaker policy than the one
above it. A signature that fails is a `RuntimeError` and is never returned.

`verify` is keyword-only because `dsa.sign` reached six arguments, which
PLR0913 refuses; the `noqa` it carries has the reason above it. A caller
that wants the old cost passes `verify=False`, which is the whole of the
remedy — the signature is the same bytes either way.

`xonly._from_keypair_` is new, and is what keeps the BIP340 half cheap:
`xonly.from_keypair` is now that call with a serialize behind it, where
reaching the key through the public half would write a point out only to
lift it back, and a lift is a field square root.

## What it costs

Alternated in one process over 7 rounds of 20 000 calls, minimum kept for
each — an Apple M5, macOS 26.6, arm64, CPython 3.13.14, noise ±0.04:

| the call | `verify=False` | `verify=True` |
| --- | --- | --- |
| `dsa.sign` | 12.15 | 31.67 |
| `ssa.sign` | 15.87 | 28.57 |
| `ssa.Signer.sign` | 8.18 | 20.82 |

The finding is the gap between the two increments: 19.5 for ECDSA against
12.7 for BIP340, and the 6.8 between them is the point multiplication
`secp256k1_ec_pubkey_create` does and `secp256k1_keypair_xonly_pub` does
not. The step the specification prescribes is also the cheaper of the two,
which is why neither is opt-in.

`grind` is deliberately absent from that table: measured against a single
key whose first attempt already had the low r, those rows would have
measured no grinding at all.

## What is tested

The fault is not, no input producing one — the `raise RuntimeError` is
excluded from coverage for the reason every other one is. The wiring around
it is: the verification is substituted for one that refuses and each entry
point held to raising rather than returning; the signature is asserted equal
with the check and without it at each of eight entry points; the default is
read off every signature that has one; and keys of both y parities are
signed with, both parities asserted to occur, because a check read off the
wrong half of the negation BIP340 prescribes would pass for the wrong reason.

`tests/test_verified_signing.py` is new. `test_every_private_half_is_paired`
and `test_the_sweep_is_whole` both caught `xonly._from_keypair_` before this
description did, which is what those two are for.

Gate green, 609 tests, coverage 100.00%.

## Not in this change

`recovery.sign` still does not verify. Core closes that hole too, and in a
different shape — `CKey::SignCompact` recovers the key from the signature
and compares it with `secp256k1_ec_pubkey_cmp`, rather than calling
`ecdsa_verify` — so it is its own design, its own tests and its own
measurement. Worth a change of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add default-on self-verification to ECDSA and Schnorr signing APIs, ensuring signatures are checked against the signing key before being returned, while allowing callers to opt out via a keyword-only flag.

New Features:
- Introduce a keyword-only `verify` parameter (defaulting to `True`) across public and internal ECDSA and Schnorr signing functions and Signer methods to control post-signature verification behavior.

Enhancements:
- Implement internal helpers to verify freshly produced signatures against their corresponding public keys for both ECDSA and BIP340 Schnorr flows, preventing invalid signatures from being emitted due to computation faults.
- Optimize Schnorr verification by deriving the x-only public key directly from keypair objects via a new `xonly._from_keypair_` helper, avoiding unnecessary serialization and decompression.
- Update changelog, README, history, and key parsing tests to document and validate the new verified-signing behavior and the x-only keypair helper, including coverage of edge cases around key parity and defaults.

Tests:
- Add `tests/test_verified_signing.py` to ensure verified signing does not alter signature bytes, that verification is enabled by default on all entry points, and that failures are correctly wired to runtime errors.
- Extend existing tests to cover the new `xonly._from_keypair_` helper and to keep private/public helper pairings in sync with the new functionality.