### PR TITLE
Stop the secrets baselines recording that a line moved

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -409,12 +409,26 @@ repos:
   #
   # The two hooks partition the tree: what the second matches, the first
   # excludes, through the filter recorded in its own baseline rather than a
-  # second copy of the pattern here. That filter also names the second
-  # baseline file, which is 40-character hashes by the hundred:
-  # detect-secrets skips a baseline of its own accord, but only the one
-  # --baseline names. Adding a vector to a file the second hook matches
+  # second copy of the pattern here. That filter also names both baseline
+  # files, which are 40-character hashes by the hundred: detect-secrets
+  # skips the one `--baseline` names of its own accord, and the pattern is
+  # what covers the other and the regeneration below, where no --baseline
+  # is passed at all. Adding a vector to a file the second hook matches
   # requires regenerating that baseline; see CONTRIBUTING.md, which carries
-  # both commands
+  # both commands.
+  #
+  # Both baselines are --slim, which omits `line_number` and
+  # `generated_at`: without it the file was rewritten whenever a flagged
+  # line moved, four times over one pull request recording nothing but a
+  # number going 40, 48, 49 — and a file that changes on pushes with
+  # nothing to do with secrets is one a reader learns to skip. What it
+  # costs is that a finding no longer says where it is, which is a grep,
+  # and that `detect-secrets audit` wants the full form: regenerate
+  # without --slim to audit, rather than keep the churn here. The
+  # regeneration passes no --baseline at all, so it also stops merging --
+  # and what --baseline merged was the audit's own product, `is_secret`
+  # and `is_verified`. Nothing carries either today; CONTRIBUTING.md says
+  # so where it names the audit
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,7 +124,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "^(\\.secrets\\.vectors\\.baseline|tests/.*\\.(csv|json))$"
+        "^(\\.secrets\\..*baseline|tests/.*\\.(csv|json))$"
       ]
     }
   ],
@@ -138,8 +134,7 @@
         "type": "Hex High Entropy String",
         "filename": "btclib_secp256k1/hashes.py",
         "hashed_secret": "a608d88cb7e04b46b5e44fa00bb7c01b7748e6f0",
-        "is_verified": false,
-        "line_number": 49
+        "is_verified": false
       }
     ],
     "scripts/cffi_build.py": [
@@ -147,8 +142,7 @@
         "type": "Base64 High Entropy String",
         "filename": "scripts/cffi_build.py",
         "hashed_secret": "9d8c445671f8c7fb72e1cab426822fdae46ad55f",
-        "is_verified": false,
-        "line_number": 453
+        "is_verified": false
       }
     ],
     "tests/test_keys.py": [
@@ -156,15 +150,13 @@
         "type": "Hex High Entropy String",
         "filename": "tests/test_keys.py",
         "hashed_secret": "1ca7070af97c241308c852cf0d57aae03b700331",
-        "is_verified": false,
-        "line_number": 79
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_keys.py",
         "hashed_secret": "558a75beb0a48857bb01a142c133f4bc1fc9755a",
-        "is_verified": false,
-        "line_number": 80
+        "is_verified": false
       }
     ],
     "tests/test_properties.py": [
@@ -172,22 +164,19 @@
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "67b4b9307479073a3e9797a99768940b2453c020",
-        "is_verified": false,
-        "line_number": 336
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "76ed68aa5911f79369040d91fc6ed9119bc7f53a",
-        "is_verified": false,
-        "line_number": 358
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_properties.py",
         "hashed_secret": "e02075c6d67aaf9bfe9fcdfa662665b12bc79dcd",
-        "is_verified": false,
-        "line_number": 361
+        "is_verified": false
       }
     ],
     "tests/test_submodule_pin.py": [
@@ -195,15 +184,13 @@
         "type": "Hex High Entropy String",
         "filename": "tests/test_submodule_pin.py",
         "hashed_secret": "4a6048a42a12da6f4a4c7d080b4bf892f8bbdba2",
-        "is_verified": false,
-        "line_number": 35
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_submodule_pin.py",
         "hashed_secret": "1ecb97dd82fe44dee912a7542f20de2af6c2e8fb",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       }
     ],
     "tests/test_vectors.py": [
@@ -211,311 +198,266 @@
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "cc61d1104ad450dc4193b6e41e320e19955f9ea6",
-        "is_verified": false,
-        "line_number": 940
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37a72e39051000f5f1eba00826330c714f341a05",
-        "is_verified": false,
-        "line_number": 941
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0ba0efc5b628c2a18da941dfd1923c72422f2fcc",
-        "is_verified": false,
-        "line_number": 942
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9fccb042eed80dd815e7e8a14af39b4bdd92733e",
-        "is_verified": false,
-        "line_number": 947
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f404f2833a0ae883be3332be3b8a0e1b0d3450c3",
-        "is_verified": false,
-        "line_number": 948
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fa5a6981207a6417f5b83e184d80b8f39c870574",
-        "is_verified": false,
-        "line_number": 949
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8acb7bfdfb828b2981e1c79a2fd3a6b8f55e132c",
-        "is_verified": false,
-        "line_number": 952
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c928eda2e4e4ee046bb63668c794662ab4f19f6",
-        "is_verified": false,
-        "line_number": 954
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bfb3ad9bf828aad801958fe1dc5ae41facebd8da",
-        "is_verified": false,
-        "line_number": 955
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a5093f5f073d9b7f6dafdf9a567bb20e5a7f7bee",
-        "is_verified": false,
-        "line_number": 956
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "aa65e358f7e3bade8f8c70ebb65c4e1213548ebf",
-        "is_verified": false,
-        "line_number": 961
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "384db16f6742203739cf58fabb9d2f5c7ba0cf7e",
-        "is_verified": false,
-        "line_number": 962
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6e361f4274d9319e7ab9d1babb0471fd8761558b",
-        "is_verified": false,
-        "line_number": 963
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "dd6693b80d9f651d12c230a5010662dd3bdad27f",
-        "is_verified": false,
-        "line_number": 971
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e0695fbefb032d29da1b27ca5e60d491da90d9be",
-        "is_verified": false,
-        "line_number": 972
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "26131481b2709149bba07642c17d01f6378bfbfc",
-        "is_verified": false,
-        "line_number": 973
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "03dbd93b55842a7b033cb934813ae11379d6faf2",
-        "is_verified": false,
-        "line_number": 981
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31c231f8e763ab5a34608608d7a52a60339c568f",
-        "is_verified": false,
-        "line_number": 982
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2c845e0670d06884e3a4bc525e54b66c9aeaaf5b",
-        "is_verified": false,
-        "line_number": 983
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9ee44d82a5e91d2c4c2d93627bd99fbdece5f299",
-        "is_verified": false,
-        "line_number": 986
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "1d70872ffa7a153f6bf02edca1ef991591e08985",
-        "is_verified": false,
-        "line_number": 991
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "31e1f86953a621f48981131948da0979870081d6",
-        "is_verified": false,
-        "line_number": 992
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "49b67383483e12a6ab9eb390b4cfe132a7aafb6b",
-        "is_verified": false,
-        "line_number": 993
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "090d7c173b78d9ee5040713027f094cbbca135fe",
-        "is_verified": false,
-        "line_number": 1047
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3b7815c85c3ef1703e212bc5fdbd51c0d12a32bc",
-        "is_verified": false,
-        "line_number": 1050
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "a85ea71e4f48611a458610b02960cc888dacd677",
-        "is_verified": false,
-        "line_number": 1051
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "e8eec9f345d229906b69a4ca9eb3e1e81aa8572a",
-        "is_verified": false,
-        "line_number": 1058
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "65363a8f3973eacf44b9741cbd1dc35ceda971c9",
-        "is_verified": false,
-        "line_number": 1059
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "8f5f5625327dc73e4c9097424402189dac923ed9",
-        "is_verified": false,
-        "line_number": 1092
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "c302522e939ac8632ab8ca56a11295904cd062f3",
-        "is_verified": false,
-        "line_number": 1093
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "2945319119dbdc9bc9cbfe74e4a69a5c8cd6f959",
-        "is_verified": false,
-        "line_number": 1098
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "fdd6e3e0e2dfb37b613e876af896a0c4d4d040da",
-        "is_verified": false,
-        "line_number": 1099
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f1bbf93d9634a52f5576abc94ab027be39f979dd",
-        "is_verified": false,
-        "line_number": 1106
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "f81513f672ebaa9ca567452ff82ec025a11f0da4",
-        "is_verified": false,
-        "line_number": 1107
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d0def4f1524dff92a078bdc969a3cfc338caf410",
-        "is_verified": false,
-        "line_number": 1118
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "0231d195e28ec23d6f4d888b3ce2c3cdef68e59d",
-        "is_verified": false,
-        "line_number": 1119
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "6db637a61fe0acf8e143d6267a5690682148c610",
-        "is_verified": false,
-        "line_number": 1121
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "9b6086d959d29b4ed4e788286ebbfaf788ce5ee5",
-        "is_verified": false,
-        "line_number": 1122
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "3406484aac38e1cf0ada765f60f256ab8a45e9ec",
-        "is_verified": false,
-        "line_number": 1230
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "936e0e7813ac74d8007e7e526eb0278549e5a007",
-        "is_verified": false,
-        "line_number": 1231
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "37dc5120ace5eb42b17ba52543fe597f1adb1863",
-        "is_verified": false,
-        "line_number": 1255
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "bf1bfdb3d89f6d3e015c0b5469ef8b2e14b2817f",
-        "is_verified": false,
-        "line_number": 1256
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "d276e19ace3bf016ea3e19cf949fbf0163848c00",
-        "is_verified": false,
-        "line_number": 1272
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_vectors.py",
         "hashed_secret": "4122da7efb38337ddd68ecab0452151f4ab993b7",
-        "is_verified": false,
-        "line_number": 1273
+        "is_verified": false
       }
     ]
