### PR TITLE
Say the landing convention in force, and write down the review standard

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,26 @@
+---
+description: Review a pull request against REVIEWING.md, this repository's standard
+argument-hint: <pull request number>
+---
+
+# Review a pull request
+
+Review the pull request named in $ARGUMENTS. With no argument, review the
+diff of the current branch against `origin/main`.
+
+`REVIEWING.md`, in this repository's root, is the standard, and reading it
+is the first step rather than a reference to consult afterwards: it states
+what is under review, what to look for and in what order, what a finding
+must contain and how it labels its severity, what becomes of everything
+noticed that the diff is not about, and the two forms the verdict takes.
+Follow it in preference to the review habits you would otherwise bring.
+
+Two files it leans on, worth loading with it:
+
+- `CLAUDE.md` for the gates and for what a review of *this* tree has to
+  know, the two arithmetic paths under `curves/` and `ecc/` above all;
+- `CONTRIBUTING.md` for the rules a finding cites, so that a finding
+  names the line that states one.
+
+Run the gates on the sha under review before writing the verdict, and
+read exit codes rather than filtered output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,39 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### The pull request is the only way into main, and the review has a standard
+
+- **The landing convention says what is in force: the squash button.**
+  `CONTRIBUTING.md` said the landing is "a push rather than a button",
+  `REPOSITORY.md` titled a section for the push its bypass was for, and
+  `CLAUDE.md` kept a fast-forward exception for a stacked pull request.
+  The `main-self-merge` bypass now reads `pull_request` mode, so it
+  excuses the approving review a solo-maintainer repository cannot
+  produce and excuses nothing else: a direct push to `main` is refused
+  for everyone, the holder included. The ruleset also names `squash` as
+  the only merge method it accepts, stating the constraint where the
+  rule is rather than only in a repository toggle. What the exception
+  bought — a stacked child keeping its base — is paid for with a rebase
+  instead, a button recreating rather than moving whatever the count of
+  commits: GitHub's documentation has rebase-and-merge "always updates
+  the committer information and creates new commit SHAs". The
+  configuration is the organization's, identical in btclib,
+  bitcoin-core-rpc and btclib-benchmarks.
+
+- **`REVIEWING.md` is the standard a review is written against**, the
+  reviewer's half of `CONTRIBUTING.md`: what a review establishes before
+  it gives an ack, what a finding must contain and how it labels its
+  severity, and what becomes of everything a reviewer notices that the
+  diff is not about — every collateral finding is filed as an issue
+  rather than asked for in a comment. It states no new rule; the rules
+  it cites stay in the files that state them. Registered the way
+  `CONTRIBUTING.md` is: a page of the sphinx toctree through a
+  `reviewing_link.md` shim, named from the README and from `CLAUDE.md`,
+  which is the file a repository-aware reviewer reads.
+  `.claude/commands/review.md` is it as the `/review` command. The body
+  is deliberately the text btclib carries, one section excepted: the
+  questions a review of *this* tree asks and a generic one would not.
+
 ### The recoverable check takes that key too
 
 - **`recovery.sign` and `recovery._sign_` take a keyword-only `pubkey`**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ permissions, publishing environments, Dependabot, secret scanning — is in
 [REPOSITORY.md](REPOSITORY.md). Read that file before changing a workflow,
 a branch rule or a repository setting. Writing code does not need it.
 
+Reviewing a pull request — what a review establishes before it gives
+an ack, what a finding must contain, and why everything it notices
+that the diff is not about becomes an issue rather than a comment — is
+[REVIEWING.md](REVIEWING.md), and `/review` is that file as a command.
+
 This file is for what is not written down elsewhere. The documentation is,
 and stays, in:
 
@@ -290,21 +295,18 @@ kill rate, which is the one failure mode that looks like good news.
   version named in `README.md` and `HISTORY.md` moved with it
 - **`main` is the only long-lived branch**, so a pull request targets it
   and a tag on it is a release; it is protected, and every change gets
-  there through a pull request. Squash is the only merge button enabled,
-  and auto-merge is what presses it once review and checks are in — the
-  default way a pull request lands, one commit regardless of how many
-  the branch carried. GitHub signs that commit itself, and that
-  signature is as good as the maintainer's own on a commit landed from
-  the command line. The exception is a single-commit pull request that
-  is the base of a stacked one: fast-forward it from the command line
-  instead, so `main` gets that exact sha — the head the gates ran on —
-  rather than a new one. Push the fast-forwarded commit to the branch
-  before it lands: GitHub reconciles a push whose commit the pull
-  request names — Merged, and `Closes #N` in the description fires — and
-  reconciles nothing when the object is one it has never seen, which
-  leaves the pull request to be closed by hand and the issue to the
-  keyword in the commit message. REPOSITORY.md has the sequence and both
-  outcomes. The `dev` this repository used to develop on, and the
+  there through a pull request, and through nothing else — a direct push
+  is refused for everyone. Squash is the only merge button enabled, and
+  auto-merge is what presses it once review and checks are in: one
+  commit regardless of how many the branch carried, composed and signed
+  by GitHub, whose signature is what the rule asks for, a valid one
+  rather than a particular signer's. GitHub therefore reconciles every
+  landing — Merged, `Closes #N` in the description fires, and the head
+  branch goes — with no case left where a commit arrives that no pull
+  request names. REPOSITORY.md has the settings that make that true. A
+  pull request stacked on another is rebased once its parent lands, and
+  pays a fresh run of the matrix for it. The `dev` this repository used
+  to develop on, and the
   release merge into `master` that went with it, are gone; RELEASING.md
   is the file that describes what replaced them
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -608,8 +608,14 @@ Every change starts with an open issue; `Closes #N` in the pull
 request's description is what closes it, once a reviewed pull request
 merges. A pull request needs an approving review from somebody other
 than its author before it can merge — GitHub refuses a self-approval.
