### PR TITLE
0.8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v0.8.0.3 (work in progress, not released yet)
+## v0.8.0.3
 
 ### A tag-integrity ruleset closes the last unsigned link in the release chain
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.8.0.3 (work in progress, not released yet)
+## v0.8.0.3
 
 **Breaking: one module is gone, and every other break is a rename.**
 The public surface of these bindings speaks in octets, and the two

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,23 +150,25 @@ Then:
 
    Then merge it into `main` with a green CI. It is an ordinary pull
    request against the only branch there is, and it lands the way every
-   other one here does: squashed locally into one signed commit where it
-   carries more than one — a version bump and two retitles, not a cycle
-   of work — and fast-forwarded onto `main` from the command line,
-   REPOSITORY.md having the sequence and the bypass it needs.
+   other one here does: squash, pressed by auto-merge once the review and
+   the checks are in — the same button and the same `pull_request`-mode
+   bypass every other pull request lands through, REPOSITORY.md's "Merge
+   methods" and "Auto-merge" sections having the ruleset that grants it.
+   A direct push, fast-forwarded from the command line, is refused for
+   everyone now, this pull request included: the bypass that once allowed
+   it moved from `always` to `pull_request` mode, so nothing reaches
+   `main` outside a pull request GitHub itself merges.
 
-   The button is the wrong landing on this pull request in particular,
-   and not merely a second-best one: it is the release commit that gets
-   tagged, and a squash composed by GitHub would leave the tag over a
-   commit signed by the web-flow key rather than by the maintainer.
-
-   This branch is the squashed case every time — a version bump and two
-   retitles is never one commit — so push the squash to the branch before
-   fast-forwarding it, and the gates below run on the object that lands
-   and GitHub still marks the pull request Merged. Land the squash
-   straight from a worktree instead and nothing is reconciled: the pull
-   request has to be closed by hand, which is a surprise worth not having
-   between here and the tag. REPOSITORY.md has both outcomes.
+   The button used to be the wrong landing on this pull request in
+   particular: it is the release commit that gets tagged, and fast-
+   forwarding from the command line kept that commit's signature the
+   maintainer's own where a squash composed by GitHub would have left it
+   under the web-flow key instead. That distinction stopped mattering
+   once `required_signatures` was read as asking for a valid signature
+   and not for a particular signer — a commit GitHub composes and signs
+   on merge is exactly as good a base for the release tag as one signed
+   from the command line, and CLAUDE.md now says so for every pull
+   request here, this one included.
 
    What no landing here can cost any more is the history of a cycle. It
    could once: 0.7.1 was *Squash and merge* on a release pull request


### PR DESCRIPTION
Everything since v0.8.0.2 is in the closed sections of
[CHANGELOG.md](../blob/main/CHANGELOG.md) and
[RELEASE_NOTES.md](../blob/main/RELEASE_NOTES.md), written as each change
landed. In short:

- **Breaking:** every entry point that took a parsed libsecp256k1 object
  is now private (`foo_` → `_foo_`); `mult` is gone, folded into
  `keys.pubkey_from_prvkey`. A rename is the whole of what a caller has
  to do.
- **Breaking behaviour:** `dsa.sign`, `ssa.sign`, `ssa.sign_custom`,
  `ssa.Signer` and `recovery.sign` now verify the signature they just
  made before returning it, and raise instead of returning a bad one —
  BIP340's own last step. Opt out with `verify=False`.
- The checks in `dsa`, `ssa` and `recovery` can take a public key the
  caller already holds, instead of deriving one.
- Importing the package is ten times cheaper (1.69 vs 15.85
  microseconds), and several serialize/parse calls cost measurably less.
- A `tag-integrity` ruleset closes the last unsigned link in the release
  chain, and REVIEWING.md now states the review standard `/review` and
  CI both hold a pull request to.
- `HISTORY.md` is `RELEASE_NOTES.md` now (#279).
- A substantial CI/build-matrix rework: one wheel job per image instead
  of per interpreter, the vendored library compiled once a job rather
  than once a wheel, a pull request builds one wheel on macOS/Windows and
  the rest after merge, and `github-release` no longer skips a real
  release (#151 — the fix step 7 of RELEASING.md still describes for a
  release that predates it).

Also in this pull request, not in the two files above:

- Closes the `v0.8.0.3` sections of `CHANGELOG.md` and
  `RELEASE_NOTES.md` (drops "work in progress, not released yet").
- Fixes `RELEASING.md`'s landing step, stale since #271: it still
  described squashing this pull request locally and fast-forwarding it
  from the command line, a path branch protection now refuses for
  everyone. It lands the way every other pull request here does, by the
  squash/auto-merge button.

The submodule has not moved since v0.8.0.2 (still libsecp256k1 v0.8.0,
`6e2c8bc`), so no version renumbering and no README change.

`latest` dispatched on `main` before this pull request:
[run 32375660064](https://github.com/btclib-org/btclib-secp256k1/actions/runs/32375660064)
(queued at the time of this pull request; check the run for its result —
it gates nothing either way).

**A TestPyPI rehearsal is worth running before tagging, unlike the last
few releases.** The build matrix changed substantially in this cycle —
wheel jobs collapsed from one per interpreter to one per image, the
vendored library now compiles once a job rather than once a wheel, and a
pull request builds a single wheel on macOS/Windows rather than the
whole set — which is exactly the case RELEASING.md's "Rehearsing on
TestPyPI" section calls out ("when the workflow, the packaging metadata
or the build matrix changed"). Not run yet: dispatching `release.yml`
manually, on this branch or on `main` after merge, is how to.

## Summary by Sourcery

Finalize the v0.8.0.3 release documentation and modernize its release-landing procedure.

Enhancements:
- Finalize the v0.8.0.3 release documentation and align release landing instructions with the repository’s current pull-request and auto-merge workflow.

Documentation:
- Update release guidance to reflect protected-branch rules, GitHub auto-merge, and valid release-commit signatures.

Chores:
- Mark v0.8.0.3 as released in the changelog and release notes.