### PR TITLE
Price the check a signer makes, and correct the record around it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,10 @@ release-notes length in the first place, and are still in
   `r` and `s` verify, so an inconsistent pair does not fail, it comes
   back as a different key -- and fails only where `r` is not the x of a
   point at all, which a faulted `r` is about half the time. Which is the
-  stronger argument: the recovered
-  key is by construction the key that verifies the signature, so
-  `recovered == signer` **is** a verification, with the id checked
-  besides. Nothing is given up by not verifying, and that is provable
-  rather than argued.
+  stronger argument: the recovered key is by construction the key that
+  verifies the signature, so `recovered == signer` **is** a verification,
+  with the id checked besides. Nothing is given up by not verifying, and
+  that is provable rather than argued.
 - **What that check costs was measured in a session of its own**, which
   re-measured `dsa.sign` beside it rather than printing the two
   together: `recovery.sign` 12.02 against 34.41, `dsa.sign` 12.06
@@ -109,24 +108,105 @@ release-notes length in the first place, and are still in
   `test_every_private_half_is_paired` excuses it from the parametrized
   tables the way it already excuses `ssa._verify_` and
   `xonly._tweak_add_`, and a test of its own holds the equality.
-- **The fault itself is not tested, because no input produces one.** The
-  `raise RuntimeError` is excluded from coverage for the reason every
-  other one is. What is tested is the wiring around it: the verification
-  is substituted for one that refuses, and each entry point is held to
+- **The fault is out of reach for the two that verify, and reachable for
+  the one that recovers.** No input makes a fresh ECDSA or BIP340
+  signature fail its own verification, so in `dsa` and `ssa` the `raise
+  RuntimeError` is excluded from coverage for the reason every other one
+  is. What is tested there is the wiring around it: the verification is
+  substituted for one that refuses, and each entry point is held to
   raising rather than returning -- and, in the other direction, to *not*
   raising where `verify=False` was passed, which is the only assertion
   that sees the flag at all: the signature is the same bytes whether or
   not it was honoured, so a `verify` ignored altogether answers exactly
   what it should. Replacing every `if verify:` with `if True:` leaves
   the rest of the suite passing, which is how that hole was found rather
-  than argued for. The keys of both y parities are signed
-  with as well, both parities asserted to occur, because a check read
-  off the wrong half of the negation BIP340 prescribes would pass for
-  the wrong reason.
+  than argued for. The keys of both y parities are signed with as well,
+  both parities asserted to occur, because a check read off the wrong
+  half of the negation BIP340 prescribes would pass for the wrong
+  reason. `recovery` is the exception, and it is the test that says what
+  the check is for rather than that the raise is wired to it: what that
+  check reads is the recovery id, a wrong id is one `parse_compact`
+  away, and `test_the_recovery_id_is_what_the_check_catches` produces
+  the fault from an input and holds real libsecp256k1 to refusing it
+  with no stand-in anywhere — the other parity of the same `r` recovers
+  somebody else's key, ids 2 and 3 recover nothing, and the octets
+  refused three lines up still verify as a plain ECDSA signature.
 - **`dsa.sign` carries a `noqa: PLR0913`** and the reason above it: six
   arguments where the rule allows five, and the alternative is an
   options object for one function whose four questions group with
   nothing.
