### PR TITLE
Tell a session what it does not inherit, and what a mutant cannot say

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -13,6 +13,23 @@ name: mutation
 # the line still runs. What kills it is a test at 31 octets *and* one at 33,
 # and whether every bound has both is what nobody has measured.
 #
+# What it cannot ask is the other half of that same boundary, and a green
+# session does not say otherwise. The operators replace arithmetic,
+# comparisons, literals, branches and decorators; not one of them puts a
+# different expression in an argument list, so *which argument a `lib` call
+# is handed* -- the whole of what a binding decides -- is mutated by
+# nothing here. core/VariableReplacer and core/VariableInserter are the two
+# that come closest and .github/mutation/bindings.toml instantiates
+# neither: both declare cause_variable and effect_variable arguments it
+# does not supply, and configured they would substitute a random number,
+# which cffi refuses where a pointer was declared -- a mutant dying because
+# the boundary type-checks, not because a test read what the call wrote.
+# So an out-parameter's semantics rest on a test that exercises both of its
+# answers, and writing that test is not something this session will prompt.
+# The first revision of #220 is the instance: `ffi.NULL` in place of the
+# `int *` a caller allocated left the suite passing, an even-y key and a
+# zeroed allocation agreeing on 0 on every side of every comparison.
+#
 # It gates nothing, and that is the design rather than a caution. A gate
 # needs a number nobody has yet, and a survival rate is not a regression: a
 # mutant survives because a test is missing, so a red merge would block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1579,6 +1579,24 @@ release-notes length in the first place, and are still in
   the description fires. A contributor reading only this file would have
   expected the other outcome, and the two pull requests that landed the
   rule went the way it now describes