-  },
-  "generated_at": "2026-08-17T10:49:53Z"
+  }
 }

--- a/.secrets.vectors.baseline
+++ b/.secrets.vectors.baseline
@@ -120,477 +120,409 @@
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "ac5b7f735b0c165f6ca84275d318c741e5ac197a",
-        "is_verified": false,
-        "line_number": 18
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "9014e28bcc1ec06ea6c77e9bb49a7727deaecd7d",
-        "is_verified": false,
-        "line_number": 30
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "29c9de0048dd93b07ba7656981a16644955544e3",
-        "is_verified": false,
-        "line_number": 50
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "50cc3802aaa1a3775771fad433bb061297221f3f",
-        "is_verified": false,
-        "line_number": 89
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "500a75bb2d65d75f8f879aac7368858b64eb2bab",
-        "is_verified": false,
-        "line_number": 90
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "52ca1393c2850ce9f4aa6428d114aa41b3e32355",
-        "is_verified": false,
-        "line_number": 100
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "54aae1048605dffe0de5fc1ebe6422d7d59316a9",
-        "is_verified": false,
-        "line_number": 106
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "8740880ad6eac8c197bbeb2bec26c4ab0dfd7621",
-        "is_verified": false,
-        "line_number": 320
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "881fdc41c96a32edaae5ccbd8b9c22dfc83f8ce5",
-        "is_verified": false,
-        "line_number": 326
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "18a9660bd24ebbb628f865be7b6515591cceed79",
-        "is_verified": false,
-        "line_number": 430
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "93ff485e509db31f941b62d8b694b77414984775",
-        "is_verified": false,
-        "line_number": 436
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "8ba873608bf3696c88d8daa67ec3aeaed42a1754",
-        "is_verified": false,
-        "line_number": 540
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "9f80b8234dd3542f00257218f9d8327469297f02",
-        "is_verified": false,
-        "line_number": 546
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "5ded8e84e41efa7421b4189887836b5a148601f8",
-        "is_verified": false,
-        "line_number": 600
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "aeecd3b4f1f4adf07b14d6a7476327b920efce2a",
-        "is_verified": false,
-        "line_number": 650
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "aa5546487be554fb480f37d292ce282f0eb6b29d",
-        "is_verified": false,
-        "line_number": 656
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "331517a439348dfcedcfb7300a79da4d2f7c76d9",
-        "is_verified": false,
-        "line_number": 690
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "dfcf55aac726b21d11295f468b2dffd4c28f9aad",
-        "is_verified": false,
-        "line_number": 710
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "783100b4a6cfc4d22534f63f4a026f790a7521ed",
-        "is_verified": false,
-        "line_number": 760
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "0f831c10b4e8959baf1c01be3699c376e2487899",
-        "is_verified": false,
-        "line_number": 766
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "4b2ef729823c8b1aae429b673e1d62aec3a7569f",
-        "is_verified": false,
-        "line_number": 800
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "56642fb267241825670be0454399b12c2607d03f",
-        "is_verified": false,
-        "line_number": 820
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "6e920dbf31cf62487a41452024c2aafff7bbd88b",
-        "is_verified": false,
-        "line_number": 870
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "ac0ca22397269313a8f1b2972924c0537aa34725",
-        "is_verified": false,
-        "line_number": 876
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "76a95f638c17e35ee67c52b50a7f2e6941855a96",
-        "is_verified": false,
-        "line_number": 910
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "1690ebb3e408b2ddd4950d843f6313cbe291d5d4",
-        "is_verified": false,
-        "line_number": 930
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "8b31ff1e53b3933e3bbc3d78fbdfbe6ae4096232",
-        "is_verified": false,
-        "line_number": 980
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "df1698a1e2f3d32f24e05174b79f97a2a6fbcd10",
-        "is_verified": false,
-        "line_number": 986
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "064901a28040d8ab50f86cf0f9b09c320a046f08",
-        "is_verified": false,
-        "line_number": 1040
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "3eb7ef378b96ec68462c7efcab88fe8e446dbab0",
-        "is_verified": false,
-        "line_number": 1090
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "93f947861daa82f877da8d57dad7fa667ce098fd",
-        "is_verified": false,
-        "line_number": 1096
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "10f5adecd25973990208f9a43b8894bfa2a56803",
-        "is_verified": false,
-        "line_number": 1130
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "011a3ea4ca7a3cfbc3d31466c47c02aeacaa4c2a",
-        "is_verified": false,
-        "line_number": 1157
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "ffc546e7f3828d05a1cf64c4d2d53c76a6aaefa7",
-        "is_verified": false,
-        "line_number": 1208
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "82b1d48251b32be70b36acb9028e37a47d3f3257",
-        "is_verified": false,
-        "line_number": 1213
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "1e07fd9915c77588614fe2b5fd920e3b30d7436a",
-        "is_verified": false,
-        "line_number": 1219
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "8860d3dbac005c5513bca06abdcd3872bf24a7f9",
-        "is_verified": false,
-        "line_number": 1328
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "240611db2503cfff9de6b95bedd3e16165d8160b",
-        "is_verified": false,
-        "line_number": 1329
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "d036463938342b97f76be2a0a3286108a5400e9c",
-        "is_verified": false,
-        "line_number": 1339
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "c82f06ad00b9ede4df6adce312b3b994171c8553",
-        "is_verified": false,
-        "line_number": 1344
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "db141f634ec6c9eaa34a1e61929408b92fe394cd",
-        "is_verified": false,
-        "line_number": 1350
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "ac86921f78ebd17c2b9237ee2dc77a926ee6d084",
-        "is_verified": false,
-        "line_number": 1461
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "ab889b1716eee2e077d879adfa605777c19301f1",
-        "is_verified": false,
-        "line_number": 1578
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "15cde81f8d42cb85a11bb27b2e9277edcc05a298",
-        "is_verified": false,
-        "line_number": 1695
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "74304548d12c5b81d7263027d2fee3f23ceae029",
-        "is_verified": false,
-        "line_number": 1820
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "f5cae4b6c238637eea91db47baf6a88290de25e0",
-        "is_verified": false,
-        "line_number": 1951
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "27e9c1c2c9525c66d6bf3467f9cff8d212f13b72",
-        "is_verified": false,
-        "line_number": 2156
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "4ad6378c365e84e055b60fc751972a74ce82046f",
-        "is_verified": false,
-        "line_number": 2166
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "fc7b8e8bfd769d8b643153732498e1f340b67f27",
-        "is_verified": false,
-        "line_number": 2171
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "4eef84cf2bddac4fe07e7ee1df08619505138b2d",
-        "is_verified": false,
-        "line_number": 2278
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "b4d52cf30a06b8b29530b95c3d2b23876f3588c1",
-        "is_verified": false,
-        "line_number": 2279
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "0be45c50395caae7c1d6347896e2033db8f43743",
-        "is_verified": false,
-        "line_number": 2292
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "86b5e287fd62b84fa49a91b23da49bb62131f723",
-        "is_verified": false,
-        "line_number": 2298
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "f0f0860b301981df5c8617f69023207f10845ec7",
-        "is_verified": false,
-        "line_number": 2476
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "aac67c69638097a2a580f02c8fa4ded6d139b43e",
-        "is_verified": false,
-        "line_number": 2482
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "e46a225eb992301302ab84374f449bea6837ac7d",
-        "is_verified": false,
-        "line_number": 2528
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "a86dbafaed4b74fdedf6ff67c8a9180568ffb1c8",
-        "is_verified": false,
-        "line_number": 2548
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "b9c2dd9ef4704709b9c42513d30d1fc4e9520f82",
-        "is_verified": false,
-        "line_number": 2610
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "4aa5b6bf46942236c64adf9925b08e4644eae2cd",
-        "is_verified": false,
-        "line_number": 2616
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "32067fa96d54d0776bd41c1990ca9f5129e50278",
-        "is_verified": false,
-        "line_number": 2742
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "63f4f9a365f40fcb01554fffd9440299f22ae8da",
-        "is_verified": false,
-        "line_number": 2748
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "141f7289b44fcd86827f64a368bacbbcdc38ce4d",
-        "is_verified": false,
-        "line_number": 3105
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "b20c3afa286e7979376c2b4642a64a88ca6558ef",
-        "is_verified": false,
-        "line_number": 3117
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "b630d40e87aa6003946ae0f5784df5f0e8233cb0",
-        "is_verified": false,
-        "line_number": 3311
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "adb98d7a91413d3032ccd31f1b374ddb1d7f05d3",
-        "is_verified": false,
-        "line_number": 3317
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "5639303696732e4234e699513f0a740a9ba813a8",
-        "is_verified": false,
-        "line_number": 5709
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "00889b02e19146721c06f0e03f5bf684a540ba67",
-        "is_verified": false,
-        "line_number": 5710
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/bip352_send_and_receive_test_vectors.json",
         "hashed_secret": "e1182b204b838e17951f171b2cf1cc2965dd8a89",