+- **The default is Bitcoin Core's, and what it costs is now in the
+  docstrings** (#224). Whether `dsa.sign` should default to
+  `verify=False` — no standard asking the check of ECDSA, and the caller
+  paying for a public key the signing itself did not need — was asked
+  and answered the other way: one policy across the three modules, which
+  is `CKey::Sign`'s, and a caller that has measured the check against
+  its own threat model turns it off by name. A default per scheme would
+  make the safer answer the one a reader has to look up, and
+  `verify=False` is already the whole of the remedy. What was missing is
+  the magnitude: the docstrings priced `grind` at "what the octet is
+  worth" and left the check that is on by default at "a point
+  multiplication and a verification", which is its shape and not its
+  size. `dsa.sign` says 31.67 microseconds against 12.15 now, `ssa.sign`
+  28.57 against 15.87 with the 6.8 between the two increments named as
+  the `secp256k1_ec_pubkey_create` ECDSA has to do and BIP340 does not,
+  and `recovery.sign` 34.41 against 12.02, the dearest of the three.
+  `ssa.Signer.sign` carries the ratio rather than a third increment —
+  20.82 against 8.18, the check being more than half again a signature
+  whose keypair was built already, where `ssa.sign`'s is four fifths of
+  one, and 1.545 against `dsa.sign`'s 1.607 is where BIP340's cheaper
+  check costs what ECDSA's does — and `ssa.sign_custom`, the entry point
+  btclib calls, carries `sign`'s figure with the sentence that a longer
+  message costs more to sign and to check by the same hash. The figures
+  are the ones measured above rather than a second session. `dsa.sign`
+  also says what a caller grinding *outside* the call pays, that being
+  one check per attempt where the wrapper's own `grind` checks only the
+  attempt it settles on — which is the reading the caller that raised
+  the issue was getting.
+- **The record said the fault is not tested, and a test produces one**
+  (#225). The bullet above opened "The fault itself is not tested,
+  because no input produces one", which was true of #216 and false after
+  #218: `recovery`'s check reads the recovery id, a wrong id is one
+  `parse_compact` away, and the test that produces one holds real
+  libsecp256k1 to refusing it with no stand-in. The test module's own
+  header carried the same sentence and was qualified in #218; this file
+  was not, so the record stated of the suite the opposite of what the
+  suite does — the same defect as the "eight entry points" count #218
+  removed, a claim about the tests that the tests disprove. It now
+  carries the qualification the test module already found. Two lines
+  from the same tail go with it: the docstring of
+  `test_a_signature_that_does_not_verify_is_not_answered_with`
+  documented `refusal` as "unused where the test does not refuse one",
+  which was true of the other readers of `SIGNERS` and false of exactly
+  this one, where it is the `match=`; and the 34-character line of this
+  file's own prose, between lines of 69 to 72, which was the reflow a
+  qualifier insertion did not get. That last one is why the paragraph
+  above is rewrapped whole rather than at the line named: inserting the
+  qualification left two more widows of the same shape, at 14 and 27
+  columns, so a fix line by line would have closed one instance of the
+  class and opened two. #233 counts the thirteen this change does not
+  reach. No hook reflows prose, which is why every one of them passed
+  the gate.
+- **`SIGNERS` stops handing a test an argument no body reads** (#226).
+  It grew a third element in #218 and that closed a real gap: before it
+  one `match="signing produced"` matched all three modules, so the test
+  could not say which failure it had provoked. The cost was that four
+  tests are parametrized over the table, one reads the refusal, and the
+  three that do not each carried two lines of docstring explaining that
+  they do not — which is how that sentence reached the fourth.
+  `SIGNING_CALLS` is the calls alone and `REFUSING_CALLS` the call with
+  its refusal, both derived from `SIGNERS` in a comprehension, and the
+  name goes with the refusal: it is the `ids=` and no body has ever read
+  it, so five tests stop declaring it and five docstrings stop excusing
+  it. `_DEFAULTING` is the same move on the one table that is not
+  `SIGNERS` — a mapping of the ten functions whose default is asserted,
+  its keys being those ids. The mapping the issue proposed instead —
+  `_REFUSALS` keyed by module, with `SIGNERS` back to pairs — is
+  declined for the reason the issue states against itself: a row would
+  no longer be the whole truth about its entry point, and finding a
+  module by splitting a test id on `.` is a weaker statement than the
+  message written beside the call. The ids are stated once as well,
+  every table here being those rows in that order.
 
 ### The frames between an entry point and libsecp256k1
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -373,6 +373,18 @@ def sign(  # noqa: PLR0913
     it more cheaply, BIP340 needing the public key to sign at all where
     ECDSA needs it for neither of the two things `sign` does.
 
+    What that comes to, since "more than grinding" is the useful
+    comparison and the sentence above does not make it: 31.67
+    microseconds against 12.15, where `ssa.sign` is 28.57 against 15.87.
+    So the check is more than the signature it checks, and the 6.8
+    between the two increments is the `secp256k1_ec_pubkey_create` this
+    one has to do and BIP340's does not. CHANGELOG.md names the session
+    every figure in this module comes from. A caller grinding *outside*
+    this call -- signing repeatedly and choosing among the answers --
+    pays it once per attempt rather than once, and `verify=False` on the
+    attempts with a check of whichever signature is kept is the shape
+    that costs what one signature's check costs.
+
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -187,6 +187,13 @@ def sign(
     induced on purpose, whose cost is a published signature that is
     invalid or attributes itself to somebody else.
 
+    It is also the dearest of the three, which is the other half of what
+    a caller weighing it needs: 34.41 microseconds against 12.02, where
+    `dsa.sign` measured beside it in the same session was 31.54 against
+    12.06 and `ssa.sign` is 28.57 against 15.87. A recovery is about a
+    verification's work, and the comparison and the derivation are the
+    rest. CHANGELOG.md names the session.
+
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -168,7 +168,11 @@ def sign(
     puts it inside the algorithm rather than beside it, and it can be
     turned off because the BIP says that too, "if the computation cost
     is prohibitive" -- which here is one verification and no
-    multiplication. `_abort_unless_verified` carries the rest of the reasoning.
+    multiplication: 28.57 microseconds against 15.87, where ECDSA's same
+    check is 31.67 against 12.15 for having to derive the public key
+    first. The cheaper of the two is the one a specification asks for.
+    CHANGELOG.md names the session those come from, and
+    `_abort_unless_verified` carries the rest of the reasoning.
 
     Args:
         msg_bytes: the 32-byte message hash.
@@ -240,7 +244,11 @@ def sign_custom(
             fresh randomness.
         verify: whether to check the signature under its own public key
             before returning it, as `sign` documents and BIP340
-            prescribes.
+            prescribes. One verification and no point multiplication,
+            which on a 32-byte message is `sign`'s 28.57 microseconds
+            against 15.87, the extraparams struct this fills aside;
+            a longer message costs more to sign and to check by the
+            same hash.
 
     Returns:
         The 64-byte signature.
@@ -347,7 +355,16 @@ class Signer:
                 own public key before returning it, as `ssa.sign`
                 documents and BIP340 prescribes. It is the same cost
                 here as there, the point being read off the keypair
-                either way.
+                either way -- and because the signature is the cheaper,
+                the keypair being built already, it is the larger share:
+                20.82 microseconds against 8.18, where `ssa.sign` is
+                28.57 against 15.87. The check is more than half again
+                this signature and four fifths of that one, which is the
+                same increment either way. 1.545 of a signature here
+                against `dsa.sign`'s 1.607 is the reading worth having:
+                this is where BIP340's cheaper check costs what ECDSA's
+                does, the keypair already built having taken the
+                signature down to where the increment dominates.
 
         Returns:
             The 64-byte signature.

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -106,6 +106,39 @@ SIGNERS: list[tuple[str, Callable[..., Any], str]] = [
     ),
 ]
 
+# what each test is actually handed, derived from the rows above rather
+# than written a second time: the calls alone for the three that never
+# provoke a refusal, the call and its refusal for the one that does.
+# `SIGNERS` stays the whole truth about an entry point and the refusal
+# stays beside the call it belongs to, while no test declares an argument
+# it does not read -- the name included, which `ids` supplies and no body
+# has ever looked at
+SIGNING_CALLS: list[Callable[..., Any]] = [signer for _, signer, _ in SIGNERS]
+REFUSING_CALLS: list[tuple[Callable[..., Any], str]] = [
+    (signer, refusal) for _, signer, refusal in SIGNERS
+]
+
+# one statement of the ids, every table here being those rows in that
+# order
+SIGNER_IDS = [name for name, *_ in SIGNERS]
+
+# every function that took a `verify`, which is not the same list: a
+# default is a property of a signature rather than of a call, so the
+# private halves are here and the three shapes of `dsa.sign` are not. A
+# mapping, because the name is the id and nothing else reads it
+_DEFAULTING: dict[str, Callable[..., Any]] = {
+    "dsa.sign": dsa.sign,
+    "dsa._sign_": dsa._sign_,
+    "ssa.sign": ssa.sign,
+    "ssa.sign_custom": ssa.sign_custom,
+    "ssa._sign32": ssa._sign32,
+    "ssa._sign_custom": ssa._sign_custom,
+    "Signer.sign": ssa.Signer.sign,
+    "Signer.sign_custom": ssa.Signer.sign_custom,
+    "recovery.sign": recovery.sign,
+    "recovery._sign_": recovery._sign_,
+}
+
 
 def _refusing(*_args: Any, **_kwargs: Any) -> bool:
     """Stand in for a verification, and refuse whatever it is handed.
@@ -193,10 +226,8 @@ def _through_signer(method: str, **kwargs: Any) -> bytes:
     return signed
 
 
-@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
-def test_the_check_changes_no_signature(
-    name: str, signer: Callable[..., Any], refusal: str
-) -> None:
+@pytest.mark.parametrize("signer", SIGNING_CALLS, ids=SIGNER_IDS)
+def test_the_check_changes_no_signature(signer: Callable[..., Any]) -> None:
     """Checking a signature is a question, so it answers the same bytes.
 
     The point of the parametrization is the entry points rather than the
@@ -207,18 +238,13 @@ def test_the_check_changes_no_signature(
     two that happen to verify.
 
     Args:
-        name: the entry point, for the test id.
-        signer: it, as a call taking the keyword under test.
-        refusal: what a refused check reports there, unused where the
-            test does not refuse one.
+        signer: the entry point, as a call taking the keyword under test.
     """
     assert signer(verify=True) == signer(verify=False)
 
 
-@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
-def test_the_check_is_on_where_nothing_asks(
-    name: str, signer: Callable[..., Any], refusal: str
-) -> None:
+@pytest.mark.parametrize("signer", SIGNING_CALLS, ids=SIGNER_IDS)
+def test_the_check_is_on_where_nothing_asks(signer: Callable[..., Any]) -> None:
     """Not passing the argument is passing True, which is the default.
 
     Stated in a docstring at every entry point and checked here,
@@ -227,32 +253,13 @@ def test_the_check_is_on_where_nothing_asks(
     way, and only the cost and the guarantee differ.
 
     Args:
-        name: the entry point, for the test id.
-        signer: it, as a call taking the keyword under test.
-        refusal: what a refused check reports there, unused where the
-            test does not refuse one.
+        signer: the entry point, as a call taking the keyword under test.
     """
     assert signer() == signer(verify=True)
 
 
-@pytest.mark.parametrize(
-    "name,function",
-    [
-        ("dsa.sign", dsa.sign),
-        ("dsa._sign_", dsa._sign_),
-        ("ssa.sign", ssa.sign),
-        ("ssa.sign_custom", ssa.sign_custom),
-        ("ssa._sign32", ssa._sign32),
-        ("ssa._sign_custom", ssa._sign_custom),
-        ("Signer.sign", ssa.Signer.sign),
-        ("Signer.sign_custom", ssa.Signer.sign_custom),
-        ("recovery.sign", recovery.sign),
-        ("recovery._sign_", recovery._sign_),
-    ],
-)
-def test_every_signer_defaults_to_checking(
-    name: str, function: Callable[..., Any]
-) -> None:
+@pytest.mark.parametrize("function", list(_DEFAULTING.values()), ids=list(_DEFAULTING))
+def test_every_signer_defaults_to_checking(function: Callable[..., Any]) -> None:
     """The default is True everywhere it exists, private halves included.
 
     A private half left at False would be the hole the public ones
@@ -260,15 +267,14 @@ def test_every_signer_defaults_to_checking(
     so a default that disagreed would be a second policy nobody stated.
 
     Args:
-        name: the entry point, for the test id.
-        function: it, to read the signature of.
+        function: the entry point, to read the signature of.
     """
     assert inspect.signature(function).parameters["verify"].default is True
 
 
-@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
+@pytest.mark.parametrize("signer,refusal", REFUSING_CALLS, ids=SIGNER_IDS)
 def test_a_signature_that_does_not_verify_is_not_answered_with(
-    name: str, signer: Callable[..., Any], refusal: str
+    signer: Callable[..., Any], refusal: str
 ) -> None:
     """The raise is wired to the check, and not merely written near it.
 
@@ -279,10 +285,11 @@ def test_a_signature_that_does_not_verify_is_not_answered_with(
     returned, at every entry point rather than at one of them.
 
     Args:
-        name: the entry point, for the test id.
-        signer: it, as a call taking the keyword under test.
-        refusal: what a refused check reports there, unused where the
-            test does not refuse one.
+        signer: the entry point, as a call taking the keyword under test.
+        refusal: what a refused check reports there, and what this
+            matches on: the module and not the package, `dsa` and `ssa`
+            saying a signature does not verify where `recovery` says no
+            key recovers from one.
     """
     with pytest.MonkeyPatch.context() as patch:
         _refuse_every_check(patch)
@@ -290,10 +297,8 @@ def test_a_signature_that_does_not_verify_is_not_answered_with(
             signer()
 
 
-@pytest.mark.parametrize("name,signer,refusal", SIGNERS, ids=[n for n, *_ in SIGNERS])
-def test_the_refused_check_is_not_made_at_all(
-    name: str, signer: Callable[..., Any], refusal: str
-) -> None:
+@pytest.mark.parametrize("signer", SIGNING_CALLS, ids=SIGNER_IDS)
+def test_the_refused_check_is_not_made_at_all(signer: Callable[..., Any]) -> None:
     """`verify=False` does not reach the check, which nothing else sees.
 
     The other direction, and the one no assertion above can stand in for:
@@ -307,10 +312,7 @@ def test_the_refused_check_is_not_made_at_all(
     what this asserts is that a signature comes back instead.
 
     Args:
-        name: the entry point, for the test id.
-        signer: it, as a call taking the keyword under test.
-        refusal: what a refused check reports there, unused where the
-            test does not refuse one.
+        signer: the entry point, as a call taking the keyword under test.
     """
     with pytest.MonkeyPatch.context() as patch:
         _refuse_every_check(patch)


### PR DESCRIPTION
Three readings of the tail of the same work. Nothing changes about what
any entry point answers.

## The default stays Core's, and the docstrings say what it costs (#224)

Asked and answered the other way from the issue's option (1): one policy
across `dsa`, `ssa` and `recovery` — `CKey::Sign`'s — and a caller that
has measured the check against its own threat model turns it off by
name. A default per scheme would make the safer answer the one a reader
has to look up, and saves that caller nothing `verify=False` does not
already save it.

Option (3) is taken, and it is what the issue is right about: the
docstrings priced `grind` at "what the octet is worth" and left the
check that is *on by default* at "a point multiplication and a
verification" — its shape, not its size.

| entry point | without | with |
| --- | --- | --- |
| `dsa.sign` | 12.15 | 31.67 |
| `ssa.sign` | 15.87 | 28.57 |
| `recovery.sign` | 12.02 | 34.41 |

Microseconds, and every figure is one already measured in `CHANGELOG.md`
rather than a second session; each docstring says where they come from.
`dsa.sign` also says the thing the caller who raised this was actually
paying: grinding **outside** the call pays the check once per attempt,
where the `grind` inside it checks only the attempt it settles on.

Option (2) is the other half and belongs to btclib: `_grind_low_r` is
exactly that caller, and passing `verify=False` at its two call sites is
what makes its own comments true again. Opened as btclib-org/btclib#984.

## The record said the fault is not tested (#225)

"The fault itself is not tested, because no input produces one" was true
of #216 and false after #218 — `recovery`'s check reads the recovery id,
a wrong id is one `parse_compact` away, and
`test_the_recovery_id_is_what_the_check_catches` produces the fault from
an input with no stand-in anywhere. The test module's header was
qualified in #218 and this file was not.

The two lines from the same tail go with it: the docstring that
documented `refusal` as unused in the one test that uses it, and the
34-character line at what was `CHANGELOG.md:75`, reflowed.

## `SIGNERS` stops handing three tests an argument they ignore (#226)

Neither of the issue's two outcomes, and the reason is in the issue
itself. `SIGNING_CALLS` is the same rows without the refusal, derived
from `SIGNERS` in one comprehension:

- a row of `SIGNERS` is still the whole truth about its entry point, and
  the refusal stays written beside the call it belongs to;
- no test declares an argument it does not read, so no docstring has to
  excuse one — which is what copied the wrong sentence to the fourth;
- no module is found by splitting a test id on `.`.

The ids are stated once as well, the two tables being the same rows in
the same order.

## Verified

640 passed, coverage 100%, `uvx pre-commit run --all-files` exits 0.
Rebased onto `main` at `71fbd0a`, which is PR #221 landed; the gate was re-run there.

Closes #224
Closes #225
Closes #226

## Summary by Sourcery

Clarify the default verification policy for signing entry points and update documentation and tests to accurately reflect the cost and behavior of the signer checks.

Enhancements:
- Document measured performance costs of verification checks for dsa.sign, ssa.sign, and recovery.sign in their docstrings and changelog, aligning defaults with Bitcoin Core’s signing policy.

Documentation:
- Revise CHANGELOG notes to describe which faults are reachable in verification vs recovery, and to record that recovery’s fault is now explicitly tested and costed.

Tests:
- Introduce a dedicated SIGNING_CALLS table and shared id list so tests that never exercise refusals no longer receive unused arguments, and update test docstrings and parametrization to match the new structure and behavior of recovery fault testing.