+- **The worktree recipe checks the submodule out** (#223). CLAUDE.md tells
+  every session to work in a worktree and gives the commands that get one,
+  and what they set up could not build: a worktree isolates files, a
+  submodule is a checkout of its own, and `git submodule status` in a
+  fresh one answers a leading `-`. What `uv sync --locked` then says is
+  forty lines of CMake and traceback naming the empty `secp256k1/`, closing
+  on "Build failures usually indicate a problem with the package or the
+  build environment" — the two things that are not wrong — and mentioning
+  the submodule nowhere, so a reader who does not already know goes and
+  audits their toolchain. `git submodule update --init secp256k1` before
+  the sync is the whole of the fix, verified in a fresh worktree rather
+  than reasoned about: with it the sync exits 0 and the suite passes in
+  that worktree's own venv, without it the sync exits 1. Nothing here was
+  unknown — CONTRIBUTING.md documents the submodule for a clone and again
+  for the documentation build — but the recipe a session actually follows
+  is the one in CLAUDE.md, it reads as complete, and it was the one place
+  the line was missing. CI never meets it, every checkout there passing
+  `submodules: true`
 
 - **The concurrency ceiling is written down, with the column that
   decides it** (#194). REPOSITORY.md's plan-gated section now carries the
@@ -1806,6 +1824,31 @@ release-notes length in the first place, and are still in
   from the hook would take the keyword and provider-token detectors off
   it too. The baseline is now written when a file that has a finding
   changes, which was 7 of those 40 rather than all of them
+- **`mutation.yml` says what its session cannot ask** (#222). The
+  operators replace arithmetic, comparisons, literals, branches and
+  decorators; not one of them puts a different expression in an argument
+  list, so which argument a `lib` call is handed — the whole of what a
+  binding decides — is mutated by nothing in the session, and a green
+  Sunday says nothing about it. `core/VariableReplacer` and
+  `core/VariableInserter` are the two that come closest and
+  `.github/mutation/bindings.toml` instantiates neither, both declaring
+  `cause_variable` and `effect_variable` arguments it does not supply;
+  configured they would substitute a random number, which cffi refuses
+  where a pointer was declared, and a mutant that dies of a `TypeError`
+  proves the boundary type-checks rather than that a test read what the
+  call wrote. The instance is the first revision of #220: `ffi.NULL` in
+  place of the `int *` its caller allocated left the whole suite passing,
+  the key having even y and `ffi.new("int *")` zeroing what it allocates,
+  so every side of every comparison was 0 either way. A paragraph in the
+  header is the change, and it is what would have made that hole visible
+  while the test was being written rather than after. An operator of our
+  own, replacing each argument of a `lib.*` call with `ffi.NULL` in turn,
+  is what a second instance would justify and what nothing yet does: the
+  optional out-parameters of the wrapped surface are the two occurrences
+  of `Ignored if NULL` in the vendored headers, both in
+  `secp256k1_extrakeys.h` and both now exercised over either answer, plus
+  `sigout` of `secp256k1_ecdsa_signature_normalize`, for which `dsa`
+  passes `ffi.NULL` already
 
 ## v0.8.0.2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,13 @@ lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
 ```shell
 WT=<scratchpad>/wt<issue>
 git worktree add -b <branch> "$WT" origin/main
-cd "$WT" && uv sync --locked      # a second venv, and a second build of
-                                  # the extension: minutes, not seconds
+cd "$WT"
+git submodule update --init secp256k1  # a worktree isolates files, and a
+                                       # submodule is a checkout of its
+                                       # own that it does not inherit
+uv sync --locked                       # a second venv, and a second build
+                                       # of the extension: minutes, not
+                                       # seconds
 # edit, gate and commit here, then
 git push origin HEAD:refs/heads/<branch>
 git worktree remove --force "$WT" # removing it is part of finishing
@@ -102,6 +107,16 @@ git worktree remove --force "$WT" # removing it is part of finishing
 The venv and the C build are the whole of the cost, and they buy the thing
 that matters: a commit cannot contain work that was never in it, and the
 maintainer's branch does not move under them.
+
+**The submodule line is what makes the rest of the recipe run**, and
+leaving it out costs a session rather than a build: `git submodule status`
+answers a leading `-` in a fresh worktree, and `uv sync --locked` then dies
+inside CMake naming the empty `secp256k1/` and closing on "Build failures
+usually indicate a problem with the package or the build environment" —
+the two things that are not wrong. CI never meets it, every checkout there
+passing `submodules: true`. It is the same sentence as the one below about
+`refs/stash`: a worktree isolates files, and neither a submodule checkout
+nor a ref is one.
 
 **Never `git stash`, in the primary checkout or in a worktree:
 `refs/stash` is shared.** A worktree isolates files, not refs, so


### PR DESCRIPTION
Two files a session reads before it starts, each missing the thing it was
being read for. No code changes.

## The worktree recipe cannot build what it sets up (#223)

`CLAUDE.md` tells every session to work in a worktree and gives the
commands. A worktree isolates files, a submodule is a checkout of its
own, and `git submodule status` in a fresh one answers a leading `-` —
so `uv sync --locked` dies in forty lines of CMake and traceback naming
the empty `secp256k1/` and closing on "Build failures usually indicate a
problem with the package or the build environment", the two things that
are not wrong. The submodule is named nowhere in them.

`git submodule update --init secp256k1` before the sync is the fix, and
the paragraph under the recipe says *why* it is there, as the recipe's
other comments do — the sentence a few lines below about `refs/stash`,
which a worktree shares for the same reason.

Verified rather than reasoned about, in the fresh worktree this branch
was written in: submodule at its pin, `uv sync --locked` exit 0, suite
passing in that worktree's own venv. CI never meets it, every checkout
there passing `submodules: true`.

## The mutation session cannot mutate an argument (#222)

Option (1) of the issue, which is what it asked for now: a paragraph in
`mutation.yml`'s header, where its other reasoning already lives.

The operators replace arithmetic, comparisons, literals, branches and
decorators; not one of them puts a different expression in an argument
list, so which argument a `lib` call is handed — the whole of what a
binding decides — is mutated by nothing in the session.
`core/VariableReplacer` and `core/VariableInserter` come closest and
`bindings.toml` instantiates neither; configured they would substitute a
random number, which cffi refuses where a pointer was declared, and a
mutant dying of a `TypeError` proves the boundary type-checks rather
than that a test read what the call wrote.

The instance is the first revision of #220. The paragraph is what would
have made that hole visible while the test was being written rather than
after. Options (2) and (3) are not taken, for the issue's own reasons —
a plugin wants a second instance as its evidence, and the three optional
out-parameters of the wrapped surface are all accounted for.

## Verified

`uvx pre-commit run --all-files` exits 0. `CHANGELOG.md` carries both
under the sections that already hold this kind of change: Documentation
for the recipe, CI for the sentinel.

Closes #222
Closes #223

## Summary by Sourcery

Document worktree submodule initialization and clarify limitations of the mutation testing session.

CI:
- Add explanatory comments to mutation.yml describing which aspects of bindings (argument selection and out-parameter semantics) are not exercised by the configured mutation operators.

Documentation:
- Update CLAUDE.md to require initializing the secp256k1 submodule when using the worktree-based development recipe and explain why it is necessary.
- Extend CHANGELOG.md with entries describing the worktree submodule requirement and the documented limits of the mutation session.