### PR TITLE
Group a pull_request run by its own number, not github.ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,10 @@ on:
   push:
     # main only, for the reason lint.yml gives at the same key: a push to a
     # branch with an open pull request would run this twice, in two
-    # concurrency groups that do not cancel each other, and the pull_request
-    # run is the one worth keeping
+    # concurrency groups that do not cancel each other for every
+    # pull_request action except closed on a merge -- see that trigger's
+    # own comment below -- and the pull_request run is the one worth
+    # keeping
     branches: [main]
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
@@ -31,12 +33,20 @@ on:
     # for its next push to be checked at all.
     # closed joins them for a different reason: merging or closing a pull
     # request is neither a push nor a synchronize, so a run still held in
-    # this ref's concurrency group survives it -- cancel-in-progress only
-    # fires when a new run lands in that group, and nothing otherwise does.
-    # Landing the closed event there is what lets it supersede the stale
-    # run instead of leaving it to finish on a branch nobody is going to
-    # look at again; the job below declines the real work on it, the merge
-    # commit being main's own push trigger's question
+    # this pull request's own concurrency group survives it --
+    # cancel-in-progress only fires when a new run lands in that group,
+    # and nothing otherwise does. Landing the closed event there is what
+    # lets it supersede the stale run instead of leaving it to finish on
+    # a branch nobody is going to look at again; the job below declines
+    # the real work on it, the merge commit being main's own push
+    # trigger's question. "This pull request's own group" is the part
+    # github.ref alone got wrong: for a closed, merged pull request it
+    # resolves to the base branch's ref, the same one the push trigger's
+    # own run computes, so the closed run landed in *that* group instead
+    # and cancelled the run building the actual merge commit's
+    # documentation -- observed on this repository's own main. The
+    # concurrency block below groups by the pull request's own number
+    # instead, immune to that collision under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:
@@ -59,11 +69,11 @@ permissions:
 
 # cancel superseded runs on the same branch/PR, named literally and
 # discriminated by an input rather than left to github.ref alone, for the
-# two reasons lint.yml gives at length: release.yml calls this workflow
+# three reasons lint.yml gives at length: release.yml calls this workflow
 # beside lint.yml and test.yml, and a group computed from github.workflow
 # would have the three cancel each other
 concurrency:
-  group: docs-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: docs-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,10 +43,11 @@ on:
     # github.ref alone got wrong: for a closed, merged pull request it
     # resolves to the base branch's ref, the same one the push trigger's
     # own run computes, so the closed run landed in *that* group instead
-    # and cancelled the run building the actual merge commit's
-    # documentation -- observed on this repository's own main. The
-    # concurrency block below groups by the pull request's own number
-    # instead, immune to that collision under any action
+    # and would cancel the run building the actual merge commit's
+    # documentation -- observed doing exactly that to bitcoin-core-rpc's
+    # own main, after its #136 merged there. The concurrency block below
+    # groups by the pull request's own number instead, immune to that
+    # collision under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,11 +46,18 @@ on:
     # would wait for its next push to be checked at all.
     # closed joins them for a different reason: merging or closing a pull
     # request is neither a push nor a synchronize, so a run still held in
-    # this ref's concurrency group survives it -- cancel-in-progress only
-    # fires when a new run lands in that group, and nothing otherwise
-    # does. Landing the closed event there is what lets it supersede the
-    # stale run instead of leaving it to finish on a branch nobody is
-    # going to look at again
+    # this pull request's own concurrency group survives it --
+    # cancel-in-progress only fires when a new run lands in that group,
+    # and nothing otherwise does. Landing the closed event there is what
+    # lets it supersede the stale run instead of leaving it to finish on
+    # a branch nobody is going to look at again. "This pull request's
+    # own group" is the part github.ref alone gets wrong: for a closed,
+    # merged pull request it resolves to the base branch's ref, which
+    # this workflow has no push trigger to collide with, but the weekly
+    # schedule and a workflow_dispatch both also run on the default
+    # branch and would resolve to that same ref. The concurrency block
+    # below groups by the pull request's own number instead, immune to
+    # that under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/links.yml
@@ -69,9 +76,14 @@ permissions:
 
 # cancel superseded runs. Named literally rather than through
 # github.workflow, as everywhere else here: in a called workflow what that
