### PR TITLE
Let the caller of a keypair ask for the parity it reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,46 @@ release-notes length in the first place, and are still in
   Nothing else changes: the attribute, the `from … import __version__`,
   and reading the metadata directly all answer what they answered.
 
+### The out-parameter that is the caller's to ask for
+
+- **`xonly._from_keypair_` takes its parity pointer, defaulting to NULL**
+  (#219), which is the shape the entry below gives `xonly._drop_y` and
+  which libsecp256k1 documents in the same words for both:
+  `secp256k1_extrakeys.h` says `pk_parity: Ignored if NULL` of
+  `secp256k1_keypair_xonly_pub` as it does of
+  `secp256k1_xonly_pubkey_from_pubkey`. `from_keypair` allocates one and
+  reads it; `ssa._abort_unless_verified`, which threw it away, passes
+  nothing. The allocation sits at the one call site that wants it rather
+  than behind a helper — `_drop_y` needed `_drop_y_with_parity` because
+  it has two such callers, and this has one.
+- **It is worth 28% of the conversion and nothing where the conversion
+  is**, and both halves of that are the point of taking it. Same session
+  shape as the entry below — the two spellings alternated in one process
+  over 15 rounds, a noise row beside each, an Apple M5, macOS 26.6,
+  arm64, CPython 3.14.6:
+
+  | | with the parity | with NULL |
+  | --- | --- | --- |
+  | the conversion alone | 0.2384 | 0.1718 |
+  | `ssa.sign` with the check on, which is where it runs | 19.9400 | 20.0303 |
+  | *noise*, the conversion twice | 0.2353 | 0.2404 |
+
+  −28.0% on the call, +0.45% on the path against a noise row that moved
+  2.18% — which is to say nothing, an `ffi.new` being some hundredths of
+  a microsecond against a signature and a verification. **So this is
+  taken for the convention and not for the speed**: the package had two
+  answers to one question, written a week apart, and now has one.
+- **One test holds it, and it takes two keys to.**
+  `test_the_keypair_parity_is_the_callers_to_ask_for` runs over an even-y
+  key and an odd-y one and asserts the 0 and the 1, because
+  `ffi.new("int *")` zeroes what it allocates: over an even-y key alone
+  every side of every comparison is 0 whether the pointer was written
+  through or not, and discarding it inside the helper is then a mutant
+  the whole suite passes while `xonly.from_keypair` answers 0 for every
+  odd-y key. With both keys that mutant fails at the assertion meant to
+  catch it. The same mutation on `_drop_y` fails eight tests, so the
+  claim these two conversions now share is one the suite holds on both.
+
 ### What a wrapper works out per call, and now works out once
 
 - **An interpolated cdecl is resolved at import, not at every call**
@@ -375,8 +415,8 @@ release-notes length in the first place, and are still in
   places is 0.1314. A quarter of what was on the table, for one copy of
   the line that overwrites a secret rather than two.
 - **The parity nobody reads is not allocated.**
-  `secp256k1_xonly_pubkey_from_pubkey` documents `pk_parity` as "can be
-  NULL", and the callers that want the object alone — `parse`, `_parsed`
+  `secp256k1_xonly_pubkey_from_pubkey` documents `pk_parity` as "Ignored
+  if NULL", and the callers that want the object alone — `parse`, `_parsed`
   and `_tweak_add_` — are why NULL is the default. `_drop_y` takes the
   pointer as an argument now: 0.1747 microseconds against 0.2425 on the
   conversion alone. `_from_pubkey_` and `to_pubkey` read a parity and go

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -317,6 +317,16 @@ it, and does afterwards. Reading it — as the attribute, as
 metadata — answers what it always answered, and costs what it always
 cost, the first read and every one after it.
 
+**On both conversions, the parity is the caller's to ask for.**
+`xonly._drop_y` and `xonly._from_keypair_` take an `int *` where one is
+wanted, and the NULL libsecp256k1 documents as "Ignored" where it is
+not: `from_pubkey`, `to_pubkey` and `from_keypair` allocate one, and
+`parse`, `_parsed`, `_tweak_add_` and the check `ssa` makes of its own
+signature pass nothing. Both conversions are new in this release, so
+there is nothing here to act on — what a caller of the octets API sees
+is unchanged, and so is what it costs, a signature with its verification
+being 20 microseconds either way.
+
 **Serializing and parsing cost a little less, and nothing changed about
 what they answer.** Four things a wrapper used to work out at every call
 are worked out once: the cffi type of a buffer whose declaration was

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -595,7 +595,7 @@ def _abort_unless_verified(
             can make happen: what it reports is the computation itself
             having gone wrong.
     """
-    xonly_pubkey, _ = xonly._from_keypair_(keypair_obj)
+    xonly_pubkey = xonly._from_keypair_(keypair_obj)
     if not _verify_(msg_bytes, xonly_pubkey, signature_bytes):
         raise RuntimeError("signing produced a signature that does not verify")
 

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -72,7 +72,7 @@ def _drop_y(pubkey: CData, parity: CData = ffi.NULL) -> CData:
             reading it, which is the default because the callers that
             want the object alone are why it exists: `parse`, `_parsed`
             and `_tweak_add_`. libsecp256k1 documents `pk_parity` as
-            "can be NULL", so the allocation is the caller's to make
+            "Ignored if NULL", so the allocation is the caller's to make
             rather than this function's, and skipping it is 0.4295
             microseconds against 0.5021 on `xonly.parse` of a 65-byte
             key -- CHANGELOG.md names the session every figure in this
@@ -207,7 +207,7 @@ def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
     return _from_pubkey_(keys._pubkey_from_prvkey_(prvkey))
 
 
-def _from_keypair_(keypair_obj: CData) -> tuple[CData, int]:
+def _from_keypair_(keypair_obj: CData, parity: CData = ffi.NULL) -> CData:
     """Return the x-only public key of a keypair, as the parsed point.
 
     The private half of `from_keypair`, for a caller about to hand the
@@ -221,11 +221,19 @@ def _from_keypair_(keypair_obj: CData) -> tuple[CData, int]:
     Args:
         keypair_obj: the libsecp256k1 keypair object, as `ssa.Signer`
             holds and as `secp256k1_keypair_create` writes.
+        parity: an `int *` to receive the parity of y, 0 for even and 1
+            for odd -- or the NULL that says nobody is reading it, which
+            is the default because `ssa._abort_unless_verified` is in
+            that case and `from_keypair` is the one that is not.
+            libsecp256k1 documents `pk_parity` as "Ignored if NULL", the
+            same words it gives `secp256k1_xonly_pubkey_from_pubkey`,
+            which is why `_drop_y` above takes its pointer the same way.
 
     Returns:
-        The libsecp256k1 x-only public key object, and the parity of y:
-        0 for even, 1 for odd. The parity is of the point the private
-        key gives, the keypair being the negated key where that y is odd.
+        The libsecp256k1 x-only public key object. The parity written
+        through the pointer, where one is given, is of the point the
+        private key gives, the keypair being the negated key where that
+        y is odd.
 
     Raises:
         RuntimeError: if libsecp256k1 will not read the object -- a NULL
@@ -235,11 +243,10 @@ def _from_keypair_(keypair_obj: CData) -> tuple[CData, int]:
             deserves, and `context.check` is what tells the two apart.
     """
     xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    parity = ffi.new("int *")
     converted = lib.secp256k1_keypair_xonly_pub(ctx, xonly_pubkey, parity, keypair_obj)
     if not converted:
         raise RuntimeError("x-only public key conversion failed")
-    return xonly_pubkey, parity[0]
+    return xonly_pubkey
 
 
 def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
@@ -274,8 +281,11 @@ def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
             fails to serialize the result, which a keypair it built
             cannot make it do.
     """
-    xonly_pubkey, parity = _from_keypair_(keypair_obj)
-    return serialize(xonly_pubkey), parity
+    # the one caller of the two that reads a parity, so the allocation
+    # is here rather than behind a helper: `_drop_y` needed
+    # `_drop_y_with_parity` because it has two
+    parity = ffi.new("int *")
+    return serialize(_from_keypair_(keypair_obj, parity)), parity[0]
 
 
 def _tweak_add_(pubkey: CData, tweak: BytesLike | int) -> tuple[bytes, int]:

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -43,6 +43,9 @@ from btclib_secp256k1._secret import keypair, wipe
 N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 PRVKEY = 7
+# the small scalar whose point has odd y, as tests/test_nonces.py keeps
+# it: a parity test over an even-y key alone compares zeros with zeros
+ODD_Y_PRVKEY = 6
 TWEAK = 11
 SCAN_PRVKEY = 13
 MSG = hashlib.sha256(b"btclib_secp256k1").digest()
@@ -354,15 +357,51 @@ def test_the_keypair_pair_reads_the_point_it_already_holds() -> None:
     caller could have handed in. What the private half saves is that
     serialize and the lift back that reading it again would cost, which
     is what `ssa.sign(verify=True)` takes it for.
+
+    The parity is asked for through the pointer, which is the half of
+    the pair a NULL default leaves to the caller: passing none is what
+    `ssa._abort_unless_verified` does, and the test below is where that
+    spelling answers alike.
     """
     keypair_obj = keypair(PRVKEY)
     try:
-        xonly_pubkey, parity = xonly._from_keypair_(keypair_obj)
-        assert (xonly.serialize(xonly_pubkey), parity) == xonly.from_keypair(
+        parity = ffi.new("int *")
+        xonly_pubkey = xonly._from_keypair_(keypair_obj, parity)
+        assert (xonly.serialize(xonly_pubkey), parity[0]) == xonly.from_keypair(
             keypair_obj
         )
     finally:
         wipe(keypair_obj)
+
+
+def test_the_keypair_parity_is_the_callers_to_ask_for() -> None:
+    """`xonly._from_keypair_` answers the same key with a parity and without.
+
+    The NULL default is what `ssa._abort_unless_verified` takes, so the
+    key it verifies against has to be the key `from_keypair` names --
+    libsecp256k1 documenting `pk_parity` as "Ignored if NULL" is the
+    claim, and this is it held to.
+
+    Both parities, and the 0 and the 1 asserted rather than only the
+    agreement between the two calls: `ffi.new("int *")` zeroes the
+    buffer it allocates, so over an even-y key alone every side of every
+    comparison here is 0 whether the pointer was written through or not.
+    Discarding the caller's pointer inside the helper is then a mutant
+    the whole suite passes, while `from_keypair` answers 0 for every
+    odd-y key. 6 is the odd-y scalar `tests/test_nonces.py` already
+    keeps for this, under the name it gives it there.
+    """
+    for prvkey, expected in ((PRVKEY, 0), (ODD_Y_PRVKEY, 1)):
+        keypair_obj = keypair(prvkey)
+        try:
+            parity = ffi.new("int *")
+            with_parity = xonly._from_keypair_(keypair_obj, parity)
+            without = xonly._from_keypair_(keypair_obj)
+            assert xonly.serialize(with_parity) == xonly.serialize(without)
+            assert parity[0] == expected
+            assert parity[0] == xonly.from_keypair(keypair_obj)[1]
+        finally:
+            wipe(keypair_obj)
 
 
 def test_the_taproot_pair_starts_from_the_point_the_x_belongs_to() -> None:


### PR DESCRIPTION
The other half of #212's first bullet, arriving from the direction
`e8902ee` came from.

**Stacked on #215**, whose `xonly.py` this touches: the base is
`cheaper-buffers` at `2e175b0`, so the diff here is this change alone.
Retarget to `main` once #215 fast-forwards — its sha survives that merge,
which is what leaves this branch applying with nothing to redo.

## What changed

- `xonly._from_keypair_(keypair_obj, parity=ffi.NULL)`, matching
  `_drop_y`. It answers the key alone now.
- `xonly.from_keypair` allocates the `int *` it reads. At the call site
  rather than behind a helper: `_drop_y` needed `_drop_y_with_parity`
  because two of its callers read a parity, and this has one.
- `ssa._abort_unless_verified` drops the `, _`.

libsecp256k1 documents the pointer as optional in the same words for
both calls — `secp256k1_extrakeys.h`, on `secp256k1_keypair_xonly_pub`:

```
 *    pk_parity: Ignored if NULL. Otherwise, pointer to an integer that will be set to the
 *               pk_parity argument of secp256k1_xonly_pubkey_from_pubkey.
```

## The measurement, and the half of it that says nothing

The issue asked for one on `ssa.sign` with the check on, against a noise
row, and said the figure goes wherever it lands. It landed in two
places. Two spellings alternated in one process, 15 rounds, an Apple M5,
macOS 26.6, arm64, CPython 3.14.6:

| | with the parity | with NULL |
| --- | --- | --- |
| the conversion alone | 0.2384 | 0.1718 |
| `ssa.sign` with the check on, which is where it runs | 19.9400 | 20.0303 |
| *noise*, the conversion twice | 0.2353 | 0.2404 |

**−28.0% on the call, +0.45% on the path** — the second against a noise
row that moved 2.18%, which is to say nothing, and the wrong way at
that. An `ffi.new` is some hundredths of a microsecond; a signature with
its verification is twenty.

So this is taken **for the convention and not for the speed**, which is
the outcome the issue put first, and the negative half is in CHANGELOG.md
rather than dropped — it is the same sentence that would have gone into
a declining comment had the first row landed in the noise too.

## What judges it

`tests/test_parsed_keys.py` gains
`test_the_keypair_parity_is_the_callers_to_ask_for`: the key is the same
whether a parity is asked for or not, and the parity is the one
`from_keypair` answers. That is "Ignored if NULL" held to rather than
quoted. The pair test beside it moves to the new signature and says why
in its docstring.

628 passed, coverage gate at 100.00%, every hook passes.

Closes #219

## Summary by Sourcery

Make xonly keypair conversion treat the parity out-parameter as an optional caller-owned pointer, aligning internal helpers and SSA verification with libsecp256k1’s convention.

Enhancements:
- Change `xonly._from_keypair_` to return only the x-only public key and accept an optional parity pointer, with `from_keypair` allocating and reading parity at its call site.
- Update SSA verification to call `xonly._from_keypair_` without a parity pointer, reflecting that it does not use the parity value.
- Document the new out-parameter convention and its performance implications in CHANGELOG and HISTORY, emphasizing consistency with libsecp256k1.

Tests:
- Add tests ensuring the keypair parity is requested explicitly by callers and that key output is identical whether or not parity is read, with `from_keypair` remaining the source of parity information.