### PR TITLE
Say which half of the no-hook argument is the strong one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1764,10 +1764,30 @@ release-notes length in the first place, and are still in
   not defects at all and stay: a line before a markdown link of 63, 84
   and 125 columns is short because nothing can follow it, and the filter
   measured the link's first word rather than the link. No hook does
-  this, which #233 asked about and answers no: the thresholds are a
+  this, which #233 asked about and answers no. The thresholds are a
   heuristic, a false positive has no `# noqa` to be marked with in
   prose, and a gate that is exact everywhere else is the wrong place for
-  one that is nearly right.
+  one that is nearly right — but the stronger half of that is the false
+  *negative*, and this change produced one of its own (#240). Correcting
+  a sentence in `CLAUDE.md` left a 35-column line mid-sentence under a
+  57-column one, and the detector that had just counted ten of exactly
+  that shape -- thirteen reported, ten of them defects -- walked past
+  it: 35 is under the 46-column ceiling but 57 is under the 65 the line
+  above has to reach, and the line at 57 is itself the same shape and
+  over the ceiling. A *pair* of short lines hides a widow, because the
+  first break is too long to be flagged and the second has no long line
+  above it. So what a hook would have missed here is the instance a
+  reader found, which is a better reason to decline it than the noise it
+  would have added — and the two short lines left in that paragraph
+  after the rewrap are token-forced, 47 columns before a 32-character
+  path and 58 before a 40-character one, the same shape as the three
+  links. Those are columns and not bytes, which is worth saying where
+  the figures are: the second line carries an em dash, three bytes and
+  one column, so `awk` in a byte locale and `wc -c` answer 60 where the
+  detector's own `len` answers 58, and every figure in this bullet is
+  the second kind. No consecutive short pair anywhere in it is what says
+  the rewrap is complete, and it is cheaper to check by eye than either
+  threshold.
 - **The worktree recipe costs a submodule clone, and the sentence under
   it counts it now** (#234). It said the venv and the C build "are the
   whole of the cost" and after the submodule line they are not: a linked


### PR DESCRIPTION
#240, in the bullet it belongs to. Prose only, one file.

## What the bullet said, and what it left out

#233's bullet declines a hook for mid-sentence short lines and gives one
reason: the thresholds are a heuristic, and a false positive has no
`# noqa` to be marked with in prose. That is the **weaker** half.

The stronger half is a false negative, and the change that closed #233
produced one of its own. Correcting a sentence in `CLAUDE.md` left this:

```
126[72]  lives rather than a refusal to share objects, which is why `--reference`
127[57]  is allowed to share them and why it changes nothing about
128[35]  `core.worktree`. For a recipe whose
129[74]  last line removes the worktree anyway that is a trade worth declining, and
```

Line 128 is the defect, and the detector that had just counted thirteen of
exactly that shape walked past it, because **both** thresholds miss it at
once:

| the filter asks | line 128 | line 127 |
| --- | --- | --- |
| this line ≤ 46 columns | 35 ✓ | 57 ✗ |
| the previous line ≥ 65 columns | 57 ✗ | 72 ✓ |

A *pair* of short lines hides a widow: the first break is too long to be
flagged, and the second has no long line above it. So what a hook would
have missed here is the instance a reader found — a better reason to
decline one than the noise it would have added.

## The two smaller facts, because together they are what "complete" means

The two short lines left in that paragraph after the rewrap are
token-forced rather than left: 47 columns before a 32-character path and 60
before a 40-character one, the same shape as the three links #233 leaves
alone. And *no consecutive short pair anywhere in the paragraph* is the
property that says the rewrap is done, which is cheaper to check by eye
than either threshold.

## Verified

The bullet is rewrapped whole rather than patched, so the extension leaves
no widow of its own — #233's detector reports none in `CHANGELOG.md` on
this head, and the one hit a looser scan shows is line 9, the
`markdownlint-configure-file` comment, which is pre-existing and not prose.
640 passed, `uvx pre-commit run --all-files` exits 0.

Rebased on `main` at `3b915d2`. It touches only `CHANGELOG.md`, so
`changes` skips the matrix for it — which is what #241 is about, one file
kind over.

Closes #240

## Summary by Sourcery

Clarify both the false-positive and false-negative reasons for declining a prose widow-detection hook.

Enhancements:
- Clarify the rationale for rejecting a prose widow-detection hook by documenting false negatives, including hidden widows formed by consecutive short lines, alongside false positives.
- Clarify that the remaining short lines are token-forced and that completion is assessed by ensuring no consecutive short-line pairs remain.

Documentation:
- Expand the CHANGELOG discussion of prose widow detection to explain its limitations and why a hook is not appropriate.