-# expression resolves to is undocumented
+# expression resolves to is undocumented.
+# github.event.pull_request.number, not github.ref alone, is what a
+# pull_request run of any action groups by -- the pull_request trigger's
+# own comment above has the reasoning. Neither schedule nor
+# workflow_dispatch carries pull_request context, so github.ref is still
+# what groups either, unchanged
 concurrency:
-  group: links-${{ github.ref }}
+  group: links-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,12 @@ on:
   push:
     # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/<branch> against
-    # refs/pull/N/merge) so neither cancels the other. The pull_request
-    # run is the one worth keeping, because it tests the merge commit and
-    # is the only run a fork's pull request produces at all.
+    # different concurrency groups for every pull_request action except
+    # closed on a merge -- see that trigger's own comment below, and the
+    # concurrency block, for why closed is the exception and how the
+    # group now avoids it. The pull_request run is the one worth
+    # keeping, because it tests the merge commit and is the only run a
+    # fork's pull request produces at all.
     # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request tested, and nothing else would
     # ever test it. Tag pushes are covered by the release workflow

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,12 +27,20 @@ on:
     # would wait for its next push to be checked at all.
     # closed joins them for a different reason: merging or closing a pull
     # request is neither a push nor a synchronize, so a run still held in
-    # this ref's concurrency group survives it -- cancel-in-progress only
-    # fires when a new run lands in that group, and nothing otherwise does.
-    # Landing the closed event there is what lets it supersede the stale
-    # run instead of leaving it to finish on a branch nobody is going to
-    # look at again; the job below declines the real work on it, the merge
-    # commit being main's own push trigger's question
+    # this pull request's own concurrency group survives it --
+    # cancel-in-progress only fires when a new run lands in that group,
+    # and nothing otherwise does. Landing the closed event there is what
+    # lets it supersede the stale run instead of leaving it to finish on
+    # a branch nobody is going to look at again; the job below declines
+    # the real work on it, the merge commit being main's own push
+    # trigger's question. "This pull request's own group" is the part
+    # github.ref alone got wrong: for a closed, merged pull request it
+    # resolves to the base branch's ref, the same one the push trigger's
+    # own run computes, so the closed run landed in *that* group instead
+    # and cancelled the run linting the actual merge commit -- observed
+    # on this repository's own main. The concurrency block below groups
+    # by the pull request's own number instead, immune to that collision
+    # under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:
@@ -73,9 +81,18 @@ permissions:
 # A tag run is unaffected, refs/tags/v* being a ref nothing else uses.
 # release.yml passes a suffix of its own, which keeps the release path
 # out of the branch groups while still letting a second rehearsal of the
-# same branch supersede the first
+# same branch supersede the first.
+#
+# github.event.pull_request.number, not github.ref alone, is a third
+# problem with the same shape: for a closed, merged pull request's run,
+# github.ref resolves to the base branch's ref rather than
+# refs/pull/N/merge, colliding with the push trigger's own group --
+# the pull_request trigger's own comment above has the evidence. A
+# pull_request run of any action, closed included, now groups by the
+# pull request's own number instead, which a push never carries and so
+# still groups by github.ref, unchanged
 concurrency:
-  group: lint-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: lint-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,10 +37,11 @@ on:
     # github.ref alone got wrong: for a closed, merged pull request it
     # resolves to the base branch's ref, the same one the push trigger's
     # own run computes, so the closed run landed in *that* group instead
-    # and cancelled the run linting the actual merge commit -- observed
-    # on this repository's own main. The concurrency block below groups
-    # by the pull request's own number instead, immune to that collision
-    # under any action
+    # and would cancel the run linting the actual merge commit --
+    # observed doing exactly that to bitcoin-core-rpc's own main, after
+    # its #136 merged there. The concurrency block below groups by the
+    # pull request's own number instead, immune to that collision under
+    # any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse this gate
   workflow_call:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,12 @@ on:
   push:
     # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/<branch> against
-    # refs/pull/N/merge) so neither cancels the other. The pull_request
-    # run is the one worth keeping, because it tests the merge commit and
-    # is the only run a fork's pull request produces at all.
+    # different concurrency groups for every pull_request action except
+    # closed on a merge -- see that trigger's own comment below, and the
+    # concurrency block, for why closed is the exception and how the
+    # group now avoids it. The pull_request run is the one worth
+    # keeping, because it tests the merge commit and is the only run a
+    # fork's pull request produces at all.
     # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request tested, and nothing else would
     # ever test it. Tag pushes are covered by the release workflow
