### PR TITLE
Stop the submodule-pin hook from discovering the wrapper repo

### DIFF
--- a/.github/scripts/check_submodule_pin.py
+++ b/.github/scripts/check_submodule_pin.py
@@ -144,6 +144,29 @@ def pinned_commit() -> str | None:
     return fields[1] if len(fields) == 4 and fields[0] == "160000" else None
 
 
+def _checked_out(path: Path) -> bool:
+    """Whether a submodule has a `.git` of its own under `path`.
+
+    `-C path` does not stop git from discovering a repository above
+    `path` when `path` has no `.git` -- a fresh `git worktree add` does
+    not initialize submodules, so `path` can exist, empty, with the
+    wrapper repository one directory up being the first `.git` upward
+    discovery finds. Checking for `path/.git` directly, before any git
+    command runs in it, is what keeps that discovery from having
+    anywhere to walk to: a submodule's `.git` is a file pointing at its
+    module elsewhere, a plain clone's is a directory, and `Path.exists`
+    reads either without caring which.
+
+    Args:
+        path: the submodule's working directory.
+
+    Returns:
+        True where `path/.git` exists, False where the submodule was
+        never initialized (or `path` itself does not exist).
+    """
+    return (path / ".git").exists()
+
+
 def commit_of(tag: str) -> str | None:
     """Return the commit a tag names in the vendored clone.
 
@@ -155,6 +178,8 @@ def commit_of(tag: str) -> str | None:
         does not have that tag -- an uninitialized submodule, or a
         shallow checkout carrying no tags.
     """
+    if not _checked_out(_ROOT / _SUBMODULE):
+        return None
     return _git(
         "rev-parse",
         "--verify",
@@ -182,7 +207,7 @@ def why_no_tag(tag: str) -> str:
     Returns:
         A sentence naming the state and what would change it.
     """
-    if _git("rev-parse", "--git-dir", cwd=_ROOT / _SUBMODULE, disown=True) is None:
+    if not _checked_out(_ROOT / _SUBMODULE):
         return (
             f"the {_SUBMODULE} submodule is not checked out, so nothing here"
             " can resolve a tag: git submodule update --init"

--- a/tests/test_submodule_pin.py
+++ b/tests/test_submodule_pin.py
@@ -141,11 +141,8 @@ def test_a_readme_naming_no_release_fails(
     "answers, expected",
     [
         ({}, "is not checked out"),
-        ({"--git-dir": ".git", "--is-shallow-repository": "true"}, "is shallow"),
-        (
-            {"--git-dir": ".git", "--is-shallow-repository": "false"},
-            "neither absent nor shallow",
-        ),
+        ({"--is-shallow-repository": "true"}, "is shallow"),
+        ({"--is-shallow-repository": "false"}, "neither absent nor shallow"),
     ],
 )
 def test_a_clone_without_the_tag_says_which_of_the_three_it_is(
@@ -168,14 +165,50 @@ def test_a_clone_without_the_tag_says_which_of_the_three_it_is(
         tmp_path: where the README the check reads is written.
         capsys: the captured streams.
         answers: what git answers each question, by its last argument; a
-            question missing from it is a git that exited non-zero.
+            question missing from it is a git that exited non-zero. An
+            empty dict is also the signal to leave `secp256k1/.git`
+            absent, `why_no_tag` reading that state off the filesystem
+            rather than asking git.
         expected: the clause the message has to carry.
     """
     _tree(monkeypatch, tmp_path, tagged=None)
+    if answers:
+        (tmp_path / "secp256k1").mkdir()
+        (tmp_path / "secp256k1" / ".git").touch()
     monkeypatch.setattr(check, "_git", lambda *args, **_kwargs: answers.get(args[-1]))
 
     assert check.main() == 1
     assert expected in capsys.readouterr().err
+
+
+def test_git_is_never_asked_when_the_submodule_has_no_git_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A missing `secp256k1/.git` is read from the filesystem, not asked of git.
+
+    `-C secp256k1` does not stop git's own upward directory discovery
+    when `secp256k1/` has no `.git` -- a fresh `git worktree add` does
+    not initialize submodules, and the first `.git` discovery finds
+    walking up from an uninitialized `secp256k1/` is this wrapper
+    repository's, one directory up. Never calling git at all for that
+    question is what keeps that discovery from having anywhere to run;
+    a stub that raises is what makes a regression here fail loudly
+    rather than pass by resolving against the wrong repository.
+
+    Args:
+        monkeypatch: the fixture the substitutions are made through.
+        tmp_path: stands in for the wrapper repository's root.
+    """
+    monkeypatch.setattr(check, "_ROOT", tmp_path)
+    (tmp_path / "secp256k1").mkdir()
+
+    def _unreachable(*args: str, **_kwargs: Any) -> str:
+        raise AssertionError(f"git must not run when secp256k1/.git is absent: {args}")
+
+    monkeypatch.setattr(check, "_git", _unreachable)
+
+    assert check.commit_of("v0.8.0") is None
+    assert "is not checked out" in check.why_no_tag("v0.8.0")
 
 
 def test_a_tree_with_no_submodule_fails(

--- a/tests/test_submodule_pin.py
+++ b/tests/test_submodule_pin.py
@@ -256,6 +256,10 @@ def test_the_submodule_is_read_with_the_hook_environment_off(
     monkeypatch.setenv("GIT_DIR", "/elsewhere/.git")
     monkeypatch.setenv("GIT_INDEX_FILE", "/elsewhere/.git/index")
     monkeypatch.setattr(check.subprocess, "run", fake_run)
+    # this test is about the environment a real git call is made with, not
+    # about whether the submodule is checked out -- true in a git checkout,
+    # false in the sdist jobs, which unpack a tarball with no .git in it
+    monkeypatch.setattr(check, "_checked_out", lambda _path: True)
 
     check.commit_of("v0.8.0")
     submodule_env = captured[-1]


### PR DESCRIPTION
## Summary
- `commit_of()` and `why_no_tag()`'s first check ran `git -C secp256k1 rev-parse ...` with `disown=True`, which strips the inherited `GIT_*` env vars but does not stop git's own upward directory discovery.
- When `secp256k1/` has no `.git` of its own -- a fresh `git worktree add` does not initialize submodules -- those commands silently resolved one directory up, inside this wrapper repository, rather than reporting the submodule as absent.
- Added `_checked_out()`, which reads `secp256k1/.git`'s existence off the filesystem before any git command runs there, and used it in both `commit_of()` and the first branch of `why_no_tag()`.

## Test plan
- [x] `tests/test_submodule_pin.py` updated: the shallow/not-shallow cases now create `secp256k1/.git` explicitly since `why_no_tag` no longer asks git whether it exists; a new test stubs `_git` to raise if called at all, and asserts `commit_of`/`why_no_tag` never reach it when `secp256k1/.git` is absent.
- [x] `uv run --locked --no-default-groups --group test pytest --cov` -- 726 passed, 100% coverage
- [x] `uvx pre-commit run --all-files`

Closes #265

## Summary by Sourcery

Ensure submodule-pin checks report an uninitialized submodule instead of discovering the enclosing repository.

Bug Fixes:
- Prevent submodule-pin checks from accidentally resolving against the wrapper repository when the submodule is not initialized.

Enhancements:
- Detect submodule checkout state directly from the filesystem before running Git commands.

Tests:
- Add coverage confirming Git is never invoked when the submodule’s own metadata is absent and update related test fixtures.