### PR TITLE
Take the public key the caller already has, and say which way a check failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,86 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### The check takes a public key the caller already has
+
+- **`dsa.sign` and `dsa._sign_` take a keyword-only `pubkey`**, the key
+  the check verifies under, so that a caller who already holds it does
+  not pay for deriving it again. It is taken on trust and never checked
+  against the private key on the way in: checking it would cost the
+  point multiplication the argument exists to avoid.
+- **What that saves is most of what ECDSA's check costs over BIP340's.**
+  Measured on an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the five
+  shapes alternated in one process, 9 rounds of 3 000 calls with the
+  minimum of each kept, and the unchecked signature run again at the end
+  so the noise has a figure of its own -- ±0.04 against an unchecked
+  11.72. The check is **20.20** deriving the key per call, **15.08** with
+  a compressed key handed in, **13.06** with an uncompressed one, and
+  **12.80** with the point already parsed and `_sign_` called directly.
+  The 7.40 between the first and the last is the derivation, which is
+  `secp256k1_ec_pubkey_create` through `keys._pubkey_from_prvkey_`;
+  timed alone in a session of the same shape it is 7.31, against a
+  noise of ±0.14. The 7.55 the README carries and the 7.16 measured for
+  `secp256k1_keypair_create` are that other call rather than this one,
+  and land within half a microsecond of it because the two do the same
+  work. Within the handed-in rows, 2.02 is what a compressed key costs
+  to parse over an uncompressed one -- the field square root -- and
+  0.26 is the uncompressed parse: what the parse adds back above the
+  fully parsed row, not slices of the derivation. Under all of it is a
+  bare verification, which is what BIP340's check has always been.
+- **A failed check now says which of two things failed**, and that is
+  what makes the trust affordable rather than merely cheap. A key that
+  is not this private key's makes the verification fail exactly as a
+  faulted computation does, and reporting one as the other would tell a
+  caller their hardware is wrong because they passed the wrong argument.
+  So the failing branch, and only the failing branch, derives the key
+  and asks again: `RuntimeError` where the signature does not verify
+  under the key the private key actually has, `ValueError` where it does
+  and the one handed in is simply not it. The rare branch pays the
+  derivation the common one saved.
+- **The trust cannot let a bad signature through**, which is the
+  property the whole argument rests on and is now a test rather than a
+  paragraph. The keys a signature verifies under are a property of that
+  signature -- `recovery.recover` walks them -- so a key fixed before
+  the signature exists is not one of them.
+  `test_a_key_fixed_in_advance_cannot_pass_a_signature_of_another_key`
+  holds that over forty keys and messages.
+- **And it catches a fault the derived check cannot.** A private key
+  corrupted before it was signed with passes the derived check in
+  silence: the signature and the key it is verified against come out of
+  the same corrupted octets and agree. A key handed in came from
+  somewhere no fault in that call could reach, so it does not agree --
+  which means the `ValueError` names the likelier of two causes rather
+  than the only one, and the docstring says so.
+- **Both halves of the discrimination are held to.** The `ValueError`
+  side has a case of its own; the `RuntimeError` side has one too, and
+  it needs a substituted verification because no input reaches it --
+  `raise RuntimeError` is outside the coverage ratchet, so nothing else
+  would have said that stubbing the second verification to succeed
+  turns every genuine fault under a handed-in key into a report that
+  the caller mistyped an argument. That mutation now fails the suite.
+- **Refused rather than resolved**, as `aux_rand32` beside `grind`
+  already is: a key given with `verify=False` raises, being a caller
+  contradicting themselves, and octets that are not a key are parsed and
+  refused on the way in rather than arriving as a failed check on a
+  signature the caller now holds.
+- **Not on `ssa`, and deliberately.** The check there is 13.2
+  microseconds whether the key is held or not, the keypair already
+  holding the point, so the argument would buy nothing and sell one
+  thing: a second reason a check can fail, and the discrimination step
+  that reason costs. btclib-org/btclib#982 has the measurement.
+- **Not on `recovery` yet, and that is a decision to take rather than
+  one taken.** `_abort_unless_recovered` derives the same key --
+  `keys._pubkey_cmp_(recovered, keys._pubkey_from_prvkey_(...))` -- so
+  the saving available there is exactly the one taken here: the recovery
+  stays and the derivation goes. What differs is the discrimination, a
+  recovered key that is not the one handed in having a third possible
+  cause the two schemes above do not, which is the recovery id. It wants
+  its own measurement and its own cases, so it is left to #246 rather
+  than folded in here.
+- **The README carries all of this**, in the section on the check, which
+  said `verify=False` was the only thing a caller could do about the
+  cost and is where CLAUDE.md puts the design.
+
 ### A signer checks its own signature
 
 - **`dsa.sign` and `ssa.sign` verify what they made before answering

