### PR TITLE
Take the two file kinds nothing built reads off the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,8 +144,39 @@ jobs:
           # the root and of .github, and neither README.md nor a file
           # under docs/, which the sdist carries. An empty list is not a
           # documentation change, it is a question this could not answer,
-          # so the count is checked before the pattern
-          prose='^(CHANGELOG|CLAUDE|CONTRIBUTING|HISTORY|RELEASING|REPOSITORY|SECURITY)\.md$|^\.github/[^/]*\.md$'
+          # so the count is checked before the pattern.
+          #
+          # The mutation configuration and the detect-secrets baselines are
+          # on it for the same reason as the prose and were measured off it:
+          # a change to bindings.toml alone cost 23 jobs and 45.7
+          # runner-minutes (#239), and cosmic-ray takes that path as an
+          # argument from mutation.yml, which is a workflow the matrix does
+          # not contain. A baseline is detect-secrets' own output, read by a
+          # hook -- and by lint.yml, which has no changed-file gate at all,
+          # so a malformed one is still caught by the job that catches it
+          # today.
+          #
+          # Anchored on the *file* and not on the directory, which is the
+          # same staleness this comment declines below in the direction that
+          # looks cheap: `^\.github/mutation/` would exempt in advance any
+          # file a later change drops there, and two tests already load a
+          # script by path one directory over (`.github/scripts/`), so such
+          # a script would skip the matrix and take its own test with it.
+          # `.toml` rather than `bindings\.toml` so a second configuration
+          # needs no edit here; a script belongs in .github/scripts/, which
+          # is where the three of them are.
+          #
+          # A workflow is *not* on it, deliberately, and that is the answer
+          # to the other half of #239 rather than an omission. Which
+          # workflows the matrix reads is a judgement -- this file and what
+          # it calls, plus release.yml -- and naming the rest would be right
+          # today and stale the first time a sentinel is folded into the
+          # gate or one of these is split out, both of which have happened
+          # here. A stale list of that kind skips a matrix that should have
+          # run, which is the expensive direction; leaving every workflow
+          # change to run everything is the cheap one, at the cost this
+          # comment now records
+          prose='^(CHANGELOG|CLAUDE|CONTRIBUTING|HISTORY|RELEASING|REPOSITORY|SECURITY)\.md$|^\.github/[^/]*\.md$|^\.github/mutation/[^/]*\.toml$|^\.secrets\..*baseline$'
           if [ ! -s files.txt ] || grep -qvE "$prose" files.txt; then
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "something the matrix reads changed: everything runs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2076,6 +2076,34 @@ release-notes length in the first place, and are still in
   and the paragraph says what the ratchet does and does not catch
   instead: a line that stops running is caught, a line still run by
   another test and asserted by none is what neither question sees.
