### PR TITLE
Read a pull request against REVIEWING.md, from CI

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,226 @@
+---
+name: claude-review
+
+# Claude reading a pull request against REVIEWING.md, which is the standard
+# a review here is written against and the whole of what this workflow has
+# to say: the prompt below names that file rather than restating it, so a
+# change to the standard reaches this workflow without editing it.
+#
+# Not a required check, and it must not become one. What it produces is a
+# comment, which is an opinion for the author to weigh -- REPOSITORY.md's
+# rule is that `main`'s required contexts are named outside the repository,
+# and a review that gates a merge would make a model's judgement a branch
+# rule. The four required checks stay what they are.
+#
+# It is one more job on every pull request, which is not free: GitHub Free
+# gives this organization twenty concurrent jobs and REPOSITORY.md measures
+# what a commit at that ceiling costs in wall clock. It earns the slot by
+# being short -- it reads a diff, it does not build a matrix -- and by
+# skipping a draft, which is the condition test.yml and lint.yml already
+# carry.
+
+on:
+  pull_request:
+    # ready_for_review so a pull request marked ready gets the review the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request would
+    # wait for its next push to be reviewed at all. The same reasoning
+    # links.yml carries for the same type
+    types: [opened, reopened, synchronize, ready_for_review]
+  # the on-demand half: somebody writes @claude in a comment on a pull
+  # request, or on a line of its diff, and asks for something the automatic
+  # pass did not answer
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# least privilege for the GITHUB_TOKEN, elevated per job below and nowhere
+# else
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Claude review
+    # a draft is work its author is not asking anyone to read yet, and a
+    # comment event is the other job's.
+    #
+    # The fork condition is not a policy but a fact about secrets: "with
+    # the exception of GITHUB_TOKEN, secrets are not passed to the runner
+    # when a workflow is triggered from a forked repository", so on a
+    # contributor's pull request this job would start, find
+    # CLAUDE_CODE_OAUTH_TOKEN empty and fail -- a red job on the pull
+    # requests of exactly the people least able to tell it apart from
+    # their own mistake. Skipped, it reports nothing at all, and the
+    # mention job below is the path that still works there: issue_comment
+    # is a base-repository event, so it is handed the secret.
+    #
+    # Compared by full_name rather than by `.fork`, which asks whether the
+    # head repository is a fork of anything and is true of a branch of
+    # btclib-org/bbt, itself a fork
+    if: >-
+      ${{ github.event_name == 'pull_request'
+          && !github.event.pull_request.draft
+          && github.event.pull_request.head.repo.full_name
+             == github.repository }}
+    runs-on: ubuntu-latest
+    # a diff read and a comment posted; a job past this is hung on the API
+    timeout-minutes: 15
+    # per job rather than per workflow, so that a push cancelling a
+    # superseded review does not also cancel somebody's @claude question
+    # running beside it. Named literally rather than through
+    # github.workflow, as everywhere else here
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      # what posting the review takes
+      pull-requests: write
+      # not for workload identity federation, which this does not use: the
+      # action mints a GitHub OIDC token during its own startup whatever
+      # the Anthropic credential is. Measured by leaving it out -- the run
+      # died before reaching authentication at all, with "Could not fetch
+      # an OIDC token. Did you remember to add `id-token: write` to
+      # your workflow permissions?"
+      id-token: write
+    steps:
+      # every action pinned to a commit SHA with the tag in the comment: a
+      # tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # as every other checkout here, lint.yml's included
+          persist-credentials: false
+          # depth 1 is enough because the diff comes from `gh pr diff`,
+          # which is the base...head three-dot diff REVIEWING.md asks for,
+          # computed by the forge rather than from local history
+          fetch-depth: 1
+      # a missing credential is a silent pass without this, which is the
+      # worst shape a gate can take: measured on the first run after the
+      # organization secret was deleted -- the action found the token
+      # empty, reviewed nothing, and reported success. Fail loudly
+      # instead, and say which secret and where it lives
+      - name: Refuse to review without a credential
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is empty. It is an" \
+                 "organization secret of btclib-org, visible to all" \
+                 "repositories; without it this workflow reviews nothing."
+            exit 1
+          fi
+      - name: Review against REVIEWING.md
+        id: review
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Read REVIEWING.md in the repository root and review this pull
+            request against it. That file is the standard: what is under
+            review, what to look for and in what order, what a finding
+            must contain and how it labels its severity, what becomes of
+            everything you notice that the diff is not about, and the two
+            forms the verdict takes. Follow it rather than the review
+            habits you would otherwise bring. CLAUDE.md has the facts
+            about this tree a review has to know, and CONTRIBUTING.md the
+            rules a finding cites.
+
+            One deviation from REVIEWING.md, because this is CI and not a
+            session: do not run the gates. They are running beside you on
+            this same sha, in test.yml, lint.yml and docs.yml, and a
+            second run of them here would buy nothing and cost a slot.
+            Review everything else the standard asks for, and say in the
+            summary that the gates were left to those workflows.
+
+            Do not file issues from here: a collateral finding goes in the
+            summary comment, under a line saying it is not a finding
+            against this pull request, and a person decides whether it
+            becomes one.
+
+            Post GitHub comments only, never review text as a message.
+            `gh pr comment` for the summary,
+            `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for a finding a line is the subject of.
+          # folded rather than literal, and `gh pr` rather than the three
+          # subcommands spelled out: the flag has to reach the CLI as one
+          # line, and the line that spells out comment, diff and view is
+          # past the 100 columns yamllint holds this file to
+          claude_args: >-
+            --allowedTools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Read,Grep,Glob"
+
+      # the action refuses to run when this file differs from the copy on
+      # the default branch -- a pull request must not be able to edit the
+      # workflow that holds the credential -- and it reports that refusal
+      # by *skipping*, with the job still green. Two runs were read as
+      # proof that this workflow worked before the log said otherwise, so
+      # the skip is made loud here: `execution_file` is empty exactly when
+      # the action did not run.
+      #
+      # The consequence is deliberate: on the pull request that adds or
+      # edits this file, this job is red until the change is on `main`.
+      # It gates nothing, and a red check that says "no review happened"
+      # is the honest shape of that.
+      - name: Refuse to report a review that never ran
+        env:
+          EXECUTION: ${{ steps.review.outputs.execution_file }}
+        run: |
+          if [ -z "$EXECUTION" ]; then
+            echo "::error::the action produced no execution file, so no" \
+                 "review was written. The usual cause is workflow" \
+                 "validation: this file differs from the copy on the" \
+                 "default branch, which the action refuses to run under."
+            exit 1
+          fi
+
+  mention:
+    name: Claude answers a mention
+    # no prompt on this one, deliberately: the action reads the comment
+    # that triggered it and answers what was actually asked, where a
+    # prompt of ours would answer something else. `github.event.issue.pull
+    # _request` is what tells a comment on a pull request from a comment
+    # on an issue, the issue_comment event carrying both
+    if: >-
+      ${{ (github.event_name == 'issue_comment'
+           && github.event.issue.pull_request
+           && contains(github.event.comment.body, '@claude'))
+          || (github.event_name == 'pull_request_review_comment'
+              && contains(github.event.comment.body, '@claude')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      # the same startup OIDC token the review job above needs
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      # a missing credential is a silent pass without this, which is the
+      # worst shape a gate can take: measured on the first run after the
+      # organization secret was deleted -- the action found the token
+      # empty, reviewed nothing, and reported success. Fail loudly
+      # instead, and say which secret and where it lives
+      - name: Refuse to review without a credential
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is empty. It is an" \
+                 "organization secret of btclib-org, visible to all" \
+                 "repositories; without it this workflow reviews nothing."
+            exit 1
+          fi
+      - name: Answer the mention
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,38 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### Claude reads a pull request against REVIEWING.md
+
+- **`claude-review.yml`**, two jobs: one on every non-draft pull request,
+  whose prompt names `REVIEWING.md` rather than restating it, so the
+  standard moves without the workflow being edited; one answering
+  `@claude` in a comment, carrying no prompt of ours on purpose — the
+  action reads the comment that triggered it. It gates nothing and must
+  not: `main`'s required contexts are named outside the repository, and
+  a review that held a merge would make a model's judgement a branch
+  rule. The gates are not re-run, `test.yml`, `lint.yml` and `docs.yml`
+  running them beside it on the same sha.
+
+  Three things it refuses to do silently, each measured in btclib before
+  being asked not to. Without `CLAUDE_CODE_OAUTH_TOKEN` the action
+  reviews nothing and reports **success**. Without `id-token: write` it
+  dies before authentication, the action minting a GitHub OIDC token at
+  startup whatever the Anthropic credential is. And it refuses to run at
+  all when the workflow file differs from the copy on the default
+  branch — a pull request must not be able to edit the workflow holding
+  the credential — reporting that refusal by skipping, green. It now
+  fails on an empty secret and on an empty `execution_file`, which is
+  exactly when no review was written. The consequence is deliberate: on
+  a pull request that adds or edits this file the job is red until the
+  change is on `main`.
+
+  The automatic job skips a pull request from a fork, which is not a
+  policy but what secrets do: none but `GITHUB_TOKEN` reaches a runner a
+  fork triggered. `@claude` still answers there, `issue_comment` being a
+  base-repository event. It is also the one workflow in
+  `CONTRIBUTING.md`'s table taking no `workflow_dispatch`, both jobs
+  reading the pull request or the comment that triggered them.
+
 ### The pull request is the only way into main, and the review has a standard
 
 - **The landing convention says what is in force: the squash button.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,7 @@ read by every checkout of this repository.
 | --- | --- | --- |
 | `test` | pull request, push | the wheels, and ubuntu × every interpreter |
 | `lint`, `docs` | pull request, push | — |
+| `claude-review` | pull request, and `@claude` in a comment | — |
 | `vendored-vectors` | monthly, a change to itself | — |
 | `codeql` | push to main, Tuesday | the two scanned languages |
 | `macos` | Wednesday, a release | both macOS images, both linkages |
@@ -211,7 +212,9 @@ it builds it, and the release publishes the artifacts of that run. What
 waits a week is pip's *selection* among them, and the dynamic build.
 Everything but the first two rows also takes `workflow_dispatch`, which for
 `codeql` and the two platform workflows is the only way to ask about a
-branch at all.
+branch at all. `claude-review` is the exception that takes none: both its
+jobs read the pull request or the comment that triggered them, so a manual
+run would start with nothing to read.
 
 `codeql` runs on `main` and on its Tuesday schedule and not on a pull
 request, which is the same arithmetic as the rows above: three slots held


### PR DESCRIPTION
## What this changes

`claude-review.yml`, the same workflow btclib carries since #1024 in btclib, so
that a pull request here is read against `REVIEWING.md` — which landed
on `main` and is currently read by nothing.

Two jobs:

- **`review`**, on every non-draft pull request. Its prompt names
  `REVIEWING.md` rather than restating it, so the standard moves without
  this workflow being edited.
- **`mention`**, on `@claude` in a comment, carrying no prompt of ours on
  purpose: the action reads the comment that triggered it and answers
  what was asked. It is also how a pull request that needs no push asks
  for a review, `issue_comment` firing on its own.

**It gates nothing, and must not.** `main`'s required contexts are named
outside the repository, and a review that held a merge would make a
model's judgement a branch rule.

## The three silent failures it refuses to repeat

Each was measured in btclib rather than reasoned about, and each
reported a **green** check while reviewing nothing:

1. **No credential.** Without `CLAUDE_CODE_OAUTH_TOKEN` the action found
   the token empty, reviewed nothing, and succeeded.
2. **No `id-token: write`.** The action mints a GitHub OIDC token during
   its own startup whatever the Anthropic credential is; without the
   permission the run dies before authentication, with
   `Could not fetch an OIDC token`. This one at least failed loudly.
3. **Workflow validation.** The action refuses to run when the workflow
   file differs from the copy on the default branch — a pull request
   must not be able to edit the workflow that holds the credential — and
   it reports that refusal by *skipping*, green. Two runs were read as
   proof that the workflow worked before the log said otherwise.

So the workflow now fails on an empty secret, and fails when the
action's `execution_file` output is empty, which is exactly when no
review was written.

**Consequence, deliberate: the `Claude review` job on this pull request
is red.** The file is not on `main` yet, so the action refuses it. That
is the honest report of a review that did not happen, and it gates
nothing. The first real run is the pull request after this lands.

## How it was verified

```shell
uv run pre-commit run --all-files          # clean: actionlint and zizmor included
```

The behaviour itself cannot be verified before merge, for the reason
above.

## Checks

- [x] `pre-commit` is clean
- [x] `CHANGELOG.md` has an entry
- [ ] the suite — untouched by this change

## Anything the reviewer should know

**External contributors get no automatic review.** Secrets are not
passed to a runner a fork triggered, so the job would start, find the
token empty and fail on the pull requests of the people least able to
tell that apart from their own mistake. It skips a fork instead, and
`@claude` still answers there.


**Adapted where this repository differs**: the checkout comment points
at `lint.yml`'s rather than at a suite job `test.yml` does not have
under that name, and `CONTRIBUTING.md`'s table gains a row — which would
have made the sentence below it false, that sentence saying everything
but the first two rows also takes `workflow_dispatch`. This one takes
none: both jobs read the pull request or the comment that triggered
them, so a manual run would start with nothing to read.

## Summary by Sourcery

Add a non-blocking CI workflow that reviews pull requests against the repository review standard and answers explicit Claude mentions.

New Features:
- Add a Claude review workflow that automatically reviews non-draft pull requests against REVIEWING.md and responds to @claude mentions on pull requests.

Bug Fixes:
- Fail explicitly when the Claude credential is unavailable or when the action skips execution without producing a review, preventing false-success checks.

Enhancements:
- Keep the Claude review advisory-only and skip automatic reviews for fork-originated pull requests while retaining mention-based responses.
- Document the new workflow and its trigger behavior in the changelog and contributing guide.

CI:
- Add pinned-action GitHub Actions jobs with least-privilege permissions, concurrency control, timeouts, and OIDC support for automated and on-demand Claude interactions.

Documentation:
- Document claude-review triggers and its exclusion from manual workflow dispatch.