-        "is_verified": false,
-        "line_number": 5723
+        "is_verified": false
       }
     ],
     "tests/ecdsa_custom_nonce_sig.json": [
@@ -598,1394 +530,1195 @@
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
-        "is_verified": false,
-        "line_number": 7
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
-        "is_verified": false,
-        "line_number": 13
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
-        "is_verified": false,
-        "line_number": 19
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
-        "is_verified": false,
-        "line_number": 25
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
-        "is_verified": false,
-        "line_number": 31
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
-        "is_verified": false,
-        "line_number": 37
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
-        "is_verified": false,
-        "line_number": 43
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
-        "is_verified": false,
-        "line_number": 49
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
-        "is_verified": false,
-        "line_number": 55
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
-        "is_verified": false,
-        "line_number": 61
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
-        "is_verified": false,
-        "line_number": 67
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
-        "is_verified": false,
-        "line_number": 73
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
-        "is_verified": false,
-        "line_number": 79
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
-        "is_verified": false,
-        "line_number": 85
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
-        "is_verified": false,
-        "line_number": 91
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
-        "is_verified": false,
-        "line_number": 97
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
-        "is_verified": false,
-        "line_number": 103
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
-        "is_verified": false,
-        "line_number": 109
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
-        "is_verified": false,
-        "line_number": 115
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
-        "is_verified": false,
-        "line_number": 121
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
-        "is_verified": false,
-        "line_number": 127
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
-        "is_verified": false,
-        "line_number": 133
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
-        "is_verified": false,
-        "line_number": 139
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
-        "is_verified": false,
-        "line_number": 145
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
-        "is_verified": false,
-        "line_number": 151
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
-        "is_verified": false,
-        "line_number": 157
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
-        "is_verified": false,
-        "line_number": 163
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
-        "is_verified": false,
-        "line_number": 169
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
-        "is_verified": false,
-        "line_number": 175
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
-        "is_verified": false,
-        "line_number": 181
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
-        "is_verified": false,
-        "line_number": 187
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
-        "is_verified": false,
-        "line_number": 193
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
-        "is_verified": false,
-        "line_number": 199
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
-        "is_verified": false,
-        "line_number": 205
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
-        "is_verified": false,
-        "line_number": 211
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
-        "is_verified": false,
-        "line_number": 217
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
-        "is_verified": false,
-        "line_number": 223
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
-        "is_verified": false,
-        "line_number": 229
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
-        "is_verified": false,
-        "line_number": 235
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
-        "is_verified": false,
-        "line_number": 241
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
-        "is_verified": false,
-        "line_number": 247
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
-        "is_verified": false,
-        "line_number": 253
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
-        "is_verified": false,
-        "line_number": 259
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
-        "is_verified": false,
-        "line_number": 265
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
-        "is_verified": false,
-        "line_number": 271
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
-        "is_verified": false,
-        "line_number": 277
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
-        "is_verified": false,
-        "line_number": 283
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
-        "is_verified": false,
-        "line_number": 289
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
-        "is_verified": false,
-        "line_number": 295
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
-        "is_verified": false,
-        "line_number": 301
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
-        "is_verified": false,
-        "line_number": 307
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
-        "is_verified": false,
-        "line_number": 313
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
-        "is_verified": false,
-        "line_number": 319
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
-        "is_verified": false,
-        "line_number": 325
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
-        "is_verified": false,
-        "line_number": 331
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
-        "is_verified": false,
-        "line_number": 337
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
-        "is_verified": false,
-        "line_number": 343
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
-        "is_verified": false,
-        "line_number": 349
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
-        "is_verified": false,
-        "line_number": 355
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
-        "is_verified": false,
-        "line_number": 361
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
-        "is_verified": false,
-        "line_number": 367
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
-        "is_verified": false,
-        "line_number": 373
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
-        "is_verified": false,
-        "line_number": 379
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
-        "is_verified": false,
-        "line_number": 385
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
-        "is_verified": false,
-        "line_number": 391
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
-        "is_verified": false,
-        "line_number": 397
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
-        "is_verified": false,
-        "line_number": 403
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
-        "is_verified": false,
-        "line_number": 409
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
-        "is_verified": false,
-        "line_number": 415
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
-        "is_verified": false,
-        "line_number": 421
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
-        "is_verified": false,
-        "line_number": 427
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
-        "is_verified": false,
-        "line_number": 433
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
-        "is_verified": false,
-        "line_number": 439
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
-        "is_verified": false,
-        "line_number": 445
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
-        "is_verified": false,
-        "line_number": 451
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
-        "is_verified": false,
-        "line_number": 457
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
-        "is_verified": false,
-        "line_number": 463
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
-        "is_verified": false,
-        "line_number": 469
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
-        "is_verified": false,
-        "line_number": 475
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
-        "is_verified": false,
-        "line_number": 481
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
-        "is_verified": false,
-        "line_number": 487
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
-        "is_verified": false,
-        "line_number": 493
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
-        "is_verified": false,
-        "line_number": 499
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
-        "is_verified": false,
-        "line_number": 505
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
-        "is_verified": false,
-        "line_number": 511
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
-        "is_verified": false,
-        "line_number": 517
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
-        "is_verified": false,
-        "line_number": 523
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
-        "is_verified": false,
-        "line_number": 529
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
-        "is_verified": false,
-        "line_number": 535
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
-        "is_verified": false,
-        "line_number": 541
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
-        "is_verified": false,
-        "line_number": 547
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
-        "is_verified": false,
-        "line_number": 553
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
-        "is_verified": false,
-        "line_number": 559
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
-        "is_verified": false,
-        "line_number": 565
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
-        "is_verified": false,
-        "line_number": 571
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
-        "is_verified": false,
-        "line_number": 577
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
-        "is_verified": false,
-        "line_number": 583
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
-        "is_verified": false,
-        "line_number": 589
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
-        "is_verified": false,
-        "line_number": 595
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
-        "is_verified": false,
-        "line_number": 601
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
-        "is_verified": false,
-        "line_number": 607
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
-        "is_verified": false,
-        "line_number": 613
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
-        "is_verified": false,
-        "line_number": 619
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
-        "is_verified": false,
-        "line_number": 625
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
-        "is_verified": false,
-        "line_number": 631
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
-        "is_verified": false,
-        "line_number": 637
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
-        "is_verified": false,
-        "line_number": 643
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
-        "is_verified": false,
-        "line_number": 649
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
-        "is_verified": false,
-        "line_number": 655
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
-        "is_verified": false,
-        "line_number": 661
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
-        "is_verified": false,
-        "line_number": 667
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
-        "is_verified": false,
-        "line_number": 673
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
-        "is_verified": false,
-        "line_number": 679
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
-        "is_verified": false,
-        "line_number": 685
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
-        "is_verified": false,
-        "line_number": 691
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
-        "is_verified": false,
-        "line_number": 697
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
-        "is_verified": false,
-        "line_number": 703
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
-        "is_verified": false,
-        "line_number": 709
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
-        "is_verified": false,
-        "line_number": 715
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
-        "is_verified": false,
-        "line_number": 721
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
-        "is_verified": false,
-        "line_number": 727
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
-        "is_verified": false,
-        "line_number": 733
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
-        "is_verified": false,
-        "line_number": 739
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
-        "is_verified": false,
-        "line_number": 745
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
-        "is_verified": false,
-        "line_number": 751
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
-        "is_verified": false,
-        "line_number": 757
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
-        "is_verified": false,
-        "line_number": 763
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
-        "is_verified": false,
-        "line_number": 769
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
-        "is_verified": false,
-        "line_number": 775
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
-        "is_verified": false,
-        "line_number": 781
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
-        "is_verified": false,
-        "line_number": 787
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
-        "is_verified": false,
-        "line_number": 793
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
-        "is_verified": false,
-        "line_number": 799
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
-        "is_verified": false,
-        "line_number": 805
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
-        "is_verified": false,
-        "line_number": 811
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
-        "is_verified": false,
-        "line_number": 817
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
-        "is_verified": false,
-        "line_number": 823
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
-        "is_verified": false,
-        "line_number": 829
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
-        "is_verified": false,
-        "line_number": 835
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
-        "is_verified": false,
-        "line_number": 841
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
-        "is_verified": false,
-        "line_number": 847
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
-        "is_verified": false,
-        "line_number": 853
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
-        "is_verified": false,
-        "line_number": 859
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
-        "is_verified": false,
-        "line_number": 865
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
-        "is_verified": false,
-        "line_number": 871
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
-        "is_verified": false,
-        "line_number": 877
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
-        "is_verified": false,
-        "line_number": 883
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
-        "is_verified": false,
-        "line_number": 889
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
-        "is_verified": false,
-        "line_number": 895
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
-        "is_verified": false,
-        "line_number": 901
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
-        "is_verified": false,
-        "line_number": 907
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
-        "is_verified": false,
-        "line_number": 913
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
-        "is_verified": false,
-        "line_number": 919
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
-        "is_verified": false,
-        "line_number": 925
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
-        "is_verified": false,
-        "line_number": 931
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
-        "is_verified": false,
-        "line_number": 937
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
-        "is_verified": false,
-        "line_number": 943
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
-        "is_verified": false,
-        "line_number": 949
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
-        "is_verified": false,
-        "line_number": 955
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
-        "is_verified": false,
-        "line_number": 961
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
-        "is_verified": false,
-        "line_number": 967
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
-        "is_verified": false,
-        "line_number": 973
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
-        "is_verified": false,
-        "line_number": 979
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
-        "is_verified": false,
-        "line_number": 985
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
-        "is_verified": false,
-        "line_number": 991
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
-        "is_verified": false,
-        "line_number": 997
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
-        "is_verified": false,
-        "line_number": 1003
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
-        "is_verified": false,
-        "line_number": 1009
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
-        "is_verified": false,
-        "line_number": 1015
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
-        "is_verified": false,
-        "line_number": 1021
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
-        "is_verified": false,
-        "line_number": 1027
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
-        "is_verified": false,
-        "line_number": 1033
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
-        "is_verified": false,
-        "line_number": 1039
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
-        "is_verified": false,
-        "line_number": 1045
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
-        "is_verified": false,
-        "line_number": 1051
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
-        "is_verified": false,
-        "line_number": 1057
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
-        "is_verified": false,
-        "line_number": 1063
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
-        "is_verified": false,
-        "line_number": 1069
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
-        "is_verified": false,
-        "line_number": 1075
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
-        "is_verified": false,
-        "line_number": 1081
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
-        "is_verified": false,
-        "line_number": 1087
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
-        "is_verified": false,
-        "line_number": 1093
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
-        "is_verified": false,
-        "line_number": 1099
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
-        "is_verified": false,
-        "line_number": 1105
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
-        "is_verified": false,
-        "line_number": 1111
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
-        "is_verified": false,
-        "line_number": 1117
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
-        "is_verified": false,
-        "line_number": 1123
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
-        "is_verified": false,
-        "line_number": 1129
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
-        "is_verified": false,
-        "line_number": 1135
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
-        "is_verified": false,
-        "line_number": 1141
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
-        "is_verified": false,
-        "line_number": 1147
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
-        "is_verified": false,
-        "line_number": 1153
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
-        "is_verified": false,
-        "line_number": 1159
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
-        "is_verified": false,
-        "line_number": 1165
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
-        "is_verified": false,
-        "line_number": 1171
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
-        "is_verified": false,
-        "line_number": 1177
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
-        "is_verified": false,
-        "line_number": 1183
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
-        "is_verified": false,
-        "line_number": 1189
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_custom_nonce_sig.json",
         "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
-        "is_verified": false,
-        "line_number": 1195
+        "is_verified": false
       }
     ],
     "tests/ecdsa_sig.json": [
@@ -1993,1396 +1726,1196 @@
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "db495e5da3fdf80a0c4a5fa6f1d9103eba82159e",
-        "is_verified": false,
-        "line_number": 6
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "04920e3c15c698366cd14d6b0ba2e3ccdba0dae9",
-        "is_verified": false,
-        "line_number": 11
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e9a9a3e0b7bb063662ccd54aa3f38fb57a992be4",
-        "is_verified": false,
-        "line_number": 16
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2fe6678bfcb275ac9fcb05e22a759218ab92e341",
-        "is_verified": false,
-        "line_number": 21
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9ab9a336a29c80bad95bd12030916b7044153092",
-        "is_verified": false,
-        "line_number": 26
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "814b32f1606b00e28e07d9acc46d41adda42ade0",
-        "is_verified": false,
-        "line_number": 31
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c9317dcc2778ac08c5d886cbe905b7f89d995b7f",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e469d8f9d115a36324f25bea2d5ad6465605fc26",
-        "is_verified": false,
-        "line_number": 41
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c3ba5616fcf390f38c8e976e5c4eabd87ccd9c38",
-        "is_verified": false,
-        "line_number": 46
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ac9c3b82480763b07a1003a3ac890e306792b0fb",
-        "is_verified": false,
-        "line_number": 51
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "aa8b843aeba9ae5b9f9956da76aee02609510818",
-        "is_verified": false,
-        "line_number": 56
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9cd74b96f7ed3cb2205fc96cac7e8908ea97c65b",
-        "is_verified": false,
-        "line_number": 61
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7efdd6760f9a26ae35a5e6535ff1ba6bb4734f77",
-        "is_verified": false,
-        "line_number": 66
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f3a8da450dfb49f666e8c60ebd21969b1cff2082",
-        "is_verified": false,
-        "line_number": 71
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "084f90b3c4b975cb01a7be6ade9c1a698b301f01",
-        "is_verified": false,
-        "line_number": 76
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "eee07ef272a845eee582c60b4c8342e59fe85099",
-        "is_verified": false,
-        "line_number": 81
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1b50fdde5018a0d1b3d5bdf1dd429303daa6e547",
-        "is_verified": false,
-        "line_number": 86
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "93eee9e92e7501694066b4788ea8bf9521e88fbc",
-        "is_verified": false,
-        "line_number": 91
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2b4a056a148b059cc5a1774fe5da8c0d4c912066",
-        "is_verified": false,
-        "line_number": 96
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9f8cd1d6f2e9a015f250db05cf26690dd429d026",
-        "is_verified": false,
-        "line_number": 101
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a28a38aa4a637451030dd2330057e019c9a1f062",
-        "is_verified": false,
-        "line_number": 106
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "eddafe2bef6a45cf4dad143db56b3a64e306079f",
-        "is_verified": false,
-        "line_number": 111
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f1695619cbbe7c81f5f2b8271f3d4ba667423b9d",
-        "is_verified": false,
-        "line_number": 116
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a781c518f2e6d6665549f8397872ef21c3ddaff2",
-        "is_verified": false,
-        "line_number": 121
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "388b584b5736e88da5db216c72a2e0cf11690722",
-        "is_verified": false,
-        "line_number": 126
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "3bbe45a66a26d52aacd1ab1b755eba1d8ea176c5",
-        "is_verified": false,
-        "line_number": 131
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "06fa7c145854f4611a17a08c5f77be534547dacf",
-        "is_verified": false,
-        "line_number": 136
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "806d4dc65348536d62903048726ee27027becc23",
-        "is_verified": false,
-        "line_number": 141
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b8a2eb87e4231a9412fc1510c8d83ca9a5a63473",
-        "is_verified": false,
-        "line_number": 146
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f16a5ab4666a988fe340002896c3f3d32eb033a8",
-        "is_verified": false,
-        "line_number": 151
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a721dcb37d7b61debba9704f80ead1ee686b126e",
-        "is_verified": false,
-        "line_number": 156
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1f0c6bc1f003fb393b3fd6cb64563edb6964d6cd",
-        "is_verified": false,
-        "line_number": 161
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c18cbc6b8fc247a80e1a3cded741f61bf5217494",
-        "is_verified": false,
-        "line_number": 166
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ae8e6f167b812c1bda60466356edc2310ed84e8b",
-        "is_verified": false,
-        "line_number": 171
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f068c57d92507898e971008e5673fbf3397ce272",
-        "is_verified": false,
-        "line_number": 176
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fa7c8c730d9f624ca3b7d98bec303b3c562a0bbf",
-        "is_verified": false,
-        "line_number": 181
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "55f31319fd0a379c0fd94c7434e94877a9cc8199",
-        "is_verified": false,
-        "line_number": 186
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "6aa39f4f625dc05bc3b7d53cecdbd965bf12a29c",
-        "is_verified": false,
-        "line_number": 191
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fca01961984e5835cb972ddb2e3a2d59cbb0fe0b",
-        "is_verified": false,
-        "line_number": 196
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d0457d3648fe2db798e04568b55926d0597c0a3d",
-        "is_verified": false,
-        "line_number": 201
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d53cc7da064d18312e4ce60619e624734c4a3f01",
-        "is_verified": false,
-        "line_number": 206
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ecd729b5a18e5c3c1158def23d29274862212765",
-        "is_verified": false,
-        "line_number": 211
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "074c4c1ec4c7e31f402f7271d6ec117c07494316",
-        "is_verified": false,
-        "line_number": 216
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f895dbe45758ec8cdc8882c617133e0b1d455336",
-        "is_verified": false,
-        "line_number": 221
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "44591c23de284f942de222b6735bd5f1375fbbf2",
-        "is_verified": false,
-        "line_number": 226
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "bb537e57fc19e43f47f730e573bb9cbdee830577",
-        "is_verified": false,
-        "line_number": 231
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "741259a89c9c89c71af70f2835b5f97459d4d84a",
-        "is_verified": false,
-        "line_number": 236
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9027afeea479b0cb02eae8c4dac0f9e9352af2f0",
-        "is_verified": false,
-        "line_number": 241
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2c5b202de89f3f06939d5272eb3ce7295a2b538d",
-        "is_verified": false,
-        "line_number": 246
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "904d7076870b56b30b77bf31e447cb0629c0d7bb",
-        "is_verified": false,
-        "line_number": 251
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "8aaa23eea4fa7683379216757ef0d7e89b912833",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "db40bc0f0cb10c3fc3fee07771c78ab745f4007b",
-        "is_verified": false,
-        "line_number": 261
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "0b93dcb21c1192af1e60b14bbb6e73eb8f1f1ed7",
-        "is_verified": false,
-        "line_number": 266
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a22fb5b13733414c9add8c7f05f9ef323f1d954d",
-        "is_verified": false,
-        "line_number": 271
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b37dc841011e95c9cce7e67d173ccae662ac00b0",
-        "is_verified": false,
-        "line_number": 276
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "8f4efc8ba3f6dee85b78281801498edb3f5b8535",
-        "is_verified": false,
-        "line_number": 281
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fa154b2750f0af905789630805525cc0c2ec15f5",
-        "is_verified": false,
-        "line_number": 286
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ba2e098588595de85a01bd9df8f2878a8937e34d",
-        "is_verified": false,
-        "line_number": 291
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "6997c5e97319712367b7d2efdc5e3ebcf996183a",
-        "is_verified": false,
-        "line_number": 296
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "17378d62e9865bebf1cba2d8ceed2b653c48a401",
-        "is_verified": false,
-        "line_number": 301
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "45f6e47b103fafd116d9bd0a8672f3cd35a76cf2",
-        "is_verified": false,
-        "line_number": 306
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2584d473acf1415609658fec8b235b72e9a3a5b1",
-        "is_verified": false,
-        "line_number": 311
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "84ee05db2f4db722cc27882b7c4b4381bd844a64",
-        "is_verified": false,
-        "line_number": 316
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "23730190e0f2447f62506a56f9427c5163c4eb4a",
-        "is_verified": false,
-        "line_number": 321
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "055e2d1a08a4e4058189b7c956555d7be233d23e",
-        "is_verified": false,
-        "line_number": 326
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1ab1bfbc1e3274e5f0e5c6cc371fc0ad55decace",
-        "is_verified": false,
-        "line_number": 331
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f40ae959fa65a0021b2adf7f63e973d2767f372b",
-        "is_verified": false,
-        "line_number": 336
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c0d0a8830872d1e79e727fc8367c575959527087",
-        "is_verified": false,
-        "line_number": 341
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "507bab4d07a79c617dc30473b79617b93bece964",
-        "is_verified": false,
-        "line_number": 346
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fa0301d64010e95ff3cbad3311864a72536de282",
-        "is_verified": false,
-        "line_number": 351
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4945e6410df2d8ac90dfae26fe7c65b18797296e",
-        "is_verified": false,
-        "line_number": 356
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b630785f361a7210e00028c24fd12ab4e16a554b",
-        "is_verified": false,
-        "line_number": 361
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "56b8d3b9cd3d3a54ff4788b1c2653c113fead964",
-        "is_verified": false,
-        "line_number": 366
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "622984a52cd00e0d52d69a7466c25ae20850c177",
-        "is_verified": false,
-        "line_number": 371
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fcc1c44744934d5bf0f85e785186063dab4432ec",
-        "is_verified": false,
-        "line_number": 376
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "cfc0f7baa4065103c5c250ed8fa8398ec7b9be7f",
-        "is_verified": false,
-        "line_number": 381
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "90db11c4767388b7715825c8734eb2e135bbab37",
-        "is_verified": false,
-        "line_number": 386
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a012aca93b6e1d57769e5f4c0b28de709e2b135d",
-        "is_verified": false,
-        "line_number": 391
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "eea3ddaa147fce1e38eb90769d1691edc2c4e3ad",
-        "is_verified": false,
-        "line_number": 396
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b7d1e82eb7c5e49d4149ab15086f6bf15d5cd28c",
-        "is_verified": false,
-        "line_number": 401
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ec89beca1e231e375cad979013677a3fc7874d9c",
-        "is_verified": false,
-        "line_number": 406
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e4d3263ce304cd136ddf289706444255a1a6c2b1",
-        "is_verified": false,
-        "line_number": 411
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e512772e600ec305b27cb427011c6e6f87204fc6",
-        "is_verified": false,
-        "line_number": 416
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "84ef16b4db1996dcd56ddd7325452ea6f9a1811e",
-        "is_verified": false,
-        "line_number": 421
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d0ccbac5d4458e75d1ff07918aba74397fb63be3",
-        "is_verified": false,
-        "line_number": 426
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a2c31160829350019848f3e6cdace17b8f15d69d",
-        "is_verified": false,
-        "line_number": 431
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ad599dc6a576f20c3bae4e30f24bae4079465936",
-        "is_verified": false,
-        "line_number": 436
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d0cfff7c8d13d0f12d7d735ba97a29529b95b340",
-        "is_verified": false,
-        "line_number": 441
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "91e0486a91a5c04fc4705c0650e80e95c63dcb4a",
-        "is_verified": false,
-        "line_number": 446
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d927587c659dbab26f108ce25f3e347bb44df787",
-        "is_verified": false,
-        "line_number": 451
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4ed3a04ec1402a9d579cb27340c6bc679dbd62b1",
-        "is_verified": false,
-        "line_number": 456
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "da845ed689e64bd17de9180acdcb2be77d7da076",
-        "is_verified": false,
-        "line_number": 461
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2075f70cddfa705cc9a68081d4851888511307b9",
-        "is_verified": false,
-        "line_number": 466
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "951f7ed9af4c726096d4dfc35edb8c701aa85767",
-        "is_verified": false,
-        "line_number": 471
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "905a93fd178151343b3aa0e5ccd10a9ecae4a26b",
-        "is_verified": false,
-        "line_number": 476
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7865e4f247b778667102f31390b3dc2f517856e5",
-        "is_verified": false,
-        "line_number": 481
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a4269fcd14691436019b3f9ffa5a488e8d09c393",
-        "is_verified": false,
-        "line_number": 486
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "59390d73983c2767330efd571b8bef8710f564b1",
-        "is_verified": false,
-        "line_number": 491
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ce19e325d6bf324ad8b77f6b107c48ff7b6deb94",
-        "is_verified": false,
-        "line_number": 496
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4b489fc5ccfa359e2270770b324c0c9c0311e18a",
-        "is_verified": false,
-        "line_number": 501
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d951564abf54f3e29e9234bef2c1bf97336222c8",
-        "is_verified": false,
-        "line_number": 506
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "010910506a124fb68eaccc946199e9df42cc0858",
-        "is_verified": false,
-        "line_number": 511
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9044ce919fdef469651e60768e550ceaae2c9ece",
-        "is_verified": false,
-        "line_number": 516
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a9657d21f705b439e6fd186b2c33cbcc7373736f",
-        "is_verified": false,
-        "line_number": 521
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9f801ed6256c0fb0099b74141dcc673e0cb77021",
-        "is_verified": false,
-        "line_number": 526
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7c135030d2c9d853a532e327745aa882fb56604b",
-        "is_verified": false,
-        "line_number": 531
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "29a903a5b92ef2d9da6e291874fdc397d0989e84",
-        "is_verified": false,
-        "line_number": 536
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a8c696f9760f1ad80e0a358288305c64a40eb374",
-        "is_verified": false,
-        "line_number": 541
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "41c08550b4bd48165969cdbedce174fa624a2844",
-        "is_verified": false,
-        "line_number": 546
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c8c37711ad434b9950b4c19b75eb8df51bfefaff",
-        "is_verified": false,
-        "line_number": 551
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "72b7abdca712a5995050bc423395cad6fdd624a6",
-        "is_verified": false,
-        "line_number": 556
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "68b9ce748ad762705a62ae79fc5aa16a5770a8b2",
-        "is_verified": false,
-        "line_number": 561
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "267c7af3ef8876f092d2932d2722f6710cb0f2b6",
-        "is_verified": false,
-        "line_number": 566
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "91c2d161896a24df5c22204c36567a8c7559635f",
-        "is_verified": false,
-        "line_number": 571
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "dddb4646b90d5e1536856985f1ae06bac99dd6b4",
-        "is_verified": false,
-        "line_number": 576
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ac576fc27dcf9293f93ba12f3fd11f274ccd8f48",
-        "is_verified": false,
-        "line_number": 581
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "35815698e42d0ee45a12d03742068a3dc1404774",
-        "is_verified": false,
-        "line_number": 586
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "77f602830b4a7b1e6f785b23bfffbfc00641468c",
-        "is_verified": false,
-        "line_number": 591
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "56eabaae9785d0f86e6318792cc9dcbef5e7cfd6",
-        "is_verified": false,
-        "line_number": 596
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c27b11f4e2cc8f2b36f1c0959d19f0ff24f26469",
-        "is_verified": false,
-        "line_number": 601
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "bda6cd6c50dbbf1fa580577dfc07d04e20c2b8ad",
-        "is_verified": false,
-        "line_number": 606
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a4e44e274da06542570d001e14f54cd431805ed9",
-        "is_verified": false,
-        "line_number": 611
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2cc72d1da5ec42638bb0d0409ee6487536f13a75",
-        "is_verified": false,
-        "line_number": 616
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "eb74588cbf444afb69d98564a73ecbd349474712",
-        "is_verified": false,
-        "line_number": 621
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f771f841113ec663195ca65b5f47422b2561cc8e",
-        "is_verified": false,
-        "line_number": 626
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2ed60187a277e943820ecca1bfc306f5c97d5093",
-        "is_verified": false,
-        "line_number": 631
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "8e95a76a0f51b8090f54a71eeedd331f1def2afe",
-        "is_verified": false,
-        "line_number": 636
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c060e0b776a0caf68dae4bcf3ebe20a95e44ecd8",
-        "is_verified": false,
-        "line_number": 641
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4c86dd75dc42466c07cbc7cb6a1bfaeb3a9834be",
-        "is_verified": false,
-        "line_number": 646
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "dc5a2b3e1ed3b179a7f8afe7f085ad627ef4d4a5",
-        "is_verified": false,
-        "line_number": 651
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "0824e35ff604093c07622695e5297b09c8dc23be",
-        "is_verified": false,
-        "line_number": 656
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e37ddaa6c5de9782cfbc0e3e5f9d0ed5b1b9cc68",
-        "is_verified": false,
-        "line_number": 661
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ca66e98d04486b6a07035934139836d33ade6d43",
-        "is_verified": false,
-        "line_number": 666
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a05507cf653f54ca37849b4c0d624a5d13dd4a18",
-        "is_verified": false,
-        "line_number": 671
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "3f229e877378dd6e8488d7ad93d9896942139181",
-        "is_verified": false,
-        "line_number": 676
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9d1a75b3af5f77ce55594bd3b80d741c69a7ea7c",
-        "is_verified": false,
-        "line_number": 681
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "60c132861a9b13f48c26c8659226423a1d835180",
-        "is_verified": false,
-        "line_number": 686
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "26595b8ae9b15e1ef6c9b95d258803ea9e6527ea",
-        "is_verified": false,
-        "line_number": 691
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "6a8c0bcb50a14595faa22d04609e2518f610e8b9",
-        "is_verified": false,
-        "line_number": 696
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "83c36c387e99825c588223bce56ef45ac16c31a2",
-        "is_verified": false,
-        "line_number": 701
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4254188d212ae32372ea97ae3ac215ff4aa09f00",
-        "is_verified": false,
-        "line_number": 706
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "0ebc4ad029b176af0e6db4a398facd947fca3db4",
-        "is_verified": false,
-        "line_number": 711
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "8673cd2e82a9a12994dca0f8234c3a9ed9d936e9",
-        "is_verified": false,
-        "line_number": 716
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d08f518cd3a8664d0ba9fa66e51fb5b6bb86c9ef",
-        "is_verified": false,
-        "line_number": 721
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a776f9d5432da11a9db831cff9d38ac084b31bce",
-        "is_verified": false,
-        "line_number": 726
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "2c1bf31ad003791d0f7a162c61b9884ef1b95414",
-        "is_verified": false,
-        "line_number": 731
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1845e9b2e34e64e36375f88a0ebf5ed0e6a4ae3b",
-        "is_verified": false,
-        "line_number": 736
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b57efc10f33d0a9a8ae834eccdbbf75d8daa826f",
-        "is_verified": false,
-        "line_number": 741
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "26f53f7826af170dd3b31fcdd43d09798e7698bf",
-        "is_verified": false,
-        "line_number": 746
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9aa2e39a3a011bf68b6fbe92cf17252d5bbbc9be",
-        "is_verified": false,
-        "line_number": 751
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c5e5ed98ca4fece52a723018a250bc63172c0223",
-        "is_verified": false,
-        "line_number": 756
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "032222d48a72410cccde60663734a5160347991c",
-        "is_verified": false,
-        "line_number": 761
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7039d163439f45cd689e967d2182af4bbe4c3ac6",
-        "is_verified": false,
-        "line_number": 766
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "f124647f0d6f49efcfab49c3d00f80620b1139ac",
-        "is_verified": false,
-        "line_number": 771
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1d273e5f52b6ee6d2b556f1477c13c8d832559ea",
-        "is_verified": false,
-        "line_number": 776
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "d24e10b2e5741c59be1a09600b71b98076518a72",
-        "is_verified": false,
-        "line_number": 781
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "05ac25498ffa7ee0662641997cd573b4fe77b2dd",
-        "is_verified": false,
-        "line_number": 786
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "13acc9db904bc751678dfce7058707e337f36ac9",
-        "is_verified": false,
-        "line_number": 791
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fbd5b61002fd97e118dea31dbedc73154dbccebe",
-        "is_verified": false,
-        "line_number": 796
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b10207017db107ce7ebbaffd094081ccce5ebb6d",
-        "is_verified": false,
-        "line_number": 801
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9323b6d12ffd818b515463478a8d61382239bd0c",
-        "is_verified": false,
-        "line_number": 806
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "cea4fca26243f4dea615efd028d0a9608360e629",
-        "is_verified": false,
-        "line_number": 811
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "ccee08c7541208a10b00a1150df0dc38ebab0fb3",
-        "is_verified": false,
-        "line_number": 816
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a9f39d73760514809dac987925c39d5750cb1b95",
-        "is_verified": false,
-        "line_number": 821
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "329a3d7a2e35f0ce0ef966f519e77064dd72e4db",
-        "is_verified": false,
-        "line_number": 826
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "aa3565174847e4416feb3e5d134bb8103b6c59c1",
-        "is_verified": false,
-        "line_number": 831
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "230160f5d3dd8365c92119d49747e69619dd9c3d",
-        "is_verified": false,
-        "line_number": 836
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "9d68e2af20e82b9761aceeb9ee463fd30690e095",
-        "is_verified": false,
-        "line_number": 841
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a778756c4258efbc59004f4cf57f7bfcbee02084",
-        "is_verified": false,
-        "line_number": 846
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "a38ab5a9a4d90a9d8f628fe0e7c6032a9177cdc6",
-        "is_verified": false,
-        "line_number": 851
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "fa8ebf182fea6a71144f475f4a5ff2a7cfcea602",
-        "is_verified": false,
-        "line_number": 856
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "1b9fab1dd1831a12eda4c15db96b01a2d731e6d8",
-        "is_verified": false,
-        "line_number": 861
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "eb730a587926180da701aa96cd6ab6c474417253",
-        "is_verified": false,
-        "line_number": 866
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "104ce6e42bba52a88dc4ab42cfc6a3656ef64d82",
-        "is_verified": false,
-        "line_number": 871
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "526ef3e9ebb3b95cc45a9c3674fc800da677f6ba",
-        "is_verified": false,
-        "line_number": 876
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "377a81c4f9fa4c2dca20ba33e1e72802cdfcd013",
-        "is_verified": false,
-        "line_number": 881
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "4a52d189df323e6f8ddb225ef608b35a3267737a",
-        "is_verified": false,
-        "line_number": 886
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7fabf18c3eca46ccfacdc74fa742b2700b365f80",
-        "is_verified": false,
-        "line_number": 891
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "728216ed4bb33cd42b3c03b4db874b2b293e9fb1",
-        "is_verified": false,
-        "line_number": 896
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c89f85c63391a25d469f976c8adf8b7bf933bddb",
-        "is_verified": false,
-        "line_number": 901
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7492b8ce0be4efa1ba87f7db5b5bc2463fe45e5b",
-        "is_verified": false,
-        "line_number": 906
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "cd073215f1c745023787346a7ec97aa76b0cad83",
-        "is_verified": false,
-        "line_number": 911
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "bfa8c72fdd893224de785af52e5ed2e533fe83ca",
-        "is_verified": false,
-        "line_number": 916
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "6036188ded9f4e19fd54d125ccdad622f6b205c5",
-        "is_verified": false,
-        "line_number": 921
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "658ebc5008f726f4097ee61abfe01b4767b294e0",
-        "is_verified": false,
-        "line_number": 926
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "317c490fa5fded812cd2b6147ab1c0ea0b07b07b",
-        "is_verified": false,
-        "line_number": 931
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "08db657e1565aaf2756efd5ea5ccb9fd1573d853",
-        "is_verified": false,
-        "line_number": 936
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "e3e5abc09ba1f1593b643fef8525a7ad33594723",
-        "is_verified": false,
-        "line_number": 941
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "7e4ac9a68524f4c4f0c9a897ea7dfb000a019f24",
-        "is_verified": false,
-        "line_number": 946
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "cb12ffd8ec4f6f44aecf3aa9e52658b96895f731",
-        "is_verified": false,
-        "line_number": 951
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "854aeccaccdb37ebbf0dae20398cc26ce62f6bfd",
-        "is_verified": false,
-        "line_number": 956
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c6900d33d65790c50069398b8a1e15aa6faf7533",
-        "is_verified": false,
-        "line_number": 961
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "311d563bdca13053837834f15cd1027f9f75d450",
-        "is_verified": false,
-        "line_number": 966
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "aa5cf70a6e7e1208eb9092845c59e3005966f712",
-        "is_verified": false,
-        "line_number": 971
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "bcc90621be6f28267a3606ccdf86c0495ca0d81f",
-        "is_verified": false,
-        "line_number": 976
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "27e5d86ec5d54cea45fb2e8d3fffa722859db66f",
-        "is_verified": false,
-        "line_number": 981
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "c2d5a2f86058386bacbf1ec6df32c1c4ed85d066",
-        "is_verified": false,
-        "line_number": 986
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "b9072d12477a0ef19f893b48951e1e67469f6b1d",
-        "is_verified": false,
-        "line_number": 991
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/ecdsa_sig.json",
         "hashed_secret": "bb9f38a040cd15c5a3db0977808a5aa8549a3ac9",
-        "is_verified": false,
-        "line_number": 996
+        "is_verified": false
       }
     ]
