### PR TITLE
Rewrap what an insertion left short, and say what the sentences omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,13 +555,13 @@ release-notes length in the first place, and are still in
   int and build the type from it. The int is the spelling that says what
   the number is, and it is the one the whole package uses now.
 - **What the eight cost, and what they cost now.** `main`'s spelling of
-  each call written out and alternated against the shipped one in a single
-  process over one build on the tree this branch lands as, minimum of 15
-  rounds — 500 000 calls for the
-  primitive, 300 000 for the serializations, 20 000 for the four hosts —
-  with every pair asserted to answer alike before it is timed, and a noise
-  row for each site rather than for one of them. An Apple M5, macOS 26.6,
-  arm64, CPython 3.14.6, microseconds per call:
+  each call written out and alternated against the shipped one in a
+  single process over one build on the tree this branch lands as,
+  minimum of 15 rounds — 500 000 calls for the primitive, 300 000 for
+  the serializations, 20 000 for the four hosts — with every pair
+  asserted to answer alike before it is timed, and a noise row for each
+  site rather than for one of them. An Apple M5, macOS 26.6, arm64,
+  CPython 3.14.6, microseconds per call:
 
   | | main | now | noise |
   | --- | --- | --- | --- |
@@ -1749,6 +1749,70 @@ release-notes length in the first place, and are still in
   unset, so the loss would show as a diff of nothing. Nothing is lost
   today, all 53 and all 466 findings being unverified and none carrying
   `is_secret`.
