### PR TITLE
Declare a buffer's width once, in every module that unpacks one

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": "btclib_secp256k1/hashes.py",
         "hashed_secret": "a608d88cb7e04b46b5e44fa00bb7c01b7748e6f0",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 49
       }
     ],
     "scripts/cffi_build.py": [
@@ -517,5 +517,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-17T08:06:26Z"
+  "generated_at": "2026-08-17T10:49:53Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,12 +400,112 @@ release-notes length in the first place, and are still in
   beside the hoisted types.
 - **`ffi.sizeof` of a buffer whose size is a constant is not asked per
   call**, and that is what asked `keys.serialize` for a type at module
-  level: each size is `ffi.sizeof` of the very type beside it, so the
+  level: the width is stated once and the type built from it, so the
   buffer and the length cannot say different numbers, and the 0.0175
   microseconds is not paid at every call. `keys.serialize` also decides
   its flag in the branch that picks its buffer, so the one condition is
   asked once. The length *object* is still built per call, for the
   thread-safety reason its comment gives.
+- **Every buffer in the package whose bytes are unpacked is spelled that
+  way now**, the eight sites that still asked `ffi.sizeof` of a cdata
+  per call included: `dsa.serialize_der`, `dsa.serialize_compact`,
+  `recovery.serialize_compact`, `hashes.tagged_sha256`,
+  `ellswift.create`, `ellswift._encode_`, `ssa._sign32` and
+  `ssa._sign_custom`. An int constant states the width, `ffi.typeof` of
+  it is the buffer's type, and that same constant is the length — and
+  where a module validates an argument against the width it writes,
+  `dsa`, `recovery`, `ssa` and `ellswift` check it against the constant
+  rather than against a second copy of the number.
+- **What the mutants say, which is not that there are more of them.**
+  `core/NumberReplacer` emits two mutants per numeric literal — `dsa.py`
+  holds 20 and `cosmic-ray init` enumerates 40 of them among its 376 — and
+  an AST census of the package counts 67 literals before this change and
+  67 after: `ellswift` sheds two and `ssa` one, `hashes` gains one and
+  `keys` two, and the surface is the size it was. Only three of the
+  seven widths had no int literal anywhere before (`hashes._HASH_SIZE`,
+  `keys._COMPRESSED_SIZE`, `keys._UNCOMPRESSED_SIZE`), so six mutants are
+  new; the other four replace the seven literals that sat at the
+  validation sites — `dsa`'s `!= 64`, `recovery.parse_compact`,
+  `ssa._verify_` and `ssa.verify`, `ellswift._decode_` and both of
+  `xdh`'s — which were fourteen of their own.
+  What changed is what each covers: a width inside `"char[64]"` was
+  reachable by no operator, so a wrong *buffer* was a mutation nobody
+  could ask about, and the mutable copy answered only for the argument
+  check. One number answers for both now, so each of the fourteen tests
+  both — same count, more code under each. All fourteen die, each applied
+  to the source one at a time with bytecode writing off and a passing
+  control run either side.
+- **The DER capacity is the one width not written as an int**, and it is
+  the site where taking that trade would have cost a kill rather than
+  bought one: what `serialize_der` unpacks is `length[0]`, the length
+  libsecp256k1 reports back, so 73 leaves the whole suite passing where 71
+  fails `test_der_reaches_all_72_octets` — the shape
+  `.github/mutation/bindings.toml` records as closed, six of thirteen
+  survivors, answered by deriving the capacity from the buffer rather than
+  writing it twice. So it keeps `ffi.typeof("char[72]")` with `ffi.sizeof`
+  of it, asked at import and not per call. Of the 40 `NumberReplacer`
+  mutants `cosmic-ray init` enumerates in the module, the two that fall in
+  the declaration block are both on `_COMPACT_SIZE` and none on those two
+  lines: the width is stated once and there is no int for the operator to
+  move.
+- **What consolidating costs, since nothing else records it.** `ellswift`
+  had three independently mutable copies of 64 — `_decode_` and both of
+  `xdh`'s — and `ssa` had two; each is one constant now, so a single
+  mutant changes every site at once and dies on whichever test reaches it
+  first. Nothing is hidden today: every one of those seven literals was
+  mutated on `main`, one at a time, and each dies on its own. But a check
+  that later loses the test that covers it can no longer surface as a
+  survivor, and `bindings.toml` asks for a survivor list to be read
+  expecting nothing — so the trade is named here rather than left for a
+  session to rediscover.
+- **Four of the eight save nothing the measurement can resolve, and are
+  spelled that way regardless.** The saving is 2.65% to 5.53% of the four
+  serializations, and some hundredths of a microsecond of the two
+  `ellswift` encodings and the two `ssa` signings, which cost 14.85 to
+  30.54 — where timing each of those four against *itself* moves 0.003 to
+  0.10, so the effect is under the resolution of its own measurement.
+  What decided them is not the figure: a reader cannot see the cost of a
+  host, so two spellings of one shape would leave the difference
+  unexplainable at both, and a comment saying why a site was *left* alone
+  is a comment about a non-change. One spelling is the whole of the
+  reason, and the saving is what pays for the four where it shows.
+- **`keys.py` derives its two the other way round**, so the six modules
+  read alike: it stated `ffi.typeof("char[33]")` and took the size as
+  `ffi.sizeof` of that type, where `xonly` and `silentpayments` state an
+  int and build the type from it. The int is the spelling that says what
+  the number is, and it is the one the whole package uses now.
+- **What the eight cost, and what they cost now.** `main`'s spelling of
+  each call written out and alternated against the shipped one in a single
+  process over one build on the tree this branch lands as, minimum of 15
+  rounds — 500 000 calls for the
+  primitive, 300 000 for the serializations, 20 000 for the four hosts —
+  with every pair asserted to answer alike before it is timed, and a noise
+  row for each site rather than for one of them. An Apple M5, macOS 26.6,
+  arm64, CPython 3.14.6, microseconds per call:
+
+  | | main | now | noise |
+  | --- | --- | --- | --- |
+  | `ffi.unpack` of a 64-byte buffer | 0.0690 | 0.0520 | 0.0005 |
+  | `dsa.serialize_compact` | 0.1823 | 0.1765 | 0.0007 |
+  | `dsa.serialize_der` | 0.2784 | 0.2665 | 0.0008 |
+  | `recovery.serialize_compact` | 0.2720 | 0.2569 | −0.0009 |
+  | `hashes.tagged_sha256` of an empty message | 0.5957 | 0.5800 | 0.0007 |
+
+  The per-site saving is 0.006 to 0.016, and it is neither one number nor
+  the primitive's 0.017. Within a session the noise rows move under 0.001,
+  so no row here is noise; across four sessions the same site moved by
+  more than that — `dsa.serialize_compact` between 0.006 and 0.013, the
+  lowest of the four every time, `recovery` and `hashes` the highest. So
+  what the measurement supports is a hundredth of a microsecond at a
+  serialization rather than a figure per site, and no row is a regression.
+
+  And the four hosts the saving disappears into, each timed against itself
+  so that the row *is* the resolution: `ellswift.encode` 14.9537 and
+  14.8501, `ellswift.create` 19.9003 and 19.9046, `ssa.sign` 30.2860 and
+  30.2031, `ssa.sign_custom` 30.5408 and 30.5379 — moving 0.003 to 0.10
+  either way around an effect of some hundredths. Every figure in the
+  comments of `dsa.py`, `recovery.py`, `hashes.py`, `ellswift.py`,
+  `ssa.py` and the last paragraph of `xonly.py`'s is from this session.
 - **`_secret.take` zeroes through the view it already holds.** It built
   an `ffi.buffer` to read the secret and then called `wipe`, which built
   a second one over the same cdata. The statement that writes the zeros

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -341,6 +341,17 @@ row beside each: `xonly.serialize` 0.197 microseconds against 0.257,
 Nothing on a signature or a verification, which are twelve microseconds
 of libsecp256k1; something on a caller doing point arithmetic in a loop,
 which is who these calls are short for.
+The second of those four now reaches every buffer in the package whose
+bytes are unpacked, and the serializations that were still working their
+own length out at each call are the ones it shows on:
+`dsa.serialize_compact` 0.177 microseconds against 0.182,
+`dsa.serialize_der` 0.267 against 0.278, `recovery.serialize_compact`
+0.257 against 0.272, `hashes.tagged_sha256` of an empty message 0.580
+against 0.596. The signing and encoding calls in `ssa` and `ellswift`
+carry the same spelling and gain nothing measurable from it, which is
+deliberate: one spelling for one shape is worth more to whoever reads
+this package than some hundredths of a microsecond are to whoever calls
+it.
 
 ## v0.8.0.2
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -25,6 +25,38 @@ from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx
 
+# the two buffers a signature is serialized into, and the lengths that go
+# with them in both directions: `_parsed` accepts a compact signature of
+# the width `serialize_compact` writes, so one statement of it answers
+# for the argument check as well. `ffi.sizeof` of a cdata is asked at
+# neither call, which is worth a hundredth of a microsecond of the 0.278
+# the DER serialization costs and of the 0.182 the compact one does --
+# 0.012 and 0.006 in the session `xonly.py` names, and not a figure this
+# site can be held to between sessions: that comment says why.
+#
+# The compact width is an int and the DER capacity is not, which is the
+# one place this module departs from the other five, and `length[0]` is
+# the reason: what `serialize_der` unpacks is the length libsecp256k1
+# reports back, so a capacity above 72 is absorbed on the way out and no
+# test can tell it from 72 -- verified, 73 leaves the suite passing where
+# 71 fails `test_der_reaches_all_72_octets`. Written as an int it would
+# be a number the mutation operator reaches and nothing checks, which is
+# the shape `.github/mutation/bindings.toml` records as closed, six of
+# thirteen survivors having been it. So it stays inside the cdecl, where
+# the width is still stated once and `ffi.sizeof` derives the capacity
+# from the buffer's own type -- at import, not per call.
+#
+# 72 is the maximum a signature of this curve can encode to, and it is
+# structural rather than generous: secp256k1_ecdsa_sig_serialize writes
+# 6 + lenR + lenS, and each of those is at most 33 -- 32 octets of
+# scalar and the leading zero DER wants when the top bit is set.
+# `to_der` reaches it, a high-s signature being one it serializes rather
+# than refuses
+_DER_BUFFER_TYPE = ffi.typeof("char[72]")
+_DER_SIZE = ffi.sizeof(_DER_BUFFER_TYPE)
+_COMPACT_SIZE = 64
+_COMPACT_BUFFER_TYPE = ffi.typeof(f"char[{_COMPACT_SIZE}]")
+
 
 @overload
 def nonce_rfc6979(
@@ -792,7 +824,7 @@ def _parsed(signature_bytes: BytesLike, compact: bool) -> CData | None:
     signature_bytes = octets(signature_bytes, name)
     signature = ffi.new("secp256k1_ecdsa_signature *")
     if compact:
-        if len(signature_bytes) != 64:
+        if len(signature_bytes) != _COMPACT_SIZE:
             return None
         parsed = lib.secp256k1_ecdsa_signature_parse_compact(
             ctx, signature, signature_bytes
@@ -857,21 +889,20 @@ def serialize_der(signature: CData) -> bytes:
             72-byte buffer makes unreachable. `context.check` is what
             tells the two apart.
     """
-    # 72 is the maximum a signature of this curve can encode to, and it
-    # is structural rather than generous: secp256k1_ecdsa_sig_serialize
-    # writes 6 + lenR + lenS, and each of those is at most 33 -- 32
-    # octets of scalar and the leading zero DER wants when the top bit
-    # is set. `to_der` reaches it, a high-s signature being one it
-    # serializes rather than refuses.
+    # the length passed in is `ffi.sizeof` of the buffer's own type, so
+    # the two cannot drift apart -- the top of this module says where 72
+    # comes from and why it is the one width not spelled as an int -- and
+    # what comes out is what libsecp256k1 says it wrote, this being the
+    # one serialization here whose length varies, 70 to 72 depending on
+    # how many octets r and s need. Where the length is fixed the width
+    # itself is unpacked instead, and keys.serialize says why.
     #
-    # The number is written once and the rest is derived from it: the
-    # length passed in is the buffer's own size, so the two cannot drift
-    # apart, and what comes out is what libsecp256k1 says it wrote --
-    # this being the one serialization here whose length varies, 70 to 72
-    # depending on how many octets r and s need. Where the length is
-    # fixed the buffer is unpacked instead, and keys.serialize says why
-    sig_bytes = ffi.new("char[72]")
-    length = ffi.new("size_t *", ffi.sizeof(sig_bytes))
+    # The length *object* is built per call and not hoisted, for the
+    # thread-safety reason keys.serialize gives: libsecp256k1 writes 0
+    # into it before it does anything and a shared one left at zero would
+    # refuse every later serialization
+    sig_bytes = ffi.new(_DER_BUFFER_TYPE)
+    length = ffi.new("size_t *", _DER_SIZE)
     serialized = lib.secp256k1_ecdsa_signature_serialize_der(
         ctx, sig_bytes, length, signature
     )
@@ -896,10 +927,10 @@ def serialize_compact(signature: CData) -> bytes:
             signature it parsed cannot make it do. `context.check` is
             what tells the two apart.
     """
-    sig_bytes = ffi.new("char[64]")
+    sig_bytes = ffi.new(_COMPACT_BUFFER_TYPE)
     serialized = lib.secp256k1_ecdsa_signature_serialize_compact(
         ctx, sig_bytes, signature
     )
     if not serialized:
         raise RuntimeError("signature serialization failed")
-    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes))
+    return ffi.unpack(sig_bytes, _COMPACT_SIZE)

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -18,6 +18,17 @@ from ._secret import take
 from .context import ctx
 from .keys import parse, serialize
 
+# the width of an ElligatorSwift encoding: 64 bytes, the two field
+# elements it is. `create` and `_encode_` write it, `_decode_` and `xdh`
+# accept it, and the one statement of it answers for all four -- the
+# buffer's type is built from it and so is every length check. It saves
+# some hundredths of a microsecond on calls of 19.90 and 14.85, where
+# timing each of those against itself moves 0.004 and 0.10: nothing that
+# measurement resolves, and not the reason either -- `xonly.py` says the
+# reason
+_ENCODING_SIZE = 64
+_ENCODING_BUFFER_TYPE = ffi.typeof(f"char[{_ENCODING_SIZE}]")
+
 
 def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> bytes:
     """Create the 64-byte ElligatorSwift encoding of a private key's public key.
@@ -40,12 +51,12 @@ def create(prvkey: BytesLike | int, aux_rand32: BytesLike | None = None) -> byte
     """
     prvkey_bytes = scalar(prvkey, "private key")
 
-    ell_bytes = ffi.new("char[64]")
+    ell_bytes = ffi.new(_ENCODING_BUFFER_TYPE)
     if not lib.secp256k1_ellswift_create(
         ctx, ell_bytes, prvkey_bytes, entropy(aux_rand32)
     ):
         raise ValueError("invalid private key: not in [1, n-1]")
-    return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
+    return ffi.unpack(ell_bytes, _ENCODING_SIZE)
 
 
 def _encode_(pubkey: CData, aux_rand32: BytesLike | None = None) -> bytes:
@@ -70,12 +81,12 @@ def _encode_(pubkey: CData, aux_rand32: BytesLike | None = None) -> bytes:
         RuntimeError: if libsecp256k1 fails to encode, which no valid
             input can make it do.
     """
-    ell_bytes = ffi.new("char[64]")
+    ell_bytes = ffi.new(_ENCODING_BUFFER_TYPE)
     aux_rand32_bytes = entropy(aux_rand32)
     encoded = lib.secp256k1_ellswift_encode(ctx, ell_bytes, pubkey, aux_rand32_bytes)
     if not encoded:
         raise RuntimeError("ElligatorSwift encoding failed")
-    return ffi.unpack(ell_bytes, ffi.sizeof(ell_bytes))
+    return ffi.unpack(ell_bytes, _ENCODING_SIZE)
 
 
 def encode(pubkey_bytes: BytesLike, aux_rand32: BytesLike | None = None) -> bytes:
@@ -125,7 +136,7 @@ def _decode_(ell_bytes: BytesLike) -> CData:
         RuntimeError: if libsecp256k1 fails to decode, which no 64 bytes
             can make it do.
     """
-    ell_bytes = octets(ell_bytes, "ElligatorSwift public key", 64)
+    ell_bytes = octets(ell_bytes, "ElligatorSwift public key", _ENCODING_SIZE)
 
     pubkey = ffi.new("secp256k1_pubkey *")
     if not lib.secp256k1_ellswift_decode(ctx, pubkey, ell_bytes):
@@ -212,8 +223,8 @@ def xdh(
             0 or 1, or if the private key is not 32 bytes, does not fit
             in them, or is not a valid scalar.
     """
-    ell_a_bytes = octets(ell_a_bytes, "ElligatorSwift public key of A", 64)
-    ell_b_bytes = octets(ell_b_bytes, "ElligatorSwift public key of B", 64)
+    ell_a_bytes = octets(ell_a_bytes, "ElligatorSwift public key of A", _ENCODING_SIZE)
+    ell_b_bytes = octets(ell_b_bytes, "ElligatorSwift public key of B", _ENCODING_SIZE)
     # 0 is A and 1 is B, which is what the argument's own name says
     party = in_range(party, "party", 1)
 

--- a/btclib_secp256k1/hashes.py
+++ b/btclib_secp256k1/hashes.py
@@ -14,6 +14,15 @@ from . import BytesLike, ffi, lib
 from ._scalar import octets
 from .context import ctx
 
+# the buffer the hash is written into: SHA256 has one output length and
+# this is it. The width is stated once and the type is built from it, and
+# what that saves is `ffi.sizeof` of a cdata per call, a hundredth of a
+# microsecond of the 0.596 a tagged hash of an empty message costs --
+# 0.016 in the session `xonly.py` names, and not a figure this site can be
+# held to between sessions: that comment says why
+_HASH_SIZE = 32
+_HASH_BUFFER_TYPE = ffi.typeof(f"char[{_HASH_SIZE}]")
+
 
 def tagged_sha256(tag_bytes: BytesLike, msg_bytes: BytesLike) -> bytes:
     """Return the BIP340 tagged hash of a message.
@@ -41,9 +50,9 @@ def tagged_sha256(tag_bytes: BytesLike, msg_bytes: BytesLike) -> bytes:
     """
     tag_bytes = octets(tag_bytes, "tag")
     msg_bytes = octets(msg_bytes, "message")
-    output = ffi.new("char[32]")
+    output = ffi.new(_HASH_BUFFER_TYPE)
     if not lib.secp256k1_tagged_sha256(
         ctx, output, tag_bytes, len(tag_bytes), msg_bytes, len(msg_bytes)
     ):
         raise RuntimeError("tagged hashing failed")
-    return ffi.unpack(output, ffi.sizeof(output))
+    return ffi.unpack(output, _HASH_SIZE)

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -30,24 +30,23 @@ from .context import ctx
 COMPRESSED = 258
 UNCOMPRESSED = 2
 
-# the two buffers `serialize` writes into, and the lengths it declares
-# them with. The pairing is what these are for: each size is
-# `ffi.sizeof` of the very type beside it, so the buffer and the length
-# cannot say different numbers, and stating the width once is what asked
-# for a type at module level in the first place. What it saves is the
-# `ffi.sizeof` per call, 0.0175 microseconds.
+# the two buffers `serialize` writes into, and the lengths it declares them
+# with. The pairing is what these are for: each type is `ffi.typeof` of the
+# width beside it, so the buffer and the length cannot say different
+# numbers, and neither is `ffi.sizeof` of a cdata per call. This is the one
+# spelling every unpacked buffer in the package uses; `xonly.py` carries
+# the session and the reason.
 #
 # It is not hoisted for the `ffi.new`. cffi already caches the parse of
 # a literal cdecl, so a hoisted type beats one by 0.003 microseconds --
 # real, 4.3% on a noise row of 0.5%, and an order below the 0.054 an
-# interpolated cdecl gives back, which is the figure a hoist has to earn
-# to be worth spelling a width twice or naming every cdecl in the
-# package. So the length pointer below stays spelled in full, like every
-# other `ffi.new` here. `xonly.py` carries the session
-_COMPRESSED_BUFFER_TYPE = ffi.typeof("char[33]")
-_COMPRESSED_SIZE = ffi.sizeof(_COMPRESSED_BUFFER_TYPE)
-_UNCOMPRESSED_BUFFER_TYPE = ffi.typeof("char[65]")
-_UNCOMPRESSED_SIZE = ffi.sizeof(_UNCOMPRESSED_BUFFER_TYPE)
+# interpolated cdecl gives back. What asks for a name here is the length,
+# and the type comes along with it: so the length pointer below stays
+# spelled in full, like every cdecl whose buffer nothing unpacks
+_COMPRESSED_SIZE = 33
+_COMPRESSED_BUFFER_TYPE = ffi.typeof(f"char[{_COMPRESSED_SIZE}]")
+_UNCOMPRESSED_SIZE = 65
+_UNCOMPRESSED_BUFFER_TYPE = ffi.typeof(f"char[{_UNCOMPRESSED_SIZE}]")
 
 
 def prvkey_verify(prvkey: BytesLike | int) -> bool:
@@ -1073,11 +1072,11 @@ def serialize(pubkey: CData, compressed: bool = True) -> bytes:
         >>> keys.serialize(keys.parse(uncompressed)).hex()[:10]
         '0279be667e'
     """
-    # the buffer's type and the size are declared together at the top of
-    # this module, each size being `ffi.sizeof` of the type beside it, so
-    # the two cannot say different numbers and neither is worked out
-    # again here. The flag is decided in the branch that picks the
-    # buffer, so the one condition is asked once.
+    # the width and the buffer's type are declared together at the top of
+    # this module, each type built from the width beside it, so the two
+    # cannot say different numbers and neither is worked out again here.
+    # The flag is decided in the branch that picks the buffer, so the one
+    # condition is asked once.
     #
     # What is unpacked is the buffer, not the length libsecp256k1 reports
     # back: this serialization has one length per flag, so a buffer of

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -19,6 +19,19 @@ from .context import ctx
 from .dsa import serialize_der
 from .keys import serialize
 
+# the width of a compact signature, in both directions: it is what
+# `serialize_compact` writes and what `parse_compact` accepts, so the
+# statement of it serves the argument check too, and the buffer's type is
+# built from it. `ffi.sizeof` of a cdata is not asked per call, which is
+# worth a hundredth of a microsecond of the 0.272 that serialization
+# costs -- 0.015 in the session `xonly.py` names, and not a figure this
+# site can be held to between sessions: that comment says why. The
+# recovery id is the `int *` beside it and is not a buffer anything
+# unpacks, so its cdecl stays spelled in full. `xonly.py` carries the
+# session behind the spelling
+_COMPACT_SIZE = 64
+_COMPACT_BUFFER_TYPE = ffi.typeof(f"char[{_COMPACT_SIZE}]")
+
 
 def _abort_unless_recovered(
     signature: CData, msg_bytes: bytes, prvkey_bytes: bytes
@@ -354,7 +367,7 @@ def parse_compact(signature_bytes: BytesLike, recid: int) -> CData:
         ValueError: if the signature is not 64 bytes, if r or s is at or
             above the group order, or if recid is outside 0 to 3.
     """
-    signature_bytes = octets(signature_bytes, "signature", 64)
+    signature_bytes = octets(signature_bytes, "signature", _COMPACT_SIZE)
     recid = in_range(recid, "recovery id", 3)
 
     signature = ffi.new("secp256k1_ecdsa_recoverable_signature *")
@@ -384,11 +397,11 @@ def serialize_compact(signature: CData) -> tuple[bytes, int]:
         RuntimeError: if libsecp256k1 fails for any other reason, which
             a signature it parsed cannot make it do.
     """
-    sig_bytes = ffi.new("char[64]")
+    sig_bytes = ffi.new(_COMPACT_BUFFER_TYPE)
     recid = ffi.new("int *")
     serialized = lib.secp256k1_ecdsa_recoverable_signature_serialize_compact(
         ctx, sig_bytes, recid, signature
     )
     if not serialized:
         raise RuntimeError("signature serialization failed")
-    return ffi.unpack(sig_bytes, ffi.sizeof(sig_bytes)), recid[0]
+    return ffi.unpack(sig_bytes, _COMPACT_SIZE), recid[0]

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -23,6 +23,16 @@ from .context import ctx
 # survive the preprocessing of the headers into cffi definitions
 EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"
 
+# the width of a BIP340 signature: 64 bytes, which is what `_sign32` and
+# `_sign_custom` write and what `_verify_` and `verify` read back, so the
+# one statement of it answers for the argument checks as well as for the
+# buffer, whose type is built from it. It saves some hundredths of a
+# microsecond on calls of 30.20 and 30.54, where timing each of those
+# against itself moves 0.08 and 0.003: nothing that measurement resolves,
+# and not the reason either -- `xonly.py` says the reason
+_SIGNATURE_SIZE = 64
+_SIGNATURE_BUFFER_TYPE = ffi.typeof(f"char[{_SIGNATURE_SIZE}]")
+
 # the tag secp256k1_schnorrsig_sign gives its nonce function, and what
 # makes the derivation BIP340's rather than another protocol's
 _NONCE_ALGO = b"BIP0340/nonce"
@@ -499,7 +509,7 @@ def _verify_(
         ValueError: if the signature is not 64 bytes.
     """
     msg_bytes = octets(msg_bytes, "message")
-    signature_bytes = octets(signature_bytes, "signature", 64)
+    signature_bytes = octets(signature_bytes, "signature", _SIGNATURE_SIZE)
 
     verified = lib.secp256k1_schnorrsig_verify(
         ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
@@ -544,7 +554,7 @@ def verify(
     # key, and tests/test_parsed_keys.py asserts the two answer alike
     xonly_pubkey = xonly.parse(pubkey_bytes)
     msg_bytes = octets(msg_bytes, "message")
-    signature_bytes = octets(signature_bytes, "signature", 64)
+    signature_bytes = octets(signature_bytes, "signature", _SIGNATURE_SIZE)
     return bool(
         lib.secp256k1_schnorrsig_verify(
             ctx, signature_bytes, msg_bytes, len(msg_bytes), xonly_pubkey
@@ -636,12 +646,12 @@ def _sign32(
     """
     msg_bytes = octets(msg_bytes, "message hash", 32)
 
-    sig = ffi.new("char[64]")
+    sig = ffi.new(_SIGNATURE_BUFFER_TYPE)
     if not lib.secp256k1_schnorrsig_sign32(
         ctx, sig, msg_bytes, keypair_obj, entropy(aux_rand32)
     ):
         raise RuntimeError("schnorr signing failed")
-    signature_bytes = ffi.unpack(sig, ffi.sizeof(sig))
+    signature_bytes = ffi.unpack(sig, _SIGNATURE_SIZE)
     if verify:
         _abort_unless_verified(keypair_obj, msg_bytes, signature_bytes)
     return signature_bytes
@@ -678,7 +688,7 @@ def _sign_custom(
     """
     msg_bytes = octets(msg_bytes, "message")
 
-    sig = ffi.new("char[64]")
+    sig = ffi.new(_SIGNATURE_BUFFER_TYPE)
     ndata = ffi.new("char[32]", entropy(aux_rand32))
     extraparams = ffi.new("secp256k1_schnorrsig_extraparams *")
     extraparams.magic = EXTRAPARAMS_MAGIC
@@ -691,7 +701,7 @@ def _sign_custom(
         ctx, sig, msg_bytes, len(msg_bytes), keypair_obj, extraparams
     ):
         raise RuntimeError("schnorr signing failed")
-    signature_bytes = ffi.unpack(sig, ffi.sizeof(sig))
+    signature_bytes = ffi.unpack(sig, _SIGNATURE_SIZE)
     if verify:
         _abort_unless_verified(keypair_obj, msg_bytes, signature_bytes)
     return signature_bytes

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -50,11 +50,34 @@ _XONLY_SIZE = 32
 # evaluated once, is the literal's price with the width still stated
 # once.
 #
-# A *literal* cdecl is already cached by cffi, and hoisting one saves
-# 0.003 -- 0.0656 against 0.0685, real at 4.3% and an order below the
-# 0.054 above. Too small to be worth a module-level name for every
-# cdecl in the package, so this is done where the string is built and
-# every other `ffi.new` here is spelled in full
+# What earns the name is the length rather than the cdecl. A name keeps
+# two statements of one width in step, and a buffer whose bytes nothing
+# unpacks states its width once already: naming that one would add a
+# statement rather than remove one, so `ecdh.py`'s `ffi.new("char[32]")`
+# and every other cdecl of that kind stay spelled in full. The price
+# agrees and does not decide it: cffi already caches the parse of a
+# literal cdecl, so hoisting one saves 0.003 -- 0.0656 against 0.0685,
+# real at 4.3% and an order below the 0.054 above.
+#
+# Every buffer in this package whose bytes *are* unpacked is declared the
+# way below -- an int constant, and `ffi.typeof` of it -- so that the
+# width is stated once and `ffi.sizeof` of a cdata is not asked per
+# call, `dsa`'s DER capacity excepted for the reason its own comment
+# gives: 0.0690 against 0.0520 microseconds on the primitive alone. That
+# is a session of its own, which CHANGELOG.md names, and every figure in
+# the comments of `dsa`, `recovery`, `hashes`, `ellswift` and `ssa` comes
+# from it rather than from the one above. At a call site it is 2.65% to
+# 5.53% of the serializations in the first three of those -- 0.006 to
+# 0.016 microseconds, which is neither one number nor the primitive's:
+# within a session each noise row moves under 0.001, and across four
+# sessions the same site moved by more than that, `dsa.serialize_compact`
+# between 0.006 and 0.013. What is solid is a hundredth of a microsecond
+# at a serialization, not a figure per site. In `ssa` and `ellswift` it is
+# that same hundredth of calls of 15 to 31 microseconds, where timing a
+# call against itself already moves as much or more: nothing those
+# measurements resolve. Those four sites are spelled this way regardless,
+# because a reader cannot see the cost of a host -- two spellings of one
+# shape would leave the difference unexplainable at both of them
 _XONLY_BUFFER_TYPE = ffi.typeof(f"char[{_XONLY_SIZE}]")
 
 


### PR DESCRIPTION
Eight sites still asked `ffi.sizeof` of a cdata at every call to say how
many bytes to unpack, where `keys`, `xonly` and `silentpayments` had
stopped doing so in #212: `dsa.serialize_der`, `dsa.serialize_compact`,
`recovery.serialize_compact`, `hashes.tagged_sha256`, `ellswift.create`,
`ellswift._encode_`, `ssa._sign32` and `ssa._sign_custom`. Each states its
width once at module level now, builds the buffer's type from it with
`ffi.typeof`, and uses it for the length — and where a module also
validates an argument against the width it writes, `dsa`, `recovery`,
`ssa` and `ellswift` check it against that one statement rather than a
second copy of the number. Nothing shared across modules: four of them
declare 64 independently, those being four different encodings that agree
on a number.

### What it saves

`main`'s spelling of each call written out and alternated against the
shipped one in a single process over one build **of the rebased tree**,
minimum of 15 rounds, a noise row for each site rather than for one of
them, every pair asserted to answer alike before it is timed. An Apple M5,
macOS 26.6, arm64, CPython 3.14.6, microseconds per call:

| | main | now | noise |
| --- | --- | --- | --- |
| `ffi.unpack` of a 64-byte buffer | 0.0690 | 0.0520 | 0.0005 |
| `dsa.serialize_compact` | 0.1823 | 0.1765 | 0.0007 |
| `dsa.serialize_der` | 0.2784 | 0.2665 | 0.0008 |
| `recovery.serialize_compact` | 0.2720 | 0.2569 | −0.0009 |
| `hashes.tagged_sha256` of an empty message | 0.5957 | 0.5800 | 0.0007 |

The per-site saving is 0.006 to 0.016 and is neither one number nor the
primitive's 0.017. Each noise row moves under 0.001, so no row above is
noise — but across four sessions the same site moved by more than its own
row, `dsa.serialize_compact` between 0.006 and 0.013, lowest of the four
every time, with `recovery` and `hashes` highest. What the measurement
supports is a hundredth of a microsecond at a serialization rather than a
figure per site; no row is a regression.

### Four of the eight save nothing measurable, and are changed anyway

`ellswift.create` and `ellswift._encode_` cost 19.90 and 14.85
microseconds, the two `ssa` signings some 30.4 each, and timing each
shipped call against *itself* moves 0.003 to 0.10 — as much as this is
worth or more. The figure is not what decides them. The cost of a host is
invisible where its buffer is declared, so two spellings of one shape
would be a difference no reader could account for at either site, and a
comment saying why a site was *left* alone documents a non-change. One
spelling, and the saving pays for the four where it shows.

### The mutation surface, measured rather than asserted

`core/NumberReplacer` emits two mutants per numeric literal — `dsa.py`
holds 20 and `cosmic-ray init` enumerates 40 of its 376 — and an AST
census of the package counts **67 literals before this change and 67
after**: `ellswift` −2 and `ssa` −1, `hashes` +1 and `keys` +2. The
surface is the size it was. Only three of the seven widths had no int
literal anywhere before (`hashes._HASH_SIZE`, `keys._COMPRESSED_SIZE`,
`keys._UNCOMPRESSED_SIZE`), so six mutants are new; the other four replace
the seven literals that already sat at the validation sites — `dsa`'s
`!= 64`, `recovery.parse_compact`, `ssa._verify_` and `ssa.verify`,
`ellswift._decode_` and both of `xdh`'s — fourteen mutants between them.

What changed is what each covers: a width inside `"char[64]"` was
reachable by no operator, so a wrong *buffer* was a mutation nobody could
ask about, and the mutable copy answered only for the argument check. One
number answers for both now — same count, more code under each. All
fourteen die, each applied to the source one at a time with
`PYTHONDONTWRITEBYTECODE=1` and a passing control run either side:

| constant | +1 | −1 |
| --- | --- | --- |
| `dsa._COMPACT_SIZE` | killed | killed |
| `recovery._COMPACT_SIZE` | killed | killed |
| `hashes._HASH_SIZE` | killed | killed |
| `ssa._SIGNATURE_SIZE` | killed | killed |
| `ellswift._ENCODING_SIZE` | killed | killed |
| `keys._COMPRESSED_SIZE` | killed | killed |
| `keys._UNCOMPRESSED_SIZE` | killed | killed |

`dsa`'s DER capacity is the one width that keeps its cdecl, with
`ffi.sizeof` deriving the capacity at import, and it is the site where
consolidating would have traded a kill for the symmetry: what
`serialize_der` unpacks is `length[0]`, so `_DER_SIZE = 73` leaves the
whole suite passing where 71 fails `test_der_reaches_all_72_octets` — the
shape `.github/mutation/bindings.toml` records as closed. Of the 40
`NumberReplacer` mutants `cosmic-ray init` enumerates in the module, the two
that fall in the declaration block are both on `_COMPACT_SIZE`, and none on
those two lines.

And what consolidating costs is recorded rather than left to be
rediscovered: `ellswift` had three independently mutable copies of 64 and
`ssa` two, so one mutant now changes every site at once and a check that
later loses its own test can no longer surface as a survivor.

### `keys` derives its two the other way round now

It had `ffi.typeof("char[33]")` with the size read back by `ffi.sizeof` of
that type: one statement of the width as well, but with the number inside
a C declaration where the other modules put it in an int. It is the int
here too, so the six modules read alike.

Rebased onto `68657e1`. **640 tests pass**, coverage 100%,
`uvx pre-commit run --all-files` exits 0.