+- **The prose allowlist covers the two file kinds nothing built reads**
+  (#239). `changes` answers whether the matrix has anything to check,
+  and its pattern was the root and `.github` prose alone — so a pull
+  request touching one file the matrix cannot read alongside prose ran
+  everything. The mutation configuration is on it now, cosmic-ray taking
+  that path as an argument from a workflow the matrix does not contain,
+  and so are the detect-secrets baselines, which are that tool's own
+  output read by a hook and by a workflow that has no changed-file gate
+  at all. It is anchored on the file --
+  `^\.github/mutation/[^/]*\.toml$` -- and not on the directory, that
+  being the same staleness this declines for workflows in the direction
+  that looks cheap: a prefix would exempt in advance whatever a later
+  change drops there, and two tests already load a script by path one
+  directory over, so such a script would skip the matrix and take its
+  own test with it. `.toml` rather than the one filename so a second
+  configuration needs no edit; a script belongs in `.github/scripts/`,
+  where all three are. Measured before and after against the file lists
+  of four real pull requests, with `/usr/bin/grep` rather than this
+  machine's `grep`: #236's `bindings.toml` and two markdown files went
+  from 23 jobs and 45.7 runner-minutes to a skipped matrix, a baseline
+  alone likewise, while #237's `silentpayments.py`, a bare `README.md`,
+  a file under `docs/` and an empty list all still run everything. A
+  workflow is deliberately not on the list, which is the other half of
+  #239 answered rather than omitted: which workflows the matrix reads is
+  a judgement — this file, what it calls, and `release.yml` — and a list
+  of the rest would be right today and stale the first time a sentinel
+  is folded into the gate, which skips a matrix that should have run.
+  The comment above the pattern carries that reasoning and the figure.
 
 ## v0.8.0.2
 


### PR DESCRIPTION
#239's option (1), with its option (2) answered rather than left open. One
line of pattern, one comment, one changelog bullet; no job changes what it
does.

## What joins the allowlist

```diff
-prose='^(CHANGELOG|CLAUDE|…|SECURITY)\.md$|^\.github/[^/]*\.md$'
+prose='^(CHANGELOG|CLAUDE|…|SECURITY)\.md$|^\.github/[^/]*\.md$|^\.github/mutation/|^\.secrets\..*baseline$'
```

`.github/mutation/` is the session's configuration, taken as a path
argument by cosmic-ray from `mutation.yml` — a workflow the matrix does not
contain. The baselines are detect-secrets' own output, read by a hook.
Nothing built reads either, which is the list's own criterion.

## Measured against real file lists

| files changed | before | after |
| --- | --- | --- |
| #236: `bindings.toml` + 2 md | runs (23 jobs, 45.7 min) | **skips** |
| a baseline alone | runs | **skips** |
| `.github/mutation/` alone | runs | **skips** |
| #237: prose + `silentpayments.py` | runs | runs |
| #227: `mutation.yml` + 2 md | runs | runs |
| a bare `README.md` | runs | runs |
| a file under `docs/` | runs | runs |
| an empty list | runs | runs |

The last four are the cases the comment above the pattern already warns
this must not get wrong, and they are unchanged.

## The measurement needed the right `grep`, which inverted the first answer

Worth reading before trusting any local reproduction of this step: this
machine's `grep` is **ugrep 7.5.0**, and it takes the exit status of `-v`
from whether the *pattern* matched rather than from whether any line was
selected.

```
$ printf '%s\n' CHANGELOG.md README.md > n.txt
$ grep -cvE '^CHANGELOG\.md$' n.txt   # ugrep: one non-matching line
1
$ grep -qvE '^CHANGELOG\.md$' n.txt; echo $?   # ugrep
1
$ /usr/bin/grep -qvE '^CHANGELOG\.md$' n.txt; echo $?
0
```

So the first pass of the table above reported "skips" for a pull request
containing `silentpayments.py`. The step is unaffected — it runs on
ubuntu-latest — but a session reproducing it by hand on macOS gets the
opposite verdict silently. Filed as a separate issue rather than fixed
here.

## What is deliberately not on the list

A workflow. Which workflows the matrix reads is a judgement — this file,
what it calls, `release.yml` — and naming the rest would be right today and
stale the first time a sentinel is folded into the gate or one of these is
split out, both of which have happened here. That staleness skips a matrix
that *should* have run, which is the expensive direction. So every workflow
change keeps running everything, and the comment says why rather than
leaving the next reader to infer it — including that #227's own shape,
`mutation.yml` plus prose, still costs the full matrix.

## Verified

640 passed, `uvx pre-commit run --all-files` exits 0 — `actionlint` and
`zizmor` included, this being a workflow change. Branches from `main` at
`3b915d2`.

Closes #239

## Summary by Sourcery

Reduce unnecessary matrix runs for file changes that are not consumed by the matrix while preserving coverage for workflow and source changes.

Enhancements:
- Refine the workflow changed-file allowlist so mutation configuration and detect-secrets baseline files no longer trigger the full test matrix when only non-consumed files change.
- Document the rationale for excluding these files while deliberately continuing to run the matrix for workflow changes.