### PR TITLE
Name what keeps a mutation session honest, and what one width stops asking

### DIFF
--- a/.github/mutation/bindings.toml
+++ b/.github/mutation/bindings.toml
@@ -57,6 +57,28 @@
 # after, the same way the filter below skips the annotations by operator
 # rather than asking every mutant of a `|` to be read again.
 #
+# One thing to know that is not a survivor at all, and is the reason
+# "expecting nothing" is worth reading as exactly that and no more (#231).
+# #221 collapsed every buffer width in the package to one statement, and in
+# two modules that turned several independently mutable copies of a number
+# into one: `ellswift` had 64 at `_decode_` and at both of `xdh`'s length
+# checks, three of them, and `ssa` had it at `_verify_` and at `verify`.
+# `core/NumberReplacer` carries `OFFSETS = [+1, -1]` and yields a position
+# per offset, so where `ellswift`'s three literals gave six mutants its one
+# constant gives two -- and either of those two changes every site at once
+# and dies on whichever test reaches it first. Nothing is hidden today: the
+# seven constants #221 introduced were each mutated both ways before it
+# landed, bytecode writing off and a control run either side, and all
+# fourteen die. What is gone is resolution for the
+# session after next: a check that later loses the test covering it can no
+# longer surface here, because the mutant that would have reported it is
+# killed elsewhere. So this is the mirror of the two shapes above -- not a
+# survivor to skip, but a silence to know about. The ratchet catches a lost
+# test only where losing it stops the line running at all; a check still
+# executed by some other test and asserted by none is what neither
+# question sees, and one constant is now the whole of what would have
+# asked about it.
+#
 # That is a statement about the shapes, not a promise about the rate:
 # what the next scheduled run reports is what it reports, and it is not
 # restated here, a number in a comment being a line every change to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1703,6 +1703,24 @@ release-notes length in the first place, and are still in
   `macos.yml`'s cells is `windows.yml`'s too, and `test.yml`'s aggregate
   job explains its name by there being a second workflow over this matrix
   shape, which is now a third
