### PR TITLE
Let a scalar be 32 octets the caller can overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,135 @@ release-notes length in the first place, and are still in
   sentence that said the saving was "available and not yet taken" for
   `recovery` is now the one that says what taking it cost.
 
+### A scalar may be memory the caller can overwrite
+
+- **`_scalar.scalar` takes a cffi array of exactly 32 octets and hands it
+  on unconverted** (#247), so wherever a private key or a tweak is
+  accepted, `ffi.new("unsigned char[32]", ...)` is too. It is the only
+  argument of these bindings that is not copied at the boundary, and the
+  reason is what the copy would be: an immutable `bytes` of a secret,
+  which nothing can overwrite and which stays until the collector gets to
+  it. A caller signing again and again under one key can now hold it in
+  memory it owns and wipe that when done, with no `bytes` of the key made
+  per call. What that gives up is stated where `octets` states the
+  opposite -- the copy is also what stops a caller changing the octets
+  libsecp256k1 is reading -- and it is the caller's to give up, the
+  buffer and its synchronization being theirs already.
+- **What decided the shape is where the coercion actually binds**, and
+  the issue's premise was wrong about it. #247 reasoned that a
+  `dsa.Signer` holding a buffer "would have to turn it back into a
+  `bytes` on every call". It would not: `dsa._signed` and `dsa._checked`
+  hand libsecp256k1 the pointer, exactly as `ssa.Signer` bypasses
+  `keypair` per signature, so a prototype signer holding
+  `ffi.new("unsigned char[32]")` produced byte-identical signatures
+  before this change and hoisted 0.37 microseconds of 23.42 -- an Apple
+  M5, macOS 26.6, arm64, CPython 3.14.6, nine rounds of 3 000 calls with
+  the minimum kept, the checked call with its key handed in as the
+  anchor and run again for a noise of 0.02. Which leaves the README's
+  verdict on speed where it was.
+- **It binds on the derivation, and the sharpest case is a diagnosis.**
+  `keys._pubkey_from_prvkey_` asks for a scalar, so a key in a buffer
+  could not have its public key derived at all -- and the failing branch
+  of `dsa._checked`, which derives precisely in order to tell a wrong
+  argument from a fault, answered `TypeError: the private key must be
+  bytes or an int, not __CDataOwn`. A caller whose hardware had faulted
+  was told they had mistyped an argument they passed correctly, which is
+  the misdiagnosis #245 built that branch to avoid. So the door is open
+  for the diagnosis rather than for the microsecond, and
+  `test_the_discrimination_holds_for_a_key_held_in_a_buffer` holds both
+  sides of it with the key in a buffer.
+- **Any item type an octet wide, because what crosses is a re-view.**
+  `ffi.from_buffer` over `ffi.buffer` answers an `unsigned char[32]`
+  pointing at the caller's own memory, which is the one item type cffi
+  will pass to `const unsigned char *`: without it the acceptance would
+  be `char` and `unsigned char` alone, and `uint8_t[32]` -- what a C
+  programmer writes for 32 octets -- would clear every check and die at
+  the boundary in cffi's words about an internal ctype. Not `ffi.cast`,
+  which answers the same pointer for nothing and does **not** keep the
+  memory alive: measured, a cast whose owner is dropped and collected
+  reads 32 octets that no longer hold the key, with no error anywhere.
+  `from_buffer` keeps a reference to what it views.
+- **Three obligations pass to the caller with the copy**, and the
+  docstring names them because none of them exists for a `bytes`. The
+  octets must stay put for the whole call, which is more than one read:
+  `secp256k1_ecdsa_sign` loads the scalar (`secp256k1.c:555`) and derives
+  the nonce from the same pointer (:563), and `dsa._sign_` reads it again
+  per grinding attempt and in `_checked`'s failing branch -- so a write in
+  between gives a nonce and a signature under two different keys, arriving
+  as the fault `RuntimeError`. The memory must outlive the call, which no
+  python argument has had to promise: a cffi view -- a slice, a cast --
+  does not keep its owner alive, measured, and a dangling one reads freed
+  memory as a key. And the length is the declaration's word, `ffi.sizeof`
+  answering what the type says: a cast of 8 octets to `unsigned char[32]`
+  clears every refusal and has libsecp256k1 read 24 octets of whatever
+  follows, which cffi cannot report and so neither can this.
+- **Three refusals, because what follows is a bare pointer** libsecp256k1
+  reads 32 octets from. A *pointer* rather than an array, whose
+  `ffi.sizeof` is 8 and says nothing about what it points at -- the trap
+  `_secret.wipe` records from the other side, where that number would
+  have wiped a quarter of a private key and reported success. An array of
+  wider items: `uint32_t[8]` is 32 octets of whatever this machine's byte
+  order made of them, refused for the reason `octets` refuses a
+  `memoryview` of wider items. And an array of the wrong length, which is
+  the check every other scalar gets and the one a bare pointer cannot be
+  given later.
+- **A `str` is refused before the question is asked, and that is a bug
+  the suite caught rather than a case somebody thought of.**
+  `ffi.typeof` reads a str as a *cdecl*: `"x" * 32` comes back as cffi's
+  own `error: undefined type name`, which is neither this function's
+  `TypeError` nor about the argument -- and `"char[32]"` is worse, being
+  a cdecl that resolves, measures 32 octets, and would have been passed
+  to libsecp256k1 as a str.
+  `test_type_checks_refuse_what_merely_has_a_length` failed on the first
+  spelling the moment the branch was written; the second was found
+  looking for why, and both are cases now.
+- **Four call sites copy the octets, and had to be taught to.**
+  `keys.prvkey_negate`, `keys.prvkey_tweak_add`, `keys.prvkey_tweak_mul`
+  and `silentpayments._create_outputs_` allocate a buffer of their own --
+  the first three because libsecp256k1 writes the answer through that
+  pointer, the last because this package wipes it in a `finally` -- so
+  handing them the caller's memory would negate or zero the key that was
+  passed in. They spelled it `ffi.new(cdecl, scalar(...))`, whose
+  initializer is `bytes` or a list and never a cdata, so each refused one
+  of the two obvious cdecls with cffi's own message about an internal
+  `char[32]`: `unsigned char[32]` failed in the three `keys` functions and
+  `char[32]` in `silentpayments`, and `ssa.nonce_bip340` therefore failed
+  for *half of all keys*, reaching `prvkey_negate` only where the point
+  has odd y. `_secret.scalar_buffer` is now the one statement of that
+  copy -- `ffi.new` then `ffi.memmove`, which takes either source and
+  makes no `bytes` of the secret in between -- and it says which of the
+  two reasons each site has.
+- **The sweep is what would have caught it, and now exists.**
+  `tests/test_bytes_like.py` drove every entry point with bytes, a
+  bytearray and a memoryview; it drives them with a 32-octet buffer too,
+  swapping the private keys and tweaks of its own table by identity. It
+  asserts the answer is the same *and* that the caller's octets are still
+  there afterwards, which is the half a comparison of answers cannot see.
+  Reverting one of the four sites fails it on that row. The parity branch
+  gets a case of its own beside it, `PRVKEY` being 7 and even-y, so that
+  the half of `nonce_bip340` no table row reaches is driven with 5 and 6
+  and both parities are asserted to occur.
+- **The public annotations do not widen, which was the cost the issue
+  named.** `CData` is `Any`, so `BytesLike | int | CData` on `dsa.sign`
+  would have stopped mypy checking every caller's private key. Only
+  `scalar`'s own parameter widens: the entry points still declare
+  `BytesLike | int`, so a `float` is still refused statically at the call
+  the caller made, while a cdata still arrives because `ffi.new` answers
+  `Any`. What is given up is mypy checking this package's own calls of
+  `scalar`, whose run-time check is the one that was doing the work.
+- **The cffi stub gains what the question reads**: `_CType.kind`,
+  `.cname` and `.item`, and `typeof` now takes a cdata as well as a
+  cdecl -- `Any`, as `sizeof`'s parameter already is for the same reason,
+  cdata being what that file cannot name. It was opaque because nothing
+  read what cffi answered, and its docstring says what now does. Two
+  functions join it, `from_buffer` and `memmove`, being the two halves of
+  what a caller's octets can become.
+- **Whether a `dsa.Signer` is worth having is still
+  btclib-org/btclib#982's question**, and this does not answer it. What
+  it does is take the blocker away: the wiping ground that issue would
+  have to be argued on no longer needs a signer at all, a caller holding
+  the buffer and calling `dsa.sign` getting the same thing.
+
 ### The check takes a public key the caller already has
 
 - **`dsa.sign` and `dsa._sign_` take a keyword-only `pubkey`**, the key

--- a/README.md
+++ b/README.md
@@ -570,6 +570,48 @@ the paragraph above describes, a second copy of the secret held for as
 long as the signer is. That trade is worth making for half a signature
 and not for a hundredth of one.
 
+**The other ground such a signer could be argued on is the memory, and
+it needs no signer.** Where a scalar is accepted — a private key, a tweak
+— a cffi array of 32 octets is accepted too, and where the call only
+*reads* it libsecp256k1 is handed the caller's own memory. So a caller
+signing again and again under one key can hold it in
+`ffi.new("unsigned char[32]")`, wipe that when done, and have no `bytes`
+of the key made per signature. It is the only argument of these bindings
+that is not copied on the way in, and the trade is stated where the
+copying one is: the copy `bytes` and `bytearray` get is also what stops
+the caller changing the octets libsecp256k1 is reading, and a caller who
+hands in memory instead of a value has taken that on.
+[SECURITY.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/SECURITY.md)
+carries it with the wipe that goes with it.
+
+Which item type the array was declared as does not matter — `char`,
+`unsigned char`, `uint8_t`, `signed char` — because what crosses is a
+re-view of those octets rather than a conversion of them. What is refused
+is a pointer, whose length is not the pointer's own to know, an array of
+wider items, which is this machine's byte order rather than a scalar, and
+any length but 32.
+
+**Four calls copy it, and are meant to.** `keys.prvkey_negate`,
+`keys.prvkey_tweak_add`, `keys.prvkey_tweak_mul` and the sender side of
+`silentpayments` each own the buffer libsecp256k1 works in: the first
+three because it writes the answer through that pointer, and the last
+because this package wipes it afterwards. Handing those the caller's
+memory would negate or zero the key they passed, so a copy is owed and
+`_secret.scalar_buffer` takes it. Each of them *answers* a new secret,
+which is the other facility's question rather than this one's — `into`
+is how that comes back into a buffer instead of a `bytes`.
+
+Where that binds is not the signing, which never asked: the private
+halves hand libsecp256k1 the pointer, so a key in a buffer reached
+`_signed` before this and reaches it now. It binds on the *derivation* —
+`keys._pubkey_from_prvkey_` asks for a scalar — and the sharpest case is
+the failing branch of the check above, which derives in order to tell a
+wrong argument from a fault: with the key in a buffer it used to answer
+`TypeError: the private key must be bytes or an int`, telling a caller
+they had mistyped the argument they had passed correctly. Which is the
+reason the door is open, rather than the microsecond a signer would have
+hoisted.
+
 What does cost in `dsa.sign` is the DER serialization, 0.757
 microseconds, and a caller who wanted the other form never has to pay it:
 `compact=True` answers the 64 octets of `r ‖ s` directly, where reaching

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,13 +103,9 @@ These are known and inherent, not vulnerabilities:
     zeroed, which is the limitation above and not this narrowing of it.
     What the caller then does with the buffer is theirs: this does not
     wipe it for them, and a buffer they never overwrite is exactly the
-    un-zeroizable copy `into` was reached for to avoid. Nor does it
-    touch the *entry* side, which is the half that cannot be improved
-    from inside this package: the `bytes` or `int` handed in already
-    existed before the call, and the arithmetic that produced it
-    happened where this package cannot see. The obligation is stated
-    rather than enforced, for the reason `ssa.Signer` has no finalizer:
-    a guarantee nothing keeps is worse than none
+    un-zeroizable copy `into` was reached for to avoid. The obligation is
+    stated rather than enforced, for the reason `ssa.Signer` has no
+    finalizer: a guarantee nothing keeps is worse than none
 
     ```python
     prvkey = bytearray(32)
@@ -149,6 +145,53 @@ These are known and inherent, not vulnerabilities:
     type, a length or a magnitude and never on the content of a secret.
     Everywhere an `int` is accepted `bytes` is too, and for a secret that
     is the form to use
+- **the entry side takes one form that is not a copy**: where a scalar is
+    accepted, so is a cffi array of 32 octets —
+    `ffi.new("unsigned char[32]", ...)`, or any other item type an octet
+    wide — and where the call only reads it, it reaches libsecp256k1 as
+    it stands. That is the whole of the difference: a `bytes` or a
+    `bytearray` is copied at the boundary, deliberately, so that nothing
+    can change what libsecp256k1 is about to read, and the copy of a
+    secret is an immutable object nothing can overwrite. A caller signing
+    again and again under one key can therefore hold it in memory it
+    owns, wipe that memory when done, and have no `bytes` of the key made
+    per call. What this does not change is what came before: the value
+    the buffer was filled from existed already, and the arithmetic that
+    produced it happened where this package cannot see — which is why
+    filling one from an `int` buys nothing the bullet above does not
+    already refuse. And the wipe stays the caller's, as it is for `into`:
+    a buffer never overwritten is the same un-zeroizable copy under
+    another name.
+
+    **What the caller takes on is three things, and `_scalar` names them
+    where it refuses the shapes it cannot take.** The octets must stay
+    put for the whole call, which is more than one read — libsecp256k1
+    loads the scalar and then derives the nonce from the same pointer, and
+    grinding and the check read it again — so a write in between yields a
+    nonce and a signature under two different keys, reported as the fault
+    it is indistinguishable from. The memory must outlive the call, which
+    no python argument has had to promise: a cffi *view*, a slice or a
+    cast, does not keep its owner alive, and a dangling one reads freed
+    memory as a private key. And the length is the declaration's word:
+    `ffi.cast("unsigned char[32]", ...)` over 8 octets is accepted, cffi
+    having no way to report what was really allocated.
+
+    Four calls copy the octets into a buffer of their own instead, and
+    have to: `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
+    `keys.prvkey_tweak_mul` have libsecp256k1 write the answer through
+    that pointer, and the sender side of `silentpayments` wipes it on the
+    way out — so passing the caller's memory would negate or zero the key
+    they handed in. Each of those answers a *new* secret, which is what
+    `into` above is for
+
+    ```python
+    prvkey = ffi.new("unsigned char[32]", secret_octets)
+    try:
+        sig = dsa.sign(msg, prvkey)   # no bytes of the key is made
+    finally:
+        ffi.buffer(prvkey)[:] = bytes(32)   # the caller's wipe
+    ```
+
 - randomness comes from `secrets.token_bytes`, i.e. from the operating
     system, both for the context randomization and for the auxiliary
     randomness of BIP340 signing and of ElligatorSwift encoding

--- a/btclib_secp256k1/_scalar.py
+++ b/btclib_secp256k1/_scalar.py
@@ -11,6 +11,12 @@ import secrets
 
 from . import BytesLike, CData, ffi
 
+# the one item type cffi will pass where libsecp256k1 declares
+# `const unsigned char *`, resolved once at import as the buffer types of
+# the wrappers are: `_owned_octets` re-views a caller's 32 octets as this,
+# whatever they declared them
+_OCTETS_TYPE = ffi.typeof("unsigned char[32]")
+
 
 def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
     """Normalize an argument to the bytes a bare pointer needs, of a length.
@@ -90,7 +96,120 @@ def octets(value: BytesLike, name: str, size: int | None = None) -> bytes:
     return value_bytes
 
 
-def scalar(num: BytesLike | int, name: str) -> bytes:
+def _owned_octets(num: CData, name: str) -> CData:
+    """Accept 32 octets of memory the caller owns, unconverted.
+
+    The one argument of these bindings that is not copied on the way in,
+    and the reason is what a copy would be: an immutable `bytes` of a
+    secret, which nothing can overwrite and which stays until the
+    collector gets to it. A caller holding the key in memory it can zero
+    -- `ffi.new("unsigned char[32]")`, wiped with `_secret.wipe` -- would
+    otherwise have one made per call, so what `octets` is right to do for
+    a value is wrong for this one.
+
+    What that gives up is stated where `octets` states the opposite: the
+    copy taken there is what stops a caller overwriting their own buffer
+    while libsecp256k1 reads it. **Three obligations pass to the caller
+    with the copy**, and none of them exists for a `bytes`:
+
+    - the octets stay put for the whole call, and the whole call is more
+      than one read. `secp256k1_ecdsa_sign` loads the scalar
+      (`secp256k1/src/secp256k1.c:555`) and then hands the same pointer
+      to the nonce derivation (:563), and above it `dsa._sign_` reads it
+      again for every grinding attempt and once more in `_checked`'s
+      failing branch. So a write in between is not "a different key
+      signed": it is a nonce and a signature derived from two different
+      keys, which arrives as the fault `RuntimeError` and looks like
+      hardware;
+    - the memory outlives the call, which no python argument has ever had
+      to promise. A cdata view does not keep its owner alive:
+      `ffi.new("unsigned char[64]")[0:32]` and `ffi.cast(...)` over a
+      temporary read freed memory, measured -- zeros here by the
+      allocator's grace, and a plausible scalar on a busier heap. What
+      this function returns is safe in that respect, `from_buffer`
+      keeping its view alive, but it cannot rescue a dangling argument;
+    - the declaration is the truth about the length, because `ffi.sizeof`
+      answers what the *type* says rather than what was allocated:
+      `ffi.cast("unsigned char[32]", <8 octets>)` clears every refusal
+      below and has libsecp256k1 read 24 octets of whatever follows.
+      cffi has nothing to check that against, so neither has this.
+
+    The alternative on offer is the copy that cannot be wiped, which is
+    why the trade is a caller's to make and not a default.
+
+    Any 1-octet array is taken, whatever the caller declared it as, and
+    what makes that safe is a re-view rather than a conversion:
+    `ffi.from_buffer` over `ffi.buffer` answers an `unsigned char[32]`
+    pointing at the caller's own memory, which is the one item type cffi
+    will pass to `const unsigned char *`. Without it the acceptance would
+    be `char` and `unsigned char` alone -- cffi holds `uint8_t` and
+    `signed char` to be primitives of their own, so `uint8_t[32]`, which
+    is what a C programmer writes for 32 octets, would clear every check
+    here and die at the boundary in cffi's words.
+
+    **Not `ffi.cast`, and this is the trap in the neighbourhood.** It
+    would answer the same pointer for nothing, and it does not keep the
+    memory alive: a cast whose owner is dropped reads freed memory, which
+    was measured rather than read off the documentation -- 32 octets that
+    no longer hold the key, with no error anywhere. `from_buffer` keeps a
+    reference to what it views, and the buffer it views keeps the cdata,
+    so the chain holds for as long as the value is in use.
+
+    Which shapes are refused is the whole of the care here, because what
+    follows is a bare pointer libsecp256k1 reads 32 octets from:
+
+    - a *pointer* rather than an array, whose `ffi.sizeof` is 8 on this
+      machine and says nothing about what it points at. That is the trap
+      `_secret.wipe` records from the other side, where `ffi.sizeof`
+      would have wiped a quarter of a private key and reported success
+    - an array whose items are wider than an octet. `uint32_t[8]` is 32
+      octets of whatever this machine's byte order made of them, which
+      is exactly what `octets` refuses a `memoryview` of wider items
+      for, and refused rather than reinterpreted for the same reason
+    - an array of the wrong length, which is the check every other
+      scalar gets and the one a bare pointer cannot be given later
+
+    Args:
+        num: the cdata, as the caller passed it.
+        name: what the scalar is, as the exception should call it.
+
+    Returns:
+        The caller's own 32 octets as an `unsigned char[32]`, which is a
+        view of that memory and not a copy of it: writing through the
+        original changes what libsecp256k1 reads.
+
+    Raises:
+        TypeError: if it is not a cdata at all, or is not an array of
+            octets. A cdata's own `cname` is in the message, that being
+            what a caller declared.
+        ValueError: if it is an array of octets and not 32 of them.
+    """
+    # what reaches here is whatever was neither bytes nor an int, and the
+    # message for it is `scalar`'s own, stated once for the two ways of
+    # arriving at it
+    not_a_scalar = f"the {name} must be bytes or an int, not {type(num).__name__}"
+    # a `str` is refused before the question rather than by it, because
+    # `ffi.typeof` reads a str as a *cdecl*: `"x" * 32` comes back as
+    # cffi's own `error: undefined type name`, which is not this
+    # function's TypeError and not about the argument -- and `"char[32]"`
+    # is worse, being a cdecl that resolves, 32 octets wide, so the str
+    # would have been accepted and handed to libsecp256k1 as a str.
+    # `tests/test_core.py` holds both
+    if isinstance(num, str):
+        raise TypeError(not_a_scalar)
+    try:
+        ctype = ffi.typeof(num)
+    except TypeError:
+        raise TypeError(not_a_scalar) from None
+    if ctype.kind != "array" or ffi.sizeof(ctype.item) != 1:
+        msg = f"the {name} must be a cffi array of octets, not {ctype.cname}"
+        raise TypeError(msg)
+    if ffi.sizeof(num) != 32:
+        raise ValueError(f"the {name} must be 32 bytes")
+    return ffi.from_buffer(_OCTETS_TYPE, ffi.buffer(num))
+
+
+def scalar(num: BytesLike | int | CData, name: str) -> bytes | CData:
     """Normalize a scalar argument to 32 bytes.
 
     An int is serialized big endian, as libsecp256k1 expects; anything
@@ -102,6 +221,23 @@ def scalar(num: BytesLike | int, name: str) -> bytes:
     disbelieved, whereas an int states only a value and the width is the
     curve's.
 
+    A cffi array of 32 octets is the one thing not copied. It is memory
+    the caller owns and can overwrite, so converting it would make the
+    copy that cannot be -- `_owned_octets` is that decision, what it
+    refuses, and the re-view that lets any 1-octet spelling through.
+    Where libsecp256k1 writes through the pointer instead of reading it,
+    or where this package wipes the buffer afterwards, a copy is owed and
+    `_secret.scalar_buffer` is the one that takes it.
+
+    Where it matters is not the per-signature path, the private halves
+    handing libsecp256k1 the pointer without coming through here at all,
+    but the *derivation*:
+    `keys._pubkey_from_prvkey_` asks for a scalar, so before this a key
+    held in a buffer could not have its public key derived -- and
+    `dsa._checked`'s failing branch, which derives in order to tell a
+    wrong argument from a fault, answered a `TypeError` about the
+    argument instead of the diagnosis it exists for.
+
     A secret is better passed as bytes, for a narrow reason. Not the
     serialization, which is a loop over nine CPython digits and measures
     as noise, but the python arithmetic that produced the int, variable
@@ -112,16 +248,19 @@ def scalar(num: BytesLike | int, name: str) -> bytes:
     must not leak belongs where that can be promised.
 
     Args:
-        num: the scalar, exactly 32 octets or an int in [0, 2**256).
+        num: the scalar, exactly 32 octets or an int in [0, 2**256). The
+            octets may be a cffi array of them, which is passed on as it
+            stands rather than copied.
         name: what the scalar is, as the exception should call it.
 
     Returns:
-        The scalar as 32 bytes, big endian.
+        The scalar as 32 bytes, big endian -- or the caller's own cdata,
+        where that is what was handed in.
 
     Raises:
         TypeError: if the value is neither an int nor one of the types
-            `octets` takes, a bool counting as neither although python
-            makes it an int.
+            `octets` takes nor a cffi array of octets, a bool counting as
+            none of them although python makes it an int.
         ValueError: if it is not exactly 32 octets long, or if an int
             does not fit in 32 bytes. Whether the value is a valid
             scalar, i.e. in [1, n-1], is for libsecp256k1 to say.
@@ -146,10 +285,12 @@ def scalar(num: BytesLike | int, name: str) -> bytes:
         if not 0 <= num < 2**256:
             raise ValueError(f"the {name} must fit in 32 bytes")
         return num.to_bytes(32, "big")
-    # the domain here is octets' plus the int above, so a value that is
-    # neither is named here: what is left for octets is the length
+    # the domain here is octets' plus the int above plus a cdata, and it
+    # is asked in that order: everything a value can be is settled before
+    # `ffi.typeof` is called at all, so the common paths pay nothing for
+    # this one. What is left for octets is the length
     if not isinstance(num, (bytes, bytearray, memoryview)):
-        raise TypeError(f"the {name} must be bytes or an int, not {type(num).__name__}")
+        return _owned_octets(num, name)
     return octets(num, name, 32)
 
 

--- a/btclib_secp256k1/_secret.py
+++ b/btclib_secp256k1/_secret.py
@@ -226,6 +226,52 @@ def take(buffer: CData, *, into: MutableBytesLike | None = None) -> bytes | None
     return None
 
 
+def scalar_buffer(prvkey: BytesLike | int | CData, name: str) -> CData:
+    """Copy a scalar into 32 octets of this package's own memory.
+
+    The copy `_scalar.scalar` does not take, taken where it is owed --
+    which is two situations rather than one, and neither is about
+    distrusting the caller:
+
+    - libsecp256k1 *writes through* the pointer.
+      `secp256k1_ec_seckey_negate`, `_tweak_add` and `_tweak_mul` all
+      answer in place, and the caller's own key must not be overwritten
+      by a function that returns a new one;
+    - this package *wipes* the buffer afterwards, which
+      `silentpayments._create_outputs_` does in a `finally` for every
+      private key it built. Wiping memory the caller handed in would zero
+      their key on the way out of a call that only read it.
+
+    So a `bytes` or a cdata arrives here and 32 octets of ours leave, and
+    `take` or an explicit `wipe` is what the caller of this owes in turn.
+    `ffi.memmove` is what fills it, rather than `ffi.new(cdecl, ...)`:
+    that takes an initializer, which is `bytes` or a list and never a
+    cdata of another item type -- the four call sites used to spell it
+    that way and refused a caller's buffer with cffi's own message about
+    an internal `char[32]`. It also means no `bytes` of the secret is made
+    in between, which is the whole of what a caller holding a buffer came
+    for.
+
+    Args:
+        prvkey: the scalar, as the caller passed it, in any form
+            `_scalar.scalar` accepts.
+        name: what the scalar is, as the exception should call it.
+
+    Returns:
+        A `char[32]` holding those octets, for the caller of this to hand
+        libsecp256k1 and then to wipe.
+
+    Raises:
+        TypeError: propagated from `_scalar.scalar`.
+        ValueError: propagated from it too, a length among the reasons.
+    """
+    buffer = ffi.new("char[32]")
+    # the length is the buffer's own, as it is in `wipe`, rather than a
+    # literal written a second time beside the cdecl
+    ffi.memmove(buffer, scalar(prvkey, name), ffi.sizeof(buffer))
+    return buffer
+
+
 def keypair(prvkey: BytesLike | int) -> CData:
     """Build the libsecp256k1 keypair of a private key.
 

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -21,7 +21,7 @@ from typing import overload
 from . import BytesLike, CData, MutableBytesLike, ffi, lib
 from ._cdata import array
 from ._scalar import octets, scalar
-from ._secret import take
+from ._secret import scalar_buffer, take
 from .context import ctx
 
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
@@ -127,7 +127,7 @@ def prvkey_negate(
         ValueError: if it is not 32 bytes, does not fit in them, or is
             not in [1, n-1]; or if `into` is not 32 bytes.
     """
-    prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
+    prvkey_buffer = scalar_buffer(prvkey, "private key")
     if not lib.secp256k1_ec_seckey_negate(ctx, prvkey_buffer):
         raise ValueError("invalid private key: not in [1, n-1]")
     return take(prvkey_buffer, into=into)
@@ -174,7 +174,7 @@ def prvkey_tweak_add(
             is zero, which is the one tweak with no valid result, or if
             `into` is not 32 bytes.
     """
-    prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
+    prvkey_buffer = scalar_buffer(prvkey, "private key")
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_add(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")
@@ -218,7 +218,7 @@ def prvkey_tweak_mul(
             is zero or at or above the group order, or if `into` is not
             32 bytes.
     """
-    prvkey_buffer = ffi.new("char[32]", scalar(prvkey, "private key"))
+    prvkey_buffer = scalar_buffer(prvkey, "private key")
     tweak_bytes = scalar(tweak, "tweak")
     if not lib.secp256k1_ec_seckey_tweak_mul(ctx, prvkey_buffer, tweak_bytes):
         raise ValueError("invalid private key or tweak")

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -31,7 +31,7 @@ from collections.abc import Callable, Mapping, Sequence
 from . import BytesLike, CData, ffi, keys, lib, xonly
 from ._cdata import array
 from ._scalar import in_range, octets, scalar
-from ._secret import keypair, take, wipe
+from ._secret import keypair, scalar_buffer, take, wipe
 from .context import ctx
 
 # the two widths this module has to check, neither of them a macro that
@@ -135,10 +135,7 @@ def _create_outputs_(
     seckeys: list[CData] = []
     try:
         keypairs.extend(keypair(prvkey) for prvkey in taproot_prvkeys)
-        seckeys.extend(
-            ffi.new("unsigned char[32]", scalar(prvkey, "private key"))
-            for prvkey in prvkeys
-        )
+        seckeys.extend(scalar_buffer(prvkey, "private key") for prvkey in prvkeys)
         created = lib.secp256k1_silentpayments_sender_create_outputs(
             ctx,
             array("secp256k1_xonly_pubkey *[]", outputs),

--- a/stubs/_btclib_secp256k1.pyi
+++ b/stubs/_btclib_secp256k1.pyi
@@ -24,6 +24,14 @@ that of the memory rather than of a pointer to it: `_secret` reads both
 from it. `memoryview` is what it is used as -- sliced, assigned to, and
 measured -- so that is what it is declared to return.
 
+`from_buffer` and `memmove` are the two halves of what a caller's own 32
+octets can become. The first re-views them as the item type the boundary
+takes, without copying and while keeping the memory alive, which is
+`_scalar._owned_octets`; the second fills a buffer this package allocated
+from either a `bytes` or a cdata, which is `_secret.scalar_buffer`, where
+a copy is owed because libsecp256k1 writes through the pointer or because
+this package wipes it afterwards.
+
 `addressof` is how a field of a struct is passed where libsecp256k1 wants
 a pointer to it: the found outputs of `silentpayments` carry an x-only
 public key and a label by value, and each has to reach its own serializer.
@@ -34,21 +42,33 @@ well as a string. `_CType` is what says so: with `Any` there instead,
 `new` accepts anything at all -- `ffi.new(_XONLY_SIZE)`, an int where a
 cdecl belongs, and the size and the type it was built from now sit a
 dozen lines apart in the same module -- which is the vacuous
-type-checking this file exists to prevent. It is opaque because nothing
-here reads what cffi answers; only where it may be passed matters.
+type-checking this file exists to prevent.
+
+`typeof` also answers *about* a cdata, which is how `_scalar.scalar`
+asks whether the 32 octets it was handed are an array of them: the
+parameter is therefore `Any`, as `sizeof`'s already is for taking either
+a cdecl or a cdata, cdata being what this file cannot name. The three
+fields of `_CType` are the ones that question reads -- the kind, the
+element type, and the name to put in the exception -- and they are here
+rather than opaque because something now reads them.
 """
 
 from typing import Any
 
-class _CType: ...
+class _CType:
+    kind: str
+    cname: str
+    item: _CType
 
 class _FFI:
     NULL: Any
     def new(self, cdecl: str | _CType, init: Any = ...) -> Any: ...
-    def typeof(self, cdecl: str) -> _CType: ...
+    def typeof(self, cdecl_or_cdata: Any) -> _CType: ...
     def addressof(self, cdata: Any, field: str) -> Any: ...
     def sizeof(self, cdecl_or_cdata: Any) -> int: ...
     def buffer(self, cdata: Any, size: int = ...) -> memoryview: ...
+    def from_buffer(self, cdecl: str | _CType, python_buffer: Any) -> Any: ...
+    def memmove(self, dest: Any, src: Any, n: int) -> None: ...
     def unpack(self, cdata: Any, length: int) -> bytes: ...
     def string(self, cdata: Any) -> bytes: ...
     def callback(self, cdecl: str, python_callable: Any) -> Any: ...

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -5,6 +5,14 @@
 
 """Every argument that takes bytes takes a bytearray and a memoryview.
 
+And every argument that takes a *scalar* takes a cffi array of 32 octets
+besides, which is memory the caller owns rather than a value: the second
+sweep here drives the same table with the private keys and tweaks handed
+in that way. It asserts the same answer and one thing more -- that the
+caller's octets are still there afterwards, since four call sites copy
+into a buffer of their own precisely because libsecp256k1 writes through
+the pointer or because this package wipes it.
+
 The check is a normalization, so it has to be the normalized value that
 reaches libsecp256k1: a call site that checks its argument and then
 passes the one it was given would still hand cffi a bytearray, and cffi
@@ -469,6 +477,102 @@ def retyped(value: Any, kind: type) -> Any:
     if isinstance(value, dict):
         return {key: retyped(item, kind) for key, item in value.items()}
     return value
+
+
+# the scalars of the table above, by identity: every other bytes argument
+# crosses as a value rather than as memory, and `entropy` and `octets`
+# take no cdata. A tuple rather than a set, `bytes` being hashable but
+# `is` being the question
+SCALARS = (PRVKEY, TWEAK, SCAN_PRVKEY, SPEND_PRVKEY)
+
+
+def held(value: Any, made: list[tuple[Any, bytes]]) -> Any:
+    """Return a scalar argument as 32 octets of cffi memory.
+
+    Sequences and mappings are walked as `retyped` walks them, for the
+    same reason: the scalars of `create_outputs` and `scan_outputs` are
+    inside a list and a pair.
+
+    Args:
+        value: one argument of a call below.
+        made: what to record each buffer and its octets in, so that the
+            caller of this can check afterwards that nothing wrote
+            through them.
+
+    Returns:
+        The same value as an `unsigned char[32]` where it is one of the
+        scalars, walked where it is a sequence, and unchanged otherwise.
+    """
+    if any(value is scalar for scalar in SCALARS):
+        buffer = ffi.new("unsigned char[32]", value)
+        made.append((buffer, value))
+        return buffer
+    if isinstance(value, list):
+        return [held(item, made) for item in value]
+    if isinstance(value, tuple):
+        return tuple(held(item, made) for item in value)
+    if isinstance(value, dict):
+        return {key: held(item, made) for key, item in value.items()}
+    return value
+
+
+@pytest.mark.parametrize("name,call,args,kwargs", CALLS, ids=[c[0] for c in CALLS])
+def test_a_scalar_may_be_a_buffer_at_every_entry_point(
+    name: str,
+    call: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    """The answer does not depend on the scalar being a value or memory.
+
+    Driven over the whole table rather than over the entry points that
+    looked interesting: which sites copy is not visible from the outside,
+    and the two that were wrong were `keys.prvkey_negate` -- reached by
+    `ssa.nonce_bip340` for half of all keys and by nothing else here --
+    and `silentpayments._create_outputs_`, each refusing one cdecl and
+    taking the other.
+
+    The second assertion is the half a comparison of answers cannot see:
+    a caller's buffer must come back holding what it held. Three sites
+    have libsecp256k1 write through the pointer and one wipes what it was
+    given, so each has to copy first, and a copy left out would show up
+    as a negated key or 32 zeros in the caller's own memory.
+
+    Args:
+        name: the entry point, for the test id.
+        call: the entry point itself.
+        args: its arguments, as bytes.
+        kwargs: its keyword arguments.
+    """
+    made: list[tuple[Any, bytes]] = []
+    swapped = tuple(held(argument, made) for argument in args)
+    assert call(*args, **kwargs) == call(*swapped, **kwargs)
+    assert all(bytes(ffi.buffer(buffer)) == octets for buffer, octets in made)
+
+
+def test_the_negating_half_of_a_nonce_takes_a_buffer_too() -> None:
+    """One table row cannot reach a branch that depends on the key.
+
+    `ssa.nonce_bip340` negates the private key where its point has odd y,
+    which is the only path in this table to `keys.prvkey_negate` other
+    than the row for it -- and `PRVKEY` is 7, whose y is even, so the
+    sweep above never takes that branch. With a buffer-held key it was a
+    coin flip on the key: 5 and 7 answered, 6 raised.
+
+    Both parities are asserted to occur rather than assumed, as
+    `tests/test_verified_signing.py` does of the same question.
+    """
+    parities = set()
+    for prvkey in (5, 6):
+        octets = prvkey.to_bytes(32, "big")
+        parities.add(xonly.from_prvkey(octets)[1])
+        held = ffi.new("unsigned char[32]", octets)
+        assert ssa.nonce_bip340(MSG, held, bytes(32)) == ssa.nonce_bip340(
+            MSG, octets, bytes(32)
+        )
+        # the negation is of a copy: what the caller handed in is intact
+        assert bytes(ffi.buffer(held)) == octets
+    assert parities == {0, 1}
 
 
 @pytest.mark.parametrize("kind", [bytearray, memoryview])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -296,6 +296,59 @@ def test_type_checks_refuse_what_merely_has_a_length() -> None:
         keys.pubkey_sort(pubkey_bytes)  # type: ignore[arg-type]
 
 
+def test_a_scalar_may_be_octets_this_package_can_overwrite() -> None:
+    """A cffi array of 32 octets is taken as it stands, and nothing else is.
+
+    Why it is taken is `tests/test_secret.py`'s subject: memory a caller
+    can zero, where the `bytes` this would otherwise convert to is a copy
+    of the secret that nothing can. What is refused is every shape whose
+    32 octets cannot be known to be 32 octets of scalar, and the three
+    are three different mistakes.
+
+    A pointer answers 8 for its own `ffi.sizeof` and says nothing about
+    what it points at -- the trap `_secret.wipe` records from the other
+    side, where that number would have wiped a quarter of a private key
+    and reported success. An array of wider items is 32 octets of
+    whatever this machine's byte order made of them, which is what
+    `_scalar.octets` refuses a `memoryview` of wider items for. And an
+    array of the wrong length is the length check every other scalar
+    gets, made here because a bare pointer cannot be given one later.
+    """
+    secret = bytes([7]) * 32
+
+    # four item types rather than one spelled four ways: cffi holds
+    # `uint8_t` and `signed char` to be primitives of their own, so
+    # nothing but a re-view of the octets lets all four cross
+    for cdecl in ("unsigned char[32]", "char[32]", "uint8_t[32]", "signed char[32]"):
+        held = ffi.new(cdecl)
+        ffi.buffer(held)[:] = secret
+        assert keys.pubkey_from_prvkey(held) == keys.pubkey_from_prvkey(secret)
+
+    # a view of the caller's memory and not a copy of it, which is the
+    # whole of what "unconverted" buys and also what it costs: writing
+    # through the buffer changes what libsecp256k1 would read
+    held = ffi.new("unsigned char[32]", secret)
+    viewed = _scalar.scalar(held, "private key")
+    held[0] = 0x09
+    assert bytes(ffi.buffer(viewed))[0] == 0x09
+
+    for cdecl in ("unsigned char *", "secp256k1_keypair *", "uint32_t[8]"):
+        with pytest.raises(TypeError, match="must be a cffi array of octets"):
+            keys.prvkey_verify(ffi.new(cdecl))
+    with pytest.raises(ValueError, match="private key must be 32 bytes"):
+        keys.prvkey_verify(ffi.new("unsigned char[31]"))
+
+    # a str is the one thing the question itself would get wrong, and
+    # `"char[32]"` is why it is refused before being asked rather than
+    # by the answer: `ffi.typeof` reads a str as a cdecl, so that one
+    # resolves, measures 32 octets, and would have been passed on as a
+    # str. The other spelling raises cffi's own `undefined type name`,
+    # which is not a TypeError and not about the argument
+    for text in ("char[32]", "x" * 32):
+        with pytest.raises(TypeError, match="private key must be bytes or an int"):
+            keys.prvkey_verify(text)  # type: ignore[arg-type]
+
+
 def test_a_bool_is_not_a_scalar() -> None:
     """A bool is refused where a scalar goes, python making it an int.
 

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -290,3 +290,28 @@ def test_the_two_spellings_of_a_producer_agree() -> None:
         into = bytearray(32)
         assert call(*args, into=into) is None, call.__name__
         assert bytes(into) == call(*args), call.__name__
+
+
+def test_a_key_held_in_a_buffer_never_becomes_a_bytes_of_the_secret() -> None:
+    """The copy `into` cannot help with, and the one `scalar` no longer makes.
+
+    `into` is for a secret coming *out* of this package. This is the
+    other direction: a caller signing again and again under one key can
+    hold it in memory it owns -- `ffi.new`, and `_secret.wipe` when done
+    -- and hand that to the boundary, where before it was converted to an
+    immutable `bytes` per call and nothing could overwrite those.
+
+    Both halves are asserted, because either alone would be misleading.
+    The signature and the derived key are the ones the same secret gives
+    as `bytes`, so nothing about the answers changed; and the buffer is
+    zero after the wipe, which is what the `bytes` could never be.
+    """
+    held = ffi.new("unsigned char[32]", SECRET)
+    msg = bytes(range(32))
+
+    assert dsa.sign(msg, held) == dsa.sign(msg, SECRET)
+    assert keys.pubkey_from_prvkey(held) == keys.pubkey_from_prvkey(SECRET)
+    assert ssa.sign(msg, held, bytes(32)) == ssa.sign(msg, SECRET, bytes(32))
+
+    _secret.wipe(held)
+    assert bytes(ffi.buffer(held)) == bytes(32)

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -69,7 +69,7 @@ from typing import Any, NoReturn
 
 import pytest
 
-from btclib_secp256k1 import CData, dsa, keys, recovery, ssa, xonly
+from btclib_secp256k1 import CData, dsa, ffi, keys, recovery, ssa, xonly
 
 MSG = hashlib.sha256(b"a message to sign twice").digest()
 PRVKEY = 7
@@ -681,3 +681,32 @@ def test_the_derivation_the_argument_saves_is_not_made_at_all() -> None:
         assert recovery.sign(MSG, PRVKEY, pubkey=pubkey) == recovery.sign(
             MSG, PRVKEY, verify=False
         )
+
+
+def test_the_discrimination_holds_for_a_key_held_in_a_buffer() -> None:
+    """The reason `scalar` takes a cffi array, rather than the mechanism.
+
+    The failing branch derives, and the derivation asks for a scalar. So
+    a caller holding the private key in memory it can wipe -- which is
+    what `tests/test_secret.py` is about -- used to reach this branch and
+    be told `the private key must be bytes or an int`: a type error about
+    an argument they had passed correctly, in place of the one diagnosis
+    this check exists to make.
+
+    Both sides of that diagnosis are held here with the key in a buffer.
+    The wrong public key is still a `ValueError` about the argument, and a
+    fault under the right one is still the `RuntimeError` -- and the
+    second needs the stand-in for the reason it always did: no input makes
+    a fresh signature fail its own verification.
+    """
+    held = ffi.new("unsigned char[32]", PRVKEY_BYTES)
+
+    other = keys.pubkey_from_prvkey(PRVKEY + 1, compressed=False)
+    with pytest.raises(ValueError, match="not this private key's"):
+        dsa.sign(MSG, held, pubkey=other)
+
+    pubkey = keys.pubkey_from_prvkey(PRVKEY)
+    with pytest.MonkeyPatch.context() as patch:
+        _refuse_every_check(patch)
+        with pytest.raises(RuntimeError, match=_UNVERIFIED):
+            dsa.sign(MSG, held, pubkey=pubkey)


### PR DESCRIPTION
Wherever a private key or a tweak is accepted, a cffi array of exactly 32
octets is now accepted too and handed to libsecp256k1 unconverted — the
only argument of these bindings that is not copied on the way in. The
reason is what the copy is: an immutable `bytes` of a secret, which
nothing can overwrite and which stays until the collector gets to it.

**[ISS 247](https://github.com/btclib-org/btclib-secp256k1/issues/247)'s
premise turned out to be wrong, and the finding narrowed the change.** It
reasoned that a `dsa.Signer` holding a buffer "would have to turn it back
into a `bytes` on every call". It would not: `dsa._signed` and
`dsa._checked` hand libsecp256k1 the pointer, exactly as `ssa.Signer`
bypasses `keypair` per signature. A prototype signer holding
`ffi.new("unsigned char[32]")` produced byte-identical signatures
*before* this change and hoisted 0.37 µs of 23.42 — Apple M5, macOS 26.6,
arm64, CPython 3.14.6, nine rounds of 3 000 calls, minimum kept, the
checked call run twice for a noise of 0.02. So the README's verdict on
speed stands untouched.

**What does bind is the derivation, and the sharpest case is a
diagnosis.** `keys._pubkey_from_prvkey_` asks for a scalar, so the failing
branch of `dsa._checked` — which derives precisely in order to tell a
wrong argument from a fault — answered `TypeError: the private key must be
bytes or an int, not __CDataOwn` under a buffer-held key. A caller whose
hardware had faulted was told they had mistyped an argument they passed
correctly, which is the misdiagnosis
[ISS 245](https://github.com/btclib-org/btclib-secp256k1/issues/245) built
that branch to avoid. That is why the door is open — for the diagnosis,
not for the microsecond — and
`test_the_discrimination_holds_for_a_key_held_in_a_buffer` holds both
sides of it with the key in a buffer.

**Three refusals**, because what follows is a bare pointer libsecp256k1
reads 32 octets from: a *pointer* (`ffi.sizeof` 8, the trap `_secret.wipe`
records from the other side), an array of wider items (`uint32_t[8]` is 32
octets of this machine's byte order, refused as `octets` refuses a
`memoryview` of wider items), and the wrong length.

**A `str` is refused before `ffi.typeof` is asked, and that is a bug the
suite caught rather than a case I thought of.** `ffi.typeof` reads a str as
a *cdecl*: `"x" * 32` raises cffi's own `error: undefined type name` —
neither this function's `TypeError` nor about the argument — and
`"char[32]"` is worse, resolving to a 32-octet type, so the str would have
been handed to libsecp256k1. `test_type_checks_refuse_what_merely_has_a_length`
failed on the first spelling the moment the branch existed; the second was
found looking for why. Both are cases now.

**The public annotations do not widen**, which was the cost ISS 247 named:
`CData` is `Any`, so `BytesLike | int | CData` on `dsa.sign` would stop
mypy checking every caller's private key. Only `scalar`'s own parameter
widens — the entry points still declare `BytesLike | int`, a `float` is
still refused statically at the call the caller made, and a cdata still
arrives because `ffi.new` answers `Any`. What is given up is mypy checking
this package's own calls of `scalar`, whose run-time check does the work.

The cffi stub gains the three ctype fields the question reads (`kind`,
`cname`, `item`) and `typeof` now takes a cdata as `sizeof` already does;
`SECURITY.md`'s claim that the entry side "cannot be improved from inside
this package" is no longer true and says what it now is.

Whether a `dsa.Signer` is worth having stays btclib-org/btclib#982's
question. This answers it only by removing the blocker: the wiping ground
it would be argued on no longer needs a signer at all.

Evidence, local, on this sha:

- `uv run --locked --no-default-groups --group test pytest --cov` — exit 0, 650 passed, 100% coverage
- `uvx pre-commit run --all-files` — exit 0, 37 hooks
- by hand: the buffer passes through as the same object, signs and derives identically, wipes to zero; the pointer/struct/wider-item/short shapes and both str spellings all refused with their own messages; the fault path answers `RuntimeError` and the wrong key `ValueError`

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow callers to pass wipeable cffi-backed 32-byte scalars while preserving copying for operations that modify or erase scalar memory.

New Features:
- Accept caller-owned cffi arrays of exactly 32 octets for private keys and tweaks without copying them at read-only scalar boundaries.

Bug Fixes:
- Preserve correct key-validation and hardware-fault diagnostics when private keys are held in cffi buffers.
- Reject invalid cffi scalar shapes and string inputs with clear type and length errors.
- Ensure operations that mutate or wipe scalar data continue copying into package-owned buffers.

Enhancements:
- Add safe scalar buffer handling and broaden cffi stubs for inspecting and re-viewing cdata.
- Document caller responsibilities, memory-lifetime considerations, and wiping guidance for caller-owned scalar buffers.

Documentation:
- Update the README, security guidance, and changelog to describe caller-owned scalar buffers and their security trade-offs.

Tests:
- Add coverage for cffi-backed scalars across scalar entry points, validation failures, parity-dependent paths, diagnostics, and wiping behavior.