### PR TITLE
Compare the recovered key with the one the caller already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,101 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### The recoverable check takes that key too
+
+- **`recovery.sign` and `recovery._sign_` take a keyword-only `pubkey`**
+  (#246), the key the recovered one is compared with, so that
+  `_abort_unless_recovered` no longer derives a key the caller is
+  holding. Everything around it is what #245 settled for `dsa` and is
+  not restated in a second shape: the key is taken on trust, it is
+  refused beside `verify=False` in both halves, and octets are parsed at
+  the boundary so that a mistyped argument is refused before anything is
+  signed rather than arriving as a verdict on a signature the caller now
+  has.
+- **The dearest check of the three, and the same saving as `dsa`'s.**
+  Measured in one session with `dsa.sign` beside it so the two
+  are comparable rather than merely printed together -- an Apple M5,
+  macOS 26.6, arm64, CPython 3.14.6, nine rounds of 3 000 calls with the
+  minimum of each kept, the private key handed in as octets in every row,
+  and the unchecked signature run a second time so the noise has a figure
+  of its own:
+
+  | `recovery.sign` | per call | the check |
+  | --- | --- | --- |
+  | `verify=False` | 12.07 | |
+  | the key derived, as before | 35.00 | 22.93 |
+  | a compressed key handed in | 29.67 | 17.60 |
+  | an uncompressed key handed in | 27.49 | 15.42 |
+  | the point already parsed, through `_sign_` | 27.25 | 15.18 |
+  | `verify=False` again (the noise) | 12.09 | ±0.02 |
+
+  `dsa.sign` in that same session was 12.14 unchecked, 31.97 with the key
+  derived and 24.55 with an uncompressed one handed in, so its check went
+  19.83 to 12.41 -- both within a few tenths of #245's own session, which
+  is between sessions and not within either. The 7.51 removed here is
+  `secp256k1_ec_pubkey_create` and nothing besides: timed alone in the
+  same session it is 7.53. The 2.18 between the two serializations is the
+  field square root that recovers y and the 0.24 under it is the
+  uncompressed parse only the private half avoids, both agreeing with the
+  2.02 and 0.26 measured for `dsa`. What is left is what a recovery and a
+  comparison cost over a verification, and it is the same ~3 microseconds
+  before and after -- 22.93 against 19.83 derived, 15.42 against 12.41
+  handed in -- which is what says the argument removed the derivation and
+  changed nothing else.
+
+  Which also settles a guess #246 made before anything was measured:
+  "It is the scheme whose check is doing the most work, so the saving is
+  largest". The check is the most work, 22.93 against 19.83; the saving
+  is not larger. 7.51 here against 7.42 in `dsa` is 0.09, in a session
+  whose own noise row is ±0.02 but which calls a 0.16 difference between
+  the two square roots "agreeing" -- and both land on the 7.53 the call
+  costs timed alone, which is the reading that matches "and nothing
+  besides". The saving is one `secp256k1_ec_pubkey_create`, in both
+  modules, at one price.
+- **A mismatch now has three causes, and two of them share an answer.**
+  The key given is not this private key's, the recovery id is not the
+  signature's, or the computation faulted; the first is an argument and
+  the other two are not. One comparison separates them and it is paid
+  only where something already went wrong: the recovered key against the
+  derived one. Where those agree the signature is the signer's and the
+  argument is wrong, which is the `ValueError`; where they do not, the
+  signature does not recover its own signer, which is what a wrong id and
+  a fault both look like from here. That they share the `RuntimeError` is
+  the decision rather than an oversight -- a caller of `sign` cannot pass
+  an id at all, it coming back from `secp256k1_ecdsa_sign_recoverable`
+  beside the signature, so an id that is not the signature's is a fault
+  by the time the check runs.
+- **So the discrimination is `dsa`'s shape, and the third cause is what
+  the issue asked about.** #246 left open whether `recovery` should take
+  the argument at all, the saving being the largest and the diagnosis
+  having the most ways to go wrong. What decided it is that the third
+  cause needs no third message: it is unreachable from any argument of
+  `sign`, and where it is reachable -- through the parsed signature the
+  private half takes -- it is the fault the `RuntimeError` already names.
+  So the cost of taking the saving is one comparison on a path that was
+  already failing.
+- **The case no other module in this package can write.** A wrong
+  recovery id is one `parse_compact` away, so all three causes are
+  reachable with no stand-in anywhere:
+  `test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key`
+  signs once and asks the real libsecp256k1 three questions -- the
+  signature's own id under the signer's key, the other id under that same
+  key, and the signature's own id under a stranger's -- and holds the
+  first to passing and the other two to the two different exceptions.
+  Both misdiagnoses are what it rules out: a right key with a wrong id
+  reported as a wrong argument, and a wrong key reported as a fault.
+- **The rest of the group is `dsa`'s, asserted again here** rather than
+  assumed to carry over: the same signature and the same recovery id
+  whichever way the check got its key and in both serializations of it,
+  the refusal of a key beside `verify=False` in both halves, octets that
+  are not a key refused before signing, and the property over forty keys
+  and messages -- which is a stronger sentence here than there, since the
+  key handed in has to be the single key the signature recovers rather
+  than one of the keys it verifies under.
+- **The README's section on the check carries the tables**, and the
+  sentence that said the saving was "available and not yet taken" for
+  `recovery` is now the one that says what taking it cost.
+
 ### The check takes a public key the caller already has
 
 - **`dsa.sign` and `dsa._sign_` take a keyword-only `pubkey`**, the key
@@ -89,15 +184,15 @@ release-notes length in the first place, and are still in
   holding the point, so the argument would buy nothing and sell one
   thing: a second reason a check can fail, and the discrimination step
   that reason costs. btclib-org/btclib#982 has the measurement.
-- **Not on `recovery` yet, and that is a decision to take rather than
-  one taken.** `_abort_unless_recovered` derives the same key --
-  `keys._pubkey_cmp_(recovered, keys._pubkey_from_prvkey_(...))` -- so
-  the saving available there is exactly the one taken here: the recovery
-  stays and the derivation goes. What differs is the discrimination, a
-  recovered key that is not the one handed in having a third possible
-  cause the two schemes above do not, which is the recovery id. It wants
-  its own measurement and its own cases, so it is left to #246 rather
-  than folded in here.
+- **Not folded in for `recovery`, and taken there in a change of its
+  own** (#246, the section above). `_abort_unless_recovered` derived the
+  same key -- `keys._pubkey_cmp_(recovered,
+  keys._pubkey_from_prvkey_(...))` -- so the saving available there was
+  exactly the one taken here: the recovery stays and the derivation goes.
+  What differed was the discrimination, a recovered key that is not the
+  one handed in having a third possible cause the two schemes above do
+  not, which is the recovery id. That wanted a measurement and cases of
+  its own, and is what got them.
 - **The README carries all of this**, in the section on the check, which
   said `verify=False` was the only thing a caller could do about the
   cost and is where CLAUDE.md puts the design.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -109,6 +109,30 @@ against each other and not across two runs of the machine.
 So every signing call of the package now checks itself, and the same
 `verify=False` declines any of them.
 
+**And the check can be handed a key you already hold.** `dsa.sign` and
+`recovery.sign` take a keyword-only `pubkey`, the public key of the
+private key that is signing, so that the check verifies or compares
+against it rather than deriving it again:
+
+```diff
+-sig = dsa.sign(msg, prvkey)
++sig = dsa.sign(msg, prvkey, pubkey=pubkey)
+```
+
+That derivation is most of what ECDSA's check costs over BIP340's, and it
+is one call at one price in both modules — what differs is the check
+around it, `recovery`'s being the dearest of the three. Measured in one
+session, which is what makes the pair comparable: `dsa.sign` 31.97
+microseconds with the key derived and 24.55 with an uncompressed one
+handed in, `recovery.sign` 35.00 and 27.49. The key is taken on trust
+rather than checked against the private one, that check being the very
+multiplication the argument saves — so a key that is not this private
+key's raises `ValueError` and says so, which
+is told apart from the `RuntimeError` that means the computation went
+wrong. A `pubkey` beside `verify=False` is refused rather than ignored,
+and `ssa` takes no such argument because its keypair already holds the
+point.
+
 What the rest of the release adds: one for a caller that signs more than
 once under one key, one for a caller whose ECDSA signatures go into a
 transaction, one for a caller computing a taproot output key from a

--- a/README.md
+++ b/README.md
@@ -690,12 +690,12 @@ does not agree with one that came from anywhere else.
 `ssa.sign` takes no such argument, and that is a decision rather than an
 omission: its check is a bare verification already, the keypair holding
 the point, so there would be nothing to save and one more way for a
-check to fail. `recovery.sign` is the one where the same saving is
-available and not yet taken — its check derives the very same key before
-comparing what it recovered against it — and what it would cost to take
-is
-[issue 246](https://github.com/btclib-org/btclib-secp256k1/issues/246):
-a third way for the comparison to fail, which is the recovery id.
+check to fail. `recovery.sign` takes it: its check derived the very same
+key before comparing what it recovered against it, and that check is the
+dearest of the three. The saving is not larger for that, being the same
+call at the same price, and the table below is where both are read. What
+taking it cost is a third cause a mismatch can have, which is the
+recovery id.
 
 **`recovery.sign` recovers instead of verifying**, and the difference is
 the recovery id. A verification does not look at it: a recoverable
@@ -737,6 +737,49 @@ as it is in Core, whose `CKey::Sign` verifies the
 defensible, the serializers being memcpy-shaped where the signing is
 arithmetic, and the difference is worth a sentence rather than a
 change.
+
+**The derivation inside it is what a caller can hand in**, exactly as
+`dsa.sign` takes it. Measured in one session with `dsa.sign` beside it so
+that the two are comparable rather than merely printed together — an
+Apple M5, macOS 26.6, arm64, CPython 3.14.6, nine rounds of 3 000 calls
+with the minimum of each kept, and the unchecked signature run a second
+time so the noise has a figure of its own:
+
+| `recovery.sign` | per call | the check |
+| --- | --- | --- |
+| `verify=False` | 12.07 | |
+| the key derived, as before | 35.00 | 22.93 |
+| a compressed key handed in | 29.67 | 17.60 |
+| an uncompressed key handed in | 27.49 | 15.42 |
+| the point already parsed, through `_sign_` | 27.25 | 15.18 |
+| `verify=False` again (the noise) | 12.09 | ±0.02 |
+
+`dsa.sign` in that same session was 12.14 unchecked, 31.97 with the key
+derived and 24.55 with an uncompressed one handed in — a check of 19.83
+becoming 12.41 — which puts both of its tables here within a few tenths
+of the ones above, between sessions and not within either. The 7.51 the
+argument removes is `secp256k1_ec_pubkey_create` and nothing else: timed
+alone in the same session it is 7.53. The 2.18 between the two
+serializations is the field square root that recovers y, and the 0.24
+under it is the uncompressed parse only the private half avoids. What
+stays is what a recovery and a comparison cost over a verification, about
+3 microseconds either way it is read — 15.42 against 12.41 with a key
+handed in, 22.93 against 19.83 with it derived — and that it is the same
+3 both times is what says the argument took the derivation away and left
+the rest alone.
+
+The diagnosis costs one comparison more than `dsa`'s, and pays it only
+where something is already wrong. A mismatch here has three causes where
+`dsa`'s has two — the key given, the recovery id, or the computation —
+and the derivation the matching path skipped is what separates the one
+that is an argument from the two that are not. Where the recovered key
+is the signer's after all, the key handed in is the wrong one, which is a
+`ValueError`; where it is not, the signature does not recover its own
+signer, which is what a wrong id and a fault both look like from here.
+Neither of those is anything a caller of `sign` passed — the id comes
+back from `secp256k1_ecdsa_sign_recoverable` beside the signature, so a
+wrong one is a fault by the time the check runs — and that is why the two
+share the `RuntimeError`.
 
 Every other microsecond figure in this file was measured before this
 argument existed and is therefore the signature without the check:

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -34,7 +34,7 @@ _COMPACT_BUFFER_TYPE = ffi.typeof(f"char[{_COMPACT_SIZE}]")
 
 
 def _abort_unless_recovered(
-    signature: CData, msg_bytes: bytes, prvkey_bytes: bytes
+    signature: CData, msg_bytes: bytes, prvkey_bytes: bytes, pubkey: CData | None
 ) -> None:
     """Recover from a signature just made, and refuse another key.
 
@@ -65,13 +65,47 @@ def _abort_unless_recovered(
     it raises where a `_foo_` half would answer, and the verb is the one
     BIP340 uses of the step.
 
+    **A key handed in is compared with instead of derived**, which is
+    `dsa._checked`'s arrangement and buys the same
+    `secp256k1_ec_pubkey_create` here, at the same price it costs there:
+    what is dearest in this package is the check, not the saving. What it
+    costs is that a mismatch now has three causes where `dsa`'s has two:
+    the key given is not this private key's, the recovery id is not the
+    signature's, or
+    the computation faulted. The first is an argument and the other two
+    are not, and one comparison separates them -- the recovered key
+    against the derived one, paid only where something already went
+    wrong. Where they agree, the signature is the signer's and it is the
+    argument that is wrong; where they do not, the signature does not
+    recover its own signer, which is what a wrong id and a fault both
+    look like from here and neither is anything the caller passed.
+
+    That those two share an answer is the decision rather than an
+    oversight. A caller of `sign` cannot pass an id at all -- it comes
+    back from `secp256k1_ecdsa_sign_recoverable` beside the signature --
+    so an id that is not the signature's is a fault by the time this
+    runs, and `test_the_recovery_id_is_what_the_check_catches` reaches
+    that state the only way anything can: through the parsed signature
+    this private half takes.
+
     **Neither call below needs a `context.check` behind it, and both are
     the kind that usually would.** `keys._pubkey_cmp_` answers an
     ordering that means nothing where libsecp256k1 could not read an
-    object, and that answer is a security decision here -- but both
-    objects come from calls that returned success a line earlier, so the
-    only way its `0` could lie is both keys being unreadable at once,
-    which is not a state either call can leave behind. And
+    object, and that answer is a security decision here. One of the two
+    objects is no longer proved by a preceding success: `recovered` is,
+    but `pubkey` is what this half takes on trust, and a caller handing
+    in a `secp256k1_pubkey` nothing has written to reaches
+    `secp256k1_ec_pubkey_cmp` with it -- so an illegal argument *is*
+    recorded on the thread here, which the comparison against a derived
+    key could not do. What holds instead is the comparison itself:
+    libsecp256k1 serializes a key it cannot load as 33 zero octets,
+    documented there as "less than any valid public key", and the
+    recovered key is readable and serializes with an `0x02` or `0x03`
+    prefix. So the `0` still cannot lie -- an unreadable key compares
+    *unequal*, the fall-through derives, and what the caller is told is
+    that the key they gave is not this private key's, which is the truth
+    about it. `dsa._verify_` documents the same trust from the other
+    side, and `dsa._checked` passes such a key straight into it. And
     `keys._pubkey_from_prvkey_` raises a `ValueError` for a key outside
     [1, n-1], which this one is not: libsecp256k1 accepted it for signing
     immediately above. That is why `_recover_`'s `ValueError` is
@@ -84,13 +118,20 @@ def _abort_unless_recovered(
         signature: the recoverable signature just made.
         msg_bytes: the 32-byte hash it was made over, already checked.
         prvkey_bytes: the 32-byte private key that made it, already
-            checked.
+            checked, and what the failing branch derives from.
+        pubkey: the public key the recovered one is compared with,
+            parsed, or None to derive it -- which is what a caller
+            holding nothing gets.
 
     Raises:
         RuntimeError: if no key recovers from the signature, or if the
             one that does is not the signer's. Neither is reachable by
-            any input: what they report is the computation itself having
-            gone wrong.
+            any input to `sign`: what they report is the computation
+            itself having gone wrong, the recovery id included.
+        ValueError: if the recovered key is the signer's and not the one
+            handed in, which is the wrong key given -- or a private key
+            that was already corrupt when it was signed with, as
+            `dsa._checked` says of the same branch.
     """
     try:
         recovered = _recover_(msg_bytes, signature)
@@ -102,8 +143,14 @@ def _abort_unless_recovered(
         raise RuntimeError("signing produced a signature no key recovers from") from (
             failure
         )
+    if pubkey is not None and not keys._pubkey_cmp_(recovered, pubkey):
+        return
+    # either nothing was handed in, or what was did not match: the
+    # derivation the common path skipped is what says which
     if keys._pubkey_cmp_(recovered, keys._pubkey_from_prvkey_(prvkey_bytes)):
         raise RuntimeError("signing produced a signature that recovers another key")
+    if pubkey is not None:
+        raise ValueError("the public key given is not this private key's")
 
 
 def _sign_(
@@ -112,6 +159,7 @@ def _sign_(
     aux_rand32: BytesLike | None = None,
     *,
     verify: bool = True,
+    pubkey: CData | None = None,
 ) -> CData:
     """Create a recoverable ECDSA signature, as the parsed signature.
 
@@ -130,19 +178,32 @@ def _sign_(
         verify: whether to recover the key from the signature and refuse
             one that is not the signer's, as `sign` documents and
             `_abort_unless_recovered` reasons about.
+        pubkey: the public key the recovered one is compared with,
+            parsed, where the caller already holds it and would rather
+            not have it derived again. Taken on trust;
+            `_abort_unless_recovered` says what that does and does not
+            risk. Refused beside `verify=False`, which declines the
+            check it is for.
 
     Returns:
         The libsecp256k1 recoverable signature object.
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
-            given and is not 32 bytes, or if the private key is not 32
-            bytes, does not fit in them, or is not in [1, n-1].
+            given and is not 32 bytes, if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1], if a
+            `pubkey` is given beside `verify=False`, or if the recovered
+            key is this private key's and not the one given -- the wrong
+            key handed in, most likely, and `_abort_unless_recovered`
+            says what else it can be.
         RuntimeError: if `verify` asks and the signature does not recover
             the key that made it.
     """
     prvkey_bytes = scalar(prvkey, "private key")
     msg_bytes = octets(msg_bytes, "message hash", 32)
+
+    if pubkey is not None and not verify:
+        raise ValueError("pubkey is for the check that verify=False declines")
 
     signature = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
@@ -159,7 +220,7 @@ def _sign_(
     ):
         raise ValueError("invalid private key: not in [1, n-1]")
     if verify:
-        _abort_unless_recovered(signature, msg_bytes, prvkey_bytes)
+        _abort_unless_recovered(signature, msg_bytes, prvkey_bytes, pubkey)
     return signature
 
 
@@ -169,6 +230,7 @@ def sign(
     aux_rand32: BytesLike | None = None,
     *,
     verify: bool = True,
+    pubkey: BytesLike | None = None,
 ) -> tuple[bytes, int]:
     """Create a recoverable ECDSA signature.
 
@@ -194,6 +256,19 @@ def sign(
     verification's work, and the comparison and the derivation are the
     rest. CHANGELOG.md names the session.
 
+    `pubkey` is how a caller already holding the key stops the comparison
+    deriving it, and what it removes is the same call `dsa.sign` removes,
+    at the same price: the check here is the dearest of the three, the
+    saving is not. In a session of its own: 35.00 microseconds with the
+    key derived, 29.67 with a compressed one handed in, 27.49 with an
+    uncompressed one, against 12.07 unchecked and a noise of
+    ±0.02. The 7.51 that removes is `secp256k1_ec_pubkey_create`, which
+    timed alone there is 7.53, and what stays is the recovery and the
+    comparison -- about 3 microseconds over what `dsa.sign` pays for a
+    verification, whether the key is handed in or derived. The README
+    carries both tables, and `_abort_unless_recovered` what the trust
+    costs in diagnosis.
+
     Args:
         msg_bytes: the 32-byte hash of the message.
         prvkey: the private key, 32 bytes or an int below 2**256.
@@ -203,6 +278,14 @@ def sign(
             does not give the signer's back. It costs a recovery, a point
             multiplication and a comparison, and False is what a caller
             that has measured those against its own threat model passes.
+        pubkey: the public key of this private key, where the caller
+            already holds it, so that the comparison does not derive it
+            again. That derivation is the multiplication named above, and
+            this is how not to pay it twice. It is taken on trust rather
+            than checked against the private key, which would cost the
+            multiplication it saves; where it is wrong, the check says so
+            and says which of the three things went wrong. Refused
+            beside `verify=False`, which declines the check it is for.
 
     Returns:
         The 64-byte compact signature and its recovery id. The id is 0
@@ -212,8 +295,11 @@ def sign(
 
     Raises:
         ValueError: if the message hash is not 32 bytes, if aux_rand32 is
-            given and is not 32 bytes, or if the private key is not 32
-            bytes, does not fit in them, or is not in [1, n-1].
+            given and is not 32 bytes, if the private key is not 32
+            bytes, does not fit in them, or is not in [1, n-1], if pubkey
+            is not a public key or is given beside `verify=False`, or if
+            pubkey is not this private key's -- which is told apart from
+            the failure below rather than reported as it.
         RuntimeError: if libsecp256k1 fails to serialize the signature,
             which no input can make it do, or if `verify` asks and the
             signature does not recover the key that made it.
@@ -227,7 +313,26 @@ def sign(
         >>> pubkey == keys.pubkey_from_prvkey(1)
         True
     """
-    return serialize_compact(_sign_(msg_bytes, prvkey, aux_rand32, verify=verify))
+    # the contradiction before the value, as `dsa.sign` answers it and
+    # for the same reason: a caller who asked for no check and handed in
+    # a key to check with should hear about the two arguments rather than
+    # about the octets of one of them
+    if pubkey is not None and not verify:
+        raise ValueError("pubkey is for the check that verify=False declines")
+
+    return serialize_compact(
+        _sign_(
+            msg_bytes,
+            prvkey,
+            aux_rand32,
+            verify=verify,
+            # parsed here rather than inside the check, so that octets
+            # which are not a public key are refused before anything is
+            # signed: a caller who mistyped an argument should not be
+            # told about it by a check on a signature they now hold
+            pubkey=None if pubkey is None else keys.parse(pubkey),
+        )
+    )
 
 
 def _recover_(msg_bytes: BytesLike, signature: CData) -> CData:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -20,6 +20,13 @@ comparison, and 32 bytes from an ECDH that succeeded with nobody. The
 public entry points are the counter-case, parsing their octets and so
 leaving the thread clean.
 
+One of those shapes is not an object the caller handed `lib` but an
+argument of a wrapper: the public key `recovery._sign_` compares against
+is taken on trust, so an unreadable one is recorded on the thread from
+inside a call that answers its own `ValueError` about the key. That the
+verdict is right anyway is the reasoning that docstring gives, and the
+last test here is it.
+
 An internal error is reachable through neither: libsecp256k1 reports
 through that callback what it holds to be unreachable, so the recording
 function is called directly, the way test_extension.py drives the branch
@@ -32,7 +39,7 @@ import threading
 
 import pytest
 
-from btclib_secp256k1 import context, dsa, ecdh, ffi, keys, lib, ssa, xonly
+from btclib_secp256k1 import context, dsa, ecdh, ffi, keys, lib, recovery, ssa, xonly
 from btclib_secp256k1.context import ctx
 
 # a public key libsecp256k1 is asked to parse into nowhere: the bindings
@@ -304,4 +311,30 @@ def test_reported_per_thread() -> None:
     assert elsewhere == ["nothing reported"]
     # the calling thread still has it
     with pytest.raises(ValueError, match="pubkey != NULL"):
+        context.check()
+
+
+def test_the_key_the_recoverable_check_trusts_is_the_one_nobody_validated() -> None:
+    """A wrapper's own argument, unreadable, and a verdict that still holds.
+
+    Every other shape above is an object a caller passed through `lib`.
+    This one is an argument of a wrapper: `recovery._sign_` takes the key
+    its check compares against on trust -- that being what the private
+    half is for -- so a `secp256k1_pubkey` nothing has written to reaches
+    `secp256k1_ec_pubkey_cmp`, and the illegal argument is recorded from
+    inside a call that raises about the key instead.
+
+    What is pinned here is that the answer is right regardless.
+    libsecp256k1 serializes a key it cannot load as 33 zero octets,
+    "less than any valid public key" by its own comment, so the readable
+    recovered key compares unequal to it: the comparison falls through to
+    the derivation, finds the signature is the signer's after all, and
+    reports the key handed in. A `RuntimeError` there would have told the
+    caller their hardware was faulty because they passed a zeroed struct.
+    """
+    msg = bytes(range(32))
+    unreadable = ffi.new("secp256k1_pubkey *")
+    with pytest.raises(ValueError, match="not this private key's"):
+        recovery._sign_(msg, 7, pubkey=unreadable)
+    with pytest.raises(ValueError, match="secp256k1_fe_is_zero"):
         context.check()

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -46,8 +46,18 @@ check instead of having it derived. Those turn on the key being taken on
 trust: what it costs -- a failure that has two causes, told apart in both
 directions, one of them needing the same stand-in as above -- and what it
 cannot cost, which is a signature wrongly accepted. That last one is the
-strongest thing in this file, and the only one here that is a property
-over many keys rather than a case.
+strongest thing in this file, and it is a property over many keys rather
+than a case.
+
+`recovery` takes the same key and adds the group after it, where the
+failure has three causes rather than two: the key given, the recovery id,
+or the computation. The first is an argument and the other two are not,
+and what separates them is the derivation the matching path skipped. The
+last of those tests is the one nothing else in the package can write --
+a right key and a wrong id, both real, no stand-in anywhere -- and the
+property over many keys is asserted again there, because what makes the
+trust safe is a different sentence when the key is recovered rather than
+verified against.
 """
 
 from __future__ import annotations
@@ -201,6 +211,25 @@ def _recovering_another_key(*_args: Any, **_kwargs: Any) -> CData:
         The parsed public key of a different private key.
     """
     return keys._pubkey_from_prvkey_(PRVKEY + 1)
+
+
+def _refusing_to_derive(*_args: Any, **_kwargs: Any) -> NoReturn:
+    """Stand in for the derivation, and fail if anything makes it.
+
+    What a key handed in is for is not deriving one, and every other test
+    of that argument would pass with the saving deleted: the derived
+    comparison that follows agrees with the one handed in, so a check
+    ignoring the argument answers the same signature. Substituting the
+    multiplication itself is what turns the saving into an assertion.
+
+    Args:
+        _args: whatever the derivation would have taken.
+        _kwargs: the same.
+
+    Raises:
+        AssertionError: always.
+    """
+    raise AssertionError("the key handed in was derived anyway")
 
 
 def _refuse_every_check(patch: pytest.MonkeyPatch) -> None:
@@ -395,17 +424,20 @@ def test_the_recovery_id_is_what_the_check_catches() -> None:
     # the id it was made with, which is what makes the refusals below a
     # refusal of the id rather than of the signature
     recovery._abort_unless_recovered(
-        recovery.parse_compact(signature, recid), MSG, PRVKEY_BYTES
+        recovery.parse_compact(signature, recid), MSG, PRVKEY_BYTES, None
     )
 
     with pytest.raises(RuntimeError, match="recovers another key"):
         recovery._abort_unless_recovered(
-            recovery.parse_compact(signature, 1 - recid), MSG, PRVKEY_BYTES
+            recovery.parse_compact(signature, 1 - recid), MSG, PRVKEY_BYTES, None
         )
     for beyond_the_field in (2, 3):
         with pytest.raises(RuntimeError, match=_UNRECOVERED):
             recovery._abort_unless_recovered(
-                recovery.parse_compact(signature, beyond_the_field), MSG, PRVKEY_BYTES
+                recovery.parse_compact(signature, beyond_the_field),
+                MSG,
+                PRVKEY_BYTES,
+                None,
             )
 
     assert dsa._verify_(
@@ -520,3 +552,132 @@ def test_a_fault_under_a_handed_in_key_is_not_reported_as_a_wrong_key() -> None:
         _refuse_every_check(patch)
         with pytest.raises(RuntimeError, match=_UNVERIFIED):
             dsa.sign(MSG, PRVKEY, pubkey=pubkey)
+
+
+def test_a_key_handed_in_is_the_key_recovery_would_have_derived() -> None:
+    """The signature is the same pair, whichever way the check got its key.
+
+    `recovery`'s answer is the compact signature and its id, so both have
+    to be the same: an argument that changed the id would be a different
+    signature recovering a different key, which is the one thing this
+    module cannot get wrong quietly. Both serializations of the key are
+    handed in, the parse being the only difference between them.
+    """
+    derived = recovery.sign(MSG, PRVKEY)
+    for held in (
+        keys.pubkey_from_prvkey(PRVKEY, compressed=False),
+        keys.pubkey_from_prvkey(PRVKEY, compressed=True),
+    ):
+        assert recovery.sign(MSG, PRVKEY, pubkey=held) == derived
+
+
+def test_the_key_given_is_told_apart_from_the_signature_being_wrong() -> None:
+    """A key that is not this private key's is an argument, not a fault.
+
+    The reason the failing branch derives, and here it separates one
+    cause from two rather than one from one: `RuntimeError` means the
+    signature does not recover its own signer -- a wrong id or a fault,
+    neither of them anything the caller passed -- while a wrong key given
+    is a `ValueError` and stays one.
+    """
+    other = keys.pubkey_from_prvkey(PRVKEY + 1, compressed=False)
+    with pytest.raises(ValueError, match="not this private key's"):
+        recovery.sign(MSG, PRVKEY, pubkey=other)
+
+
+def test_octets_that_are_not_a_key_are_refused_before_signing_recoverably() -> None:
+    """Parsed on the way in, so a mistyped argument is not a verdict.
+
+    `dsa.sign` is held to this too. Here what a key parsed inside the
+    check would produce is a report that the signature recovers somebody
+    else, which is the module's most alarming message and would be about
+    the caller's own typing.
+    """
+    with pytest.raises(ValueError, match="invalid public key"):
+        recovery.sign(MSG, PRVKEY, pubkey=b"\x02" + bytes(32))
+
+
+def test_a_key_is_refused_where_the_recoverable_check_is_declined() -> None:
+    """A key to compare with is refused where the comparison is declined.
+
+    Both halves refuse it, and the private one is not a copy for its own
+    sake: a caller holding a parsed point calls `_sign_` precisely to save
+    the parse, so that is where the argument is cheapest and where it must
+    not be silently ignored.
+    """
+    with pytest.raises(ValueError, match="verify=False declines"):
+        recovery.sign(MSG, PRVKEY, verify=False, pubkey=keys.pubkey_from_prvkey(PRVKEY))
+    with pytest.raises(ValueError, match="verify=False declines"):
+        recovery._sign_(
+            MSG, PRVKEY, verify=False, pubkey=keys._pubkey_from_prvkey_(PRVKEY_BYTES)
+        )
+
+
+def test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key() -> None:
+    """The three-way failure, all three real, no stand-in anywhere.
+
+    This is the case no other module can write. A wrong recovery id is
+    reachable from an input -- `parse_compact` is one call -- so the two
+    causes that are not the caller's can be told from the one that is
+    without substituting a recovery: the same signature, its own id and
+    the other, and the signer's key handed in beside a stranger's.
+
+    What it guards is the misdiagnosis in both directions. A right key
+    with a wrong id must not arrive as "the public key given is not this
+    private key's", which would send a caller to check an argument that
+    was correct; and a wrong key with a right id must not arrive as the
+    `RuntimeError`, which is this package's word for the computation
+    having gone wrong.
+    """
+    signature, recid = recovery.sign(MSG, PRVKEY)
+    signer = keys._pubkey_from_prvkey_(PRVKEY_BYTES)
+    stranger = keys._pubkey_from_prvkey_(PRVKEY + 1)
+
+    # the signature's own id and the key that made it: the case the other
+    # two are read against
+    recovery._abort_unless_recovered(
+        recovery.parse_compact(signature, recid), MSG, PRVKEY_BYTES, signer
+    )
+
+    with pytest.raises(RuntimeError, match="recovers another key"):
+        recovery._abort_unless_recovered(
+            recovery.parse_compact(signature, 1 - recid), MSG, PRVKEY_BYTES, signer
+        )
+    with pytest.raises(ValueError, match="not this private key's"):
+        recovery._abort_unless_recovered(
+            recovery.parse_compact(signature, recid), MSG, PRVKEY_BYTES, stranger
+        )
+
+
+def test_a_key_fixed_in_advance_cannot_pass_a_recovered_signature() -> None:
+    """What makes taking the key on trust safe here, as a property.
+
+    Stronger than the `dsa` sentence rather than the same one: there the
+    key handed in has to be one of the keys the signature verifies under,
+    and here it has to be the single key the signature recovers. So a key
+    chosen before the signature exists passes only by having been the
+    signer's, and over forty keys and messages none of them is.
+    """
+    wrong = keys.pubkey_from_prvkey(PRVKEY, compressed=False)
+    for other_key in range(PRVKEY + 1, PRVKEY + 41):
+        msg = hashlib.sha256(other_key.to_bytes(32, "big")).digest()
+        with pytest.raises(ValueError, match="not this private key's"):
+            recovery.sign(msg, other_key, pubkey=wrong)
+
+
+def test_the_derivation_the_argument_saves_is_not_made_at_all() -> None:
+    """The saving itself, asserted rather than measured.
+
+    The check compares the recovered key with the one handed in and
+    derives only where they differ, so nothing that reads the answer can
+    tell that early return from its absence -- delete it and the derived
+    comparison below agrees, answering the same signature and the same
+    id. With the multiplication substituted for one that raises, the
+    signature coming back at all is what says it was never made.
+    """
+    pubkey = keys.pubkey_from_prvkey(PRVKEY)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(keys, "_pubkey_from_prvkey_", _refusing_to_derive)
+        assert recovery.sign(MSG, PRVKEY, pubkey=pubkey) == recovery.sign(
+            MSG, PRVKEY, verify=False
+        )


### PR DESCRIPTION
`recovery.sign` and `recovery._sign_` take a keyword-only `pubkey`, the key
`_abort_unless_recovered` compares the recovered one with, so the check no
longer derives a key the caller is holding. Everything around it is what
[ISS 245](https://github.com/btclib-org/btclib-secp256k1/issues/245)
settled for `dsa` and is not restated in a second shape: taken on trust,
refused beside `verify=False` in both halves, octets parsed at the
boundary.

**The decision [ISS 246](https://github.com/btclib-org/btclib-secp256k1/issues/246)
left open** — whether `recovery` should take the argument at all, the
saving being the largest and the diagnosis having the most ways to go
wrong — is taken, and the reason is that the third cause needs no third
message. A mismatch means the key given is wrong, the recovery id is not
the signature's, or the computation faulted; the derivation the matching
path skipped separates the first from the other two, and those two share
the `RuntimeError` because a caller of `sign` cannot pass an id at all —
it comes back from `secp256k1_ecdsa_sign_recoverable` beside the
signature, so a wrong one is a fault by the time the check runs. The cost
of the largest saving in the package is therefore one comparison, on a
path that was already failing.

**The measurement**, one session with `dsa.sign` beside it so the two are
comparable rather than merely printed together — Apple M5, macOS 26.6,
arm64, CPython 3.14.6, nine rounds of 3 000 calls, minimum kept, private
key handed in as octets in every row:

| `recovery.sign` | per call | the check |
| --- | --- | --- |
| `verify=False` | 12.07 | |
| the key derived, as before | 35.00 | 22.93 |
| a compressed key handed in | 29.67 | 17.60 |
| an uncompressed key handed in | 27.49 | 15.42 |
| the point already parsed, through `_sign_` | 27.25 | 15.18 |
| `verify=False` again (the noise) | 12.09 | ±0.02 |

`dsa.sign` there: 12.14 unchecked, 31.97 derived, 24.55 uncompressed in —
19.83 becoming 12.41, within a few tenths of ISS 245's own session. The
7.51 removed is `secp256k1_ec_pubkey_create` and nothing besides (7.53
timed alone in the same session); 2.18 is the field square root and 0.24
the uncompressed parse, agreeing with the 2.02 and 0.26 measured for
`dsa`. What stays is the ~3 µs a recovery and a comparison cost over a
verification, the same 3 before and after — which is what says the
argument removed the derivation and left the rest alone.

**Cases.** `dsa`'s group repeated for this module, plus two of its own:
`test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key` puts
all three causes in front of the real libsecp256k1 with no stand-in
anywhere (right key + right id passes, right key + wrong id is the
`RuntimeError`, wrong key + right id is the `ValueError`), and
`test_the_derivation_the_argument_saves_is_not_made_at_all` pins the
saving rather than the answer — `keys._pubkey_from_prvkey_` substituted
for a raise, the signature still returned. Verified by deleting the early
return, which fails both.

`README.md` carries the table and the three-cause paragraph; the sentence
that called the saving "available and not yet taken" for `recovery` is now
the one that says what taking it cost. `HISTORY.md` gains the release note
for `pubkey`, which covers `dsa` too — the notes describe the release
rather than the commit, and ISS 245 left that paragraph unwritten.

Evidence, local, in a worktree on this commit:

- `uv run --locked --no-default-groups --group test pytest --cov` — exit 0, 654 passed, 100% coverage
- `uvx pre-commit run --all-files` — exit 0, 37 hooks
- the saving deleted, `pytest -k` on the three cases — 2 failed, as intended; restored, full suite green again (`PYTHONDONTWRITEBYTECODE=1` throughout)

Noticed and filed, not addressed here: [ISS 251 — dsa's own saving is asserted by nothing](https://github.com/btclib-org/btclib-secp256k1/issues/251)

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Let recoverable signing compare against a caller-held public key to avoid redundant key derivation while preserving clear verification failures.

New Features:
- Allow `recovery.sign` and `recovery._sign_` callers to provide an existing public key for recoverable-signature verification.

Bug Fixes:
- Distinguish a mismatched caller-provided public key from signatures that recover the wrong key or otherwise indicate a signing failure.
- Reject invalid public-key inputs before signing and reject `pubkey` when verification is disabled.

Enhancements:
- Avoid deriving a public key during the successful verification path when the caller already provides one, while retaining fallback diagnosis for mismatches.

Documentation:
- Document the new recovery public-key parameter, its performance impact, error behavior, and rationale in the README, changelog, and history.

Tests:
- Add coverage for matching and mismatched keys, invalid inputs, disabled verification, wrong recovery IDs, no-derivation behavior, key trust handling, and recovery properties.