-Allow maintainer edits so the branch can be updated for a merge, and
-mark review conversations resolved as you address them.
+[REVIEWING.md](./REVIEWING.md) is the standard that review is written
+against, and is this file's other half: what a review establishes before
+it gives an ack, how a finding states its severity, and why everything it
+notices that the pull request is not about becomes an issue rather than a
+comment. Read before opening a pull request, it is what the pull request
+will be answered against. Allow maintainer edits so the branch can be
+updated for a merge, and mark review conversations resolved as you
+address them.
 
 `main` enforces four things on every commit that reaches it, not only
 at review time: a verified signature, linear history, no force push, no
@@ -643,33 +649,21 @@ landed change. A merge commit would put the branch's steps into `main`
 and a rebase merge would replay them one by one — `main` is linear by
 branch rule, and one change is one commit there.
 
-**How that commit reaches `main` is a push rather than a button**, which
-is the maintainer's own path and needs the `main-self-merge` bypass no
-contributor has: REPOSITORY.md describes it, squashing the branch locally
-where it carries more than one commit, pushing that squash to the branch,
-and fast-forwarding the branch from there. Three things about it are
-worth knowing from here. The commit that lands is signed by the
-maintainer rather than by GitHub's web-flow key. Where your branch is
-already a single commit and needs no rebase to land, its sha does not
-change, so `main` receives the very commit the gates ran on and a branch
-stacked on it keeps applying — a rebase moves the sha like any other
-force-push, which is why the gates are asked for after one and not only
-before. And the squash reaches your branch before it reaches `main`,
-which is the second of those two force-pushes: that order is what leaves
-the pull request naming the commit that lands, so GitHub marks it
-**Merged** on its own and the `Closes #N` in the description closes the
-issue. Landed from a worktree instead, the pull request would name an
-object `main` never received, and would be closed by hand with the change
-in it all the same. None of the three changes the shape of a correction:
-whether a branch is squashed or fast-forwarded is decided when it lands,
-and by then the review has its record either way.
+**How that commit reaches `main` is the squash button**, pressed by
+auto-merge once the review and the checks are in. GitHub composes it and
+signs it with its web-flow key, which is a valid signature and therefore
+all the branch rule asks for. There is no other way in: `main` takes a
+pull request and nothing else, a direct push being refused for everyone.
+REPOSITORY.md has the settings that make that true, and what the other
+two merge methods would have cost.
 
-Squash is the only merge *button* this repository enables, so there is
-no other to read; REPOSITORY.md has that setting, what the other two
-would have cost, and the fast-forward that is not a button at all.
-Auto-merge is what presses it, the dialog that switches it on carrying
-one method: what a pull request set to merge itself once the checks go
-green is holding is still `gh pr view <n> --json autoMergeRequest`.
+What a pull request set to merge itself once the checks go green is
+holding is `gh pr view <n> --json autoMergeRequest`.
+
+None of that changes the shape of a correction: it is decided at the
+landing and not on the branch, so a fix added on top of a reviewed branch
+is still the right shape — by the time it is squashed the review has its
+record.
 Enabling it is the way to not wait for a matrix that compiles C on every
 platform, and what it costs is the paragraph above: GitHub signs what it
 composes, so a pull request left to merge itself lands a commit signed

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,9 @@ x86_64 only.
 How to get the submodule, set up the development environment, run the
 suite, reproduce each CI job locally, and what a change is expected to
 satisfy are in
