### PR TITLE
Say whose refusal the lower-s form is, and what normalize accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1913,6 +1913,24 @@ release-notes length in the first place, and are still in
   `serialize_label` does with it is the other kind of use and is named
   as such — unpacking the buffer this module declared, which is exactly
   what `keys` does with its own.
+- **`dsa.verify` says whose refusal the lower-s form is** (#249). The
+  docstring motivated the default by who wants it -- "what a caller
+  enforcing the lower-s form of its own signatures wants" -- which reads
+  as this wrapper choosing between two behaviours libsecp256k1 offers. It
+  is the other way round: `secp256k1_ecdsa_verify` accepts the lower-s
+  form alone, "to avoid accepting malleable signatures", so `False` is
+  that call passed through and `normalize=True` is the one way of not
+  passing it through. Which is also what makes the flag unlike the rest
+  of this module's booleans: `grind` and `verify` weigh a cost against a
+  benefit and `compact` picks a serialization, where this one spends no
+  measurable time and pays in the malleability itself -- two encodings
+  verifying one message under one key, which whatever hashes or stores
+  the signature has both to account for. Bitcoin Core makes the same
+  refusal a standardness rule, `SCRIPT_VERIFY_LOW_S`, so a signature
+  from elsewhere and a signature a transaction can carry are not the same
+  set, and "a caller checking signatures it did not make normalizes" is
+  now stated with what it accepts in exchange. `_verify_`'s argument
+  entry, which has no prose above it to lean on, points at both.
 
 ### CI
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -577,7 +577,9 @@ def _verify_(
             `parse_compact` return. Mutated in place where `normalize`
             asks for it.
         normalize: whether to verify the lower-s form of the signature
-            rather than reject a signature that is not in it.
+            rather than reject a signature that is not in it. The
+            rejection is `secp256k1_ecdsa_verify`'s own, and `verify`
+            documents what accepting the other form costs.
 
     Returns:
         True if the signature is valid for that key and message -- and
@@ -609,12 +611,25 @@ def verify(
     """Verify a ECDSA signature.
 
     A signature which is not in the normalized lower-s form is rejected,
-    unless `normalize` is set: which of the two forms a signature carries
-    was the signer's choice, so a caller checking signatures it did not
-    make normalizes rather than refuses, and says so here rather than
-    round-tripping the signature through `normalize` and back into DER.
-    The default is the refusal, that being what a caller enforcing the
-    lower-s form of its own signatures wants.
+    and the refusal is libsecp256k1's rather than this wrapper's:
+    `secp256k1_ecdsa_verify` accepts the lower-s form alone, so that the
+    second signature `is_low_s` describes does not verify. `normalize` is
+    therefore not a choice between two behaviours the library offers but
+    the one way of declining to pass that refusal on, and what it
+    verifies is s replaced by n - s -- a signature the caller was never
+    handed.
+
+    Which of the two forms a signature carries was the signer's choice,
+    so a caller checking signatures it did not make normalizes rather
+    than refuses, and says so here rather than round-tripping the
+    signature through `normalize` and back into DER. What it accepts in
+    exchange is the malleability itself: two encodings verify one message
+    under one key, and whatever hashes or stores the signature has both
+    to account for. Bitcoin Core makes the same refusal a standardness
+    rule, `SCRIPT_VERIFY_LOW_S`, so a signature from elsewhere and a
+    signature a transaction can carry are not the same set. The default
+    is the refusal, that being what a caller enforcing the lower-s form
+    of its own signatures wants too.
 
     Args:
         msg_bytes: the 32-byte hash of the message.
@@ -622,7 +637,9 @@ def verify(
         signature_bytes: the signature, DER encoded or the 64 octets of
             `r || s`, as `compact` says.
         normalize: whether to verify the lower-s form of the signature
-            rather than reject a signature that is not in it.
+            rather than reject a signature that is not in it. The
+            rejection is libsecp256k1's, and True is what accepts the
+            malleability it rules out.
         compact: whether the signature is the 64-byte `r || s` rather
             than DER. Which of the two it is has to be said and cannot be
             read off the length: a DER signature of 64 octets exists,


### PR DESCRIPTION
`dsa.verify` motivated `normalize=False` by who wants it — "what a caller
enforcing the lower-s form of its own signatures wants" — which reads as
this wrapper choosing between two behaviours libsecp256k1 offers. It is
the other way round, and `secp256k1.h` says so where
`secp256k1_ecdsa_verify` is declared: "To avoid accepting malleable
signatures, only ECDSA signatures in lower-S form are accepted." So
`False` is that call passed through, and `normalize=True` is the one way
of not passing it through.

Which is what makes the flag unlike the rest of the module's booleans,
and the reason the asymmetry is worth a paragraph: `grind` and `verify`
weigh a cost against a benefit, `compact` picks a serialization, and this
one spends no measurable time and pays in the malleability itself — two
encodings verifying one message under one key, which whatever hashes or
stores the signature has both to account for. Bitcoin Core makes the same
refusal a standardness rule, `SCRIPT_VERIFY_LOW_S`, so a signature from
elsewhere and a signature a transaction can carry are not the same set:
that is the half of "a caller checking signatures it did not make
normalizes" the docstring left out.

`_verify_` carries the same argument with no prose above it to lean on,
so its entry now points at libsecp256k1 for the rejection and at `verify`
for what accepting the other form costs.

Docstrings and a CHANGELOG bullet: no behaviour changes, and the suite
already holds the behaviour described —
`tests/test_keys.py::test_dsa_verify_normalizes_when_it_is_told_to` and
the malleated-signature case before it.

Gate and suite, in a worktree on this commit: `uvx pre-commit run
--all-files` green, 37 hooks; `uv run --locked --no-default-groups --group
test pytest --cov` 647 passed, 100% coverage.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the ownership and implications of lower-S signature rejection and normalization in the ECDSA verification documentation.

Enhancements:
- Clarify that lower-S signature rejection is enforced by libsecp256k1 and explain the malleability trade-off of enabling normalization.

Documentation:
- Update the changelog with the clarified lower-S verification semantics and normalization trade-offs.