### PR TITLE
Recover the key a recoverable signature claims, before answering with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,23 +54,53 @@ release-notes length in the first place, and are still in
 - **A caller that signs and does not publish pays for a guarantee it may
   not want**, and `verify=False` is the whole of the remedy: the
   signature is the same bytes either way, which
-  `tests/test_verified_signing.py` asserts for each of the eight entry
-  points rather than for one of them.
-- **`recovery.sign` is not in it, and the shipped documentation says so
-  rather than leaving it to a pull request description.** It answers a
-  signature nothing here has checked, and the reason is that the check
-  is a different one: Core closes the same hole in `CKey::SignCompact`
-  by recovering the public key and comparing it with
-  `secp256k1_ec_pubkey_cmp`, which is the question a recovery id invites
-  and is its own design, tests and measurement -- #217 carries it, and
-  names the three files to correct when it closes. README.md carries
-  the asymmetry beside the one it already carries for `grind`.
-- **The two halves do not check quite the same region**, which is worth
-  a sentence and not a change. `ssa` verifies the 64 octets it answers
+  `tests/test_verified_signing.py` asserts at each entry point rather
+  than at one of them.
+- **`recovery.sign` is in it too, and asks a different question** (#217).
+  It takes the same keyword-only `verify`, defaulting to `True`, and so
+  does `recovery._sign_`; what it does with it is recover the public key
+  from the signature and refuse one that is not the signer's, rather
+  than verify. The difference is the recovery id, which a verification
+  does not look at: a signature carrying the wrong one verifies
+  perfectly and then recovers somebody else's key, and recovering a key
+  is what a caller of that module does with the answer. Core makes the
+  same distinction in the same file -- `CKey::Sign` ends in
+  `secp256k1_ecdsa_verify`, `CKey::SignCompact` in
+  `secp256k1_ecdsa_recover` and `secp256k1_ec_pubkey_cmp` -- and it
+  subsumes the verification exactly rather than probably. Recovery is
+  not selective: for a given id it answers *the* key under which that
+  `r` and `s` verify, so an inconsistent pair does not fail, it comes
+  back as a different key -- and fails only where `r` is not the x of a
+  point at all, which a faulted `r` is about half the time. Which is the
+  stronger argument: the recovered
+  key is by construction the key that verifies the signature, so
+  `recovered == signer` **is** a verification, with the id checked
+  besides. Nothing is given up by not verifying, and that is provable
+  rather than argued.
+- **What that check costs was measured in a session of its own**, which
+  re-measured `dsa.sign` beside it rather than printing the two
+  together: `recovery.sign` 12.02 against 34.41, `dsa.sign` 12.06
+  against 31.54 there, agreeing with the 12.15 and 31.67 above. So the
+  recovery shape costs 22.4 against ECDSA's 19.5, a recovery being about
+  a verification's work with the comparison and the derivation making up
+  the rest. Same method as the rest, noise +/-0.02.
+- **`_abort_unless_recovered` turns `_recover_`'s `ValueError` into a
+  `RuntimeError`**, which is the one place the two exception kinds of
+  this package meet. "No key can be recovered" is an argument error of a
+  signature a caller handed in, and nothing of the sort for one made a
+  line earlier: what it reports there is the computation having gone
+  wrong, which is what a `RuntimeError` means throughout.
+- **The three do not check quite the same region**, which is worth a
+  sentence and not a change. `ssa` verifies the 64 octets it answers
   with; `dsa` verifies the signature object and serializes it after, so
-  the encoding is outside what was checked -- as it is in Core, for the
-  same reason, the serializers being memcpy-shaped where the signing is
-  arithmetic.
+  the encoding is outside what was checked. `recovery` is the case worth
+  the sentence most: what its check reads is the id inside the
+  `secp256k1_ecdsa_recoverable_signature`, and the id the caller
+  receives is the one `serialize_compact` writes afterwards -- so the id
+  is outside the checked region exactly as the DER is. Core does the
+  same, `CKey::SignCompact` recovering from `rsig` and not from the
+  octets it filled, and for the same reason: the serializers are
+  memcpy-shaped where the signing is arithmetic.
 - **`xonly._from_keypair_` is new**, and is what makes the BIP340 half
   cheap: `xonly.from_keypair` is now that call with a serialize behind
   it, where reaching the key through the public half would have written

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -96,11 +96,18 @@ back where it was:
 +sig = dsa.sign(msg, prvkey, verify=False)
 ```
 
-`recovery.sign` is the one signing call this does not cover: it answers a
-signature nothing here has checked, and it takes no `verify`. The check a
-recoverable signature wants is a different one — recover the key from the
-signature and compare it, which is what Bitcoin Core's `CKey::SignCompact`
-does — so it is a change of its own rather than this one applied twice.
+`recovery.sign` takes the same argument and asks a different question:
+it recovers the public key from the signature and refuses one that is not
+the signer's, rather than verifying. The difference is the recovery id,
+which a verification does not look at — a signature carrying the wrong
+one verifies perfectly and then recovers somebody else's key, which is
+exactly what a caller of that module is going to use it for. It costs
+12.02 microseconds against 34.41 — measured in a session of its own,
+where `dsa.sign` was 12.06 against 31.54, so that the two are compared
+against each other and not across two runs of the machine.
+
+So every signing call of the package now checks itself, and the same
+`verify=False` declines any of them.
 
 What the rest of the release adds: one for a caller that signs more than
 once under one key, one for a caller whose ECDSA signatures go into a

--- a/README.md
+++ b/README.md
@@ -579,12 +579,12 @@ them through `to_compact` writes the DER and parses it straight back.
 
 ## Checking the signature before answering with it
 
-`dsa.sign` and `ssa.sign` verify what they just made, under the public
-key of the very key that made it, and a signature that fails is raised
+`dsa.sign`, `ssa.sign` and `recovery.sign` check what they just made
+against the very key that made it, and a signature that fails is raised
 on rather than returned. It is the one argument here that defaults to
 on, and `verify=False` is how a caller declines it.
 
-The two have the same reasoning behind them and did not arrive by the
+The three have the same reasoning behind them and did not arrive by the
 same route. For BIP340 it is a step of the algorithm: *Default Signing*
 ends with "If Verify(bytes(P), m, sig) returns failure, abort", and the
 note beside it says why — "Verifying the signature before leaving the
@@ -603,6 +603,9 @@ it runs. It catches the computation itself going wrong, whether by bad
 memory or by a fault induced on purpose, and the whole of the protection
 is not publishing the result.
 
+`recovery.sign` asks a different question, and the section below says
+why. What it shares with the other two is the reason and the argument.
+
 It costs what a verification costs, and in ECDSA a point multiplication
 besides — the public key, which BIP340 needs to sign at all and ECDSA
 needs for neither of the two things `sign` does. Measured with the
@@ -618,6 +621,15 @@ has a figure of its own:
 | `ssa.Signer.sign` | 8.18 | 20.82 |
 | `ssa.sign` again (the noise) | | ±0.04 |
 
+and `recovery.sign` in a session of its own, which re-measured `dsa.sign`
+beside it so that the two are comparable rather than merely printed
+together — 12.06 against 31.54 for `dsa.sign` there, agreeing with the
+row above, and a noise row of ±0.02:
+
+| the call | `verify=False` | `verify=True` |
+| --- | --- | --- |
+| `recovery.sign` | 12.02 | 34.41 |
+
 Microseconds per signature. The finding is the gap between the two
 increments: 19.5 for ECDSA against 12.7 for BIP340, and the 6.8 between
 them is the multiplication `secp256k1_ec_pubkey_create` does and
@@ -626,25 +638,46 @@ already, which is the same 7.55 the [signer](#two-outposts-past-the-boundary)
 hoists. So the step the specification prescribes is also the cheaper of
 the two, and a `Signer` pays it at the same price as a bare `ssa.sign`.
 
-**`recovery.sign` has no `verify`, and answers a signature nothing here
-has checked.** It is the one signing entry point this does not cover, and
-saying so is the point: the two sections above read as a policy of the
-package, and a caller reaching for a recoverable signature would
-otherwise conclude it was checked. The reason is that the check is a
-different one. Core closes the same hole in `CKey::SignCompact`, and not
-with a verification: it recovers the public key from the signature and
-compares it with `secp256k1_ec_pubkey_cmp`, which is the natural question
-to ask of a signature carrying a recovery id, and it is its own design,
-its own tests and its own measurement rather than this argument applied
-twice.
+**`recovery.sign` recovers instead of verifying**, and the difference is
+the recovery id. A verification does not look at it: a recoverable
+signature carrying the wrong one verifies perfectly and then recovers a
+key that is not the signer's — and recovering a key is the one thing a
+caller of that module is going to do with the answer. So the check is
+the one the id deserves: recover from the signature, and refuse a key
+that is not the one that signed.
 
-What each half checks is not quite the same region either. `ssa` verifies
-the very 64 octets it answers with; `dsa` verifies the signature *object*
-and serializes it afterwards, so the DER or compact encoding is outside
-what was checked — as it is in Core, whose `CKey::Sign` verifies the
-`secp256k1_ecdsa_signature` and serializes after. Both are defensible,
-the serializers being memcpy-shaped where the signing is arithmetic, and
-the difference is worth a sentence rather than a change.
+That is Bitcoin Core's own distinction, and it makes it in the same
+file. `CKey::Sign` ends in `secp256k1_ecdsa_verify`; `CKey::SignCompact`
+ends in `secp256k1_ecdsa_recover` followed by `secp256k1_ec_pubkey_cmp`
+against the key derived from the private one. Both under the same
+comment.
+
+It subsumes the verification exactly, rather than probably. Recovery is
+not selective: for a given id it answers *the* key under which that `r`
+and `s` verify, so an inconsistent pair does not fail — it comes back as
+a different key, and fails only where `r` is not the x of a point at
+all. That is the stronger argument rather than a weaker one. Because the
+recovered key is by construction the key that verifies the signature,
+`recovered == signer` **is** a verification, with the id checked besides;
+nothing is given up by no longer verifying, and it is provable rather
+than argued. What it costs is 22.4 microseconds against ECDSA's 19.5 — a
+recovery being about a verification's work, and the comparison and the
+derivation making up the rest.
+
+What the three check is not quite the same region either, and
+`recovery`'s is the one worth knowing: what its check reads is the id
+held inside the `secp256k1_ecdsa_recoverable_signature`, while the id the
+caller receives is the one `serialize_compact` writes afterwards — so the
+recovery id is outside the checked region exactly as a DER encoding is.
+Core does the same, `CKey::SignCompact` recovering from its `rsig` and
+not from the octets it filled. `ssa` verifies the very 64 octets it
+answers with; `dsa` verifies the signature *object* and serializes it
+afterwards, so the DER or compact encoding is outside what was checked —
+as it is in Core, whose `CKey::Sign` verifies the
+`secp256k1_ecdsa_signature` and serializes after. All three are
+defensible, the serializers being memcpy-shaped where the signing is
+arithmetic, and the difference is worth a sentence rather than a
+change.
 
 Every other microsecond figure in this file was measured before this
 argument existed and is therefore the signature without the check:

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -13,15 +13,92 @@ id, which is what `to_der` drops.
 
 from __future__ import annotations
 
-from . import BytesLike, CData, ffi, lib
+from . import BytesLike, CData, ffi, keys, lib
 from ._scalar import in_range, octets, optional_entropy, scalar
 from .context import ctx
 from .dsa import serialize_der
 from .keys import serialize
 
 
+def _abort_unless_recovered(
+    signature: CData, msg_bytes: bytes, prvkey_bytes: bytes
+) -> None:
+    """Recover from a signature just made, and refuse another key.
+
+    What `dsa` and `ssa` do after signing, in the shape a recoverable
+    signature asks for. Bitcoin Core makes the same distinction:
+    `CKey::Sign` ends in `secp256k1_ecdsa_verify`, and `CKey::SignCompact`
+    ends in `secp256k1_ecdsa_recover` followed by
+    `secp256k1_ec_pubkey_cmp` against the key that signed.
+
+    The reason is the recovery id, which is what this signature has
+    beyond a plain one and what a verification does not look at. A
+    signature carrying the wrong id verifies perfectly and recovers
+    somebody else's key -- and recovering a key is the one thing a caller
+    of this module is going to do with it, so the check has to be the one
+    the id answers.
+
+    It subsumes the verification exactly rather than probably, which is
+    what makes not verifying safe here. Recovery is not selective: for a
+    given id it answers *the* key under which that `r` and `s` verify, so
+    an inconsistent pair does not fail, it comes back as a different key
+    -- and fails only where `r` is not the x of a point at all, which is
+    the branch below that reports no key recovering.
+    So the recovered key is by construction the key that verifies the
+    signature, and `recovered == signer` is a verification with the id
+    checked besides.
+
+    Named as `ssa._abort_unless_verified` is, and for the same reason:
+    it raises where a `_foo_` half would answer, and the verb is the one
+    BIP340 uses of the step.
+
+    **Neither call below needs a `context.check` behind it, and both are
+    the kind that usually would.** `keys._pubkey_cmp_` answers an
+    ordering that means nothing where libsecp256k1 could not read an
+    object, and that answer is a security decision here -- but both
+    objects come from calls that returned success a line earlier, so the
+    only way its `0` could lie is both keys being unreadable at once,
+    which is not a state either call can leave behind. And
+    `keys._pubkey_from_prvkey_` raises a `ValueError` for a key outside
+    [1, n-1], which this one is not: libsecp256k1 accepted it for signing
+    immediately above. That is why `_recover_`'s `ValueError` is
+    converted below and this one is not -- the first reports a property
+    of the signature, which a fault can change, and the second a property
+    of an argument that has already been proved. `dsa._sign_` leaves the
+    same call unconverted for the same reason.
+
+    Args:
+        signature: the recoverable signature just made.
+        msg_bytes: the 32-byte hash it was made over, already checked.
+        prvkey_bytes: the 32-byte private key that made it, already
+            checked.
+
+    Raises:
+        RuntimeError: if no key recovers from the signature, or if the
+            one that does is not the signer's. Neither is reachable by
+            any input: what they report is the computation itself having
+            gone wrong.
+    """
+    try:
+        recovered = _recover_(msg_bytes, signature)
+    except ValueError as failure:
+        # `_recover_` reports "no key can be recovered" as a ValueError,
+        # that being an argument error for a signature a caller handed
+        # in. For one made a line ago it is not: nothing was passed that
+        # could have caused it
+        raise RuntimeError("signing produced a signature no key recovers from") from (
+            failure
+        )
+    if keys._pubkey_cmp_(recovered, keys._pubkey_from_prvkey_(prvkey_bytes)):
+        raise RuntimeError("signing produced a signature that recovers another key")
+
+
 def _sign_(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    verify: bool = True,
 ) -> CData:
     """Create a recoverable ECDSA signature, as the parsed signature.
 
@@ -37,6 +114,9 @@ def _sign_(
         prvkey: the private key, 32 bytes or an int below 2**256.
         aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
             None for the RFC6979 nonce alone.
+        verify: whether to recover the key from the signature and refuse
+            one that is not the signer's, as `sign` documents and
+            `_abort_unless_recovered` reasons about.
 
     Returns:
         The libsecp256k1 recoverable signature object.
@@ -45,6 +125,8 @@ def _sign_(
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, or if the private key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
+        RuntimeError: if `verify` asks and the signature does not recover
+            the key that made it.
     """
     prvkey_bytes = scalar(prvkey, "private key")
     msg_bytes = octets(msg_bytes, "message hash", 32)
@@ -63,19 +145,44 @@ def _sign_(
         optional_entropy(aux_rand32),
     ):
         raise ValueError("invalid private key: not in [1, n-1]")
+    if verify:
+        _abort_unless_recovered(signature, msg_bytes, prvkey_bytes)
     return signature
 
 
 def sign(
-    msg_bytes: BytesLike, prvkey: BytesLike | int, aux_rand32: BytesLike | None = None
+    msg_bytes: BytesLike,
+    prvkey: BytesLike | int,
+    aux_rand32: BytesLike | None = None,
+    *,
+    verify: bool = True,
 ) -> tuple[bytes, int]:
     """Create a recoverable ECDSA signature.
+
+    `verify` is what `dsa.sign` and `ssa.sign` take, in the shape this
+    signature asks for: the key is recovered from the signature and
+    compared with the signer's, rather than the signature verified
+    against it. That is Bitcoin Core's own distinction between
+    `CKey::Sign` and `CKey::SignCompact`, and the reason is the recovery
+    id -- a verification does not look at it, so a signature carrying the
+    wrong one verifies and then recovers a key that is not the signer's.
+    Recovering is what a caller of this module does with the answer, so
+    the check is the one that question deserves.
+
+    What it catches is not a bad argument -- those have all raised by
+    then -- but a computation gone wrong, by bad memory or by a fault
+    induced on purpose, whose cost is a published signature that is
+    invalid or attributes itself to somebody else.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
         aux_rand32: 32 bytes of extra entropy mixed into the nonce, or
             None for the RFC6979 nonce alone.
+        verify: whether to recover the key and refuse a signature that
+            does not give the signer's back. It costs a recovery, a point
+            multiplication and a comparison, and False is what a caller
+            that has measured those against its own threat model passes.
 
     Returns:
         The 64-byte compact signature and its recovery id. The id is 0
@@ -88,9 +195,19 @@ def sign(
             given and is not 32 bytes, or if the private key is not 32
             bytes, does not fit in them, or is not in [1, n-1].
         RuntimeError: if libsecp256k1 fails to serialize the signature,
-            which no input can make it do.
+            which no input can make it do, or if `verify` asks and the
+            signature does not recover the key that made it.
+
+    Example:
+        >>> import hashlib
+        >>> from btclib_secp256k1 import keys, recovery
+        >>> msg = hashlib.sha256(b"hello").digest()
+        >>> signature, recid = recovery.sign(msg, 1)
+        >>> pubkey = recovery.recover(msg, signature, recid)
+        >>> pubkey == keys.pubkey_from_prvkey(1)
+        True
     """
-    return serialize_compact(_sign_(msg_bytes, prvkey, aux_rand32))
+    return serialize_compact(_sign_(msg_bytes, prvkey, aux_rand32, verify=verify))
 
 
 def _recover_(msg_bytes: BytesLike, signature: CData) -> CData:

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -12,18 +12,34 @@ computation that went wrong, whether by bad memory or by an induced
 fault, yields a signature that is invalid and may say something about the
 key, and the protection is not publishing one.
 
-What can be tested about it is not the fault, which no input produces.
-It is the four things around it: that the check changes no signature,
-that it is on where nothing asks, that a refusal is wired to the raise
-rather than merely written near it, and that `verify=False` does not
-reach the check at all.
+`recovery` asks a different question for the same reason, as Core's
+`CKey::SignCompact` does: it recovers the key from the signature and
+refuses one that is not the signer's, the recovery id being what this
+signature has beyond a plain one and what a verification does not look
+at. So the refusal substituted below is per module rather than one for
+all three.
+
+For `dsa` and `ssa` the fault itself is out of reach -- no input makes a
+fresh signature fail its own verification -- so what is tested is the
+four things around it: that the check changes no signature, that it is on
+where nothing asks, that a refusal is wired to the raise rather than
+merely written near it, and that `verify=False` does not reach the check
+at all.
 
 The last two are one substituted verification read in both directions,
-and the last is the one nothing else covers: the signature is the same
-bytes whether or not the flag was honoured, so a `verify` ignored
-altogether would answer exactly what it should. Replacing every
+and the second of them is the one nothing else covers: the signature is
+the same bytes whether or not the flag was honoured, so a `verify`
+ignored altogether would answer exactly what it should. Replacing every
 `if verify:` in the package with `if True:` leaves every other test here
 passing.
+
+`recovery` adds a fifth, and it is the one that says what the check is
+for rather than that the raise is wired to it. There the fault *is*
+reachable from an input -- a wrong recovery id is one `parse_compact`
+away -- so the last test in this file needs no stand-in at all: it
+signs, re-parses under each id, and holds real libsecp256k1 to refusing
+every one but the signature's own, while a verification of the same
+octets still succeeds.
 """
 
 from __future__ import annotations
@@ -31,37 +47,71 @@ from __future__ import annotations
 import hashlib
 import inspect
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NoReturn
 
 import pytest
 
-from btclib_secp256k1 import dsa, ssa, xonly
+from btclib_secp256k1 import CData, dsa, keys, recovery, ssa, xonly
 
 MSG = hashlib.sha256(b"a message to sign twice").digest()
 PRVKEY = 7
+PRVKEY_BYTES = PRVKEY.to_bytes(32, "big")
 AUX = bytes(32)
 
+# what a refused check reports, which is not one message: `dsa` and `ssa`
+# verify and say so, `recovery` recovers and says which half of that
+# failed. Carried per entry point so that the test asserting the raise
+# pins the module that raised rather than the prefix they share
+_UNVERIFIED = "does not verify"
+_UNRECOVERED = "no key recovers from"
+
 # every entry point that took a `verify`, as a call of one key and one
-# message: the pair is the same signature asked for with the check and
-# without it, which is the equality every test here is built on
-SIGNERS: list[tuple[str, Callable[..., bytes]]] = [
-    ("dsa.sign", lambda **kw: dsa.sign(MSG, PRVKEY, **kw)),
-    ("dsa.sign compact", lambda **kw: dsa.sign(MSG, PRVKEY, compact=True, **kw)),
-    ("dsa.sign grind", lambda **kw: dsa.sign(MSG, PRVKEY, grind=True, **kw)),
-    ("dsa._sign_", lambda **kw: dsa.serialize_der(dsa._sign_(MSG, PRVKEY, **kw))),
-    ("ssa.sign", lambda **kw: ssa.sign(MSG, PRVKEY, AUX, **kw)),
-    ("ssa.sign_custom", lambda **kw: ssa.sign_custom(MSG, PRVKEY, AUX, **kw)),
-    ("Signer.sign", lambda **kw: _through_signer("sign", **kw)),
-    ("Signer.sign_custom", lambda **kw: _through_signer("sign_custom", **kw)),
+# message, and the refusal it answers with: the pair is the same
+# signature asked for with the check and without it, which is the
+# equality every test here is built on
+SIGNERS: list[tuple[str, Callable[..., Any], str]] = [
+    ("dsa.sign", lambda **kw: dsa.sign(MSG, PRVKEY, **kw), _UNVERIFIED),
+    (
+        "dsa.sign compact",
+        lambda **kw: dsa.sign(MSG, PRVKEY, compact=True, **kw),
+        _UNVERIFIED,
+    ),
+    (
+        "dsa.sign grind",
+        lambda **kw: dsa.sign(MSG, PRVKEY, grind=True, **kw),
+        _UNVERIFIED,
+    ),
+    (
+        "dsa._sign_",
+        lambda **kw: dsa.serialize_der(dsa._sign_(MSG, PRVKEY, **kw)),
+        _UNVERIFIED,
+    ),
+    ("ssa.sign", lambda **kw: ssa.sign(MSG, PRVKEY, AUX, **kw), _UNVERIFIED),
+    (
+        "ssa.sign_custom",
+        lambda **kw: ssa.sign_custom(MSG, PRVKEY, AUX, **kw),
+        _UNVERIFIED,
+    ),
+    ("Signer.sign", lambda **kw: _through_signer("sign", **kw), _UNVERIFIED),
+    (
+        "Signer.sign_custom",
+        lambda **kw: _through_signer("sign_custom", **kw),
+        _UNVERIFIED,
+    ),
+    ("recovery.sign", lambda **kw: recovery.sign(MSG, PRVKEY, **kw), _UNRECOVERED),
+    (
+        "recovery._sign_",
+        lambda **kw: recovery.serialize_compact(recovery._sign_(MSG, PRVKEY, **kw)),
+        _UNRECOVERED,
+    ),
 ]
 
 
 def _refusing(*_args: Any, **_kwargs: Any) -> bool:
     """Stand in for a verification, and refuse whatever it is handed.
 
-    Substituted for `dsa._verify_` and `ssa._verify_` in the two tests
-    that ask what the signing path does with each answer: no input makes
-    a real verification of a fresh signature fail, so a stand-in is the
+    Substituted for `dsa._verify_` and `ssa._verify_`: no input makes a
+    real verification of a fresh signature fail, so a stand-in is the
     only way to reach either branch.
 
     Args:
@@ -72,6 +122,60 @@ def _refusing(*_args: Any, **_kwargs: Any) -> bool:
         False, always.
     """
     return False
+
+
+def _not_recovering(*_args: Any, **_kwargs: Any) -> NoReturn:
+    """Stand in for a recovery, and fail the way a real one fails.
+
+    `recovery`'s check is a recovery and a comparison rather than a
+    verification, so refusing it is refusing this. The `ValueError` is
+    the one `recovery._recover_` raises of a signature no key comes back
+    from, which is what the signing path has to turn into a
+    `RuntimeError`: for a signature made a line earlier, nothing was
+    passed that could have caused it.
+
+    Args:
+        _args: whatever the recovery would have taken.
+        _kwargs: the same.
+
+    Raises:
+        ValueError: always.
+    """
+    raise ValueError("public key recovery failed")
+
+
+def _recovering_another_key(*_args: Any, **_kwargs: Any) -> CData:
+    """Stand in for a recovery, and answer a key that is not the signer's.
+
+    The other half of what `recovery`'s check asks. A signature carrying
+    the wrong recovery id verifies perfectly and recovers somebody else's
+    key, so answering a valid key that is not this one is the fault worth
+    substituting -- and the one a plain verification would have missed.
+
+    Args:
+        _args: whatever the recovery would have taken.
+        _kwargs: the same.
+
+    Returns:
+        The parsed public key of a different private key.
+    """
+    return keys._pubkey_from_prvkey_(PRVKEY + 1)
+
+
+def _refuse_every_check(patch: pytest.MonkeyPatch) -> None:
+    """Make the check refuse, in whichever module is about to run one.
+
+    The three modules do not ask the same question -- `dsa` and `ssa`
+    verify, `recovery` recovers and compares -- so one parametrization
+    over every entry point needs all three refusals in place at once.
+    Each is inert for the entry points that do not reach it.
+
+    Args:
+        patch: the monkeypatch context to install them in.
+    """
+    patch.setattr(dsa, "_verify_", _refusing)
+    patch.setattr(ssa, "_verify_", _refusing)
+    patch.setattr(recovery, "_recover_", _not_recovering)
 
 
 def _through_signer(method: str, **kwargs: Any) -> bytes:
@@ -89,9 +193,9 @@ def _through_signer(method: str, **kwargs: Any) -> bytes:
     return signed
 
 
-@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
 def test_the_check_changes_no_signature(
-    name: str, signer: Callable[..., bytes]
+    name: str, signer: Callable[..., Any], refusal: str
 ) -> None:
     """Checking a signature is a question, so it answers the same bytes.
 
@@ -105,24 +209,28 @@ def test_the_check_changes_no_signature(
     Args:
         name: the entry point, for the test id.
         signer: it, as a call taking the keyword under test.
+        refusal: what a refused check reports there, unused where the
+            test does not refuse one.
     """
     assert signer(verify=True) == signer(verify=False)
 
 
-@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
 def test_the_check_is_on_where_nothing_asks(
-    name: str, signer: Callable[..., bytes]
+    name: str, signer: Callable[..., Any], refusal: str
 ) -> None:
     """Not passing the argument is passing True, which is the default.
 
-    Stated in five docstrings and checked here, because the difference
-    between the two defaults is invisible in every other test in this
-    suite: the signature is the same either way, and only the cost and
-    the guarantee differ.
+    Stated in a docstring at every entry point and checked here,
+    because the difference between the two defaults is invisible in
+    every other test in this suite: the signature is the same either
+    way, and only the cost and the guarantee differ.
 
     Args:
         name: the entry point, for the test id.
         signer: it, as a call taking the keyword under test.
+        refusal: what a refused check reports there, unused where the
+            test does not refuse one.
     """
     assert signer() == signer(verify=True)
 
@@ -138,6 +246,8 @@ def test_the_check_is_on_where_nothing_asks(
         ("ssa._sign_custom", ssa._sign_custom),
         ("Signer.sign", ssa.Signer.sign),
         ("Signer.sign_custom", ssa.Signer.sign_custom),
+        ("recovery.sign", recovery.sign),
+        ("recovery._sign_", recovery._sign_),
     ],
 )
 def test_every_signer_defaults_to_checking(
@@ -156,9 +266,9 @@ def test_every_signer_defaults_to_checking(
     assert inspect.signature(function).parameters["verify"].default is True
 
 
-@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
 def test_a_signature_that_does_not_verify_is_not_answered_with(
-    name: str, signer: Callable[..., bytes]
+    name: str, signer: Callable[..., Any], refusal: str
 ) -> None:
     """The raise is wired to the check, and not merely written near it.
 
@@ -171,17 +281,18 @@ def test_a_signature_that_does_not_verify_is_not_answered_with(
     Args:
         name: the entry point, for the test id.
         signer: it, as a call taking the keyword under test.
+        refusal: what a refused check reports there, unused where the
+            test does not refuse one.
     """
     with pytest.MonkeyPatch.context() as patch:
-        patch.setattr(dsa, "_verify_", _refusing)
-        patch.setattr(ssa, "_verify_", _refusing)
-        with pytest.raises(RuntimeError, match="does not verify"):
+        _refuse_every_check(patch)
+        with pytest.raises(RuntimeError, match=refusal):
             signer()
 
 
-@pytest.mark.parametrize("name,signer", SIGNERS, ids=[n for n, _ in SIGNERS])
+@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
 def test_the_refused_check_is_not_made_at_all(
-    name: str, signer: Callable[..., bytes]
+    name: str, signer: Callable[..., Any], refusal: str
 ) -> None:
     """`verify=False` does not reach the check, which nothing else sees.
 
@@ -198,10 +309,11 @@ def test_the_refused_check_is_not_made_at_all(
     Args:
         name: the entry point, for the test id.
         signer: it, as a call taking the keyword under test.
+        refusal: what a refused check reports there, unused where the
+            test does not refuse one.
     """
     with pytest.MonkeyPatch.context() as patch:
-        patch.setattr(dsa, "_verify_", _refusing)
-        patch.setattr(ssa, "_verify_", _refusing)
+        _refuse_every_check(patch)
         assert signer(verify=False)
 
 
@@ -223,3 +335,69 @@ def test_the_keypair_is_checked_against_the_key_that_signed() -> None:
         # not raise, and the signature is held to the key besides
         assert ssa.verify(MSG, pubkey, ssa.sign(MSG, prvkey, AUX))
     assert parities == {0, 1}
+
+
+def test_a_signature_that_recovers_another_key_is_not_answered_with() -> None:
+    """The failure a verification would have missed, and this one does not.
+
+    A recoverable signature whose recovery id is wrong verifies perfectly
+    and recovers somebody else's key, so `recovery` compares the key that
+    comes back instead of verifying: this substitutes a recovery that
+    answers a valid key which is not the signer's, and holds the signing
+    path to refusing it.
+
+    The second assertion is what says the refusal is the comparison and
+    not the recovery: nothing failed on the way, a real key came back,
+    and `verify=False` still answers a signature.
+    """
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(recovery, "_recover_", _recovering_another_key)
+        with pytest.raises(RuntimeError, match="recovers another key"):
+            recovery.sign(MSG, PRVKEY)
+        assert recovery.sign(MSG, PRVKEY, verify=False)
+
+
+def test_the_recovery_id_is_what_the_check_catches() -> None:
+    """The premise of `recovery`'s check, without a stand-in anywhere.
+
+    Every other test here substitutes the recovery, so what they prove is
+    that the signing path refuses what a recovery reports -- not that a
+    wrong recovery id is what produces the report. That needs no
+    substitution at all: one real signature, parsed under each of the
+    four ids, and the real libsecp256k1 asked about each.
+
+    Which id does which is structural rather than lucky. The other
+    parity of the same `r` is a point like any other, so it recovers a
+    key -- somebody else's. Ids 2 and 3 ask for the point at `r + n`,
+    which exceeds the field for any `r` a signature is likely to carry,
+    so nothing is recovered at all and `_recover_`'s `ValueError`
+    becomes the `RuntimeError` this module converts it into. Both
+    branches, both messages, no monkeypatch.
+
+    The last assertion is the argument of the whole change in one line:
+    the octets a verification accepts are the octets refused above. `r`
+    and `s` are the signer's and verify under the signer's key -- the id,
+    which a verification never looks at, is the entire difference.
+    """
+    signature, recid = recovery.sign(MSG, PRVKEY)
+    assert recid == 1
+
+    # the id it was made with, which is what makes the refusals below a
+    # refusal of the id rather than of the signature
+    recovery._abort_unless_recovered(
+        recovery.parse_compact(signature, recid), MSG, PRVKEY_BYTES
+    )
+
+    with pytest.raises(RuntimeError, match="recovers another key"):
+        recovery._abort_unless_recovered(
+            recovery.parse_compact(signature, 1 - recid), MSG, PRVKEY_BYTES
+        )
+    for beyond_the_field in (2, 3):
+        with pytest.raises(RuntimeError, match=_UNRECOVERED):
+            recovery._abort_unless_recovered(
+                recovery.parse_compact(signature, beyond_the_field), MSG, PRVKEY_BYTES
+            )
+
+    assert dsa._verify_(
+        MSG, keys._pubkey_from_prvkey_(PRVKEY_BYTES), dsa.parse_compact(signature)
+    )


### PR DESCRIPTION
Closes #217.

[#216](https://github.com/btclib-org/btclib-secp256k1/pull/216) gave `dsa.sign` and `ssa.sign` a `verify` defaulting to `True` and left `recovery.sign` out, deliberately: the reason it was exempt is the reason it needs a different check.

## Why not a verification

**A verification does not look at the recovery id**, which is the whole of what this signature carries beyond a plain one. A recoverable signature with the wrong id verifies perfectly and then recovers a key that is not the signer's — and recovering a key is the one thing a caller of this module is going to do with the answer. Verifying it would have been a check that passes while the thing the caller wants is broken.

So the check is the one the id deserves: recover from the signature, compare with the key that signed, refuse anything else.

That is Bitcoin Core's own distinction, made in one file:

| Core | ends in |
| --- | --- |
| `CKey::Sign` | `secp256k1_ecdsa_verify` |
| `CKey::SignCompact` | `secp256k1_ecdsa_recover` + `secp256k1_ec_pubkey_cmp` |

both under the same "Additional verification step to prevent using a potentially corrupted signature". And it subsumes the verification rather than skipping it: a key comes back from `r` and `s` only where those two are consistent, so a fault in either gives a different key or no key at all.

## What changes

`recovery.sign` and `recovery._sign_` take the same keyword-only `verify: bool = True`. `_abort_unless_recovered` is named as `ssa._abort_unless_verified` is, and does the one thing this shape needs beyond the others: `_recover_` reports "no key can be recovered" as a `ValueError` — an argument error for a signature a caller handed in, and nothing of the sort for one made a line earlier — so it becomes the `RuntimeError` this package means by a computation having gone wrong.

## What it costs

Measured in a session of its own, which **re-measured `dsa.sign` beside it** rather than printing the two together. Apple M5, macOS 26.6, arm64, CPython 3.13.14, 7 rounds of 20 000 calls, minimum kept, noise ±0.02:

| the call | `verify=False` | `verify=True` |
| --- | --- | --- |
| `recovery.sign` | 12.02 | 34.41 |
| `dsa.sign`, in this same session | 12.06 | 31.54 |

The second row agrees with the 12.15 / 31.67 already in the README, which is what makes the first comparable. So this shape costs **22.4** against ECDSA's 19.5 — a recovery being about a verification's work, with the comparison and the derivation making up the rest.

## What is tested

Both entry points join `tests/test_verified_signing.py`'s table, so the four questions it already asks are asked of them too — the check changes no signature, it is on where nothing asks, a refusal is wired to the raise, and `verify=False` does not reach the check at all. The substituted refusal is now per module, since these two reach a recovery where the others reach a verification.

**The failure a verification would have missed has a test of its own**: a recovery substituted to answer a valid key that is not the signer's, held to being refused — and then held to answering normally under `verify=False`, which is what says the refusal is the comparison and not the recovery.

Both mutants die:

| the tree | result |
| --- | --- |
| recovery's `if verify:` → `if True:` | **3 failed**, 635 passed |
| recovery's `if verify:` → `if False:` | **3 failed**, 635 passed |
| restored | 638 passed, coverage 100.00% |

Before the change neither direction was covered at all.

## Documentation

README.md, CHANGELOG.md and HISTORY.md each carried a sentence saying this hole was open; all three now carry the check instead. HISTORY.md closes with the thing a user wants to know — every signing call of the package now checks itself, and the same `verify=False` declines any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add verification-style safety checks to recoverable ECDSA signing so that returned signatures are guaranteed to recover the original key by default, and document and test this behavior across the library.

New Features:
- Introduce a `verify` keyword argument (defaulting to True) to `recovery.sign` and `recovery._sign_` to validate that freshly produced recoverable signatures recover the signing key.

Bug Fixes:
- Prevent recoverable signatures with incorrect recovery IDs from being returned by refusing signatures that either fail key recovery or recover a different public key.

Enhancements:
- Add `_abort_unless_recovered` to encapsulate post-signing recovery-and-compare checks and convert internal recovery `ValueError`s into `RuntimeError`s when signing goes wrong.
- Extend the verified-signing test matrix and helpers to cover recovery-based signing, including new tests ensuring mismatched recovered keys are rejected and that `verify=False` bypasses the check.
- Update README, CHANGELOG, and HISTORY to describe the new recovery-based check, its cost, and the unified `verify` semantics across all signing entry points.

Tests:
- Broaden `tests/test_verified_signing.py` to cover recovery-based signing, with shared helpers to force verification/recovery failures and a dedicated test for signatures that would recover another key.