### PR TITLE
Document the tag-integrity ruleset closing the release chain's last gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.3 (work in progress, not released yet)
 
+### A tag-integrity ruleset closes the last unsigned link in the release chain
+
+- **`tag-integrity`, `target: tag`, `refs/tags/v*`: `required_signatures`,
+  no bypass actor.** `release.yml` publishes to PyPI on `push: tags:
+  ["v*"]`, and until now that tag was the one unattested link in an
+  otherwise fully-signed chain — every commit reaching `main` already
+  carried a verified signature, `main-integrity` requiring it with no
+  bypass actor, but nothing stopped an annotated, unsigned tag from
+  triggering a release. RELEASING.md's tagging step already produces a
+  signed tag (`git tag -s`); the ruleset now enforces the same thing at
+  the repository-settings level rather than only documenting it. No
+  `deletion` or `non_fast_forward` rule: RELEASING.md's own recovery
+  path deletes and re-tags a release that failed before the PyPI
+  upload, and either rule would block that. Created directly by the
+  maintainer, a live repository-infrastructure change rather than a
+  pull-request review — this entry documents it. Existing tags are
+  unaffected, the ruleset applying to pushes going forward only.
+  Sibling repository btclib closed the same gap as issue #1022.
+
 ### Claude reads a pull request against REVIEWING.md
 
 - **`claude-review.yml`**, two jobs: one on every non-draft pull request,

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -377,6 +377,26 @@ GitHub marks the pull request **Merged**, the `Closes #N` in its
 description closes the issue, and `delete_branch_on_merge` takes the
 head branch a second later.
 
+**A third ruleset, `tag-integrity`, targets tags rather than `main`.**
+`release.yml` publishes to PyPI on `push: tags: ["v*"]`, and until this
+ruleset existed that tag was the one unattested link in an otherwise
+fully-signed chain: every commit reaching `main` carries a verified
+signature, but nothing stopped an annotated, unsigned tag from being
+the one that triggered a release. RELEASING.md's tagging step already
+produces a signed tag (`git tag -s`); `tag-integrity` enforces the same
+thing at the repository-settings level — `target: tag`,
+`refs/tags/v*`, `required_signatures`, **no bypass actor at all**, the
+same "on every push, not at review time" shape as `main-integrity`, for
+the same reason. It carries no `deletion` or `non_fast_forward` rule:
+RELEASING.md's own recovery path deletes and re-tags a release that
+failed before the PyPI upload, and either rule would block that.
+
+```shell
+gh api repos/btclib-org/btclib-secp256k1/rulesets/<id> \
+  --jq '{name, target, conditions, rules: [.rules[].type],
+         bypass: .bypass_actors}'
+```
+
 ## Head branches after a merge
 
 `delete_branch_on_merge` is on, since 7 August 2026:


### PR DESCRIPTION
The maintainer created a `tag-integrity` ruleset directly — a live
repository-infrastructure change, outside pull-request review scope,
the same reasoning sibling repository btclib applied for its own
issue [btclib#1022](https://github.com/btclib-org/btclib/issues/1022): `target: tag`, `refs/tags/v*`, `required_signatures`, no
bypass actor.

`release.yml` publishes to PyPI on `push: tags: ["v*"]`, and until now
that tag was the one unattested link in an otherwise fully-signed
chain — every commit reaching `main` already carries a verified
signature, `main-integrity` requiring it with no bypass actor, but
nothing stopped an annotated, unsigned tag from triggering a release.
RELEASING.md's tagging step already produces a signed tag (`git tag
-s`); the ruleset now enforces the same thing at the
repository-settings level rather than only documenting it.

Verified:

```
$ gh api repos/btclib-org/btclib-secp256k1/rulesets/21088516 \
    --jq '{name, target, conditions, rules:[.rules[].type], bypass: .bypass_actors}'
{"bypass":[],"conditions":{"ref_name":{"exclude":[],"include":["refs/tags/v*"]}},"name":"tag-integrity","rules":["required_signatures"],"target":"tag"}
```

## What this PR adds

Documentation only — the ruleset itself already exists in the
repository settings.

- `REPOSITORY.md`'s ruleset section gains a paragraph on
  `tag-integrity`, alongside `main-integrity` and `main-self-merge`,
  noting it carries no `deletion` or `non_fast_forward` rule on
  purpose: RELEASING.md's own recovery path deletes and re-tags a
  release that failed before the PyPI upload, and either rule would
  block that.
- `CHANGELOG.md` records it under its own "work in progress" heading.

## Verification

```
$ uv run pre-commit run --all-files   # all hooks passed
$ uv run pytest                       # 735 passed
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
# build succeeded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document enforcement of signed release tags to complete the repository’s release-chain integrity guarantees.

Enhancements:
- Document the repository’s tag-integrity ruleset, requiring signed version tags without bypass actors while preserving the release recovery workflow.

Documentation:
- Document the tag-integrity ruleset and its role in securing PyPI-triggering release tags.

Chores:
- Record the tag-integrity ruleset in the work-in-progress changelog.
