### PR TITLE
Cancel a run still going when its pull request closes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,16 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default types
     # do not include it, and without it a readied pull request would wait
-    # for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # for its next push to be checked at all.
+    # closed joins them for a different reason: merging or closing a pull
+    # request is neither a push nor a synchronize, so a run still held in
+    # this ref's concurrency group survives it -- cancel-in-progress only
+    # fires when a new run lands in that group, and nothing otherwise does.
+    # Landing the closed event there is what lets it supersede the stale
+    # run instead of leaving it to finish on a branch nobody is going to
+    # look at again; the job below declines the real work on it, the merge
+    # commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:
     inputs:
@@ -65,7 +73,11 @@ jobs:
     # workflow that reported it, which is what let the move happen without
     # touching the rule
     name: Build the documentation
-    if: ${{ !github.event.pull_request.draft }}
+    # a draft pull request is work in progress and spends no runner here
+    # either. Neither does a closed one -- the trigger above takes the
+    # closed event only to let cancel-in-progress supersede a run still
+    # holding in this ref's group
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,8 +43,15 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed joins them for a different reason: merging or closing a pull
+    # request is neither a push nor a synchronize, so a run still held in
+    # this ref's concurrency group survives it -- cancel-in-progress only
+    # fires when a new run lands in that group, and nothing otherwise
+    # does. Landing the closed event there is what lets it supersede the
+    # stale run instead of leaving it to finish on a branch nobody is
+    # going to look at again
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/links.yml
       - .lycheeignore
@@ -72,8 +79,11 @@ jobs:
     name: Check the documentation links
     # a draft pull request is work in progress and spends no runner
     # here either: the same condition lint.yml and test.yml carry, and
-    # ready_for_review is a trigger type above for the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # ready_for_review is a trigger type above for the same reason.
+    # A closed pull request spends none either -- the trigger above
+    # takes the closed event only to let cancel-in-progress supersede a
+    # run still holding in this ref's group
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # a few hundred requests with retries; a job past this is hung on one
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,16 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed joins them for a different reason: merging or closing a pull
+    # request is neither a push nor a synchronize, so a run still held in
+    # this ref's concurrency group survives it -- cancel-in-progress only
+    # fires when a new run lands in that group, and nothing otherwise does.
+    # Landing the closed event there is what lets it supersede the stale
+    # run instead of leaving it to finish on a branch nobody is going to
+    # look at again; the job below declines the real work on it, the merge
+    # commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:
     inputs:
@@ -77,8 +85,11 @@ jobs:
     # these checks on a tree its author is not asking anyone to review
     # yet. A run on the merge result still happens the moment the pull
     # request is marked ready, which is why ready_for_review is a
-    # trigger type above
-    if: ${{ !github.event.pull_request.draft }}
+    # trigger type above.
+    # A closed pull request spends no runner either -- the trigger above
+    # takes the closed event only to let cancel-in-progress supersede a
+    # run still holding in this ref's group
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,16 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed joins them for a different reason: merging or closing a pull
+    # request is neither a push nor a synchronize, so a run still held in
+    # this ref's concurrency group survives it -- cancel-in-progress only
+    # fires when a new run lands in that group, and nothing otherwise does.
+    # Landing the closed event there is what lets it supersede the stale
+    # run instead of leaving it to finish on a branch nobody is going to
+    # look at again; every job below declines the real work on it, the
+    # merge commit being main's own push trigger's question
+    types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
     inputs:
@@ -111,7 +119,7 @@ jobs:
   #   everything and be reported as a pass
   changes:
     name: Decide whether the matrix has anything to check
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # the file list of a pull request, which contents: read does not carry
@@ -196,8 +204,15 @@ jobs:
     # skips uniformly and the gate does not read that skip as a job that
     # should have run. A run on the merge result still happens the moment
     # the pull request is marked ready, which is why ready_for_review is a
-    # trigger type above
-    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
+    # trigger type above.
+    # A closed pull request spends none either: the trigger above takes
+    # the closed event only to let cancel-in-progress supersede a run
+    # still holding in this ref's group, and every job in this workflow
+    # carries the same skip for the reason the draft one already does
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && needs.changes.outputs.code == 'true'
+      && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     # every job below caps its own runtime, this one included: the default
     # is six hours, and with tens of jobs compiling C a single hang is
@@ -236,7 +251,10 @@ jobs:
 
   build-cibuildwheel:
     name: Build wheels on ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && needs.changes.outputs.code == 'true'
+      && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     # the interpreter uv runs the build tools with is the one setup-python
@@ -359,7 +377,10 @@ jobs:
 
   build-dynamic:
     name: Build dynamic wheel on ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && needs.changes.outputs.code == 'true'
+      && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     # see build-cibuildwheel; here the platform tag of the wheel is the
@@ -436,7 +457,10 @@ jobs:
 
   build-sdist:
     name: Build sdist
