### PR TITLE
Say which grep reproduces the changes job, and why it matters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2104,6 +2104,27 @@ release-notes length in the first place, and are still in
   of the rest would be right today and stale the first time a sentinel
   is folded into the gate, which skips a matrix that should have run.
   The comment above the pattern carries that reasoning and the figure.
+- **and the list that promises to reproduce each gating job was missing
+  the job that decides whether the others run** (#242), which is the same
+  step again from the other side. Reproducing it by hand answers the
+  opposite where the shell's `grep` is ugrep: `-qv` there takes its
+  status from whether the pattern matched anywhere and inverts that,
+  rather than from whether `-v` selected a line, so a list mixing prose
+  with code — the case the step exists to judge — exits 1 and reads as
+  "prose only", the direction that skips a matrix that should have run,
+  and nothing says it has. Measured on each shape of file list with the
+  pattern taken out of the workflow, and against the runner rather than
+  against itself: #237's own list answers "everything runs" as its run
+  did, and the pull request carrying this entry answers "prose only" with
+  its matrix skipped. Nothing in the tree moves, `test.yml`'s `grep`
+  being the runner's, which is GNU's. The entry spells the path out,
+  lifts the pattern out of `test.yml` so the two cannot drift, and names
+  `-q` as the mechanism rather than `-v`: ugrep takes the same
+  file-level path when the output is discarded, which is where dropping
+  `-q` lands next, and `-cvE` with a numeric test is what agrees with
+  both greps. `test: every job passed` gets an entry in the same pass,
+  that being the neighbouring gap and the check a contributor sees red:
+  it reproduces as nothing, reading the conclusions of the jobs above it.
 
 ## v0.8.0.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,35 @@ command at all, for the reason above, and no longer gates.
   uvx pre-commit run --all-files
   ```
 
+- `Ask which files the pull request touches`, whose answer decides whether
+  the rest of `test.yml` runs at all
+
+  ```shell
+  gh api "repos/btclib-org/btclib-secp256k1/pulls/<number>/files" \
+      --paginate --jq '.[].filename' > files.txt
+  eval "$(/usr/bin/grep -m1 '^ *prose=' .github/workflows/test.yml)"
+  if [ ! -s files.txt ] || /usr/bin/grep -qvE "$prose" files.txt; then
+      echo "everything runs"
+  else
+      echo "prose only"
+  fi
+  ```
+
+  The second line lifts the pattern out of the workflow rather than
+  restating it here, so the two cannot drift. `/usr/bin/grep` rather than
+  `grep`, because where the shell's is [ugrep](https://ugrep.com) the
+  third line answers the opposite question: ugrep takes the status from
+  whether the *pattern* matched anywhere and inverts that, rather than
+  from whether `-v` selected a line. A list of only prose and a list of
+  only code come out right either way; one mixing the two exits 1 and
+  reads as "prose only", which is the direction that skips a matrix that
+  should have run, and nothing says it has. `-q` is what asks the
+  question of the file rather than of the lines, and ugrep takes the same
+  path when the output is discarded, so `-cvE` and a numeric test agree
+  with both greps. The runner's `grep` is GNU's, so what ugrep can get
+  wrong here is the reproduction and not the workflow
+  (<https://github.com/btclib-org/btclib-secp256k1/issues/242>)
+
 - `Measure coverage, gated at 100%`
 
   ```shell
@@ -308,6 +337,11 @@ command at all, for the reason above, and no longer gates.
 
 - `Build on Linux for Windows` needs `mingw-w64`, and a Linux host to be
   faithful: the cross-compilation CI does is from ubuntu, not from macOS
+
+- `test: every job passed` reproduces as nothing, and is here because it
+  is the required check and therefore the one a contributor sees red: it
+  reads the conclusions of the jobs above it and runs no command of its
+  own. What turned it red is one of them, in the run
 
 - `Build the documentation`, the same command `.readthedocs.yaml` runs
   and `docs/README.rst` documents. Needs the submodule checked out,


### PR DESCRIPTION
Closes #242, by option (1) — the option the issue's own comment argues is
proportionate to a blast radius of one line.

## What changed

One entry in CONTRIBUTING.md's "Running what CI runs" list, for
`Ask which files the pull request touches`. That job was missing from a
list whose first sentence promises *each* job of `lint`, `docs` and
`test`, and it is the job that decides whether the rest of them run — so
the gap and the trap are the same entry.

Nothing in the tree changes. `test.yml` keeps its `grep -qvE`, which is
right on the runner, and options (2) and (3) stay available if a later
change wants the verdict to stop being an exit status.

## The mechanism, narrower than the issue states

The issue says ugrep "takes the status from whether the pattern matched".
Measured on all three shapes of file list, with the real `prose=` pattern:

| file list | `/usr/bin/grep` | `grep` (ugrep 7.5.0) |
| --- | --- | --- |
| only prose | prose only | prose only |
| only code | everything runs | everything runs |
| mixed (#237's own) | everything runs | **prose only** |

So the two agree except where the list mixes the two kinds, which is where
`-v` has both a selected and an unselected line to distinguish. ugrep
inverts the *file's* match status rather than asking whether `-v` selected
anything, and the divergent direction is the expensive one: a matrix
skipped where it should have run. `-cv` agrees with both greps in all three
rows, which is why the wrong answer is silent — the output looks right and
only the status is wrong.

The last row is #237's actual file list (`CHANGELOG.md`, `CLAUDE.md`,
`CONTRIBUTING.md`, `HISTORY.md`, `README.md`, `RELEASING.md`,
`btclib_secp256k1/silentpayments.py`), fetched with the documented `gh api`
command and run through both greps: the documented recipe answers
"everything runs" and a bare `grep` answers "prose only", reproducing the
misreading that raised this.

## Checks

- `uvx pre-commit run --all-files` — exit 0, 37 hooks, no failures
- `https://ugrep.com` answers 200, so the new link does not cost `links` a
  `.lycheeignore` entry
- `grep -qv` still occurs exactly once outside `secp256k1/`, which is what
  lets the entry claim the reproduction is all ugrep touches here

## Summary by Sourcery

Document the CI gate that decides which test jobs run and clarify how to reproduce its result reliably.

Enhancements:
- Document how to reproduce the CI job that determines whether the remaining test workflow jobs run, including the correct grep implementation and workflow pattern.
- Document the required `test: every job passed` check alongside the other CI jobs.

Documentation:
- Update CONTRIBUTING.md and CHANGELOG.md with the missing CI reproduction guidance and the ugrep-specific caveat that can produce an incorrect result for mixed prose and code file lists.