--- a/README.md
+++ b/README.md
@@ -636,6 +636,67 @@ already, which is the same 7.55 the [signer](#two-outposts-past-the-boundary)
 hoists. So the step the specification prescribes is also the cheaper of
 the two, and a `Signer` pays it at the same price as a bare `ssa.sign`.
 
+**`verify=False` is not the only thing a caller can do about that gap.**
+`dsa.sign` takes a `pubkey`, the key the check verifies under, so that a
+caller already holding it does not have the multiplication done again.
+That is most of what ECDSA's check costs above BIP340's, and handing the
+key in brings the two to the same operation — a bare verification. In a
+session of its own, an Apple M5, macOS 26.6, arm64, CPython 3.13.14, nine
+rounds of 3 000 calls with the minimum of each kept, and the unchecked
+signature run a second time so the noise has a figure of its own — its
+`dsa.sign` rows sitting a few tenths under the two sessions above, which
+is between sessions and not within any of them:
+
+| `dsa.sign` | per call | the check |
+| --- | --- | --- |
+| `verify=False` | 11.72 | |
+| the key derived, as before | 31.92 | 20.20 |
+| a compressed key handed in | 26.80 | 15.08 |
+| an uncompressed key handed in | 24.78 | 13.06 |
+| the point already parsed, through `_sign_` | 24.52 | 12.80 |
+| `verify=False` again (the noise) | 11.76 | ±0.04 |
+
+The 7.40 between the second row and the last is the derivation, which is
+`secp256k1_ec_pubkey_create` through `keys._pubkey_from_prvkey_`. Timed
+alone in a session of the same shape it is 7.31, against a noise of
+±0.14. The 7.55 above is a different call — the keypair's own
+multiplication — and lands within half a microsecond of it because the
+two do the same work.
+
+Within the rows where the key is handed in, 2.02 is what a *compressed*
+key costs to parse over an uncompressed one — the field square root that
+recovers y, which is why the longer encoding is the cheaper argument
+here — and 0.26 is the uncompressed parse itself, which only the private
+half avoids. Those are what the parse adds back above the fully parsed
+row, not slices of the derivation above.
+
+The key is taken on trust: checking it against the private key would
+cost the multiplication the argument exists to save. What that would
+otherwise confuse is a wrong argument with a wrong computation, since a
+key that is not this private key's fails verification exactly as a fault
+does, so the failing branch — and only that one — derives the key and
+asks again: `RuntimeError` where the signature does not verify under the
+key the private key actually has, `ValueError` where it does. A key
+handed in beside `verify=False` is refused rather than ignored.
+
+What the trust cannot do is pass a bad signature. The keys a signature
+verifies under are a property of that signature, so a key fixed before
+the signature exists is not one of them, and the argument can cost a
+wrong diagnosis but never a wrong success. It can also catch what the
+derived check cannot: a private key corrupted before it was signed with
+agrees with a public key derived from the same corrupted octets, and
+does not agree with one that came from anywhere else.
+
+`ssa.sign` takes no such argument, and that is a decision rather than an
+omission: its check is a bare verification already, the keypair holding
+the point, so there would be nothing to save and one more way for a
+check to fail. `recovery.sign` is the one where the same saving is
+available and not yet taken — its check derives the very same key before
+comparing what it recovered against it — and what it would cost to take
+is
+[issue 246](https://github.com/btclib-org/btclib-secp256k1/issues/246):
+a third way for the comparison to fail, which is the recovery id.
+
 **`recovery.sign` recovers instead of verifying**, and the difference is
 the recovery id. A verification does not look at it: a recoverable
 signature carrying the wrong one verifies perfectly and then recovers a

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -253,13 +253,85 @@ def _grind(signature: CData, msg_bytes: bytes, prvkey_bytes: bytes) -> None:
         _signed(signature, msg_bytes, prvkey_bytes, entropy)
 
 
-def _sign_(
+def _checked(
+    signature: CData, msg_bytes: bytes, prvkey_bytes: bytes, pubkey: CData | None
+) -> None:
+    """Verify what was just signed, and say which of two things failed.
+
+    The check itself is one call, and everything around it is about a
+    public key a caller may have handed in. It is taken on trust: a
+    signer that derived it to check it would have paid the point
+    multiplication the argument exists to avoid, so what is skipped on
+    the way in is paid for on the way out, and only where it is owed.
+
+    A key that is not this private key's makes the verification fail, and
+    a verification that fails means something quite different -- the
+    computation having gone wrong, memory gone bad or a fault induced,
+    which is what this check is here to catch at all. Reporting one as
+    the other would tell a caller their hardware is faulty because they
+    passed the wrong argument. So the failing branch, and only the
+    failing branch, derives the key and asks again: it is the rare one by
+    construction, and it is where the microseconds saved everywhere else
+    are worth giving back.
+
+    What the trust cannot do is let a bad signature through. The keys
+    under which a signature verifies are a property of that signature --
+    for ECDSA they are what `recovery.recover` walks -- so a key fixed
+    before the signature exists cannot be one of them except by knowing
+    it in advance.
+    `test_a_key_fixed_in_advance_cannot_pass_a_signature_of_another_key`
+    is that property rather than this paragraph.
+
+    What it catches that the derived path cannot is worth knowing too,
+    because it is more than a mistyped argument. A private key corrupted
+    before it was signed with passes the derived check silently: the
+    signature and the key it is checked against both come out of the
+    same corrupted octets, so they agree. A key handed in came from
+    somewhere no fault in this call could have reached, and does not
+    agree -- so the `ValueError` below is raised over a fault the other
+    branch has no way of seeing, and names only the likelier of its two
+    causes.
+
+    Args:
+        signature: the signature just produced, parsed.
+        msg_bytes: the 32-byte hash it was made over, already checked.
+        prvkey_bytes: the 32-byte private key that made it, already
+            checked, and what the failing branch derives from.
+        pubkey: the public key to check against, parsed, or None to
+            derive it -- which is what a caller holding nothing gets.
+
+    Raises:
+        RuntimeError: if the signature does not verify under the key this
+            private key actually has, which is the fault this is for.
+        ValueError: if it verifies under that key but not under the one
+            handed in -- the wrong key given, most likely, or else a
+            private key that was already corrupt when it was signed
+            with, as the paragraph above says.
+    """
+    if pubkey is not None:
+        if _verify_(msg_bytes, pubkey, signature):
+            return
+        # the given key did not verify it, and the two reasons for that
+        # are told apart here rather than guessed at
+        if _verify_(msg_bytes, keys._pubkey_from_prvkey_(prvkey_bytes), signature):
+            raise ValueError("the public key given is not this private key's")
+        raise RuntimeError("signing produced a signature that does not verify")
+
+    if not _verify_(msg_bytes, keys._pubkey_from_prvkey_(prvkey_bytes), signature):
+        raise RuntimeError("signing produced a signature that does not verify")
+
+
+# six arguments here for the reason `sign` below carries at greater
+# length: the four ECDSA questions plus the two this package adds, and
+# `pubkey` is `verify`'s argument rather than a group with any of them
+def _sign_(  # noqa: PLR0913
     msg_bytes: BytesLike,
     prvkey: BytesLike | int,
     aux_rand32: BytesLike | None = None,
     grind: bool = False,
     *,
     verify: bool = True,
+    pubkey: CData | None = None,
 ) -> CData:
     """Create an ECDSA signature, as the parsed signature.
 
@@ -284,6 +356,11 @@ def _sign_(
             signature the grinding settled on: the attempts it discarded
             are never answered with, so a fault in one of them is a
             wasted attempt rather than a published signature.
+        pubkey: the public key to check under, parsed, where the caller
+            already holds it and would rather not have it derived again.
+            Taken on trust; `_checked` says what that does and does not
+            risk. Refused beside `verify=False`, which declines the
+            check it is for.
 
     Returns:
         The libsecp256k1 signature object, in the lower-s form
@@ -292,8 +369,12 @@ def _sign_(
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, if aux_rand32 and grind are given
-            together, or if the private key is not 32 bytes, does not fit
-            in them, or is not in [1, n-1].
+            together, if the private key is not 32 bytes, does not fit
+            in them, or is not in [1, n-1], if a `pubkey` is given beside
+            `verify=False`, or if the signature verifies under the key
+            this private key has and not under the one given -- the
+            wrong key handed in, most likely, and `_checked` says what
+            else it can be.
         RuntimeError: if libsecp256k1 fails to serialize an attempt while
             grinding, which a signature it has just made cannot do, or if
             `verify` asks and the signature does not verify.
@@ -303,20 +384,22 @@ def _sign_(
     if grind and aux_rand32 is not None:
         raise ValueError("aux_rand32 and grind are the same 32 octets")
 
+    if pubkey is not None and not verify:
+        raise ValueError("pubkey is for the check that verify=False declines")
+
     signature = ffi.new("secp256k1_ecdsa_signature *")
     _signed(signature, msg_bytes, prvkey_bytes, optional_entropy(aux_rand32))
     if grind:
         _grind(signature, msg_bytes, prvkey_bytes)
     if verify:
-        # through `_verify_` and `keys._pubkey_from_prvkey_` rather than
-        # through the two public halves, which would serialize this
-        # signature into DER and the point into octets only to parse both
-        # straight back -- and for a compressed key that parse is a field
-        # square root. `normalize` is not passed: libsecp256k1 has just
-        # answered the lower-s form, so there is nothing to normalize
-        pubkey = keys._pubkey_from_prvkey_(prvkey_bytes)
-        if not _verify_(msg_bytes, pubkey, signature):
-            raise RuntimeError("signing produced a signature that does not verify")
+        # `_checked` goes through `_verify_` and `keys._pubkey_from_prvkey_`
+        # rather than through the two public halves, which would serialize
+        # this signature into DER and the point into octets only to parse
+        # both straight back -- and for a compressed key that parse is a
+        # field square root. `normalize` is not passed either: libsecp256k1
+        # has just answered the lower-s form, so there is nothing to
+        # normalize
+        _checked(signature, msg_bytes, prvkey_bytes, pubkey)
     return signature
 
 
@@ -334,6 +417,7 @@ def sign(  # noqa: PLR0913
     grind: bool = False,
     *,
     verify: bool = True,
+    pubkey: BytesLike | None = None,
 ) -> bytes:
     """Create an ECDSA signature.
 
@@ -403,6 +487,15 @@ def sign(  # noqa: PLR0913
             multiplication and a verification, and False is what a
             caller that has measured those against its own threat model
             passes.
+        pubkey: the public key of this private key, where the caller
+            already holds it, so that the check does not derive it
+            again. That derivation is the larger half of what the check
+            costs, and this is how not to pay it twice. It is taken on
+            trust rather than checked against the private key, which
+            would cost the multiplication it saves; where it is wrong,
+            the check says so and says which of the two things went
+            wrong. Refused beside `verify=False`, which declines the
+            check it is for.
 
     Returns:
         The signature, in the lower-s form libsecp256k1 always produces:
@@ -412,10 +505,15 @@ def sign(  # noqa: PLR0913
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
             given and is not 32 bytes, if aux_rand32 and grind are given
-            together, or if the private key is not 32 bytes, does not fit
-            in them, or is not in [1, n-1].
+            together, if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1], if pubkey is not a public key or
+            is given beside `verify=False`, or if pubkey is not this
+            private key's -- which is told apart from the failure below
+            rather than reported as it.
         RuntimeError: if libsecp256k1 fails to serialize the signature,
-            which no input can make it do.
+            which no input can make it do, or if the check asks and the
+            signature does not verify under the key this private key
+            actually has.
 
     Example:
         >>> import hashlib
@@ -426,6 +524,13 @@ def sign(  # noqa: PLR0913
         >>> dsa.sign(msg, 1, grind=True, compact=True)[0] < 0x80
         True
     """
+    # the contradiction before the value, and in that order deliberately:
+    # a caller who asked for no check and handed in a key to check with
+    # should hear about the two arguments rather than about the octets of
+    # one of them, which is what parsing first would have told them
+    if pubkey is not None and not verify:
+        raise ValueError("pubkey is for the check that verify=False declines")
+
     # composed, where `verify` below is spelled out: the frames this
     # would save were measured and are not there. Shipped against a
     # spelling with `_sign_` inlined, with the DER serialization inlined,
@@ -434,7 +539,18 @@ def sign(  # noqa: PLR0913
     # three land within 0.03 microseconds of this one and on the wrong
     # side of it. A signature is 11.9 microseconds of libsecp256k1, and
     # two python frames do not show against it
-    signature = _sign_(msg_bytes, prvkey, aux_rand32, grind, verify=verify)
+    signature = _sign_(
+        msg_bytes,
+        prvkey,
+        aux_rand32,
+        grind,
+        verify=verify,
+        # parsed here rather than inside `_checked`, so that octets which
+        # are not a public key are refused before anything is signed: a
+        # caller who mistyped an argument should not be told about it by
+        # a check on a signature they now hold
+        pubkey=None if pubkey is None else keys.parse(pubkey),
+    )
     return serialize_compact(signature) if compact else serialize_der(signature)
 
 

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -40,6 +40,14 @@ away -- so the last test in this file needs no stand-in at all: it
 signs, re-parses under each id, and holds real libsecp256k1 to refusing
 every one but the signature's own, while a verification of the same
 octets still succeeds.
+
+`dsa` adds a group of its own, for the public key a caller may hand the
+check instead of having it derived. Those turn on the key being taken on
+trust: what it costs -- a failure that has two causes, told apart in both
+directions, one of them needing the same stand-in as above -- and what it
+cannot cost, which is a signature wrongly accepted. That last one is the
+strongest thing in this file, and the only one here that is a property
+over many keys rather than a case.
 """
 
 from __future__ import annotations
@@ -403,3 +411,112 @@ def test_the_recovery_id_is_what_the_check_catches() -> None:
     assert dsa._verify_(
         MSG, keys._pubkey_from_prvkey_(PRVKEY_BYTES), dsa.parse_compact(signature)
     )
+
+
+def test_a_key_handed_in_is_the_key_that_would_have_been_derived() -> None:
+    """The signature is the same one, whichever way the check got its key.
+
+    What the argument is for is skipping a point multiplication, so what
+    has to hold is that nothing else changed with it: the same message
+    and key answer the same octets in both serializations and with the
+    grinding loop, which is the third place the check could have been
+    reached from.
+    """
+    uncompressed = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+    compressed = keys.pubkey_from_prvkey(PRVKEY, compressed=True)
+    for compact, grind in ((False, False), (True, False), (False, True)):
+        derived = dsa.sign(MSG, PRVKEY, None, compact, grind)
+        for held in (uncompressed, compressed):
+            assert dsa.sign(MSG, PRVKEY, None, compact, grind, pubkey=held) == derived
+
+
+def test_the_wrong_key_is_told_apart_from_a_wrong_computation() -> None:
+    """A key that is not this private key's is an argument, not a fault.
+
+    The whole reason the failing branch derives: without it a caller who
+    passed the wrong key is told the computation went wrong, which is
+    what `RuntimeError` means here and what somebody would go looking
+    for their hardware over. The two are distinguishable only by which
+    exception arrives, since the signature is fine either way.
+    """
+    other = keys.pubkey_from_prvkey(PRVKEY + 1, compressed=False)
+    with pytest.raises(ValueError, match="not this private key's"):
+        dsa.sign(MSG, PRVKEY, pubkey=other)
+
+
+def test_octets_that_are_not_a_key_are_refused_before_anything_is_signed() -> None:
+    """Parsed on the way in, so a mistyped argument is not a verdict.
+
+    A key parsed inside the check would make bad octets arrive as a
+    failed verification of a signature the caller now holds, which reads
+    as the signature being wrong. Refusing at the boundary is the same
+    discipline every other argument of this package gets.
+    """
+    with pytest.raises(ValueError, match="invalid public key"):
+        dsa.sign(MSG, PRVKEY, pubkey=b"\x02" + bytes(32))
+
+
+def test_a_key_is_refused_beside_the_flag_that_declines_the_check() -> None:
+    """A key to check with is refused where the check is declined.
+
+    `verify=False` and a key to check under is a caller contradicting
+    themselves, and the package answers those rather than resolving
+    them -- as it does for `aux_rand32` beside `grind`.
+    """
+    pubkey = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+    with pytest.raises(ValueError, match="verify=False declines"):
+        dsa.sign(MSG, PRVKEY, verify=False, pubkey=pubkey)
+
+
+def test_the_private_half_refuses_that_contradiction_too() -> None:
+    """`_sign_` is the row the table recommends, not an internal detail.
+
+    A caller holding a parsed point calls `_sign_` to save the parse, so
+    the private half is where the argument is cheapest and the one place
+    a `pubkey` must not be ignored beside `verify=False`. The copy of the
+    refusal there is for that caller, and this is the case that reaches
+    it -- the same reason `test_every_signer_defaults_to_checking`
+    exists.
+    """
+    with pytest.raises(ValueError, match="verify=False declines"):
+        dsa._sign_(
+            MSG, PRVKEY, verify=False, pubkey=keys._pubkey_from_prvkey_(PRVKEY_BYTES)
+        )
+
+
+def test_a_key_fixed_in_advance_cannot_pass_a_signature_of_another_key() -> None:
+    """What makes taking the key on trust safe, stated as a property.
+
+    The keys a signature verifies under are a property of that signature
+    -- `recovery.recover` walks them -- so a key chosen before the
+    signature exists is not one of them. That is why the trust can cost
+    a wrong diagnosis and never a wrong success, and it is checked here
+    over keys and messages rather than argued in a docstring.
+    """
+    wrong = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+    for other_key in range(PRVKEY + 1, PRVKEY + 41):
+        msg = hashlib.sha256(other_key.to_bytes(32, "big")).digest()
+        with pytest.raises(ValueError, match="not this private key's"):
+            dsa.sign(msg, other_key, pubkey=wrong)
+
+
+def test_a_fault_under_a_handed_in_key_is_not_reported_as_a_wrong_key() -> None:
+    """The other half of the discrimination, and the one coverage hides.
+
+    `raise RuntimeError` is outside the coverage ratchet by design, so a
+    hundred percent says nothing about this branch. What it guards is the
+    inversion of the misdiagnosis the whole argument is built to avoid:
+    with the second verification stubbed to succeed, every genuine fault
+    met under a handed-in key would be reported as "the public key given
+    is not this private key's" -- a caller told they mistyped an argument
+    because their hardware went wrong.
+
+    The key handed in here is the right one, so the only reason either
+    verification can fail is the substitution, and what has to arrive is
+    the fault.
+    """
+    pubkey = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+    with pytest.MonkeyPatch.context() as patch:
+        _refuse_every_check(patch)
+        with pytest.raises(RuntimeError, match=_UNVERIFIED):
+            dsa.sign(MSG, PRVKEY, pubkey=pubkey)


### PR DESCRIPTION
`dsa.sign` derives the public key on every checked signature and drops
it. That derivation is a point multiplication and it is most of what
ECDSA's check costs over BIP340's, so a caller who already holds the key
-- a psbt signer, a wallet that has the address, anything signing twice
under one key -- pays for it anyway.

`dsa.sign` and `dsa._sign_` now take a keyword-only `pubkey`, and the
check verifies under it. Measured against a signature of 11.76
microseconds, an Apple M5, macOS 26.6, arm64, CPython 3.13.14, the five
shapes alternated in one process, 9 rounds of 3 000 calls with the
minimum of each kept, and the unchecked signature run again at the end
so the noise has a figure of its own:

| `dsa.sign` | per call | the check |
| --- | --- | --- |
| `verify=False` | 11.72 | |
| the key derived, as before | 31.92 | 20.20 |
| a compressed key handed in | 26.80 | 15.08 |
| an uncompressed key handed in | 24.78 | 13.06 |
| the point already parsed, through `_sign_` | 24.52 | 12.80 |
| `verify=False` again (the noise) | 11.76 | ±0.04 |

The 7.40 between the second row and the last is the derivation, which
is `secp256k1_ec_pubkey_create` through `keys._pubkey_from_prvkey_`;
timed alone in a session of the same shape it is 7.31, against a noise
of 0.14. The 7.55 the README carries and the 7.16 measured for
`secp256k1_keypair_create` are that other call, and land within half a
microsecond of it because the two do the same work. Within the
handed-in rows, 2.02 is what a compressed key costs to parse over an
uncompressed one -- the field square root that recovers y, which is why
the longer encoding is the cheaper argument -- and 0.26 is the
uncompressed parse itself: what the parse adds back above the fully
parsed row, not slices of the derivation. Under all of it is a bare
verification, which is what BIP340's check has always been.

## Taken on trust, and the failing branch pays for it

Checking the key against the private key on the way in would cost the
multiplication the argument exists to avoid. So it is not checked -- and
that changes what a failed check *means*, a key that is not this private
key's failing verification exactly as a faulted computation does.
Telling a caller their hardware is wrong because they mistyped an
argument is worse than the microseconds are worth.

`_checked` is where that is resolved and it is the whole of the new
logic: where a supplied key fails, and only there, it derives and asks
again. `RuntimeError` if the signature does not verify under the key the
private key actually has, which is the fault this check has always been
for; `ValueError` if it does and the supplied one is simply not it. The
rare branch pays back the derivation the common one saved.

## What the trust cannot do

It cannot let a bad signature through, and that is the property the
argument rests on. The keys a signature verifies under are a property of
that signature -- `recovery.recover` walks them -- so a key fixed before
the signature exists is not one of them, and the trust can cost a wrong
diagnosis but never a wrong success.
`test_a_key_fixed_in_advance_cannot_pass_a_signature_of_another_key`
holds that over forty keys and messages rather than leaving it in a
docstring.

## Refused rather than resolved

A key given beside `verify=False` raises: the check it is for is the one
that flag declines, and this package answers a caller contradicting
themselves rather than picking for them, as it already does for
`aux_rand32` beside `grind`. Octets that are not a key are parsed and
refused on the way in, so a mistyped argument does not arrive as a
failed check on a signature the caller is now holding.

## Not on `ssa`

The check there costs 13.2 microseconds whether the key is held or not,
so the argument would buy nothing and sell one thing: a second reason a
check can fail. Its absence is a decision.

## Verification

`uv run pytest` -- 647 passed, coverage back at 100. `uv run pre-commit
run --all-files` is clean, every hook, no skips.

`tests/test_verified_signing.py` gains seven cases: the signature
unchanged in both serializations and while grinding, the wrong key told
apart from a wrong computation, bad octets refused early, a key refused
beside `verify=False` and the same refusal reached through `_sign_`, the
property above, and the other half of the discrimination -- which needs
a substituted verification, `raise RuntimeError` being outside the
coverage ratchet, and which fails if the second verification is stubbed
to succeed.

The private half keeps its own copy of the contradiction rather than
leaning on `sign`'s: `_sign_` is the row the table recommends to a
caller holding a parsed point, so it is the one place a `pubkey` beside
`verify=False` must not be silently ignored.

`recovery` has the same derivation available to save and a third way for
the comparison to fail, so what it would take is
btclib-org/btclib-secp256k1#246 rather than a paragraph here.

The README's section on the check carries the design, the table and the
reasoning; the CHANGELOG carries the record behind it.

Part of btclib-org/btclib#982, whose comment carries the design this
implements. The `dsa.Signer` that issue also asks for is not here: it
needs the private key to live in memory this package owns, and `scalar`
coerces every path to an immutable `bytes`, so a `Signer` offering
`wipe` would promise what it cannot keep. What settling that would take
is btclib-org/btclib-secp256k1#247.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Let checked ECDSA signing reuse a caller-provided public key and clearly classify verification failures.

New Features:
- Allow callers to provide an existing public key to `dsa.sign` and `dsa._sign_` for signature verification.

Bug Fixes:
- Distinguish an incorrect supplied public key from a signature verification failure using separate exceptions.
- Reject invalid public keys before signing and reject public keys when verification is disabled.

Enhancements:
- Avoid repeated public-key derivation during checked ECDSA signing while preserving verification safety guarantees.

Documentation:
- Document the supplied-public-key verification behavior, failure semantics, performance impact, and its deliberate scope.

Tests:
- Add coverage for supplied-key signing, validation, contradictory arguments, failure classification, and prevention of false verification success.