### PR TITLE
Name the tests the docstring points at, rather than where they sit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,28 @@ release-notes length in the first place, and are still in
   module by splitting a test id on `.` is a weaker statement than the
   message written beside the call. The ids are stated once as well,
   every table here being those rows in that order.
+- **The module docstring of `tests/test_verified_signing.py` names the
+  tests it points at** (#256). Two of its landmarks were positions rather
+  than names, and each had come to name the wrong test. "The last test in
+  this file" arrived with #217 meaning
+  `test_the_recovery_id_is_what_the_check_catches`, and #245 appended the
+  `dsa` group after it. "The last of those tests" meant
+  `test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key` and
+  arrived with #246 -- which in that same diff put two tests after the one
+  it points at, so it was false in the commit that wrote it. That is the
+  whole argument against the form: a position is a claim nothing checks,
+  and an append falsifies it in silence, sometimes its own. Both now name
+  the test.
+- **And the account of the two key-handed-in groups gains the third thing
+  they hold**, in one clause for both halves rather than one for `dsa`:
+  that the saving is asserted and not only priced, by
+  `test_the_derivation_the_argument_saves_is_not_made_at_all` and
+  `test_the_derivation_the_recoverable_check_saves_is_not_made_at_all`.
+  Raised as a non-blocking review finding on #254, where folding it into
+  that diff would have put the asymmetry in a second place. What a name
+  still does not buy is a check -- a rename falsifies it as quietly as an
+  append falsified a position -- which is #258, and the count in the same
+  docstring is #259.
 
 ### The frames between an entry point and libsecp256k1
 

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -36,10 +36,10 @@ passing.
 `recovery` adds a fifth, and it is the one that says what the check is
 for rather than that the raise is wired to it. There the fault *is*
 reachable from an input -- a wrong recovery id is one `parse_compact`
-away -- so the last test in this file needs no stand-in at all: it
-signs, re-parses under each id, and holds real libsecp256k1 to refusing
-every one but the signature's own, while a verification of the same
-octets still succeeds.
+away -- so `test_the_recovery_id_is_what_the_check_catches` needs no
+stand-in at all: it signs, re-parses under each id, and holds real
+libsecp256k1 to refusing every one but the signature's own, while a
+verification of the same octets still succeeds.
 
 `dsa` adds a group of its own, for the public key a caller may hand the
 check instead of having it derived. Those turn on the key being taken on
@@ -52,12 +52,19 @@ than a case.
 `recovery` takes the same key and adds the group after it, where the
 failure has three causes rather than two: the key given, the recovery id,
 or the computation. The first is an argument and the other two are not,
-and what separates them is the derivation the matching path skipped. The
-last of those tests is the one nothing else in the package can write --
-a right key and a wrong id, both real, no stand-in anywhere -- and the
-property over many keys is asserted again there, because what makes the
-trust safe is a different sentence when the key is recovered rather than
-verified against.
+and what separates them is the derivation the matching path skipped.
+`test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key` is the
+one nothing else in the package can write -- a right key and a wrong id,
+both real, no stand-in anywhere -- and the property over many keys is
+asserted again there, because what makes the trust safe is a different
+sentence when the key is recovered rather than verified against.
+
+Each group also asserts the saving itself, which no other case of the
+argument can see: with the multiplication substituted for one that
+raises, `test_the_derivation_the_argument_saves_is_not_made_at_all` and
+`test_the_derivation_the_recoverable_check_saves_is_not_made_at_all` hold
+the signature to coming back anyway, so the derivation a key handed in
+skips is asserted absent rather than only priced.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
`tests/test_verified_signing.py` opens with a map of itself: which group
asks what, and which case in each group needs no stand-in. Two of its
landmarks were positions rather than names, and each had come to name the
wrong test.

- **`:39`, "the last test in this file"**, arrived with
  [PR 217](https://github.com/btclib-org/btclib-secp256k1/issues/217)
  meaning `test_the_recovery_id_is_what_the_check_catches`, and
  [PR 245](https://github.com/btclib-org/btclib-secp256k1/pull/245)
  appended the `dsa` group after it. It had come to point at
  `test_the_discrimination_holds_for_a_key_held_in_a_buffer`, which is
  [ISS 247](https://github.com/btclib-org/btclib-secp256k1/issues/247)'s
  and about a buffer.
- **`:56`, "the last of those tests"**, meant
  `test_a_wrong_id_under_a_right_key_is_not_reported_as_a_wrong_key` and
  arrived with
  [PR 252](https://github.com/btclib-org/btclib-secp256k1/pull/252) — which
  in that same diff put two tests after the one it points at. It was false
  in the commit that wrote it, and that is read from git rather than
  reasoned about: `git log -S"last of those tests"` names `5d2ad86`, whose
  own tree has that test at 616 and two more at 652 and 668.

Which is the whole argument against the form, and the answer
[ISS 256](https://github.com/btclib-org/btclib-secp256k1/issues/256) asks
for: a position is a claim nothing checks, an append falsifies it in
silence, and one of these two was falsified by its own commit. Both now
name the test.

**The third thing each group holds.** The account of the key-handed-in
groups was "what it costs … and what it cannot cost", two things where the
groups now hold three: that the saving is taken. One clause carries it for
both halves rather than one for `dsa`, naming both saving cases — a clause
on the `dsa` half alone would put in a second place the very asymmetry
[PR 257](https://github.com/btclib-org/btclib-secp256k1/pull/257) removed.

Evidence, local, on `c74700c`:

- `uv run --locked --no-default-groups --group test pytest --cov` — exit 0,
  725 passed, 100.00%
- every name the docstring now cites resolves to a `def` in the file, and
  neither old landmark survives anywhere in it. That pair is the check this
  change *is*: prose is what no hook reads, so the only thing that makes
  the diff true is having asked the file
- `uvx pre-commit run --all-files` — exit 0, 37 hooks, nothing modified

Noticed and filed, not addressed here:

- [ISS 258 — nothing checks that a test named in prose is still a test](https://github.com/btclib-org/btclib-secp256k1/issues/258).
  A name is better than a position but still unchecked: PR 257 renamed two
  of the four tests this docstring now cites. The guard carries a design
  question, which is why it is not folded in — `tests/test_vectors.py`
  cites rust-secp256k1's own `test_low_r`, correct prose that a naive walk
  would report as dangling.
- [ISS 259 — what this docstring calls four things is five for `ssa`](https://github.com/btclib-org/btclib-secp256k1/issues/259).
  `test_the_keypair_is_checked_against_the_key_that_signed` is none of the
  four, and correcting the number means rewriting the chain of three
  paragraphs that lean on it.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the verified-signing test documentation name the cases it describes and cover the derivation-saving assertions.

Enhancements:
- Replace positional references in the verified-signing test module docstring with explicit test names.
- Document that the key-supplied verification groups also assert that the skipped derivation is not performed.

Documentation:
- Update the changelog with the corrected test references and expanded explanation of the verified-signing test coverage.