### PR TITLE
Name the two saving tests the way the file names every other pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ release-notes length in the first place, and are still in
   derived comparison, which agreed and gave back the same signature, so
   every other case of the argument passed with the derivation paid for
   again -- the figures above false and nothing red.
-  `test_the_derivation_is_not_made_where_the_key_handed_in_verifies`
+  `test_the_derivation_the_argument_saves_is_not_made_at_all`
   substitutes the multiplication for one that raises, and the signature
   coming back at all is what says it was never made. That mutation now
   fails the suite, and it failed nothing before.

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -554,7 +554,7 @@ def test_a_fault_under_a_handed_in_key_is_not_reported_as_a_wrong_key() -> None:
             dsa.sign(MSG, PRVKEY, pubkey=pubkey)
 
 
-def test_the_derivation_is_not_made_where_the_key_handed_in_verifies() -> None:
+def test_the_derivation_the_argument_saves_is_not_made_at_all() -> None:
     """`dsa`'s early return, which is the whole of what its argument saves.
 
     `_checked` verifies under the key handed in and returns there,
@@ -684,7 +684,7 @@ def test_a_key_fixed_in_advance_cannot_pass_a_recovered_signature() -> None:
             recovery.sign(msg, other_key, pubkey=wrong)
 
 
-def test_the_derivation_the_argument_saves_is_not_made_at_all() -> None:
+def test_the_derivation_the_recoverable_check_saves_is_not_made_at_all() -> None:
     """The saving itself, asserted rather than measured.
 
     The check compares the recovered key with the one handed in and


### PR DESCRIPTION
Three lines: two test names swapped, and the one changelog citation that
follows them.

Where `tests/test_verified_signing.py` states a claim twice — once for
`dsa`, once for `recovery` — the `recovery` name is the one carrying a
qualifier and the `dsa` name is the plain sentence. Four pairs do it that
way:

| the claim | `dsa` | `recovery` |
| --- | --- | --- |
| the key handed in is the derived one | `…that_would_have_been_derived` | `…recovery_would_have_derived` |
| bad octets refused early | `…before_anything_is_signed` | `…before_signing_recoverably` |
| a key beside the flag | `…the_flag_that_declines_the_check` | `…where_the_recoverable_check_is_declined` |
| a key fixed in advance | `…a_signature_of_another_key` | `…a_recovered_signature` |

The fifth pair was inverted. `recovery`'s saving case held the plain
`test_the_derivation_the_argument_saves_is_not_made_at_all`, so the `dsa`
case of that same claim, added by
[PR 254](https://github.com/btclib-org/btclib-secp256k1/pull/254), had to
be given a qualifier to sit beside it — and what it got named was the code
path its early return sits on rather than the property being claimed. The
unmarked name is how a reader going down the file tells the base case from
the variant, and it pointed at the wrong module.

So `recovery`'s takes the qualifier its four neighbours have and the `dsa`
one takes the sentence.

**Nothing but the names moves, and two things were left alone
deliberately.** Each docstring describes its own test and stays true under
the new name, so neither was touched — churning true prose to match a rename
is how a diff stops being three lines. And there is no changelog bullet of
its own: 0.8.0.3 has not shipped, so neither name has been outside this
repository, the bullet that cites the test is the record, and it now cites
the right one. A second bullet saying a name changed would document a name
no reader of that release can meet.

Evidence, local, on `d9f14de`:

- `uv run --locked --no-default-groups --group test pytest --cov` — exit 0,
  656 passed, 100.00%
- `pytest --collect-only` — both cases collected under their new names and
  neither under an old one, which is what says the rename reached the
  definitions and not only the prose
- `uvx pre-commit run --all-files` — exit 0, 37 hooks, nothing modified
- `grep` over the tree — no citation of either old name survives

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the two derivation-saving tests and update their changelog reference for consistent naming.

Enhancements:
- Align the paired verified-signing test names so the base and recoverable cases consistently describe the derivation-saving behavior.

Chores:
- Update the changelog citation to use the renamed test.