### PR TITLE
Grant the release workflow's test call pull-requests: read

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,23 @@ jobs:
     # not match the tree is worth discovering before the matrices start
     needs: version-check
     uses: ./.github/workflows/test.yml
+    # a called workflow's jobs are capped at what the caller grants here,
+    # not at what the called workflow's own top-level default declares:
+    # this workflow's contents: read alone left `changes`, which asks for
+    # pull-requests: read to list a pull request's files, "only allowed
+    # pull-requests: none" -- refused before a single job starts, version
+    # -check included, rather than started and skipped for the one job
+    # that asked for more. `changes` never runs on a pull request here --
+    # it answers code=true unconditionally and reads no file list -- but
+    # the check is against what the job declares, not against what it
+    # goes on to do. contents: read is repeated rather than left to
+    # test.yml's own default for the same reason: a caller's grant
+    # replaces the callee's default outright, so anything this list
+    # leaves off becomes none for every job over there, not only for the
+    # one this comment names
+    permissions:
+      contents: read
+      pull-requests: read
     with:
       # empty on the tag path, where the step computing it is skipped and
       # a skipped step's output is the empty string: a release ships the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2626,6 +2626,24 @@ release-notes length in the first place, and are still in
   same fix though neither has a push trigger to collide with, their
   `schedule` and `workflow_dispatch` triggers resolving to the same ref
   a closed run does.
+- **`release.yml`'s call into `test.yml` grants `pull-requests: read`
+  now, `contents: read` beside it** (#281). A called workflow's jobs
+  are capped at what the caller grants, not at what the called
+  workflow's own top-level default declares, and `release.yml` granted
+  only `contents: read` -- so `test.yml`'s `changes` job (#189), which
+  declares `pull-requests: read` to list a pull request's files,
+  refused the whole call before a single job started, `version-check`
+  included, `changes` never actually reading a file list on a release
+  or a rehearsal. Found tagging `v0.8.0.3`: three tag pushes and a
+  `workflow_dispatch` all came back `startup_failure` with zero jobs
+  scheduled, the REST API answering nothing more than a generic
+  "workflow file issue" -- the actual error only shows on the run page
+  itself. Nothing had exercised this call since `changes` was added,
+  the prior release predating it. `contents: read` is repeated rather
+  than left to `test.yml`'s own default because a caller's grant
+  replaces the callee's default outright: leaving it off would have
+  starved every other job over there of the checkout permission it has
+  today, not only `changes` of the one it asked for.
 
 ### `HISTORY.md` is `RELEASE_NOTES.md` now
 


### PR DESCRIPTION
Blocked `v0.8.0.3` from tagging: every attempt at pushing the tag —
three of them, two hours apart — came back `startup_failure` with
**zero jobs scheduled**, not even `version-check`, which has no
dependencies at all. A `workflow_dispatch` of the same commit failed
identically, ruling out anything specific to the `push: tags` trigger.
`actionlint` and `yamllint` both pass clean on every workflow file
involved, so the REST API's generic "workflow file issue" message and
an empty `jobs` array were the whole of what was visible through `gh`.

The actual error only shows on the run page itself, not through the
API:

> Error calling workflow
> 'btclib-org/btclib-secp256k1/.github/workflows/test.yml@\<sha\>'. The
> nested job 'changes' is requesting 'pull-requests: read', but is
> only allowed 'pull-requests: none'.

`test.yml`'s `changes` job (#189, this cycle) declares
`permissions: pull-requests: read` to list a pull request's changed
files. That is fine when `test.yml` runs from its own `push` or
`pull_request` trigger. `release.yml` instead calls it with
`uses: ./.github/workflows/test.yml`, and a called workflow's jobs are
capped at what the *caller* grants, not at what the called workflow's
own top-level default declares — `release.yml` grants only
`contents: read`, so the call is refused before a single job starts,
`version-check` included, rather than started and skipped for the one
job that asked for more. `changes` never actually reads a file list
here (it answers `code=true` unconditionally off anything that is not
a `pull_request` event), but the check is against what the job
declares, not against what it goes on to do.

Nobody had exercised `release.yml`'s call into `test.yml` since the
`changes` job was added: the last real release, v0.8.0.2, predates it,
and nothing short of a release or a rehearsal takes this path. This is
exactly the case RELEASING.md's "Rehearsing on TestPyPI" section
describes rehearsing for.

Fix: the `test:` job in `release.yml` grants `contents: read` and
`pull-requests: read` explicitly, `contents: read` repeated rather
than left to `test.yml`'s own default because a caller's grant
replaces the callee's default outright — anything the list leaves off
becomes `none` for every job over there, not only for `changes`.

Verified live: dispatched `release.yml` on this branch
([run 32393208128](https://github.com/btclib-org/btclib-secp256k1/actions/runs/32393208128)) —
before the fix, the same dispatch failed the same way in under two
seconds; after it, dozens of jobs are running.

No version or release-notes change: this is a workflow-only fix,
independent of the `0.8.0.3` content in #280.

## Summary by Sourcery

Restore release workflow execution by granting its reusable test workflow call the permissions required by downstream jobs.

Bug Fixes:
- Grant the release workflow’s reusable test-workflow call the pull-request permission it requires, preventing release runs from failing before any jobs are scheduled.

CI:
- Update the release workflow permissions to explicitly provide both contents and pull-request read access to the called test workflow.

Chores:
- Record the workflow permission fix and its release-blocking incident in the changelog.