-[CONTRIBUTING.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/CONTRIBUTING.md);
+what a pull request is answered against is in
+[REVIEWING.md](https://github.com/btclib-org/btclib-secp256k1/blob/main/REVIEWING.md).
 
 ## Release process
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -309,7 +309,7 @@ branch it protected. Nothing was weakened by that: what it guarded was a
 trunk a pull request did not have to pass through, and every change now
 reaches `main` through the rules above.
 
-## The rulesets, and the push their bypass is for
+## The rulesets, and what their bypass is for
 
 Two rulesets sit on `main` beside that protection, and what separates
 them is who may bypass:
@@ -337,72 +337,45 @@ maintainer cannot satisfy, GitHub refusing a self-approval; the integrity
 four are the rules nobody should be able to. One ruleset each is what
 lets the first be bypassed without the second going with it.
 
-**What the bypass is for is a push, not a button.** A reviewed branch
-reaches `main` from the command line:
+**What the bypass is for is the review, and nothing else.** It is set to
+`pull_request` mode, which excuses its holder from the rule *while
+merging a pull request* and at no other time — so it answers the one
+thing a solo-maintainer repository cannot produce, an approving review
+from somebody else, and answers nothing further. A direct push to `main`
+is refused for everyone, the holder included: outside a pull request
+there is no bypass to apply, and the rule says changes come through one.
+
+The ruleset also names `squash` as the only merge method it will accept,
+so that constraint is stated where the rule is and not only in the
+repository setting "Merge methods" below reads back.
 
 ```shell
-git fetch origin && git rebase origin/main   # replayed on the tip
-git log --format='%h %G?' origin/main..      # every commit G, none N
-git push origin HEAD:main                    # a fast-forward, nothing rewritten
+gh api repos/btclib-org/btclib-secp256k1/rulesets/<id> \
+  --jq '{bypass: [.bypass_actors[].bypass_mode],
+         methods: [.rules[] | select(.type=="pull_request")
+                            | .parameters.allowed_merge_methods]}'
 ```
 
-Where the branch carries more than one commit it is squashed into a
-single signed commit first — `git reset --soft origin/main && git
-commit`, with `--author` where the branch is somebody else's, GitHub's
-button being what would otherwise have kept their name on it — and that
-commit is what the push fast-forwards.
+The other mode, `always`, permits a direct push as well, and it is not
+used here. What it would buy is a landing that keeps the maintainer's
+own signature on the commit; what it costs is a `main` any local mistake
+can reach. The first half is worth nothing once the branch rule is read
+as asking for a valid signature rather than for a particular signer,
+which makes GitHub's web-flow key as good as the maintainer's.
 
 **The bypass is not the whole of the permission.** The protection above
-still carries `required_pull_request_reviews` and its `strict` required
-checks, and what a push to `main` clears those with is `enforce_admins`
-being `false` and the pusher holding `admin`; the ruleset bypass alone
-would not be enough. So the path depends on two settings and not one,
-and the fragile one is that: turning `enforce_admins` on closes the
-fast-forward whatever the ruleset says, and moving the review
-requirement onto a ruleset of its own is what would leave the bypass
-answering for all of it.
+still carries `required_pull_request_reviews`, and what clears it for
+the maintainer is `enforce_admins` being `false` together with holding
+`admin`; the ruleset bypass alone would not be enough. Turning
+`enforce_admins` on would deadlock every solo merge instead, the classic
+review requirement having no bypass list to be named in.
 
-What this buys is what no button can give. GitHub composes a squash
-server-side and signs it with its own web-flow key, so the commit that
-lands is `verified` with GitHub as the signer; a push signs nothing and
-has nothing to sign, the commit arriving with the signature it already
-carried. And where the branch was a single commit and the rebase moved
-nothing, its sha does not change either, so `main` receives the very
-commit the gates ran on and a branch stacked on that one keeps applying
-instead of needing a rebase and a fresh run of the matrix per level.
-Where the rebase did move it, re-running the gates after it is what buys
-that back — and it is discipline on this path rather than a rule, the
-`strict` above being one of the things the push clears. What `strict`
-holds is the merge nobody performs here.
-
-**Whether GitHub reconciles the push depends on one thing: whether what
-lands is the sha the pull request names at that moment**, a pull request
-being marked merged when its head becomes reachable from the base
-branch.
-
-- **it names what lands** — the branch's own head is fast-forwarded,
-  whether it reached that shape as one commit or as a squash **pushed to
-  the branch first**, and a rebase force-pushed to the branch is this
-  case too. GitHub marks the pull request **Merged** on its own, and the
-  `Closes #N` in its description closes the issue.
-- **it names something else** — the squash or the rebase was made
-  locally and pushed straight to `main`. What lands is an object no pull
-  request names, so nothing is reconciled: close it by hand, and let the
-  issue close from the `Closes #N` in the *commit message*, which is the
-  reason for the keyword to be there and not only in the description.
-
-Which is an argument for pushing the squash to the branch before landing
-it, where the branch is one whose head may move: the matrix then runs on
-the very object that will land rather than on a head that never will,
-and the reconciliation does the closing. Measured in btclib the other
-way, on the day this was written:
-<https://github.com/btclib-org/btclib/pull/953> was squashed locally and
-pushed straight to `main`, landing as `7f7a269b` — signed by the
-maintainer, so both halves of the rule worked — and is **Closed** with
-`mergedAt: null`, its issue having closed twenty-two seconds earlier
-from the commit message. Which of the two happened is also what decides
-when the head branch goes, and "Head branches after a merge" below is
-where that is.
+**Every landing is a pull request GitHub merges**, which retires the
+question this section used to answer at length: whether the object
+arriving on `main` is the one the pull request names. It always is.
+GitHub marks the pull request **Merged**, the `Closes #N` in its
+description closes the issue, and `delete_branch_on_merge` takes the
+head branch a second later.
 
 ## Head branches after a merge
 
@@ -426,21 +399,15 @@ branch is never deleted, protection winning over it — which used to reach
 the release pull request, whose head branch was protected. No head branch
 is protected now.
 
-**It reaches one of the two landings above**, and which one is the
-reconciliation again — the setting hangs on the merge GitHub records, so
-it fires wherever GitHub records one:
-
-- **the pull request named what landed**: nothing to do. Measured on
-  <https://github.com/btclib-org/btclib-secp256k1/pull/185>, whose
-  squash was pushed to the branch and then fast-forwarded: marked Merged
-  at 12:39:19 and `head_ref_deleted` at 12:39:20, with nobody asking.
-  What is left is not to get ahead of it — deleting the branch before
-  the reconciliation is what leaves a pull request Closed with its
-  commit on `main` all the same, as btclib's
-  <https://github.com/btclib-org/btclib/pull/930> came out.
-- **it named something else** — the squash or the rebase went straight
-  to `main`: nothing is reconciled, so nothing is deleted either. Close
-  the pull request by hand and delete the branch with it.
+**The setting hangs on the merge GitHub records**, and every landing
+here is one it records, so it fires on its own and nothing is left to
+delete by hand. Measured on
+<https://github.com/btclib-org/btclib-secp256k1/pull/185>: marked Merged
+at 12:39:19 and `head_ref_deleted` at 12:39:20, with nobody asking. The
+thing not to do is get ahead of it — deleting the branch before the
+reconciliation is what leaves a pull request Closed with its commit on
+`main` all the same, as btclib's
+<https://github.com/btclib-org/btclib/pull/930> came out.
 
 ## Merge methods
 
@@ -454,12 +421,10 @@ gh api repos/btclib-org/btclib-secp256k1 \
 
 answers `true` for the first and `false` for the other two.
 
-A button is not how a pull request lands here, and this section named one
-as if it were: every merge is the fast-forward above, and the squash the
-branch may need first is made locally. What that leaves the setting doing
-is bounding the damage of a landing nobody drove from a shell — auto-merge
-below is the one that reaches the button, and GitHub's key is what signs
-what it presses.
+**It is also how a pull request lands here**, auto-merge below being
+what presses it once the review and the checks are in. The commit that
+reaches `main` is therefore one GitHub composes and signs with its
+web-flow key, which is the valid signature the rule asks for.
 
 The merge commit was refused by `main`'s required linear history already,
 so turning it off takes away a button that could not have worked. The
@@ -468,10 +433,12 @@ branch's commits onto `main`, where one change is one commit and the steps
 of a review belong to the pull request that carries them.
 
 What a single method takes away is the dropdown. GitHub preselects
-whichever method was used last, and the dialog below carries the same one,
-so the answer could be given hours before anything merged and by whoever
-switched auto-merge on. One method is one entry: there is no wrong one to
-preselect, and nothing to read before pressing.
+whichever method was used last, and the dialog below carries the same
+one, so the answer could be given hours before anything merged and by
+whoever switched auto-merge on. One method is one entry: there is no
+wrong one to preselect, and nothing to read before pressing — and the
+ruleset above names the same one, so the constraint holds even if the
+repository setting is flipped.
 
 ## Auto-merge
 
@@ -481,24 +448,22 @@ preselect, and nothing to read before pressing.
 gh api repos/btclib-org/btclib-secp256k1 --jq '.allow_auto_merge'
 ```
 
-It bypasses nothing, and it is not the admin escape hatch above: GitHub
-offers the button **only on a pull request that cannot be merged
-immediately**, and then merges it when the last thing blocking it clears —
-one of the three required checks, the approving review, an unresolved
-conversation. Where nothing is pending there is nothing to wait for and the
-button is not offered at all, so this setting does something here precisely
-because the rule on `main` is what it is: the matrix is tens of jobs
-compiling C, and `test.yml`'s header measures what waiting for it costs.
+It bypasses nothing: GitHub offers the button **only on a pull request
+that cannot be merged immediately**, and then merges it when the last
+thing blocking it clears — one of the required checks, the approving
+review, an unresolved conversation. Where nothing is pending there is
+nothing to wait for and the button is not offered at all, so this
+setting does something here precisely because the rule on `main` is what
+it is: the matrix is tens of jobs compiling C, and `test.yml`'s header
+measures what waiting for it costs.
 
-**Required signatures survive it**, measured rather than assumed, because
-GitHub composes the squash commit server-side and signs it with its own key
-exactly as the merge button does — its own key and not the author's, which
-is the trade this setting makes and the fast-forward above is what does
-not make it. Nor does every landing from a shell keep a signature:
-`gh pr merge --rebase --admin` replays the author's commits as they were,
-unsigned, where a fast-forward moves commits that were signed before it
-was run. So the check is worth making on whatever landed, whichever way it
-got there:
+**Required signatures survive it**, measured rather than assumed,
+because GitHub composes the squash commit server-side and signs it with
+its own key exactly as a press of the button does. That the signer is
+GitHub rather than the author is not a trade this setting makes on its
+own: it is what any landing here carries, the rule asking for a valid
+signature and not for a particular signer. The check is worth making on
+whatever landed all the same:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1/commits/<sha> \
@@ -507,14 +472,11 @@ gh api repos/btclib-org/btclib-secp256k1/commits/<sha> \
 
 **What auto-merge will press was chosen when it was switched on, rather
 than when the merge happened.** That dropdown carries one entry, squash
-being the only button enabled — "Merge methods" above is the setting and
-the reason — so switching auto-merge on answers nothing a reviewer has to
-catch before it lands. The fast-forward is not in the dropdown at all,
-being a push: a pull request left to merge itself is one that will not
-land that way, and what it costs is the signature on the commit. Not
-waiting for a matrix that compiles C on every platform is what is bought
-with it. What a pull request is holding is still worth reading, the wait
-itself being what this bypasses:
+being the only method either the repository setting or the ruleset will
+accept — "Merge methods" above is both — so switching auto-merge on
+answers nothing a reviewer has to catch before it lands. What a pull
+request is holding is still worth reading, the wait itself being what
+this bypasses:
 
 ```shell
 gh pr view <n> --json autoMergeRequest

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,315 @@
+# Reviewing a btclib_secp256k1 pull request
+
+The standard a review of this repository is written against: what a
+review has to establish before it can be given, how a finding is stated,
+and what becomes of everything a reviewer notices that the diff under
+review is not about.
+
+This is the reviewer's half of [CONTRIBUTING.md](./CONTRIBUTING.md),
+which is the author's. It does not restate the rules a review cites —
+those are in that file, in REPOSITORY.md and in CLAUDE.md, and a finding
+names the line that states them rather than a copy kept here.
+
+It is for whoever reviews: a contributor reading somebody else's pull
+request, the maintainer, an agent session that starts with the pull
+request and no memory of how the last review went. Read the other way
+round, before a pull request is opened, it is what that pull request
+will be answered against.
+
+A review produces comments on a pull request and issues filed against
+the repository. **A reviewer writes nothing to the branch**: no push, no
+amend, no merge. The one commit a review can lead to is the author's own
+click on a suggestion, below, which is theirs to make and theirs to
+decline.
+
+## The standard an ack is given against
+
+**A diff is acked when it leaves the tree better than it found it**, not
+when it is the diff the reviewer would have written. Perfection is not
+the bar and is not reachable; the question is whether `main` with this
+change is in better shape than `main` without it. The formulation, and
+the reasoning under it, is Google's
+[standard of code review](https://google.github.io/eng-practices/review/reviewer/standard.html).
+
+Two things follow, and they are what reviews get wrong in opposite
+directions:
+
+- **A matter of taste is not a finding.** Where the author's choice and
+  the reviewer's are both defensible, the author's stands. Say it once
+  as a nit, if it is worth saying at all.
+- **Work the diff never set out to do is not a finding either.** It is
+  an issue; the section below is the whole of what to do with it.
+
+## What is under review
+
+1. **A sha, never a branch.** `gh pr view <N> --json
+   url,headRefOid,baseRefName` — `headRefOid` is what is reviewed, and
+   a branch name moves under a review that names it.
+1. **The issues it closes**, all of them: one pull request may answer
+   more than one, and answering one of two is a finding.
+1. **The diff against the pull request's base**, not against `main`:
+   `git diff <baseRefName>...<headRefOid>`, three dots, the base being
+   the parent branch where this one is stacked. A finding that belongs
+   to the parent goes on the parent's pull request — repeated on the
+   child, the author answers it twice and resolves it once.
+1. **The tree at that sha**, checked out and gated. `gh pr checkout <N>`
+   and `uv sync --locked`; `CLAUDE.md` has where a checkout may be made
+   and where it may not.
+
+Read the whole diff before writing the first comment. A comment on line
+5 that line 60 answers costs the author a reply and the reviewer their
+credit for the rest of the review.
+
+## What to look for
+
+In priority order, stopping at what this diff can be wrong about:
+
+- **Does it answer its issues?** The whole of them, and nothing beside.
+  A diff carrying an unrelated fix cannot be acked for either question.
+- **Is it correct?** Reason about the code as it will run, not as it
+  reads. Where a claim can be checked, check it rather than believing
+  it.
+- **Does it break a rule this repository states?** Not a rule the
+  reviewer would have written — one the repository's own documents
+  state, cited by the line that states it. This is the class of finding
+  a review exists for: the author has the diff in view and the document
+  out of view.
+- **Is what it adds tested and documented the way this repository tests
+  and documents things?** Its `CHANGELOG.md` entry included.
+- **Is it simpler than it needs to be?** As a non-blocking finding, and
+  never as a rewrite.
+
+**Never review what a hook already gates.** Formatting, import order,
+line length and the rest are decided by `.pre-commit-config.yaml`, and a
+comment about one of them is either wrong or a bug in the hook.
+
+## Every collateral finding becomes an issue
+
+A review notices more than its subject: a defect the diff did not cause,
+a document that has gone stale, a rule the tree quietly stopped
+following. **None of it is a review comment, and every one of it is an
+issue.** File it, and go back to the diff.
+
+The reason is the author's round trip. A finding they cannot address
+without leaving the subject is a round of review spent on something the
+pull request was not for, and asking for it anyway is how a branch stops
+converging. Filing costs the reviewer one command and loses nothing: the
+defect is recorded, with its evidence, where the next person to touch
+that code will find it.
+
+What is *not* collateral, and stays in the review, is what this diff
+introduces or breaks, and what was already wrong and this diff makes
+materially worse. The test is not whether the code sits on a changed
+line; it is whether this change is what put it there or made it worse.
+
+Look for the issue already open before filing another:
+
+```shell
+gh issue list --state open --search "<the thing, in a word or two>"
+```
+
+The issue stands on its own, read by somebody who never sees this pull
+request: what is wrong, where — `file:line` —, how it is known, and why
+it matters. No fix, and no reference to the pull request as a blocker,
+because it is not one.
+
+```shell
+gh issue create --title "<the finding, as a claim>" \
+  --body "<what was noticed and where, how it is known, why it matters>"
+```
+
+Name the issues filed at the foot of the summary comment, under a line
+saying they are **not** findings against this pull request. Without that
+line the list reads as more things to fix before merging, which is the
+opposite of what filing them was for.
+
+## What a finding says
+
+- **Where**: `file:line`, as an inline comment wherever a line is the
+  subject.
+- **What is wrong**, in a sentence.
+- **How it is known**: the command and what it printed, or the concrete
+  path through the code that produces the wrong result.
+- **What kind it is**, said explicitly and never left to be inferred:
+
+    - **blocking** — wrong, misleading or unmaintainable on `main`
+    - **non-blocking** — worth doing, does not hold the ack
+    - **nit** — taste; said once and never repeated
+    - **question** — something not reproduced, asked as a question
+      rather than asserted as a defect
+
+Labelling every comment is
+[conventional comments](https://conventionalcomments.org/)' idea and its
+whole value: an unlabelled remark makes the author guess whether it
+holds the merge, and they guess conservatively, which turns a nit into a
+round of review.
+
+No speculation dressed as a defect, no "consider maybe", no restating
+what the diff plainly does. A review of five real findings beats twenty
+of which three are real.
+
+The subject is the code and never its author: "this returns the wrong
+sign for a negative scalar", not "you forgot the sign".
+
+## A fix small enough to read at a glance is proposed, not described
+
+Where the correction is a line or a few, put it in the comment rather
+than around it. A review comment anchored to a diff line can carry a
+`suggestion` block, and the author accepts it from the pull request page
+in the browser — no checkout, no editor, one click:
+
+````text
+```suggestion
+    return p - y if y % 2 != odd else y
+```
+````
+
+*Add suggestion to batch* takes several of them into one commit, which
+is what to use when a review leaves more than one.
+`CONTRIBUTING.md` states the same thing from the author's side, as
+something they may apply directly through the interface.
+
+Two properties make this the right shape here and not merely a
+convenience: the commit GitHub writes is signed with its web-flow key,
+and `main` requires a valid signature rather than one particular
+signer; and it lands as a commit of its own on top of the branch,
+which is the shape `CONTRIBUTING.md` asks a correction to take, so the
+shas the review is attached to survive it.
+
+Two properties decide when not to:
+
+- **It is committed verbatim, and nothing local sees it.** The author's
+  `pre-commit` does not run on a commit made in the browser, so the
+  block has to be already written the way the hooks would write it —
+  indentation, quoting, line length, trailing comma. A suggestion that
+  fails a gate is worse than a sentence describing the fix, because it
+  is accepted with one click and the failure arrives after.
+- **Do not suggest a decision.** A one-click accept invites acceptance
+  without thought, so the block is for a fix whose correctness is
+  visible inside it: a wrong constant, an inverted condition, a missing
+  guard, a sentence in a docstring. Anything spanning files, wanting a
+  test beside it, or having a defensible alternative is stated in prose
+  and left to the author.
+
+A suggestion carries the severity of the finding it belongs to. Offering
+one does not make a blocking finding a nit, and accepting one is what
+closes the thread.
+
+## The gates are the evidence
+
+Run them on that sha, and read **exit codes, not filtered output** — a
+pipe into `grep -v Passed` hides the failure it was meant to find. What
+the gates are, and the two ways a run of them lies, is `CLAUDE.md`: a
+suite run over a subset is not the coverage gate, and `pre-commit`
+passing is not the lint gate, sphinx being a job of its own.
+
+A gate that fails locally is the strongest finding available. A gate
+that passes is not evidence that the diff is right.
+
+**CI is not the reviewer's concern.** Do not wait for a workflow run, do
+not read one, do not report a check as a finding, do not withhold a
+review because something is pending or red. A run is cancelled by the
+next push to the same branch, so a red or missing check is as likely to
+be the concurrency group as the diff; whether CI is green is the
+author's problem at landing time, and the local run is the evidence
+either way.
+
+## What a review of this tree checks that a generic one would not
+
+Each of these is a question, and the document that answers it is named
+because that document, and not this one, is where the rule lives.
+
+- A change to `btclib_secp256k1/__init__.py` or to the build: does it
+  keep **both branches of `_load_lib`** right? Only one of the two — the
+  extension with libsecp256k1 linked in, or the shared object
+  `ffi.dlopen`s beside it — exists in any given wheel, so the other is
+  reachable in a test only through a stand-in. `CLAUDE.md`'s
+  "Architecture" is where that lives, and it is the answer to every
+  question of the form "why does this differ between platforms".
+- A new binding: does it carry its entry in
+  `stubs/_btclib_secp256k1.pyi`? That file is what lets strict mypy
+  typecheck a module which exists only after a build.
+- A new module: is it more than one call of another? `mult` was exactly
+  that, and was folded into `keys`. And is it one the README's Design
+  section says belongs here at all — MuSig2 is deliberately not wrapped,
+  its two-round session belonging where the signing state is.
+- A check added to a workflow: is it in `.pre-commit-config.yaml`
+  instead? `CLAUDE.md` states that file as the single definition of
+  clean, and a check discovered by CI after a push is a check in the
+  wrong place.
+- Does the diff **state a count** of anything? `CONTRIBUTING.md` says why
+  it must not, and only some of those are caught by a test.
+- If the branch was rebased: do `CHANGELOG.md` and `HISTORY.md` say what
+  the branch meant them to say? They are `merge=union`, so they never
+  conflict and a rebase can put back a line the branch had removed.
+- A new or changed workflow: the conventions in `CLAUDE.md`, and
+  `REPOSITORY.md` before any rule or setting is touched. A renamed job is
+  a required check renamed out of existence.
+
+
+## The verdict
+
+Inline comments for the line-anchored findings, then exactly one summary
+comment whose last line is one of two forms:
+
+```text
+CHANGES REQUESTED <sha>
+```
+
+```text
+ACK <sha>
+```
+
+Nothing else is an ack — not "looks good", and not a forge approval,
+which `CONTRIBUTING.md` records GitHub as refusing to the author of the
+pull request. That refusal is why the record of a review here is a
+comment at all. It names the sha because an ack belongs to a tree and
+not to a branch.
+
+The summary says, in a few lines, what was reviewed — the sha, the gates
+and their exit codes —, lists the blocking findings, and names the
+issues filed. No blocking findings and no ack is a contradiction: either
+the finding is blocking or the ack is due.
+
+Post it the moment it is written, and where several pull requests are
+waiting, finish and post one before opening the next: a batch of reviews
+arrives as one wall of comments, and the first of them waited for the
+last to be written. Take a re-review before a first review, a parent
+before its child, and otherwise the oldest.
+
+## Re-review
+
+The delta is `git diff <old-sha>..<new-sha>`, and there is one to read
+because `CONTRIBUTING.md` has corrections added as commits rather than
+amended in: the shas the review was attached to are still there.
+
+- **Resolve every thread the author addressed, and only those.** A
+  thread they declined stays open only if it is still blocking; where
+  their reason is sound, resolve it and say so. A finding declined as
+  out of scope and filed as an issue is addressed.
+- Do not re-open settled ground, and do not introduce a preference late.
+  A new blocking finding at round three is legitimate only if the new
+  commits introduced it, or if leaving it would be wrong on `main`.
+- Where the author declined something still considered blocking, say so
+  once, with the argument. If they hold their position, do not spend a
+  fourth round: withhold the ack and put both positions to a human.
+  Escalating is a result; a stalemate repeated in silence is not.
+- A handoff may be a **rebase rather than new work** — the parent landed
+  and the child was retargeted, or a base was amended. Then the delta is
+  the rebase, and what to check is that it carried nothing back: a child
+  moved without naming its old base re-adds the parent's old text as
+  additions, and every gate passes in both worlds.
+
+    ```shell
+    git diff origin/main...<new-sha>
+    git merge-base --is-ancestor origin/main <new-sha>
+    ```
+
+- An acked pull request comes back for one more round when a rebase onto
+  `main` **resolved a conflict**. That is correct of the author, and the
+  delta is the resolution and nothing else: a conflict resolved by one
+  hand is the change that passes every gate and is still wrong.
+
+Ack when every blocking finding is closed, the gates passed locally on
+that sha, and the diff answers its issues. Non-blocking findings and
+nits do not hold an ack — say that they are left to the author.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -246,7 +246,6 @@ because that document, and not this one, is where the rule lives.
   `REPOSITORY.md` before any rule or setting is touched. A renamed job is
   a required check renamed out of existence.
 
-
 ## The verdict
 
 Inline comments for the line-anchored findings, then exactly one summary

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ btclib_secp256k1 documentation
    README <readme_link.md>
    PYTHON PACKAGE <modules>
    CONTRIBUTING <contributing_link.md>
+   REVIEWING <reviewing_link.md>
    SECURITY <security_link.md>
    HISTORY <history_link.md>
    CHANGELOG <changelog_link.md>

--- a/docs/source/reviewing_link.md
+++ b/docs/source/reviewing_link.md
@@ -1,0 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+```{include} ../../REVIEWING.md
+:relative-docs: docs/source/
+:relative-images:
+```
+<!-- markdownlint-enable MD041 -->


### PR DESCRIPTION
## What this changes

Two things the organization settled together, and this repository is the
second of four to receive them.

**The landing convention now says what is in force.** The
`main-self-merge` bypass reads `pull_request` mode, so it excuses the
approving review a solo-maintainer repository cannot produce and excuses
nothing else: `main` is reachable through a pull request and through
nothing else, a direct push being refused for everyone, the holder of
the bypass included. The ruleset also names `squash` as the only merge
method it will accept, so the constraint is stated where the rule is and
not only in a repository toggle.

Three files described the arrangement that preceded it:

- `REPOSITORY.md` titled a section **"The rulesets, and the push their
  bypass is for"**, and carried the push sequence, the two outcomes of
  whether GitHub reconciles what landed, and the head-branch cases that
  followed from them. There is one outcome now.
- `CONTRIBUTING.md` said the landing is "a push rather than a button".
- `CLAUDE.md` kept a fast-forward exception for a single-commit pull
  request that is the base of a stacked one — the half of #266 that was
  left in place when that pull request updated this file alone.

What the exception bought is paid for with a rebase instead. It is the
recreating and not the squashing that costs a stacked child its base:
GitHub's documentation has rebase-and-merge "always updates the
committer information and creates new commit SHAs", so the count of
commits was never what decided it.

**`REVIEWING.md` is the standard a review is written against**, the
reviewer's half of `CONTRIBUTING.md`: what a review establishes before
it gives an ack, what a finding must contain and how it labels its
severity, and what becomes of everything a reviewer notices that the
diff is not about — every collateral finding is filed as an issue rather
than asked for in a comment. It states no new rule; the rules it cites
stay in the files that state them.

Registered the way `CONTRIBUTING.md` is: a page of the sphinx toctree
through a `reviewing_link.md` shim, named from the README and from
`CLAUDE.md` — which is the file a repository-aware reviewer actually
reads — with `.claude/commands/review.md` as the `/review` command.

## How it was verified

```shell
uvx pre-commit run --all-files                     # clean
uv run --locked --no-default-groups --group test pytest --cov
# 726 passed, coverage 100.00%
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
# build succeeded; reviewing_link written
```

The sphinx build is the one that matters for the new shim.

The configuration was changed first and read back on all four
repositories:

```shell
gh api repos/btclib-org/btclib-secp256k1/rulesets/<id> \
  --jq '{bypass: [.bypass_actors[].bypass_mode],
         methods: [.rules[]|select(.type=="pull_request")
                          |.parameters.allowed_merge_methods]}'
# {"bypass":["pull_request"],"methods":[["squash"]]}
```

and `main-integrity` is untouched: four rules, empty bypass list.

## Checks

- [x] `uvx pre-commit run --all-files` is clean
- [x] the suite passes at 100% coverage
- [x] `CHANGELOG.md` has an entry

## Anything the reviewer should know

**`REVIEWING.md`'s body is deliberately the text btclib carries**, one
section excepted: "What a review of this tree checks that a generic one
would not", which asks about `_load_lib`'s two branches, the stub a new
binding needs, and `.pre-commit-config.yaml` as the single definition of
clean. `.markdownlint.jsonc` already carries the same convention in its
header — prose moves between these repositories, so a paragraph that
holds in one has to hold in the others.

**This bundles two subjects**, which `REVIEWING.md` itself would call a
finding. The reason is that the second is what makes the first legible:
the landing convention is a rule a review cites, and a repository that
gained the standard without it would cite a file describing a landing it
no longer has. Splitting them would put a known-stale `REPOSITORY.md`
under review beside the standard that says to check exactly that.

## Summary by Sourcery

Align the repository’s landing documentation with its enforced pull-request workflow and establish a standard for reviewing changes.

New Features:
- Add REVIEWING.md as the repository’s review standard and expose it through the README, documentation, contributor guidance, Claude instructions, and a `/review` command.

Enhancements:
- Clarify that main can only be reached through pull requests, with the maintainer bypass applying only to the approving-review requirement.
- Restrict the enforced merge method to squash and align repository, contributor, and maintainer guidance with the active landing convention.
- Define review expectations for findings, severity, collateral issues, evidence, verdicts, and re-reviews.

Documentation:
- Document the active landing rules and review standard across repository and user-facing documentation.

Chores:
- Record the landing-convention and review-standard changes in the changelog.