@@ -55,12 +57,20 @@ on:
     # would wait for its next push to be checked at all.
     # closed joins them for a different reason: merging or closing a pull
     # request is neither a push nor a synchronize, so a run still held in
-    # this ref's concurrency group survives it -- cancel-in-progress only
-    # fires when a new run lands in that group, and nothing otherwise does.
-    # Landing the closed event there is what lets it supersede the stale
-    # run instead of leaving it to finish on a branch nobody is going to
-    # look at again; every job below declines the real work on it, the
-    # merge commit being main's own push trigger's question
+    # this pull request's own concurrency group survives it --
+    # cancel-in-progress only fires when a new run lands in that group,
+    # and nothing otherwise does. Landing the closed event there is what
+    # lets it supersede the stale run instead of leaving it to finish on
+    # a branch nobody is going to look at again; every job below
+    # declines the real work on it, the merge commit being main's own
+    # push trigger's question. "This pull request's own group" is the
+    # part github.ref alone got wrong: for a closed, merged pull request
+    # it resolves to the base branch's ref, the same one the push
+    # trigger's own run computes, so the closed run landed in *that*
+    # group instead and cancelled the run testing the actual merge
+    # commit -- observed on this repository's own main. The concurrency
+    # block below groups by the pull request's own number instead,
+    # immune to that collision under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
@@ -92,9 +102,9 @@ permissions:
 
 # cancel superseded runs on the same branch/PR; named literally rather
 # than through github.workflow, and discriminated by an input rather than
-# left to github.ref alone, for the two reasons given in lint.yml
+# left to github.ref alone, for the three reasons given in lint.yml
 concurrency:
-  group: test-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: test-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,11 @@ on:
     # part github.ref alone got wrong: for a closed, merged pull request
     # it resolves to the base branch's ref, the same one the push
     # trigger's own run computes, so the closed run landed in *that*
-    # group instead and cancelled the run testing the actual merge
-    # commit -- observed on this repository's own main. The concurrency
-    # block below groups by the pull request's own number instead,
-    # immune to that collision under any action
+    # group instead and would cancel the run testing the actual merge
+    # commit -- observed doing exactly that to bitcoin-core-rpc's own
+    # main, after its #136 merged there. The concurrency block below
+    # groups by the pull request's own number instead, immune to that
+    # collision under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -34,11 +34,18 @@ on:
     # would wait for its next push to be checked at all.
     # closed joins them for a different reason: merging or closing a pull
     # request is neither a push nor a synchronize, so a run still held in
-    # this ref's concurrency group survives it -- cancel-in-progress only
-    # fires when a new run lands in that group, and nothing otherwise
-    # does. Landing the closed event there is what lets it supersede the
-    # stale run instead of leaving it to finish on a branch nobody is
-    # going to look at again
+    # this pull request's own concurrency group survives it --
+    # cancel-in-progress only fires when a new run lands in that group,
+    # and nothing otherwise does. Landing the closed event there is what
+    # lets it supersede the stale run instead of leaving it to finish on
+    # a branch nobody is going to look at again. "This pull request's
+    # own group" is the part github.ref alone gets wrong: for a closed,
+    # merged pull request it resolves to the base branch's ref, which
+    # this workflow has no push trigger to collide with, but the weekly
+    # schedule and a workflow_dispatch both also run on the default
+    # branch and would resolve to that same ref. The concurrency block
+    # below groups by the pull request's own number instead, immune to
+    # that under any action
     types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - .github/workflows/vendored-vectors.yml
@@ -56,7 +63,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: vendored-vectors-${{ github.ref }}
+  # github.event.pull_request.number, not github.ref alone, is what a
+  # pull_request run of any action groups by -- the pull_request
+  # trigger's own comment above has the reasoning. Neither schedule nor
+  # workflow_dispatch carries pull_request context, so github.ref is
+  # still what groups either, unchanged
+  group: vendored-vectors-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2588,6 +2588,25 @@ release-notes length in the first place, and are still in
   required check satisfies branch protection the same as a passing one,
   and the step below is unchanged, so a job cancelled on its own rather
   than by the run's own cancellation still fails the gate as before.
