### PR TITLE
Check that a test named in tests/*.py's prose still exists

### DIFF
--- a/.github/scripts/check_test_citations.py
+++ b/.github/scripts/check_test_citations.py
@@ -1,0 +1,211 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A test named in the suite's own prose is still a test.
+
+Test names in `tests/*.py` are prose that other prose refers to --
+`tests/test_verified_signing.py`'s own module docstring names four of
+its file's tests, `tests/test_vectors.py` names two more elsewhere in the
+package, and so on. An append cannot falsify such a citation, but a
+rename does, silently: nothing before this went red for one, and #255's
+rename of two test names is the reason that is not hypothetical -- only
+a human grepping for citations kept the prose in step with it.
+
+What this asks of every citation of the form `` `test_...` `` in a
+docstring or comment of `tests/*.py` is that it still names a test that
+exists. Not every such citation is of *this* suite, though:
+`tests/test_vectors.py` names, in the same breath as its own
+`src/lib.rs`, rust-secp256k1's `test_low_r` -- correct prose about a
+test this suite does not define and never will. Telling that citation
+from a stale one is the reason this does not simply flag every name
+with no matching `def`: a citation is read as another project's, and
+skipped, where the text just before it names whose test it is -- a
+possessive ("rust-secp256k1's `test_low_r`") or a foreign source file
+in the same breath (a `.c`, `.cpp` or `.rs` path, this package's own
+tests being Python). Excluding a list of upstream test names by hand
+was the alternative, and is a list nothing forces anyone to update when
+a citation of a third project arrives; the attribution a human reader
+already needs to make sense of the citation is not.
+
+Only a docstring or a `#` comment is asked, and not every string literal
+a module happens to contain: a test module's own fixtures are free to
+build a string that looks like a citation without being read as one --
+`tests/test_test_citations.py` does exactly that, to exercise this
+check without becoming a case for it.
+
+Run by the `test-citations` hook of .pre-commit-config.yaml, and so by
+the lint workflow, on every commit: nothing else walks `tests/*.py` for
+citations rather than for what they describe, `tests/test_secret.py`'s
+own walk of the package being over a different population -- callers of
+`_secret.take`, not the test suite's prose about itself.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import sys
+import tokenize
+from pathlib import Path
+from re import compile as re_compile
+
+_ROOT = Path(__file__).resolve().parents[2]
+_TESTS = _ROOT / "tests"
+
+_CITATION = re_compile(r"`(test_[A-Za-z0-9_]+)`")
+
+# a citation attributed to a name other than this suite's own: a
+# possessive naming whose test it is ("rust-secp256k1's `test_low_r`"),
+# or a source file foreign to this package's own tests -- which are
+# Python -- named in the same breath ("src/lib.rs\n`test_low_r`")
+_POSSESSIVE = re_compile(r"'s\s*$")
+_FOREIGN_SOURCE = re_compile(r"\.(?:c|cc|cpp|h|hpp|rs)\b")
+
+# far enough back to reach across one wrapped line -- a path ending one
+# line and the citation opening the next -- and no further: a citation
+# earns its own attribution, not one borrowed from a paragraph away
+_LOOKBACK = 200
+
+
+def defined_tests(tests_dir: Path) -> set[str]:
+    """Return the name of every test any module in `tests_dir` defines.
+
+    Args:
+        tests_dir: the directory to walk, non-recursively -- `tests/`
+            has no test package below it.
+
+    Returns:
+        Every `def test_...` name, pooled across every module: a
+        citation is to the suite, not to one file of it, so a test named
+        in one module and cited from another still resolves.
+    """
+    names: set[str] = set()
+    for path in sorted(tests_dir.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                names.add(node.name)
+    return names
+
+
+def _prose_spans(text: str) -> list[tuple[int, int]]:
+    """Return the character span of every docstring and comment in `text`.
+
+    A citation is prose, documentation of the suite referring to itself,
+    and confining the search to docstrings and comments is what keeps an
+    ordinary string literal -- a test module's own fixture, built to
+    look like a citation without being one -- from being read as one.
+
+    Args:
+        text: one module's source.
+
+    Returns:
+        A `(start, end)` character offset per module, class and function
+        docstring, and per `#` comment -- in the same offsets
+        `_CITATION.finditer(text)` reports its matches in.
+    """
+    line_starts = [0]
+    for line in text.splitlines(keepends=True):
+        line_starts.append(line_starts[-1] + len(line))
+
+    def offset(line: int, col: int) -> int:
+        return line_starts[line - 1] + col
+
+    spans: list[tuple[int, int]] = []
+
+    tree = ast.parse(text)
+    scopes: list[ast.Module | ast.FunctionDef | ast.ClassDef] = [tree]
+    scopes.extend(
+        n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.ClassDef)
+    )
+    for scope in scopes:
+        first = scope.body[0] if scope.body else None
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+            and first.value.end_lineno is not None
+            and first.value.end_col_offset is not None
+        ):
+            spans.append((
+                offset(first.value.lineno, first.value.col_offset),
+                offset(first.value.end_lineno, first.value.end_col_offset),
+            ))
+
+    for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+        if tok.type == tokenize.COMMENT:
+            spans.append((offset(*tok.start), offset(*tok.end)))
+
+    return spans
+
+
+def _attributed_elsewhere(text: str, start: int) -> bool:
+    """Whether the citation at `start` in `text` is prose about another suite.
+
+    Args:
+        text: the whole file's source.
+        start: the index of the citation's opening backtick.
+
+    Returns:
+        True where the text just before the citation names whose test it
+        is, rather than only naming the test.
+    """
+    before = text[max(0, start - _LOOKBACK) : start]
+    return bool(_POSSESSIVE.search(before)) or bool(_FOREIGN_SOURCE.search(before))
+
+
+def dangling_citations(tests_dir: Path) -> list[tuple[Path, int, str]]:
+    """Return every citation that names no test this suite defines.
+
+    Args:
+        tests_dir: the directory to walk; see `defined_tests`.
+
+    Returns:
+        A `(path, line, name)` triple per dangling citation, in the
+        order `tests_dir.glob` and `re.finditer` produce them; empty
+        where every citation resolves or is attributed elsewhere.
+    """
+    defined = defined_tests(tests_dir)
+    dangling: list[tuple[Path, int, str]] = []
+    for path in sorted(tests_dir.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        spans = _prose_spans(text)
+        for match in _CITATION.finditer(text):
+            if not any(start <= match.start() < end for start, end in spans):
+                continue
+            name = match[1]
+            if name in defined or _attributed_elsewhere(text, match.start()):
+                continue
+            line = text.count("\n", 0, match.start()) + 1
+            dangling.append((path, line, name))
+    return dangling
+
+
+def main() -> int:
+    """Fail where a citation names no test that exists.
+
+    Returns:
+        0 where every `` `test_...` `` citation in `tests/*.py` resolves
+        or is attributed to another project's test; 1 otherwise.
+    """
+    dangling = dangling_citations(_TESTS)
+    for path, line, name in dangling:
+        rel = path.relative_to(_ROOT)
+        print(
+            f"{rel}:{line}: `{name}` is cited but no test in tests/*.py is"
+            " named that -- a rename or removal left the citation behind;"
+            " a citation of another project's test needs an attribution"
+            " next to it (a possessive, or the foreign source file) for"
+            " this check to tell the two apart",
+            file=sys.stderr,
+        )
+    if dangling:
+        return 1
+    print("every `test_...` citation in tests/*.py names a test that exists")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_test_citations.py
+++ b/.github/scripts/check_test_citations.py
@@ -59,13 +59,24 @@ _CITATION = re_compile(r"`(test_[A-Za-z0-9_]+)`")
 # a citation attributed to a name other than this suite's own: a
 # possessive naming whose test it is ("rust-secp256k1's `test_low_r`"),
 # or a source file foreign to this package's own tests -- which are
-# Python -- named in the same breath ("src/lib.rs\n`test_low_r`")
-_POSSESSIVE = re_compile(r"'s\s*$")
-_FOREIGN_SOURCE = re_compile(r"\.(?:c|cc|cpp|h|hpp|rs)\b")
+# Python -- named in the same breath ("src/lib.rs\n`test_low_r`"). Both
+# are anchored to sit right before the citation, with only whitespace
+# between: unanchored, "the parser's `test_renamed_away`" would read an
+# ordinary English possessive as attribution, and a `.c`/`.cpp`/`.rs`
+# mention anywhere in the look-back window would excuse a citation a
+# whole unrelated sentence later. The possessive's own noun is also
+# required to look like a project slug -- a hyphen or a digit in it,
+# "rust-secp256k1" having both -- which is what tells that from "the
+# parser's" or "this suite's" without a hand-maintained list of names
+_POSSESSIVE = re_compile(r"[\w][\w.-]*[-0-9][\w.-]*'s\s*$")
+_FOREIGN_SOURCE = re_compile(r"\.(?:c|cc|cpp|h|hpp|rs)\b\s*$")
 
 # far enough back to reach across one wrapped line -- a path ending one
 # line and the citation opening the next -- and no further: a citation
-# earns its own attribution, not one borrowed from a paragraph away
+# earns its own attribution, not one borrowed from a paragraph away.
+# Both patterns above are anchored to the end of the window regardless,
+# so this bounds how far a *wrapped* attribution can reach rather than
+# doing the anchoring itself
 _LOOKBACK = 200
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,6 +175,21 @@ repos:
         entry: python .github/scripts/check_submodule_pin.py
         always_run: true
         pass_filenames: false
+  # a test named in tests/*.py's own prose -- a docstring or a comment --
+  # is still a test: an append cannot falsify such a citation, but a
+  # rename does, silently, and #255's rename of two test names is why
+  # that is not hypothetical. always_run and no `files`, for the same
+  # reason as submodule-pin above: the file a rename breaks a citation
+  # in is not necessarily the file the rename touches, so a `files`
+  # filter on what changed would miss exactly the case this exists for
+  - repo: local
+    hooks:
+      - id: test-citations
+        name: a test named in tests/*.py's prose is still a test
+        language: python
+        entry: python .github/scripts/check_test_citations.py
+        always_run: true
+        pass_filenames: false
   # .github/dependabot.yml is validated by nothing else, and a typo in it
   # updates nothing and says nothing: the whole point of that file is to
   # move the pins this repository depends on for its security updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -550,6 +550,9 @@ max-complexity = 10
 # else: what it prints is what pre-commit shows the developer whose
 # commit it just refused, and stderr is where all of that goes
 ".github/scripts/check_submodule_pin.py" = ["print"]
+# same reason, same exemption: the test-citations check is a hook too,
+# and what it prints is the developer's own commit being refused
+".github/scripts/check_test_citations.py" = ["print"]
 
 [tool.ruff.lint.flake8-copyright]
 # notice-rgx is COPYRIGHT's text as one regex, anchored with ^ so a

--- a/tests/test_test_citations.py
+++ b/tests/test_test_citations.py
@@ -1,0 +1,159 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the test-citation check of `.github/scripts`.
+
+Unlike `tests/test_submodule_pin.py`'s check, this one reads only
+`tests/*.py` off disk -- no git, no network -- so there is no state in
+which asking it about the real suite has to be skipped. Keeping that
+case here, rather than leaving it to the hook alone, is what proves the
+attribution heuristic covers this suite's one citation of another
+project's test, rust-secp256k1's `test_low_r`, without a hand-maintained
+list carrying its name.
+
+The script is loaded by path, `.github/scripts` being no package. Every
+fixture below is a plain string handed to `dangling_citations`, not a
+docstring or comment of this module, so none of it is itself prose this
+check would read -- see `check_test_citations`'s own module docstring
+for why that distinction is what keeps this file from becoming a case
+for the thing it tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load() -> ModuleType:
+    """Import the check by path.
+
+    Returns:
+        The module.
+    """
+    path = Path(__file__).parents[1] / ".github" / "scripts" / "check_test_citations.py"
+    spec = importlib.util.spec_from_file_location("check_test_citations", path)
+    assert spec
+    assert spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+
+def _write(tmp_path: Path, name: str, source: str) -> None:
+    """Write one test module into `tmp_path`, dedented.
+
+    Args:
+        tmp_path: the directory standing in for `tests/`.
+        name: the file's name, `.py` included.
+        source: its text.
+    """
+    (tmp_path / name).write_text(textwrap.dedent(source), encoding="utf-8")
+
+
+def test_the_real_suite_has_no_dangling_citation() -> None:
+    """What the hook itself answers on every commit, made visible here.
+
+    `Path(__file__).parent` is `tests/` itself -- the tree the hook
+    reads on the commit that adds this file, no monkeypatch required.
+    """
+    assert check.dangling_citations(Path(__file__).parent) == []
+
+
+def test_a_citation_of_a_test_defined_in_another_module_resolves(
+    tmp_path: Path,
+) -> None:
+    """A citation is to the suite, not to the file it appears in."""
+    _write(tmp_path, "a.py", '"""See `test_elsewhere`."""')
+    _write(tmp_path, "b.py", "def test_elsewhere() -> None:\n    pass\n")
+
+    assert check.dangling_citations(tmp_path) == []
+
+
+def test_a_citation_naming_no_test_anywhere_is_dangling(tmp_path: Path) -> None:
+    """A rename or a typo leaves exactly the citation behind, unresolved."""
+    _write(tmp_path, "a.py", '"""See `test_renamed_away`."""\n')
+
+    dangling = check.dangling_citations(tmp_path)
+
+    assert len(dangling) == 1
+    path, line, name = dangling[0]
+    assert path == tmp_path / "a.py"
+    assert line == 1
+    assert name == "test_renamed_away"
+
+
+def test_a_possessive_citation_is_read_as_another_projects_test(tmp_path: Path) -> None:
+    """Possessive prose is attribution, not a claim that a test is undefined."""
+    _write(tmp_path, "a.py", '"""Reproduces rust-secp256k1\'s `test_low_r`."""\n')
+
+    assert check.dangling_citations(tmp_path) == []
+
+
+def test_a_citation_beside_a_foreign_source_path_is_skipped(tmp_path: Path) -> None:
+    """A `.rs`/`.c`/`.cpp` path named just before a citation is attribution too.
+
+    This is the module-docstring shape `tests/test_vectors.py` actually
+    uses: the path and the citation on two wrapped lines of one bullet,
+    with no possessive anywhere in it.
+    """
+    _write(
+        tmp_path,
+        "a.py",
+        '"""rust-bitcoin/rust-secp256k1 src/lib.rs\n`test_low_r`, whose vector..."""\n',
+    )
+
+    assert check.dangling_citations(tmp_path) == []
+
+
+def test_attribution_does_not_reach_across_a_paragraph(tmp_path: Path) -> None:
+    """A foreign path several sentences back excuses no unrelated citation.
+
+    Otherwise one upstream citation in a module's docstring would quietly
+    exempt every dangling one after it -- the false negative the
+    look-back window exists to bound.
+    """
+    far = "x" * (check._LOOKBACK + 1)
+    _write(tmp_path, "a.py", f'"""src/lib.rs {far} `test_renamed_away`."""\n')
+
+    dangling = check.dangling_citations(tmp_path)
+
+    assert [name for _, _, name in dangling] == ["test_renamed_away"]
+
+
+def test_main_fails_and_names_the_dangling_citation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`main` is `dangling_citations` against `_TESTS`, reported to stderr."""
+    _write(tmp_path, "a.py", '"""See `test_renamed_away`."""\n')
+    monkeypatch.setattr(check, "_TESTS", tmp_path)
+    monkeypatch.setattr(check, "_ROOT", tmp_path)
+
+    assert check.main() == 1
+    error = capsys.readouterr().err
+    assert "a.py:1" in error
+    assert "test_renamed_away" in error
+
+
+def test_main_passes_when_every_citation_resolves(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The passing case, printed rather than only silent."""
+    _write(
+        tmp_path, "a.py", '"""See `test_here`."""\ndef test_here() -> None:\n    pass\n'
+    )
+    monkeypatch.setattr(check, "_TESTS", tmp_path)
+
+    assert check.main() == 0
+    assert "names a test that exists" in capsys.readouterr().out

--- a/tests/test_test_citations.py
+++ b/tests/test_test_citations.py
@@ -132,6 +132,48 @@ def test_attribution_does_not_reach_across_a_paragraph(tmp_path: Path) -> None:
     assert [name for _, _, name in dangling] == ["test_renamed_away"]
 
 
+def test_a_foreign_source_path_one_sentence_back_excuses_nothing(
+    tmp_path: Path,
+) -> None:
+    """The anchor, not just the look-back window, bounds attribution.
+
+    A `.rs` mention well inside `_LOOKBACK` but separated by an unrelated
+    sentence used to excuse a dangling citation anyway -- unlike
+    `_POSSESSIVE`, `_FOREIGN_SOURCE` was matched anywhere in the window
+    rather than anchored right before the citation.
+    """
+    _write(
+        tmp_path,
+        "a.py",
+        '"""Ported from upstream src/lib.rs some time ago. Since then this'
+        " suite renamed things and `test_totally_renamed_away` no longer"
+        ' exists."""\n',
+    )
+
+    dangling = check.dangling_citations(tmp_path)
+
+    assert [name for _, _, name in dangling] == ["test_totally_renamed_away"]
+
+
+def test_an_ordinary_possessive_is_not_read_as_external_attribution(
+    tmp_path: Path,
+) -> None:
+    """An ordinary possessive is this suite's own prose, not attribution.
+
+    `_POSSESSIVE` used to accept any word ending in "'s", which reads an
+    ordinary English possessive -- this repository's own prose style,
+    happy to say "this suite's" or "the parser's" -- as if it named
+    another project. Requiring a hyphen or a digit in the possessive
+    noun is what a project slug like "rust-secp256k1" has and an English
+    word does not.
+    """
+    _write(tmp_path, "a.py", '"""See the parser\'s `test_renamed_away`."""\n')
+
+    dangling = check.dangling_citations(tmp_path)
+
+    assert [name for _, _, name in dangling] == ["test_renamed_away"]
+
+
 def test_main_fails_and_names_the_dangling_citation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- An append cannot falsify a `` `test_...` `` citation in `tests/*.py`'s docstrings and comments, but a rename does, silently -- #255's rename of two test names is why that is not hypothetical: only a human grepping for citations kept the prose in step with it at the time.
- Added `.github/scripts/check_test_citations.py`, which walks every docstring and comment in `tests/*.py` (never a module's own string literals -- see below) and flags a citation naming no test any module defines.
- Not every dangling-looking citation is a bug: `tests/test_vectors.py` correctly cites rust-secp256k1's own `test_low_r` to say which upstream vector is reproduced. A citation is read as another project's, and skipped, where the text right before it attributes it -- a possessive ("rust-secp256k1's `test_low_r`") or a foreign source file named in the same breath (`.c`/`.cpp`/`.rs`, this package's own tests being Python) -- rather than through a hand-maintained list of upstream test names, which is a list nothing forces anyone to update when a citation of a third project arrives.
- The walk is scoped to docstrings and `#` comments (via `ast` + `tokenize`), not every string literal a module contains, so a test module's own fixtures -- `tests/test_test_citations.py`'s own, built to look like citations without being read as one -- don't become a case for the thing they test.
- Wired in as an `always_run` local hook, for the same reason `submodule-pin` is one: the file a rename breaks a citation in is not necessarily the file the rename touches, so a `files` filter on what changed would miss exactly the case this exists for. Unlike `submodule-pin` it needs neither git nor the network, so it runs on pre-commit.ci unmodified.

## Test plan
- [x] `tests/test_test_citations.py` -- unit tests for `defined_tests`/`dangling_citations`/`main`, plus `test_the_real_suite_has_no_dangling_citation`, which runs the check against the real `tests/` tree (no monkeypatch needed) and is what proves the attribution heuristic covers `test_low_r` without a hand-maintained list of its name
- [x] `uv run --locked --no-default-groups --group test pytest --cov` -- 733 passed, 100% coverage
- [x] `uvx pre-commit run --all-files`, including the new hook against the real tree

Closes #258

## Summary by Sourcery

Add automated validation to keep test-suite prose citations synchronized with the tests they reference.

New Features:
- Add a check that validates `test_...` citations in test-suite docstrings and comments against defined tests.
- Recognize citations referring to tests from external projects without requiring a maintained exception list.

Bug Fixes:
- Detect stale test citations left behind by renamed or removed tests.

Enhancements:
- Limit citation analysis to Python docstrings and comments while resolving tests across the entire test suite.

CI:
- Run the test-citation validation as an always-run local pre-commit hook.

Tests:
- Add unit and real-suite coverage for citation resolution, external attribution, boundary cases, and command output.