+- **Ten lines that stopped short mid-sentence are the paragraphs they
+  sit in, rewrapped** (#233). Each is the artifact an insertion leaves
+  in a block nothing reflows: the qualifier goes in, the line it lands
+  on stops early, and the diff of the change that made it shows a line
+  that was going to be rewritten anyway. The unit of repair is the block
+  and not the line, which #228 established the hard way — fixing the one
+  line #225 named left two more of the same shape. Twelve blocks moved
+  across `CHANGELOG.md`, `README.md`, `CONTRIBUTING.md`, `RELEASING.md`
+  and `HISTORY.md`, every one of them word-for-word identical to what it
+  said before, which is asserted rather than eyeballed: the rewrap
+  compares the joined words of the block before and after and refuses to
+  write where they differ. Three of the thirteen the issue counted are
+  not defects at all and stay: a line before a markdown link of 63, 84
+  and 125 columns is short because nothing can follow it, and the filter
+  measured the link's first word rather than the link. No hook does
+  this, which #233 asked about and answers no: the thresholds are a
+  heuristic, a false positive has no `# noqa` to be marked with in
+  prose, and a gate that is exact everywhere else is the wrong place for
+  one that is nearly right.
+- **The worktree recipe costs a submodule clone, and the sentence under
+  it counts it now** (#234). It said the venv and the C build "are the
+  whole of the cost" and after the submodule line they are not: a linked
+  worktree gets a module of its own rather than sharing the primary
+  checkout's, measured at 14 MB under `.git/worktrees/<wt>/modules` and
+  7 MB of tree, which is the same "minutes, not seconds" argument the
+  other two get. `--reference` is what a session asks about next and is
+  measured rather than reasoned about: it works, leaves the module
+  directory where git puts it, writes one `objects/info/alternates` at
+  the primary's `objects`, and comes to 128 KB against those 14 MB with
+  the primary's `core.worktree` untouched. What it costs is that pointer
+  — no copy of its own objects, so a `git gc` or a repack in the
+  primary, or moving it, can leave the worktree's submodule unable to
+  find them. What git keeps apart by giving each linked worktree a
+  module of its own is the submodule's *state*, so two worktrees can
+  have it at two commits; the object store inside that module follows
+  from where the state lives rather than from a refusal to share
+  objects, which is why `--reference` may share them and leaves
+  `core.worktree` alone. For a recipe that removes the worktree anyway
+  that is a trade worth declining knowingly. Two facts measured while
+  checking that go with it, both about a sharp edge: `core.worktree` is
+  a single value that a second checkout of one submodule can rewrite
+  under the first, and does not here; and `git worktree remove --force`
+  finishes with an initialized submodule inside, exit 0 and nothing left
+  for `git worktree prune`, so the recipe's last line needs no
+  companion.
+- **`silentpayments` says why its two widths are the package's only
+  public ones** (#232). Six modules name a buffer width privately and
+  this one does not, which after #221 made "the six modules read alike"
+  a claim a reader would test against the seventh. The rule is not the
+  one `xonly.py` states about its own: those are the size of a buffer
+  the module fills and unpacks, where these are lengths this module
+  answers a caller with. `SUMMARY_SIZE` has to be public — `ffi.sizeof`
+  of a struct, written down by no BIP, moving when libsecp256k1 moves,
+  and unknowable to a caller holding what `prevouts_summary` returned.
+  `LABEL_SIZE` is 33 and could be worked out, so what keeps it public is
+  that it has been since 0.8.0 and taking a released name private to
+  tidy an asymmetry is a break charged to a reader who never asked.
+  `keys._COMPRESSED_SIZE` is the same 33 and stays private: two callers'
+  arguments are checked against this one, `parse_label`'s octets and the
+  labels `_fill_label_cache` takes for `_scan_outputs_`, where nothing
+  in `keys` checks an argument against a width at all. What
+  `serialize_label` does with it is the other kind of use and is named
+  as such — unpacking the buffer this module declared, which is exactly
+  what `keys` does with its own.
 
 ### CI
 
@@ -1929,10 +1993,10 @@ release-notes length in the first place, and are still in
   v0.8.0.2 all published clean and none produced a GitHub release,
   recreated by hand from each run's own `sdist` and `attestation`
   artifacts every time
-- **A change to prose no longer rewrites `.secrets.baseline`** (#198). The
-  baseline recorded one finding in `CHANGELOG.md`, and this file grows
-  above it: of the forty commits before this one, forty rewrote the
-  baseline and thirty-three moved nothing in it but that finding's
+- **A change to prose no longer rewrites `.secrets.baseline`** (#198).
+  The baseline recorded one finding in `CHANGELOG.md`, and this file
+  grows above it: of the forty commits before this one, forty rewrote
+  the baseline and thirty-three moved nothing in it but that finding's
   `line_number`. What the rewrite costs is not the command that makes it
   — it is that every open pull request then conflicts there with every
   other and with `main`, whatever either of them touches, which is what
@@ -1940,16 +2004,16 @@ release-notes length in the first place, and are still in
   finding is a false positive this file's own entry above records: the
   `-DSECP256K1_BUILD_BENCHMARK=OFF` it names is quoted there as
   `cffi_build.py` writes it, and a string in straight quotes is what the
-  base64 detector reads. A
-  `pragma: allowlist secret` beside it takes it out of the baseline
-  without taking the quotes out of the sentence, they being why the
-  detector fires and so what the sentence is about. Measured against the
-  alternatives: dropping the quotes also clears it and says less; the
-  pragma on the previous line does *not* clear it, `is_line_allowlisted`
-  reading `context.previous_line` notwithstanding; and excluding the file
-  from the hook would take the keyword and provider-token detectors off
-  it too. The baseline is now written when a file that has a finding
-  changes, which was 7 of those 40 rather than all of them
+  base64 detector reads. A `pragma: allowlist secret` beside it takes it
+  out of the baseline without taking the quotes out of the sentence,
+  they being why the detector fires and so what the sentence is about.
+  Measured against the alternatives: dropping the quotes also clears it
+  and says less; the pragma on the previous line does *not* clear it,
+  `is_line_allowlisted` reading `context.previous_line` notwithstanding;
+  and excluding the file from the hook would take the keyword and
+  provider-token detectors off it too. The baseline is now written when
+  a file that has a finding changes, which was 7 of those 40 rather than
+  all of them
 - **`mutation.yml` says what its session cannot ask** (#222). The
   operators replace arithmetic, comparisons, literals, branches and
   decorators; not one of them puts a different expression in an argument
@@ -2504,12 +2568,12 @@ release-notes length in the first place, and are still in
 - **The documentation build is `docs.yml`, not the second job of
   `lint.yml`.** A failed docs build and a failed hook are two different
   verdicts about two different things, and one badge and one line in the
-  checks list each is what says so — the badge being a `docs` one added to
-  the second README row, beside `test` and `lint`, where the row already
-  ends with what read the docs makes of the same source. The job's display
-  name is unchanged,
-  which is what let it move without touching the branch rule: a required
-  context is matched by name, not by the workflow that reported it.
+  checks list each is what says so — the badge being a `docs` one added
+  to the second README row, beside `test` and `lint`, where the row
+  already ends with what read the docs makes of the same source. The
+  job's display name is unchanged, which is what let it move without
+  touching the branch rule: a required context is matched by name, not
+  by the workflow that reported it.
 - **Every job is named for the question it answers, and the aggregate is
   `test: every job passed`.** `Coverage` said which job it was rather than
   what it gates; the two suite matrices were *both* named
@@ -2733,30 +2797,31 @@ release-notes length in the first place, and are still in
 ### Packaging metadata
 
 - **`.gitignore` matches a versioned environment, and the sdist stops
-  shipping one.** `.venv`, `venv/` and `venv*/` between them do not match
-  `.venv-3.10`, which is what
-  `UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache pytest`
-  creates — the way of trying another interpreter that keeps the default
-  environment rather than replacing it, and CONTRIBUTING.md now gives it
-  beside the run that replaces one. Nothing downstream caught the leftover:
-  uv writes a `.gitignore` holding `*` inside the environment it creates, so
-  `git status` was clean, while hatchling builds the sdist from the root file
+  shipping one.** `.venv`, `venv/` and `venv*/` between them do not
+  match `.venv-3.10`, which is what `UV_PROJECT_ENVIRONMENT=.venv-3.10
+  uv run --python 3.10 --no-cache pytest` creates — the way of trying
+  another interpreter that keeps the default environment rather than
+  replacing it, and CONTRIBUTING.md now gives it beside the run that
+  replaces one. Nothing downstream caught the leftover: uv writes a
+  `.gitignore` holding `*` inside the environment it creates, so `git
+  status` was clean, while hatchling builds the sdist from the root file
   alone and shipped the directory — 377 paths against 297 and 13,132,264
-  bytes against 3,076,714, measured on `38ee75b` with the environment present
-  either way (`tar -tzf dist/*.tar.gz | wc -l`), the rest of the archive
-  identical. The totals move with the vendored library and the difference
-  does not: it is the environment's `bin` and the four files beside it,
-  `lib/` being matched already by the Distribution section above.
-  `twine check --strict` passed on it; `pyroma --min 10` raised
-  `tarfile.AbsoluteLinkError` on `.venv-3.10/bin/python`, the tarfile data
-  filter refusing a link to an absolute path, so the packaging gate failed
-  on one symlink rather than on the stray paths, which are the difference
-  between those two counts. `check-manifest` names every one of them — it
-  compares the sdist with what git tracks — and is not in the `check` group;
-  the pattern states the same fact where a file becomes invisible rather
-  than where an archive is built. It is `.venv*/`, in place of the `.venv`
-  beside `venv*/`: a directory of that exact name is matched by it, and by
-  the stock `# Environments` block above.
+  bytes against 3,076,714, measured on `38ee75b` with the environment
+  present either way (`tar -tzf dist/*.tar.gz | wc -l`), the rest of the
+  archive identical. The totals move with the vendored library and the
+  difference does not: it is the environment's `bin` and the four files
+  beside it, `lib/` being matched already by the Distribution section
+  above. `twine check --strict` passed on it; `pyroma --min 10` raised
+  `tarfile.AbsoluteLinkError` on `.venv-3.10/bin/python`, the tarfile
+  data filter refusing a link to an absolute path, so the packaging gate
+  failed on one symlink rather than on the stray paths, which are the
+  difference between those two counts. `check-manifest` names every one
+  of them — it compares the sdist with what git tracks — and is not in
+  the `check` group; the pattern states the same fact where a file
+  becomes invisible rather than where an archive is built. It is
+  `.venv*/`, in place of the `.venv` beside `venv*/`: a directory of
+  that exact name is matched by it, and by the stock `# Environments`
+  block above.
 
 ## v0.7.1.3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,31 @@ git push origin HEAD:refs/heads/<branch>
 git worktree remove --force "$WT" # removing it is part of finishing
 ```
 
-The venv and the C build are the whole of the cost, and they buy the thing
-that matters: a commit cannot contain work that was never in it, and the
-maintainer's branch does not move under them.
+The venv, the C build and a second clone of the submodule are the whole
+of the cost, and they buy the thing that matters: a commit cannot
+contain work that was never in it, and the maintainer's branch does not
+move under them. The clone is the third of those because a linked
+worktree gets a submodule module of its own rather than sharing the
+primary checkout's — `secp256k1/.git` there reads `gitdir:
+…/.git/worktrees/<wt>/modules/secp256k1` — which was measured at 14 MB
+under `.git/worktrees/<wt>/modules` and 7 MB of tree. `--reference`
+against the primary's module is what a session asks about next, and it
+works: `git submodule update --init --reference
+<primary>/.git/modules/secp256k1 secp256k1` leaves the module directory
+exactly where git puts it, writes one `objects/info/alternates` pointing
+at the primary's `objects`, and measures **128 KB** against those 14 MB,
+with the primary's own `core.worktree` untouched and its submodule
+clean. What it costs is the pointer: the worktree's submodule then has
+no copy of its own objects, so a `git gc` or a repack in the primary —
+or moving or deleting it — can leave this one unable to find them. What
+git is keeping apart by giving each linked worktree a module of its own
+is the submodule's *state*, so that two worktrees can have it checked
+out at two commits; the object store sitting inside that module is a
+consequence of where the state lives rather than a refusal to share
+objects, which is why `--reference` is allowed to share them and why it
+changes nothing about `core.worktree`. For a recipe whose last line
+removes the worktree anyway that is a trade worth declining, and
+declining knowingly is the point of the paragraph.
 
 **The submodule line is what makes the rest of the recipe run**, and
 leaving it out costs a session rather than a build: `git submodule status`
@@ -117,6 +139,17 @@ the two things that are not wrong. CI never meets it, every checkout there
 passing `submodules: true`. It is the same sentence as the one below about
 `refs/stash`: a worktree isolates files, and neither a submodule checkout
 nor a ref is one.
+
+**Two things the recipe leans on, both measured rather than assumed**, and
+worth knowing because a submodule inside a linked worktree is a known sharp
+edge. `core.worktree` in `.git/modules/<name>/config` is a single value, so
+a second checkout of one submodule can rewrite it under the first — and
+does not here, git giving the linked worktree its own module: the primary's
+`core.worktree` still reads `../../../secp256k1` and `git -C secp256k1
+status` there stays clean through the whole sequence. And `git worktree
+remove --force` still finishes with an initialized submodule inside: exit
+0, tree gone, `.git/worktrees` gone with it, nothing left for
+`git worktree prune`. So the recipe's last line needs no companion.
 
 **Never `git stash`, in the primary checkout or in a worktree:
 `refs/stash` is shared.** A worktree isolates files, not refs, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -630,19 +630,19 @@ in it all the same. None of the three changes the shape of a correction:
 whether a branch is squashed or fast-forwarded is decided when it lands,
 and by then the review has its record either way.
 
-Squash is the only merge *button* this repository enables, so there is no
-other to read; REPOSITORY.md has that setting, what the other two would
-have cost, and the fast-forward that is not a button at all. Auto-merge is
-what presses it, the dialog that switches it on carrying one method: what
-a pull request set to merge itself once the checks go green is holding is
-still
-`gh pr view <n> --json autoMergeRequest`. Enabling it is the way to not
-wait for a matrix that compiles C on every platform, and what it costs is
-the paragraph above: GitHub signs what it composes, so a pull request
-left to merge itself lands a commit signed by the web-flow key rather
-than by the maintainer, and one whose sha the branch never carried.
-GitHub only offers it while something is still pending, and it merges
-nothing the branch rule would not have let through by hand.
+Squash is the only merge *button* this repository enables, so there is
+no other to read; REPOSITORY.md has that setting, what the other two
+would have cost, and the fast-forward that is not a button at all.
+Auto-merge is what presses it, the dialog that switches it on carrying
+one method: what a pull request set to merge itself once the checks go
+green is holding is still `gh pr view <n> --json autoMergeRequest`.
+Enabling it is the way to not wait for a matrix that compiles C on every
+platform, and what it costs is the paragraph above: GitHub signs what it
+composes, so a pull request left to merge itself lands a commit signed
+by the web-flow key rather than by the maintainer, and one whose sha the
+branch never carried. GitHub only offers it while something is still
+pending, and it merges nothing the branch rule would not have let
+through by hand.
 
 Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
 nothing about a version needs to be touched in a pull request.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -277,12 +277,11 @@ call from three terms up, 64 terms 459.3 microseconds against 536.5, and
 the saving does not shrink with the count -- it is the naive form, one
 term at a time and one sum, libsecp256k1 exporting no batched
 multi-multiplication, so what it saves is the crossing and not the
-arithmetic. Like `xonly.from_prvkey` it
-is a composition rather than one libsecp256k1 call, and for the same
-reason — what it saves is the crossing between its halves, which is the
-caller's cost and not its own choice. The sum at infinity is
-`pubkey_sum`'s `None`, which a verification equation is written to land
-on.
+arithmetic. Like `xonly.from_prvkey` it is a composition rather than one
+libsecp256k1 call, and for the same reason — what it saves is the
+crossing between its halves, which is the caller's cost and not its own
+choice. The sum at infinity is `pubkey_sum`'s `None`, which a
+verification equation is written to land on.
 
 **And a wrong object is now told to the caller, wherever one is taken.**
 `keys.serialize` and `xonly.from_keypair` raised what libsecp256k1

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ bitcoin-core-rpc carry the same three lines. -->
 Simple python bindings to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
 ([v0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0)).
-As used by the
-[btclib](https://github.com/btclib-org/btclib) library.
+As used by the [btclib](https://github.com/btclib-org/btclib) library.
 
 To install (and/or upgrade):
 
@@ -456,12 +455,11 @@ halves take it, which is what "the private halves above hand one object
 from a call to the next" already promised. What a class would add there
 is a name, not a saving. The second is the other side of the ledger:
 this package is [stateless by construction](#design), which is also why
-MuSig2 is not
-wrapped, so an object is an exception to that, with an owner and an
-invalidation and a threading story, and the rule is what the exception
-has to be paid for with. What it does not weigh is ergonomics — the line
-a caller does not have to write is real, and belongs in btclib along
-with the lifetimes.
+MuSig2 is not wrapped, so an object is an exception to that, with an
+owner and an invalidation and a threading story, and the rule is what
+the exception has to be paid for with. What it does not weigh is
+ergonomics — the line a caller does not have to write is real, and
+belongs in btclib along with the lifetimes.
 
 So the numbers **confirm** the rule rather than establish it, and it is
 worth being clear which of them would survive a different machine. Not
@@ -1057,8 +1055,8 @@ difference *in*: not the cryptography, which is upstream's regardless of
 which wrapper calls it, but the boundary each one places around the same
 calls — how much a caller pays to cross it. Measuring that honestly, and
 publishing the run rather than a claim, is what
-[btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks)
-is for, and
+[btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks) is
+for, and
 [the libsecp256k1 wrappers table](https://github.com/btclib-org/btclib-benchmarks/blob/main/results/libsecp256k1-wrappers.md)
 is where this project's own boundary is timed against the others', one
 run kept whole rather than reduced to a single figure — an order of

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Release process
 
-Releases are published by the `release` workflow, which reuses the `lint`
-gate and the whole `test` build and test pipeline, and then uploads what
-the latter produced. Where
-it uploads is not an input to choose at dispatch time: a `v*` tag
-publishes to PyPI, a manual run publishes to TestPyPI. Both go through
+Releases are published by the `release` workflow, which reuses the
+`lint` gate and the whole `test` build and test pipeline, and then
+uploads what the latter produced. Where it uploads is not an input to
+choose at dispatch time: a `v*` tag publishes to PyPI, a manual run
+publishes to TestPyPI. Both go through
 [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so no
 long-lived token exists anywhere, and both upload PEP 740 attestations.
 The `attest` job then signs a build provenance statement for the sdist,
@@ -104,18 +104,17 @@ Then:
    submodule has moved since
 1. close the release notes. `CHANGELOG.md` and `HISTORY.md` are written
    as each change lands, not here, so what is left is to read the open
-   section of both against `git log`, drop the
-   `(work in progress, not released yet)` from each heading, and
-   renumber them if step 1 renumbered the version. `version-check`
-   refuses a tag whose section in either file is missing, empty, or still
-   carrying anything after the version in its heading, so a forgotten
-   retitle stops the release before the matrix builds anything. Dropping
-   those five words is the whole of what that check asks, and it asks it
-   of both files: it is the step this one exists to be, not a formality
-   downstream of it.
-   If the vendored libsecp256k1 moved, update the version named at the
-   top of `README.md` too (`grep -n 'wraps libsecp256k1' README.md`
-   finds the line without a search through the prose)
+   section of both against `git log`, drop the `(work in progress, not
+   released yet)` from each heading, and renumber them if step 1
+   renumbered the version. `version-check` refuses a tag whose section
+   in either file is missing, empty, or still carrying anything after
+   the version in its heading, so a forgotten retitle stops the release
+   before the matrix builds anything. Dropping those five words is the
+   whole of what that check asks, and it asks it of both files: it is
+   the step this one exists to be, not a formality downstream of it. If
+   the vendored libsecp256k1 moved, update the version named at the top
+   of `README.md` too (`grep -n 'wraps libsecp256k1' README.md` finds
+   the line without a search through the prose)
 1. give the pull request its title and its body before merging it, not
    after. The title is the version; the body says what the release is —
    what moved, what did not, and which of the two a user would notice.
@@ -360,26 +359,25 @@ Then:
    mirrors the page instead of trusting it live
 1. open the next version, in a pull request of its own and before
     anything else lands: bump `pyproject.toml` to a fourth number over
-    what was just published — `0.7.1.1` after `0.7.1` — and
-    run `uv lock`. It is a placeholder, and step 1 renumbers it if the
-    submodule moves before the next release; what it buys is a tree that
-    no longer claims to be a version it is not. `__version__` reads
-    installed metadata, so a checkout a developer installed stops
-    reporting itself as the release, and a report from it is unambiguous.
-    And pushing `v0.7.1` a second time — the mistake a just-finished
-    release invites — then fails at `version-check` in a minute, the
-    declared version having moved, rather than building the whole matrix
-    and dying at an upload PyPI refuses for a version it already carries.
-    A fourth number below the published one would be worse than no bump
-    at all: `0.7.0.1` sorts *under* `0.7.1`, so nothing would ever
-    resolve it, and `version-check` accepts it, being digits and dots.
-    Open the section for it in `CHANGELOG.md` and in `HISTORY.md` at the
-    same time, headed
-    `## v<version> (work in progress, not released yet)` and empty: what
-    lands next then has somewhere to be written down as it lands, which
-    is the whole of step 2 — and, with one branch and no long-lived
-    release pull request to hold a body, the whole of what step 3 reads
-    the cycle off at the end of it
+    what was just published — `0.7.1.1` after `0.7.1` — and run `uv
+    lock`. It is a placeholder, and step 1 renumbers it if the submodule
+    moves before the next release; what it buys is a tree that no longer
+    claims to be a version it is not. `__version__` reads installed
+    metadata, so a checkout a developer installed stops reporting itself
+    as the release, and a report from it is unambiguous. And pushing
+    `v0.7.1` a second time — the mistake a just-finished release invites
+    — then fails at `version-check` in a minute, the declared version
+    having moved, rather than building the whole matrix and dying at an
+    upload PyPI refuses for a version it already carries. A fourth
+    number below the published one would be worse than no bump at all:
+    `0.7.0.1` sorts *under* `0.7.1`, so nothing would ever resolve it,
+    and `version-check` accepts it, being digits and dots. Open the
+    section for it in `CHANGELOG.md` and in `HISTORY.md` at the same
+    time, headed `## v<version> (work in progress, not released yet)`
+    and empty: what lands next then has somewhere to be written down as
+    it lands, which is the whole of step 2 — and, with one branch and no
+    long-lived release pull request to hold a body, the whole of what
+    step 3 reads the cycle off at the end of it
 
 ## Rehearsing on TestPyPI
 

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -39,7 +39,26 @@ from .context import ctx
 # summary's is asked of the struct rather than written down, so that a
 # libsecp256k1 that changes it changes this too; the label's is the 33
 # bytes of a compressed point, which is its serialization and not the 68
-# of the object holding it
+# of the object holding it.
+#
+# Public, where the widths of the other six modules are private, and the
+# question those answer is a different one: `xonly.py` states its own for
+# the buffer it unpacks, and nothing outside the module needs it. This
+# module answers a caller two lengths (#232). `SUMMARY_SIZE` is the one
+# that has to be public: it is `ffi.sizeof` of a struct, no BIP writes it
+# down, it moves when libsecp256k1 moves, and a caller holding what
+# `prevouts_summary` returned can learn how many octets that is nowhere
+# else -- its docstring shows the check. `LABEL_SIZE` is 33 because a
+# label is a compressed point, so a caller could work it out where it
+# could not work the other out; what keeps it public is that it has been
+# since 0.8.0, and taking a released name private to tidy an asymmetry is
+# a break charged to a reader who never asked. `keys._COMPRESSED_SIZE` is
+# the same 33 and stays private: nothing there checks a caller's argument
+# against it, where two callers' arguments are checked against this one --
+# `parse_label`'s octets and the labels `_fill_label_cache` takes for
+# `_scan_outputs_`. What `serialize_label` does with it is not that: it
+# unpacks the buffer this module declared, which is exactly what `keys`
+# does with its own
 SUMMARY_SIZE = ffi.sizeof("secp256k1_silentpayments_prevouts_summary")
 LABEL_SIZE = 33
 


### PR DESCRIPTION
Prose only. Nothing changes about what any call answers.

## #233 — ten lines, twelve blocks, and three that are not defects

Each widow is what a qualifier inserted into a paragraph leaves behind
when nothing rewraps the block. **The unit of repair is the block**, which
#228 established the hard way: fixing the one line #225 named left two
more of exactly that shape.

| file | blocks rewrapped |
| --- | --- |
| `CHANGELOG.md` | 4 |
| `README.md` | 3 |
| `RELEASING.md` | 3 |
| `CONTRIBUTING.md` | 1 |
| `HISTORY.md` | 1 |

Word for word identical afterwards, and **asserted rather than
eyeballed**: the rewrap compares the joined words of each block before and
after and refuses to write where they differ. A markdown link is kept
whole for it — its inner spaces hidden from `textwrap` and restored —
because a link is one token to a reader and several to a wrapper.

**Three of the thirteen are not defects.** A line before a link of 63, 84
and 125 columns is short because nothing can follow it:

```
README.md:1059   'for, and' + [the libsecp256k1 wrappers table](…)  -> joining needs 134
RELEASING.md:7   '… Both go through' + [Trusted Publishing](…)      -> needs 102
SECURITY.md:15   '… it has its own' + [security policy](…)           -> needs 116
```

The filter measured `[security` where the token is the whole
`[security policy](url)`. With links kept whole those three blocks rewrap
to exactly what they already say, so ten is the count of real ones and
those three are the shape the heuristic cannot see.

**No hook**, which is the question the issue says it is really asking.
The thresholds are a heuristic and a false positive has no `# noqa` to be
marked with in prose; a gate exact everywhere else is the wrong place for
a check that is nearly right, and `.yamllint.yaml` already records what
that trade costs — a rule disabled at 46 findings that were all pins.

## #234 — the recipe costs a clone the sentence did not count

"The venv and the C build are the whole of the cost" stopped being true
when the submodule line went in: a linked worktree gets a module of its
own rather than sharing the primary checkout's, 14 MB under
`.git/worktrees/<wt>/modules` and 7 MB of tree. Counted now, which also
answers what a session asks next — `--reference` is cheaper and buys a
shared object store git deliberately does not give a linked worktree.

The two facts from that review go with it: `core.worktree` is a single
value a second checkout of one submodule can rewrite under the first, and
does not here; and `git worktree remove --force` finishes with an
initialized submodule inside, so the recipe's last line needs no
companion.

## #232 — why two widths are public

Not `xonly.py`'s rule, which is about a buffer the module fills and
unpacks. These are lengths the module answers a caller with.
`SUMMARY_SIZE` has to be public: `ffi.sizeof` of a struct, written down by
no BIP, moving when libsecp256k1 moves, unknowable to a caller holding
what `prevouts_summary` returned. `LABEL_SIZE` is 33 and could be worked
out — what keeps it public is that it has been since 0.8.0, and taking a
released name private to tidy an asymmetry is a break charged to a reader
who never asked. `keys._COMPRESSED_SIZE` is the same 33 and stays private:
nothing there checks a caller's argument against it, where this checks
both the label handed in and the one written back.

## Verified

640 passed, coverage 100%, `uvx pre-commit run --all-files` exits 0.
Branches from `main` at `752437d`; it shares no line with #236, which
appends to the same two changelog sections.

Closes #232
Closes #233
Closes #234

## Summary by Sourcery

Clarify documentation prose around worktree costs and public buffer widths while reflowing markdown paragraphs to remove short, mid-sentence lines.

Documentation:
- Rewrap multiple markdown paragraphs across changelog, README, CONTRIBUTING, RELEASING and HISTORY to eliminate mid-sentence short lines without changing their wording.
- Document the additional cost of a submodule clone and related git worktree behaviour in the contributor workflow guide.
- Explain in-code and in the changelog why `silentpayments` exposes two public buffer widths while other modules keep theirs private.