### PR TITLE
Point /review at this tree's own facts, not btclib's

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -18,7 +18,9 @@ Follow it in preference to the review habits you would otherwise bring.
 Two files it leans on, worth loading with it:
 
 - `CLAUDE.md` for the gates and for what a review of *this* tree has to
-  know, the two arithmetic paths under `curves/` and `ecc/` above all;
+  know, the two branches of `_load_lib` above all — only one of them
+  exists in any given wheel, so the other is reachable in a test only
+  through a stand-in;
 - `CONTRIBUTING.md` for the rules a finding cites, so that a finding
   names the line that states one.
 


### PR DESCRIPTION
## What this changes

One sentence in `.claude/commands/review.md`, which was copied from
btclib unchanged and kept btclib's facts.

It pointed a reviewer at `CLAUDE.md` "for what a review of *this* tree
has to know, **the two arithmetic paths under `curves/` and `ecc/`**
above all" — an architecture this repository does not have. A reviewer
sent to read a fact that is not here reads nothing, and that sentence is
the one place in the command where being specific was the whole point.

It now names `_load_lib`'s two branches: only one exists in any given
wheel, so the other is reachable in a test only through a stand-in,
which `CLAUDE.md`'s *Architecture* calls the answer to every question of
the form "why does this differ between platforms".

## How it was found

`bitcoin-core-rpc` had the identical defect and fixed it in
[3354985](https://github.com/btclib-org/bitcoin-core-rpc/commit/33549850),
which is what sent me to check the other two. `btclib-benchmarks` had it
as well and is getting the same correction; `btclib` is the one
repository where the sentence was already true.

The `REVIEWING.md` these commands point at was adapted per repository
when it landed — its "What a review of this tree checks that a generic
one would not" section is the one part that differs between the four.
The command file beside it was not, and that is the whole of this
change.

## How it was verified

```shell
uvx pre-commit run --all-files          # clean
```

Prose in a file no gate reads, so the check that matters is a reading:
the fact named is in `CLAUDE.md`, under *Architecture*.

## Checks

- [x] `pre-commit` is clean
- [ ] `CHANGELOG.md` — no entry: this corrects a sentence in a file that
      landed in this same unreleased cycle, and the entry describing it
      is already there. Splitting one line of it into a second bullet
      would be two entries for one change.

## Summary by Sourcery

Point review guidance at the repository’s own platform-specific facts.

Bug Fixes:
- Update the review guidance to reference this repository’s actual `_load_lib` platform branches instead of an architecture that does not exist here.

Documentation:
- Correct the repository-specific review command guidance so reviewers are directed to the relevant architecture documented in `CLAUDE.md`.