-    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && needs.changes.outputs.code == 'true'
+      && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # see build-cibuildwheel
@@ -496,7 +520,7 @@ jobs:
     name: >-
       Install from the sdist and run the suite on ${{ matrix.os }}${{
       matrix.architecture && format(' ({0})', matrix.architecture) }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -562,7 +586,10 @@ jobs:
 
   build-windows:
     name: "Build on Linux for Windows"
-    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.code == 'true' }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && needs.changes.outputs.code == 'true'
+      && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # see build-cibuildwheel
@@ -612,7 +639,7 @@ jobs:
   # only be yanked and burnt
   check-dist:
     name: Inspect the distribution files and install one
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-cibuildwheel, build-dynamic, build-sdist, build-windows]
@@ -699,7 +726,7 @@ jobs:
     name: >-
       Run the suite on the dynamic wheel,
       every interpreter, ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     # one job now walks what eight did, so the cap is the sum of theirs
     # rather than one of them: eight installs and eight suites in
@@ -798,7 +825,7 @@ jobs:
     name: >-
       Run the suite on the static wheel,
       every interpreter, ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ${{ matrix.os }}
     # see suite-dynamic, one interpreter fewer
     timeout-minutes: 30
@@ -903,8 +930,9 @@ jobs:
   test-passed:
     name: "test: every job passed"
     # and the draft condition every job above carries, so a draft
-    # skips uniformly rather than tripping the skip check below
-    if: ${{ always() && !github.event.pull_request.draft }}
+    # skips uniformly rather than tripping the skip check below -- the
+    # closed one for the same reason, added at the trigger above
+    if: ${{ always() && !github.event.pull_request.draft && github.event.action != 'closed' }}
     needs:
       - changes
       - coverage

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -31,8 +31,15 @@ on:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
     # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
+    # would wait for its next push to be checked at all.
+    # closed joins them for a different reason: merging or closing a pull
+    # request is neither a push nor a synchronize, so a run still held in
+    # this ref's concurrency group survives it -- cancel-in-progress only
+    # fires when a new run lands in that group, and nothing otherwise
+    # does. Landing the closed event there is what lets it supersede the
+    # stale run instead of leaving it to finish on a branch nobody is
+    # going to look at again
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/vendored-vectors.yml
       - .github/scripts/check_vendored_vectors.py
@@ -57,8 +64,11 @@ jobs:
     name: Check vendored vectors against upstream
     # a draft pull request is work in progress and spends no runner
     # here either: the same condition lint.yml and test.yml carry, and
-    # ready_for_review is a trigger type above for the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # ready_for_review is a trigger type above for the same reason.
+    # A closed pull request spends none either -- the trigger above
+    # takes the closed event only to let cancel-in-progress supersede a
+    # run still holding in this ref's group
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # the issue is this job's to open, close or edit, and only this
@@ -117,7 +127,7 @@ jobs:
   # signature that stops verifying, and a red run says all of that.
   pin:
     name: Check the pinned libsecp256k1 release
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What

`closed` joins `pull_request.types` in `test.yml`, `docs.yml`,
`lint.yml`, `links.yml` and `vendored-vectors.yml` -- the workflows
here that have both a `pull_request` trigger and
`cancel-in-progress: true`. Every job-level `if:` that already guards
on `!github.event.pull_request.draft` (the aggregate `test-passed` job
in `test.yml` included) now also requires
`github.event.action != 'closed'`.

## Why

GitHub Actions does not cancel a workflow run when the pull request
that triggered it closes -- only a *new* run landing in the same
`concurrency:` group does that, via `cancel-in-progress`. `closed` is
not among the default `pull_request` event types these workflows
trigger on, and a squash-merge or an "Update branch" click produces a
`synchronize` or a push to `main` rather than a `closed` event, so a
run still in progress when a pull request is merged or closed just
keeps running to completion on a branch nobody is looking at any more,
burning a runner for nothing.

Adding `closed` lands that event in the same concurrency group, so
`cancel-in-progress` cancels whatever run was still going. The
job-level condition is what stops the closed-triggered run itself from
doing the real work -- the point is to save a runner, not spend a
second one -- following the same pattern these workflows already use
to skip a draft pull request.

## What was left out, and why

- `codeql.yml`, `latest.yml`, `macos.yml`, `mutation.yml` and
  `windows.yml` have no `pull_request` trigger at all
- `published.yml` and `release.yml` have `cancel-in-progress: false`
  on purpose, a release never being cancelled -- `closed` there would
  only queue a run behind one already in progress rather than replace
  it

This mirrors btclib-org/btclib#1023, which fixes the same gap in the
sibling repository.

## Test plan

- [x] `uv run pre-commit run --all-files` exits 0, `actionlint` and
      `zizmor` included
- [x] every edited workflow file parses as YAML
      (`uv run python -c "import yaml; yaml.safe_load(open(f))"` per
      file)
- [x] `uv run --locked --no-default-groups --group test pytest --cov`:
      725 passed, 100.00% coverage (unaffected by this change, run to
      confirm rather than assume)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build
      -W --keep-going -b html docs/source docs/build/html` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cancel in-progress pull request checks when their pull request closes without starting replacement work.

Bug Fixes:
- Ensure pull request workflow runs are cancelled when the pull request is closed or merged, avoiding unnecessary runner usage.

Enhancements:
- Update test, documentation, linting, link-checking, and vendored-vector workflows to handle closed pull request events without executing their jobs.

CI:
- Add the closed pull request event to the relevant workflows so it can supersede in-progress runs through concurrency cancellation while preventing the closed-event run from performing work.