### PR TITLE
Skip the aggregate gate on a cancelled run instead of failing it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -922,17 +922,23 @@ jobs:
   # check, and macos.yml and windows.yml are two more workflows over the
   # same matrix shape.
   #
-  # `if: always()` because a job with unmet `needs` is skipped, and a
+  # `if: !cancelled()` because a job with unmet `needs` is skipped, and a
   # skipped check is not a failed one: without it a failing matrix cell
   # would leave this context reported as skipped, which satisfies a
-  # required check rather than blocking on it. Cancelled is a failure here
-  # too, a superseded run being no evidence either way
+  # required check rather than blocking on it. A cancellation of this
+  # run itself, though, is no evidence either way -- the concurrency
+  # group superseding it with a newer push -- and `always()` used to
+  # carry that into an explicit failure below despite the run's own
+  # cancellation already speaking for it. `!cancelled()` skips this job
+  # in that case instead, which satisfies the check the way any other
+  # skip does, while a job cancelled on its own rather than by the run's
+  # own cancellation still fails below
   test-passed:
     name: "test: every job passed"
     # and the draft condition every job above carries, so a draft
     # skips uniformly rather than tripping the skip check below -- the
     # closed one for the same reason, added at the trigger above
-    if: ${{ always() && !github.event.pull_request.draft && github.event.action != 'closed' }}
+    if: ${{ !cancelled() && !github.event.pull_request.draft && github.event.action != 'closed' }}
     needs:
       - changes
       - coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2574,6 +2574,20 @@ release-notes length in the first place, and are still in
   both greps. `test: every job passed` gets an entry in the same pass,
   that being the neighbouring gap and the check a contributor sees red:
   it reproduces as nothing, reading the conclusions of the jobs above it.
+- **`test-passed` skips a cancelled run instead of failing it** (#274).
+  It carried `always()`, so a run the next push's concurrency group
+  already superseded — every needed job reporting `cancelled` — still
+  reached the `case " $RESULTS " in *" failure "* | *" cancelled "*)`
+  step and turned that into a required check with no defect behind it,
+  red beside the newer run's green on the same head sha. The job's own
+  comment had called this deliberate, "Cancelled is a failure here too,
+  a superseded run being no evidence either way" — the framing #273
+  disputes: the case that is wrong is the concurrency one, where the
+  cancellation means a newer run is authoritative rather than that this
+  tree is unproven. `always()` becomes `!cancelled()`; a skipped
+  required check satisfies branch protection the same as a passing one,
+  and the step below is unchanged, so a job cancelled on its own rather
+  than by the run's own cancellation still fails the gate as before.
 
 ## v0.8.0.2
 


### PR DESCRIPTION
## What this changes

`test.yml`'s `test-passed` carries `if: always() && !draft && !closed`,
so a run superseded by the next push under this workflow's concurrency
group — every needed job reporting `cancelled` — still reaches the
gate, whose `Fail unless every job above succeeded` step exits 1 on
`RESULTS` containing `cancelled`, same as it does for `failure`. The
job's own comment called this deliberate — "Cancelled is a failure
here too, a superseded run being no evidence either way" — but the
cancellation the newer run already speaks for becomes a required check
with no defect behind it, and because both runs report on the same
head sha when the cancellation came from a re-run or a branch update,
the pull request is left carrying a red and a green check of the same
name.

`always()` becomes `!cancelled()` in the job's condition. A skipped
required check satisfies branch protection the same as a passing one,
so a cancellation of the run itself now skips the gate rather than
running it to a failure. The step itself is unchanged: a job cancelled
on its own, without the whole run being cancelled, still fails the
gate as before.

## Testing

`actionlint` passes on the workflow file. The issue that requested
this candidate over `always()` also asked that it be exercised on a
disposable branch before being trusted — the failure mode to watch for
being the opposite one, a gate that skips itself into satisfying a
rule it should have held. I don't have a way to force a real
concurrency-group cancellation from here; a maintainer with push access
can push two commits in quick succession to this branch and confirm
`test-passed` reports `skipped` rather than `failure` on the
superseded run.

Closes #273

## Summary by Sourcery

Bug Fixes:
- Prevent superseded workflow runs from turning the required aggregate test check red when the run is cancelled.