### PR TITLE
Assert the saving dsa's public key argument exists for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,16 @@ release-notes length in the first place, and are still in
   would have said that stubbing the second verification to succeed
   turns every genuine fault under a handed-in key into a report that
   the caller mistyped an argument. That mutation now fails the suite.
+- **And the saving itself is asserted rather than only measured**
+  (#251). What the argument buys is the early return in `_checked`, and
+  deleting that return changed no answer: a correct key reached the
+  derived comparison, which agreed and gave back the same signature, so
+  every other case of the argument passed with the derivation paid for
+  again -- the figures above false and nothing red.
+  `test_the_derivation_is_not_made_where_the_key_handed_in_verifies`
+  substitutes the multiplication for one that raises, and the signature
+  coming back at all is what says it was never made. That mutation now
+  fails the suite, and it failed nothing before.
 - **Refused rather than resolved**, as `aux_rand32` beside `grind`
   already is: a key given with `verify=False` raises, being a caller
   contradicting themselves, and octets that are not a key are parsed and

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -554,6 +554,25 @@ def test_a_fault_under_a_handed_in_key_is_not_reported_as_a_wrong_key() -> None:
             dsa.sign(MSG, PRVKEY, pubkey=pubkey)
 
 
+def test_the_derivation_is_not_made_where_the_key_handed_in_verifies() -> None:
+    """`dsa`'s early return, which is the whole of what its argument saves.
+
+    `_checked` verifies under the key handed in and returns there,
+    deriving only where that fails, so the saving is that return and
+    nothing else -- and `_refusing_to_derive` says why no other case of
+    the argument can see it go. The unchecked call is the independent
+    side: it never derives whatever the check does, so the checked one
+    answering the same octets with the multiplication raising is what
+    says the derivation was not made.
+    """
+    pubkey = keys.pubkey_from_prvkey(PRVKEY)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(keys, "_pubkey_from_prvkey_", _refusing_to_derive)
+        assert dsa.sign(MSG, PRVKEY, pubkey=pubkey) == dsa.sign(
+            MSG, PRVKEY, verify=False
+        )
+
+
 def test_a_key_handed_in_is_the_key_recovery_would_have_derived() -> None:
     """The signature is the same pair, whichever way the check got its key.
 


### PR DESCRIPTION
`tests/test_verified_signing.py` gains one case, and it is the one thing
about `dsa.sign(pubkey=...)` that nothing held: that the derivation the
argument exists to avoid is not made.

`dsa._checked` verifies under the key handed in and returns there,
deriving only where that fails, so the saving *is* that early return.
Hoist the derivation out of the failing branch and every answer stays
identical — the derived comparison agrees, the same signature comes back
— while the `secp256k1_ec_pubkey_create` the argument was taken for is
paid again. That is the shape a refactor drops in silence, and the table
in `README.md` would then be false with nothing red.

**The stand-in is why this could not have been written before
[PR 252](https://github.com/btclib-org/btclib-secp256k1/pull/252).**
`_refusing_to_derive` — the substituted multiplication that turns the
saving into an assertion — arrived there with `recovery`'s side of this,
so this branch reuses it rather than carrying a second copy. It was
written stacked on `31c4eb1` and moved onto `main` with
`git rebase --onto` once that landed as `5d2ad86`; the squash left the
tree identical, so the move replayed one commit and resolved nothing.
The diff below is this case alone.

The name is what distinguishes the two: `recovery`'s is
`test_the_derivation_the_argument_saves_is_not_made_at_all`, and the
`dsa` one names the path its return sits on —
`test_the_derivation_is_not_made_where_the_key_handed_in_verifies`.

Evidence, local, on `4c1cd08`:

- the mutant hand-applied — `derived = keys._pubkey_from_prvkey_(prvkey_bytes)`
  hoisted above `if pubkey is not None:` — **1 failed, 67 passed**, the
  failure being the new case and nothing else in the file seeing it.
  Restored, control run green, `PYTHONDONTWRITEBYTECODE=1` throughout, so
  no `.pyc` of the mutant outlives it
- `uv run --locked --no-default-groups --group test pytest --cov` — exit 0,
  656 passed, 100.00%
- `uvx pre-commit run --all-files` — exit 0, 37 hooks, nothing modified

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the supplied public key path in DSA signing preserves its derivation-saving early return.

Enhancements:
- Assert that signing with a valid supplied public key avoids redundant public-key derivation.

Tests:
- Add a regression test that fails if derivation occurs when the supplied key already verifies.