+- **A closed pull request's run no longer lands in its merge's own push
+  run's concurrency group** (#276). `test.yml`, `lint.yml` and
+  `docs.yml` grouped by `github.ref` alone, and github.ref for a
+  closed, merged pull request's run resolves to the base branch's ref
+  rather than `refs/pull/N/merge`, landing it in the same group as the
+  push the merge itself triggers. The two events fire about a second
+  apart on every merge, and after bitcoin-core-rpc's own #136 landed
+  there, its `docs` push run for the merge commit was cancelled two
+  seconds after being created, before any job started -- required
+  checks reading `cancelled` for a commit the run that got to run never
+  tested. The group is now
+  `github.event.pull_request.number || github.ref`: a pull_request run
+  of any action, closed included, groups by the pull request's own
+  number instead, which still cancels that same pull request's own
+  earlier run exactly as `closed` was added for, and cannot equal any
+  push's `github.ref`. `links.yml` and `vendored-vectors.yml` get the
+  same fix though neither has a push trigger to collide with, their
+  `schedule` and `workflow_dispatch` triggers resolving to the same ref
+  a closed run does.
 
 ## v0.8.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2590,7 +2590,7 @@ release-notes length in the first place, and are still in
   than by the run's own cancellation still fails the gate as before.
 - **A closed pull request's run no longer lands in its merge's own push
   run's concurrency group** (#276). `test.yml`, `lint.yml` and
-  `docs.yml` grouped by `github.ref` alone, and github.ref for a
+  `docs.yml` grouped by `github.ref` alone, and `github.ref` for a
   closed, merged pull request's run resolves to the base branch's ref
   rather than `refs/pull/N/merge`, landing it in the same group as the
   push the merge itself triggers. The two events fire about a second


### PR DESCRIPTION
## What this changes

`test.yml`, `lint.yml`, `docs.yml`, `links.yml` and
`vendored-vectors.yml` all group concurrency by `github.ref` alone
(`test.yml`/`lint.yml`/`docs.yml` also append
`inputs.concurrency-suffix`, unchanged here). `github.ref` for a
`pull_request`-triggered run is `refs/pull/N/merge` for every action
except `closed` on a merged pull request, where it resolves to the
base branch's ref -- the same ref a push carries. The merge that closes
a pull request also pushes to `main`, and the two events fire about a
second apart; whichever is processed second cancels the first under
`cancel-in-progress`. After bitcoin-core-rpc's own #136 merged there,
its `docs` push run for the merge commit was cancelled two seconds
after being created, before any job started -- a required check
reading `cancelled` for a commit the run that survived never tested,
on every single merge, since a `closed` event accompanies all of them.

`github.event.pull_request.number || github.ref` replaces `github.ref`
alone in the concurrency group of all five workflows: a `pull_request`
run of any action, `closed` included, now groups by the pull request's
own number -- stable for its lifetime, never equal to any push's
`refs/heads/<branch>` string. This keeps `closed`'s actual purpose (it
still cancels that same pull request's own leftover run, sharing its
group across every action) and removes the collision with the push
that lands on `main`. A push carries no `pull_request` context, so it
keeps grouping by `github.ref` exactly as before.

`links.yml` and `vendored-vectors.yml` have no `push` trigger to
collide with, but their `schedule` and `workflow_dispatch` triggers
also resolve to the default branch's ref, so the same fix applies
there against those, on a longer, lower-stakes timescale. `codeql.yml`
has no `pull_request` trigger at all and needed no change.

## Testing

`actionlint` passes on all five files. The reasoning rests on an
inference about `github.ref`'s value for a `closed` action, supported
by the observed cancellation timestamps (documented in the issue) but
not by anything I can cite a GitHub doc for. As #273's own candidate
asked before it: this wants confirming on a real merge rather than
trusted from the diff.

Closes #276

## Summary by Sourcery

Use pull request numbers for pull request workflow concurrency groups to prevent merge-event cancellations from interfering with merge commit validation.

Bug Fixes:
- Prevent pull request closure runs from cancelling the push workflow that validates the resulting merge commit.
- Preserve pull request-specific concurrency cancellation while avoiding collisions with scheduled, manually dispatched, and branch-push runs.

Enhancements:
- Update concurrency grouping across test, lint, documentation, link-checking, and vendored-vector workflows to prefer the pull request number and fall back to the ref for non-pull-request events.