-  },
-  "generated_at": "2026-08-11T00:10:41Z"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1721,6 +1721,34 @@ release-notes length in the first place, and are still in
   size and truncated mtime match — the same window as the hand case,
   which is why that recipe wants the control run and not only the
   variable.
+- **Both secrets baselines are `--slim`, so a line that moves stops
+  rewriting them** (#230). The files carried `line_number` and
+  `generated_at`, and over #221 that meant a rewrite on all four pushes
+  recording nothing but one entry's number going 40, 48, 49 as a comment
+  block above it grew — a file that changes on pushes with nothing to do
+  with secrets being one a reader learns to skip. `--slim` omits both
+  fields, and it needs a fresh scan: `--baseline` writes the full form
+  whatever it read, `save_to_file` calling `format_for_output` with the
+  default `is_slim_mode=False`, where `--slim` is honoured only on the
+  branch that prints to stdout. So the exclusion the tree baseline's own
+  filter used to supply is spelled out in the command, and both baseline
+  files are named in it rather than the one `--baseline` would have
+  skipped by itself. Verified rather than assumed: 53 findings in the
+  tree baseline and 466 in the vectors one before and after, identical
+  as sets of filename, hash and type; both hooks pass; and with a line
+  inserted above every finding of `hashes.py` a regeneration is
+  byte-identical to the committed file, which is the whole of what the
+  churn was. The redirect costs two things and both are written where
+  they are paid. One field of the diff — a new secret still arrives as a
+  new `hashed_secret` under its filename, and finding *where* takes a
+  grep — and the merge `--baseline` was doing, which carried an audit's
+  own product forward: `is_secret` and `is_verified`, "verification of
+  secrets, both automated and manual" in `SecretsCollection.merge`'s
+  words. A scan into a file has nothing to merge, so those marks return
+  to their defaults, and slim output prints no `is_secret` when it is
+  unset, so the loss would show as a diff of nothing. Nothing is lost
+  today, all 53 and all 466 findings being unverified and none carrying
+  `is_secret`.
 
 ### CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,14 @@ uv lock
 
 # after adding a hex constant to a test module; the vendored vector
 # data has a baseline of its own, whose command is in CONTRIBUTING.md.
-# Neither file is excluded from the scan, only recorded as reviewed
-uvx --from detect-secrets detect-secrets scan --baseline .secrets.baseline
+# Neither file is excluded from the scan, only recorded as reviewed.
+# --slim and a redirect, not --baseline: the flag is what keeps a moved
+# line from rewriting the file, and --baseline writes the full form
+# whatever it read -- it also merges, so a redirect drops what an audit
+# marked; CONTRIBUTING.md carries both halves
+uvx --from detect-secrets detect-secrets scan --slim \
+    --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
+    > .secrets.baseline
 ```
 
 ## The workflows that gate, and the ones that do not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -418,20 +418,43 @@ targets and where every change lands; a tag on `main` is a release.
   regenerated:
 
   ```shell
-  # the tree, entropy detectors on; the vendored vector data is
-  # excluded by a filter the baseline itself records
-  uvx --from detect-secrets detect-secrets scan \
-      --baseline .secrets.baseline
+  # the tree, entropy detectors on. --slim omits `line_number` and
+  # `generated_at`, so the file stops changing when a flagged line
+  # moves; a fresh scan rather than `--baseline`, which writes the full
+  # form whatever it read -- `--slim` reaches `format_for_output` only on
+  # the branch that prints to stdout -- and therefore the exclusion
+  # spelled out rather than read back from the baseline's own filter
+  uvx --from detect-secrets detect-secrets scan --slim \
+      --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
+      > .secrets.baseline
 
   # the vendored vector data, entropy detectors off: these files are
   # 64-character hex and nothing else, so a new vector would read as a
   # new secret. The paths are the hook's `files` pattern spelled out
-  uvx --from detect-secrets detect-secrets scan \
+  uvx --from detect-secrets detect-secrets scan --slim \
       --disable-plugin HexHighEntropyString \
       --disable-plugin Base64HighEntropyString \
       tests/*.csv tests/*.json \
       > .secrets.vectors.baseline
   ```
+
+  Both are slim, and what that costs is one field of the diff: a new
+  secret still arrives as a new `hashed_secret` under its filename, and
+  finding *where* it is takes a grep instead of a line number.
+  `detect-secrets audit` needs the full form and says so, which is a
+  reason to regenerate without `--slim` for an audit rather than to keep
+  the churn in the committed file.
+
+  The redirect costs a second thing, which is the one to know before
+  auditing: `--baseline` does not only save, it **merges**, and what it
+  carries forward is exactly the audit's product — `is_secret` and
+  `is_verified` per finding, "verification of secrets, both automated and
+  manual" in its own words. A scan into a file has no old baseline to
+  merge, so those marks go back to their defaults, and slim output prints
+  no `is_secret` at all when it is unset: the loss shows up as a diff of
+  nothing. Nothing is lost today, all 53 and all 466 findings being
+  unverified and none carrying `is_secret`, but an audit's marks want
+  saving elsewhere or re-applying after the next regeneration.
 
   read the diff before committing it, which is the whole point of a
   baseline: what appears there is what nobody has looked at yet


### PR DESCRIPTION
`--slim` on both baselines, and the two commands that regenerate them.
Closes #230 in the direction it recommends.

## What the churn was

`line_number` and `generated_at` meant a rewrite whenever a flagged line
moved — four pushes on #221, each recording one entry's number going 40,
48, 49. The hook was never complaining: a moved line does not fail it, it
only means the committed file is no longer what a regeneration produces,
so the regeneration lands in the next diff.

## `--slim` needs a fresh scan, which is the one thing the issue's recipe implies

Measured: `detect-secrets scan --slim --baseline .secrets.baseline` writes
`line_number` straight back — `--baseline` keeps the format of the file it
updates. So both commands are a scan redirected into the file, and the
exclusion the tree baseline's own `should_exclude_file` filter used to
supply is spelled out in the command:

```shell
uvx --from detect-secrets detect-secrets scan --slim \
    --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
    > .secrets.baseline
```

It names **both** baseline files, where `--baseline` skipped only the one
it was given, and the fresh scan records that filter — so what the hook
reads is unchanged.

## Verified

| | before | after |
| --- | --- | --- |
| `.secrets.baseline` findings | 53 | 53 |
| `.secrets.vectors.baseline` findings | 466 | 466 |

Identical as sets of filename, hash and type. Both hooks pass. And the
point of the change, measured directly: with a line inserted above every
finding in `hashes.py`, **a regeneration is byte-identical to the
committed file**.

## What it costs, said where it is paid

One field of the diff, in `CONTRIBUTING.md` and in the hook comment: a new
secret still arrives as a new `hashed_secret` under its filename, and
finding *where* takes a grep. `detect-secrets audit` wants the full form
and says so — a reason to regenerate without the flag for an audit, not to
keep the churn in the committed file.

The pattern is `\.secrets\..*baseline` rather than the exact alternation of
the two names because markdownlint's MD013 applies inside a fenced block
and the exact form was 88 and 90 columns in the two files carrying the
command. Same 53 findings, measured.

## Verified

640 passed, `uvx pre-commit run --all-files` exits 0. Branches from `main`
at `752437d`.

Closes #230

## Summary by Sourcery

Make secrets baselines slim-only to avoid churn from moved lines while preserving existing findings and hooks behavior.

Enhancements:
- Switch both secrets baselines to use detect-secrets --slim, omitting line_number and generated_at so baseline files no longer rewrite when flagged lines move.
- Update regeneration commands, hook comments, and contributor/AI usage docs to run fresh slim scans with explicit exclude patterns that cover both baseline files and test data.