### PR TITLE
Set Sonnet as the default Claude Code model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "model": "sonnet"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,16 @@ quietly: it restores from the index, so an edit made and not staged is
 gone with no output at all. Reverting a deliberate experiment is what a
 copy is for — `cp file file.bak`, then put it back.
 
+## Model
+
+The default model for this repository is Sonnet. Switch to Opus only
+for architectural decisions with conflicting constraints -- design
+choices with non-obvious trade-offs, refactors with unclear
+dependencies, diagnosis where the symptom does not point to the
+cause. Use `/model opus` for the session, then switch back to Sonnet.
+
+Do not use Fable unless explicitly instructed.
+
 ## Commands whose flags are load-bearing
 
 ```shell


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` pinning `"model": "sonnet"` as this repository's default Claude Code model.
- Add a `## Model` section to CLAUDE.md, placed right after "The primary checkout is the maintainer's": switch to Opus only for architectural decisions with conflicting constraints (design choices with non-obvious trade-offs, refactors with unclear dependencies, diagnosis where the symptom doesn't point to the cause), via `/model opus` for the session; do not use Fable unless explicitly instructed.

No `[tool.check-manifest]` ignore change needed here: this repository does not run check-manifest.

Equivalent to [checksig#660](https://github.com/checksig-custody/checksig/pull/660) and [btclib#1010](https://github.com/btclib-org/btclib/pull/1010), opened for every repository in this organization.

## Test plan
- [x] `uv run pre-commit run --files CLAUDE.md .claude/settings.json` — all hooks pass, including submodule-pin (after `git submodule update --init secp256k1`) and Pyroma
- [x] `git log -1 --format='%G? %GS'` — `G Ferdinando M. Ametrano`

## Summary by Sourcery

Configure Sonnet as the default Claude Code model and document the criteria for using Opus.

New Features:
- Set Sonnet as the repository’s default Claude Code model through project settings.

Enhancements:
- Document when to switch to Opus for architectural decisions and prohibit Fable unless explicitly requested.

Documentation:
- Add repository guidance for selecting Claude Code models.