+- **cosmic-ray's own defence against a stale `.pyc` is named rather than
+  asserted** (#229). CLAUDE.md said "cosmic-ray does not have the
+  problem" after two paragraphs on how a hand-applied mutation loses
+  one, and did not say why — which is what let the sentence be read as
+  an assumption. It is `cosmic_ray/testing.py`, which sets
+  `PYTHONDONTWRITEBYTECODE` in the environment of the test command under
+  a comment giving this very reason, so no `.pyc` is written during a
+  session; measured by looking at `btclib_secp256k1/__pycache__` before
+  and after a real `cosmic-ray exec` over `hashes.py`, one file before
+  and the same one after, and the baseline step writes none either. Two
+  things go in the same clause because each is what the next reader
+  would otherwise re-derive: grepping the package for
+  `dont_write_bytecode` finds nothing and proves nothing, the string
+  being the environment variable's own spelling; and no flag stops a
+  *read*, so a `.pyc` from an earlier `pytest` is still used where its
+  size and truncated mtime match — the same window as the hand case,
+  which is why that recipe wants the control run and not only the
+  variable.
 
 ### CI
 
@@ -1929,6 +1947,23 @@ release-notes length in the first place, and are still in
   `secp256k1_extrakeys.h` and both now exercised over either answer, plus
   `sigout` of `secp256k1_ecdsa_signature_normalize`, for which `dsa`
   passes `ffi.NULL` already
+- **`bindings.toml` records the resolution a consolidated width costs**
+  (#231). Its preamble already carries the two shapes that were answered
+  in the code and the one equivalence that cannot be, each written down
+  so a session does not spend itself rediscovering them; a width
+  collapsed to one statement belongs in that list for the opposite
+  reason. Two modules had several mutable copies of one number —
+  `ellswift` three, at `_decode_` and at both of `xdh`'s checks, and
+  `ssa` two, at `_verify_` and at `verify` — and `core/NumberReplacer`
+  carries `OFFSETS = [+1, -1]`, a position per offset, so `ellswift`'s
+  six mutants are two now and either of them changes every site at once,
+  dying on whichever test reaches it first. A check that later loses the
+  test covering it can therefore no longer surface as a survivor.
+  Nothing is hidden today, the seven constants #221 introduced having
+  each been mutated both ways before it landed and all fourteen dying,
+  and the paragraph says what the ratchet does and does not catch
+  instead: a line that stops running is caught, a line still run by
+  another test and asserted by none is what neither question sees.
 
 ## v0.8.0.2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,18 @@ findings.
   python reuses the mutated bytecode — silently, in the next unrelated run.
   `PYTHONDONTWRITEBYTECODE=1`, with a passing baseline run before and a
   passing control run after, is what makes a hand verification mean
-  anything. cosmic-ray does not have the problem
+  anything. **cosmic-ray does not have the problem, and the mechanism is
+  worth naming rather than trusting** (#229): `cosmic_ray/testing.py`
+  sets that very variable in the environment of the test command, under a
+  comment giving this reason, so a session writes no `.pyc` at all — the
+  baseline included, both measured by looking at `__pycache__` before and
+  after a real `cosmic-ray exec`. Grepping the package for
+  `dont_write_bytecode` finds nothing and means nothing: the string it
+  sets is the environment variable's own spelling. What no flag stops is
+  a *read*, so a `.pyc` already on disk from an earlier `pytest` is still
+  used where its size and truncated mtime match — which is the same
+  window as above, and the reason the hand recipe wants the control run
+  and not only the variable
 - **`detect-secrets` runs twice, over two baselines**: the tree with the
   entropy detectors on, and `tests/*.csv`/`tests/*.json` with them off,
   those files being hex and nothing else. Adding to either side fails its


### PR DESCRIPTION
Two paragraphs about the Sunday session, in the two files that describe
it. No code, nothing changes about what it runs.

## #229 is not a defect, and the measurement says so

**The claim it rests on is false, and a case-sensitive grep is why.**
cosmic-ray 8.7.0 does mitigate the stale `.pyc`, in `testing.py:52-56`:

```python
# We want to avoid writing pyc files in case our changes happen too fast for Python to
# notice them. If the timestamps between two changes are too small, Python won't recompile
# the source.
env = dict(os.environ)
env["PYTHONDONTWRITEBYTECODE"] = "1"
```

The issue's own grep — `dont_write_bytecode\|invalidate_caches\|pycache` —
sums to 0 on that same tree, and it cannot match the line above: the
string is the environment variable, with no underscores and no lower
case. `grep -ri dont_write_bytecode` is empty too.

**Measured, not read off the source.** A real scoped session over
`hashes.py`, with a `.pyc` deliberately on disk first, as a local session
inherits from any earlier `pytest`:

| | pyc for the package |
| --- | --- |
| before the session | 1 |
| after `cosmic-ray baseline` | 1 |
| after `cosmic-ray exec` (4 mutants) | 1 |

`hashes.py` byte-identical afterwards, 4 of 4 killed, 0 surviving. So
`CLAUDE.md`'s sentence is right and the issue closes — but the sentence
said *nothing about why*, which is what let it be read as an assumption,
so the mechanism is now written where the sentence is.

**And the fix it proposes would not have worked.** `-B` suppresses the
write and leaves an existing `.pyc` to be read; measured here, `-B` still
left `__init__.cpython-314.pyc` behind, because the flag does not reach a
subprocess the suite spawns where the environment variable does. Both
halves are in the clause.

Cost, in passing: the test command is 2.84 s with the variable against
2.89 s without — no measurable price for the mitigation cosmic-ray
already applies.

## #231 — the silence a consolidated width leaves

`bindings.toml`'s preamble records the two shapes answered in the code and
the one equivalence that cannot be. A width collapsed to one statement
goes in that list for the opposite reason: `ellswift` had 64 at `_decode_`
and at both of `xdh`'s checks, `ssa` had it twice, and one mutant now
changes every site at once and dies on whichever test reaches it first.
Nothing is hidden today — all seven were mutated one at a time before
#221 landed — so what it adds is a silence to know about rather than a
survivor to skip, with the limit of the alternative beside it: the ratchet
catches a line that stops running, not a line still run by another test
and asserted by none.

## Verified

640 passed, coverage 100%, `uvx pre-commit run --all-files` exits 0.
Branches from `main` at `752437d`.

Closes #231

## Summary by Sourcery

Document the rationale and limitations of the mutation-testing setup around stale bytecode handling and consolidated buffer widths.

Documentation:
- Clarify in CLAUDE.md how cosmic-ray avoids stale `.pyc` issues by setting `PYTHONDONTWRITEBYTECODE`, including the remaining risk from pre-existing bytecode files.
- Record in CHANGELOG the explanation of cosmic-ray's bytecode mitigation and the effect of consolidated buffer widths on mutation resolution and what they can no longer surface during sessions.

Tests:
- Explain in bindings.toml how collapsing multiple buffer-width literals into a single constant reduces mutation granularity and which kinds of lost-test scenarios mutation runs can no longer detect.