### PR TITLE
Wrap the musig module: KeyAggCache, Session and SecretNonce

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,6 +129,14 @@
     }
   ],
   "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "d4f74e9aa044710fbc03f018f5babea8c97cd8b5",
+        "is_verified": false
+      }
+    ],
     "btclib_secp256k1/hashes.py": [
       {
         "type": "Hex High Entropy String",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2678,7 +2678,7 @@ release-notes length in the first place, and are still in
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for
 
-- **The 17 `musig` entry points, all of them.** Parse and serialize for
+- **Every `musig` entry point.** Parse and serialize for
   `pubnonce`, `aggnonce` and `partial_sig`; `pubkey_agg`, `pubkey_get`,
   `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add` for key
   aggregation; `nonce_gen`, `nonce_gen_counter` and `nonce_agg` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2674,6 +2674,73 @@ release-notes length in the first place, and are still in
   built by Read the Docs straight from `docs/source` -- and the file's
   git history is where the old name stays reachable.
 
+### `musig` wraps MuSig2, closing the one exception `lib` was for
+
+- **The 17 `musig` entry points, all of them.** Parse and serialize for
+  `pubnonce`, `aggnonce` and `partial_sig`; `pubkey_agg`, `pubkey_get`,
+  `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add` for key
+  aggregation; `nonce_gen`, `nonce_gen_counter` and `nonce_agg` for
+  round one; `nonce_process`, `partial_sign`, `partial_sig_verify` and
+  `partial_sig_agg` for round two. Closes #282, "may deserve an issue of
+  its own" in #156, and unblocks
+  [btclib#1048](https://github.com/btclib-org/btclib/issues/1048) (the
+  bindings as a test oracle for `btclib.ecc.musig2`) and
+  [btclib#1049](https://github.com/btclib-org/btclib/issues/1049)
+  (delegating `partial_sig_verify_`).
+
+  Two of the objects wrapped have no serialization --
+  `secp256k1_musig_keyagg_cache` and `secp256k1_musig_session`, "no
+  serialization and parsing functions (yet)" in the header's own words
+  -- and #87 declined an opaque *handle* for exactly that shape, "a
+  handle is a lifetime someone has to own and invalidate." `_secret.py`
+  recorded the clause that reopened it: the handle "belongs where the
+  signing state lives," and a MuSig2 session is that place. `KeyAggCache`
+  and `Session` are the exception taken, held state beside `ssa.Signer`
+  and `keys.PubkeyTweakChain` -- and, unlike either of those, not chosen
+  for a saving over octets that do not exist to be saved: *Outposts past
+  the boundary* in the README says why the existing rule for holding an
+  object does not reach them.
+
+  `SecretNonce`, the third class this module adds, is the one that has
+  to be wiped: `ssa.Signer` is the model, a `with` statement overwriting
+  it whether the block signs or raises, and a wiped object refusing to
+  sign rather than signing with the zeros. libsecp256k1 already zeroes a
+  secnonce inside `partial_sign` -- "will abort if given a secnonce that
+  is all zeros" -- for a session that runs to completion; what
+  `SecretNonce` adds is the wipe for one abandoned before that, which
+  the C side never sees. SECURITY.md now names two such buffers instead
+  of one.
+
+  `partial_sign` verifies the partial signature it makes, by default:
+  the C call "does not verify the output partial signature, deviating
+  from the BIP 327 specification," and its header recommends verifying
+  with `partial_sig_verify` "to prevent random or adversarially
+  provoked computation errors" -- `ssa.sign`'s own argument for its
+  `verify`, on a signature assembled from more moving parts than a solo
+  one.
+
+  A parse failure and a semantic failure both answer libsecp256k1's bare
+  `0`, with nothing on the thread for `context.check` to raise: `KeyAggCache`,
+  `nonce_agg` and `Session.partial_sig_agg` each parse their array one
+  contribution at a time under its own name instead of handing a
+  comprehension to the array they build, so a `ValueError` on a bad
+  public key, nonce or partial signature names its position -- "public
+  key at index 2" rather than a refusal that could be any of them. A
+  handful of failures that examining every C code path showed
+  unreachable given already-parsed objects -- `nonce_agg`'s own
+  aggregation, `pubkey_agg`'s, `nonce_process`'s, and
+  `partial_sig_agg`'s -- are `RuntimeError` instead, matching the
+  distinction `pyproject.toml`'s coverage configuration already draws
+  between the two exceptions this package raises.
+
+  `tests/test_vectors.py`'s BIP327 cases now drive `musig` itself rather
+  than the raw bindings underneath it, and `tests/test_musig.py` is new,
+  holding the three classes to the lifetime `tests/test_signer.py`
+  already holds `ssa.Signer` to. The README's *Wrapped modules*,
+  *Outposts past the boundary* and *Thread safety* sections, and
+  REVIEWING.md's own checklist, are updated with it; `docs/source` gains
+  the module's stanza.
+
 ## v0.8.0.2
 
 ### The parsed public key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,81 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.4 (work in progress, not released yet)
 
+### `musig` wraps MuSig2, closing the one exception `lib` was for
+
+- **Every `musig` entry point.** Parse and serialize for
+  `pubnonce`, `aggnonce` and `partial_sig`; `pubkey_agg`, `pubkey_get`,
+  `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add` for key
+  aggregation; `nonce_gen`, `nonce_gen_counter` and `nonce_agg` for
+  round one; `nonce_process`, `partial_sign`, `partial_sig_verify` and
+  `partial_sig_agg` for round two. Closes #282, "may deserve an issue of
+  its own" in #156, and unblocks
+  [btclib#1048](https://github.com/btclib-org/btclib/issues/1048) (the
+  bindings as a test oracle for `btclib.ecc.musig2`) and
+  [btclib#1049](https://github.com/btclib-org/btclib/issues/1049)
+  (delegating `partial_sig_verify_`).
+
+  `secp256k1_musig_keyagg_cache` and `secp256k1_musig_session` have no
+  serialization -- "no serialization and parsing functions (yet)" in the
+  header's own words -- and #87 declined an opaque *handle* for exactly
+  that shape, "a handle is a lifetime someone has to own and invalidate."
+  `_secret.py` recorded the clause that reopened it: the handle "belongs
+  where the signing state lives," and a MuSig2 session is that place.
+  `KeyAggCache` and `Session` are the exception taken, held state beside
+  `ssa.Signer` and `keys.PubkeyTweakChain` -- and, unlike either of
+  those, not chosen for a saving over octets that do not exist to be
+  saved: *Outposts past the boundary* in the README says why the
+  existing rule for holding an object does not reach them.
+
+  `SecretNonce`, the third class this module adds, is the one that has
+  to be wiped: `ssa.Signer` is the model, a `with` statement overwriting
+  it whether the block signs or raises, and a wiped object refusing to
+  sign rather than signing with the zeros. libsecp256k1 already zeroes a
+  secnonce inside `partial_sign` -- "will abort if given a secnonce that
+  is all zeros" -- for a session that runs to completion; what
+  `SecretNonce` adds is the wipe for one abandoned before that, which
+  the C side never sees. SECURITY.md now names two such buffers instead
+  of one. The check and the wipe are also made safe against two threads
+  sharing one `SecretNonce`: `_take` reads `self._secnonce` and clears
+  it as one atomic step under a lock private to the instance, rather
+  than as two statements a scheduler could interleave between -- which
+  on the free-threaded interpreter this package ships a wheel for
+  (`cp314t`) would otherwise let two threads both pass the check and
+  both drive `secp256k1_musig_partial_sign` over the same secnonce at
+  once, the MuSig2 nonce-reuse condition that leaks the private key.
+
+  `partial_sign` verifies the partial signature it makes, by default:
+  the C call "does not verify the output partial signature, deviating
+  from the BIP 327 specification," and its header recommends verifying
+  with `partial_sig_verify` "to prevent random or adversarially
+  provoked computation errors" -- `ssa.sign`'s own argument for its
+  `verify`, on a signature assembled from more moving parts than a solo
+  one.
+
+  A parse failure and a semantic failure both answer libsecp256k1's bare
+  `0`, with nothing on the thread for `context.check` to raise: `KeyAggCache`,
+  `nonce_agg` and `Session.partial_sig_agg` each parse their array one
+  contribution at a time under its own name instead of handing a
+  comprehension to the array they build, so a `ValueError` on a bad
+  public key, nonce or partial signature names its position -- "public
+  key at index 2" rather than a refusal that could be any of them. A
+  handful of failures that examining every C code path showed
+  unreachable given already-parsed objects -- `nonce_agg`'s own
+  aggregation, `pubkey_agg`'s, `nonce_process`'s, and
+  `partial_sig_agg`'s -- are `RuntimeError` instead, matching the
+  distinction `pyproject.toml`'s coverage configuration already draws
+  between the two exceptions this package raises.
+
+  `tests/test_vectors.py`'s BIP327 cases now drive `musig` itself rather
+  than the raw bindings underneath it, `tests/test_musig.py` is new,
+  holding the three classes to the lifetime `tests/test_signer.py`
+  already holds `ssa.Signer` to, and `tests/test_concurrency.py` races
+  threads on one `SecretNonce` to hold the lock above to the guarantee
+  it exists for. The README's *Wrapped modules*, *Design*, *Outposts
+  past the boundary* and *Thread safety* sections, REVIEWING.md's own
+  checklist, and `tests/README.md`'s vendored-vector record, are
+  updated with it; `docs/source` gains the module's stanza.
+
 ## v0.8.0.3
 
 ### A tag-integrity ruleset closes the last unsigned link in the release chain
@@ -2675,73 +2750,6 @@ release-notes length in the first place, and are still in
   repository serves no website of its own to carry one -- its docs are
   built by Read the Docs straight from `docs/source` -- and the file's
   git history is where the old name stays reachable.
-
-### `musig` wraps MuSig2, closing the one exception `lib` was for
-
-- **Every `musig` entry point.** Parse and serialize for
-  `pubnonce`, `aggnonce` and `partial_sig`; `pubkey_agg`, `pubkey_get`,
-  `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add` for key
-  aggregation; `nonce_gen`, `nonce_gen_counter` and `nonce_agg` for
-  round one; `nonce_process`, `partial_sign`, `partial_sig_verify` and
-  `partial_sig_agg` for round two. Closes #282, "may deserve an issue of
-  its own" in #156, and unblocks
-  [btclib#1048](https://github.com/btclib-org/btclib/issues/1048) (the
-  bindings as a test oracle for `btclib.ecc.musig2`) and
-  [btclib#1049](https://github.com/btclib-org/btclib/issues/1049)
-  (delegating `partial_sig_verify_`).
-
-  Two of the objects wrapped have no serialization --
-  `secp256k1_musig_keyagg_cache` and `secp256k1_musig_session`, "no
-  serialization and parsing functions (yet)" in the header's own words
-  -- and #87 declined an opaque *handle* for exactly that shape, "a
-  handle is a lifetime someone has to own and invalidate." `_secret.py`
-  recorded the clause that reopened it: the handle "belongs where the
-  signing state lives," and a MuSig2 session is that place. `KeyAggCache`
-  and `Session` are the exception taken, held state beside `ssa.Signer`
-  and `keys.PubkeyTweakChain` -- and, unlike either of those, not chosen
-  for a saving over octets that do not exist to be saved: *Outposts past
-  the boundary* in the README says why the existing rule for holding an
-  object does not reach them.
-
-  `SecretNonce`, the third class this module adds, is the one that has
-  to be wiped: `ssa.Signer` is the model, a `with` statement overwriting
-  it whether the block signs or raises, and a wiped object refusing to
-  sign rather than signing with the zeros. libsecp256k1 already zeroes a
-  secnonce inside `partial_sign` -- "will abort if given a secnonce that
-  is all zeros" -- for a session that runs to completion; what
-  `SecretNonce` adds is the wipe for one abandoned before that, which
-  the C side never sees. SECURITY.md now names two such buffers instead
-  of one.
-
-  `partial_sign` verifies the partial signature it makes, by default:
-  the C call "does not verify the output partial signature, deviating
-  from the BIP 327 specification," and its header recommends verifying
-  with `partial_sig_verify` "to prevent random or adversarially
-  provoked computation errors" -- `ssa.sign`'s own argument for its
-  `verify`, on a signature assembled from more moving parts than a solo
-  one.
-
-  A parse failure and a semantic failure both answer libsecp256k1's bare
-  `0`, with nothing on the thread for `context.check` to raise: `KeyAggCache`,
-  `nonce_agg` and `Session.partial_sig_agg` each parse their array one
-  contribution at a time under its own name instead of handing a
-  comprehension to the array they build, so a `ValueError` on a bad
-  public key, nonce or partial signature names its position -- "public
-  key at index 2" rather than a refusal that could be any of them. A
-  handful of failures that examining every C code path showed
-  unreachable given already-parsed objects -- `nonce_agg`'s own
-  aggregation, `pubkey_agg`'s, `nonce_process`'s, and
-  `partial_sig_agg`'s -- are `RuntimeError` instead, matching the
-  distinction `pyproject.toml`'s coverage configuration already draws
-  between the two exceptions this package raises.
-
-  `tests/test_vectors.py`'s BIP327 cases now drive `musig` itself rather
-  than the raw bindings underneath it, and `tests/test_musig.py` is new,
-  holding the three classes to the lifetime `tests/test_signer.py`
-  already holds `ssa.Signer` to. The README's *Wrapped modules*,
-  *Outposts past the boundary* and *Thread safety* sections, and
-  REVIEWING.md's own checklist, are updated with it; `docs/source` gains
-  the module's stanza.
 
 ## v0.8.0.2
 

--- a/README.md
+++ b/README.md
@@ -1119,12 +1119,24 @@ tweaking one race, where two threads only ever *reading* it — through
 `nonce_gen`, `Session.__init__`, `partial_sign` — do not, none of those
 calls writing to it.
 
-`musig.SecretNonce` costs no guarantee of its own to state, being
-narrower than either: `partial_sign` consumes it exactly once, by
-design, so a second call from any thread is already refused before
-concurrency is the question — the ordering that matters is the one
-`wipe` and `partial_sign` already impose on a single nonce, not one
-between threads.
+`musig.SecretNonce` is neither of the two shapes above, being narrower
+than both: it is meant to be read exactly once, from whichever thread
+gets there first, and refused everywhere else — a keypair's read-any-
+number-of-times constness does not apply, and neither does a chain's
+one-object-one-thread convention, since a shared secret nonce is
+exactly the case this class has to make safe rather than ask a caller
+to avoid. Reading `self._secnonce` and then clearing it are two
+statements, and without ordering them two threads calling
+`partial_sign` on the same object could each pass the read before
+either reaches the clear, and both go on to drive
+`secp256k1_musig_partial_sign` over the same native secnonce at once —
+an unsynchronized concurrent access on the exact memory a MuSig2
+nonce-reuse leak comes from, the worst failure this module has. A lock
+private to the instance is what orders it: `SecretNonce._take` makes
+the read and the clear one atomic step, so at most one caller — from
+any thread — ever receives the object. `tests/test_concurrency.py`
+races `WORKERS` threads on one `SecretNonce` and asserts exactly one
+signs.
 
 The one way to lose that guarantee is to re-randomize the shared context
 while it is in use. `context._randomize(context.ctx)` is there for a

--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ went:
 - the surface is complete: every optional module is compiled in and
   reachable, through a validated binding where a function suffices and
   through the raw `lib` where only an object would do (see Wrapped
-  modules). What is absent — a MuSig2 session, the ECDH hash callback,
-  linking a system library — is absent by recorded decision, not by
-  omission
+  modules). What is absent — the ECDH hash callback, linking a system
+  library — is absent by recorded decision, not by omission
 - no input can take the process down: the bindings validate before
   calling, so a malformed key or signature raises `ValueError` naming
   the check that failed, before the C call could meet it; and the
@@ -291,9 +290,10 @@ python cannot give back is what happens on either side of that call:
 records both limits as inherent.
 
 And there is a way past all of it: `lib` and `ffi` are exported, and a
-call made through them has no python in front of it whatsoever. That is
-how MuSig2 is reachable, and it is the path for a caller who wants the
-library and nothing added to it.
+call made through them has no python in front of it whatsoever. It is
+the path for a caller who wants the library and nothing added to it --
+`musig` included, nothing stopping a caller from driving a MuSig2 session
+through `lib` directly the way `musig.py` itself does underneath.
 
 ## Parsing the key once
 
@@ -393,7 +393,7 @@ which is flat in the number of terms.
 already holds, which is a read rather than a multiplication, and so is
 cheaper than any composition could be.
 
-## Two outposts past the boundary
+## Outposts past the boundary
 
 The private halves above hand one object from a call to the next. What
 they do not answer is the caller who crosses the boundary again and
@@ -404,10 +404,11 @@ compressed key is a field square root — and pays it for a key it had
 already converted.
 
 `ssa.Signer` and `keys.PubkeyTweakChain` are the two outposts on that
-side of the boundary, and the only things in these bindings that hold
-state at all. Each holds the converted object across calls, so the
-conversion happens once and every crossing afterwards carries only what
-changes: a message, a tweak.
+side of the boundary held for that reason. Each holds the converted
+object across calls, so the conversion happens once and every crossing
+afterwards carries only what changes: a message, a tweak. `musig`'s
+`KeyAggCache`, `Session` and `SecretNonce` hold state too, and for a
+different reason the rule below makes precise.
 
 The two are not worth the same, and the numbers below say which is
 which. A keypair is *arithmetic* — a point multiplication, half of what
@@ -417,14 +418,23 @@ carrying the uncompressed form instead: 0.269 microseconds against
 2.326. So the signer saves what nothing else can, and the chain saves
 what a caller free to choose its serialization could have saved itself.
 
-**The rule that separates them is the test a third outpost would have to
-pass**, and it is worth stating on its own, because the answer to every
-proposal of one — a held public key for verifying, for ECDH, for
-combining — is here rather than in the proposal:
+**The rule that separates them is the test a proposal for a third one
+would have to pass**, and it is worth stating on its own, because the
+answer to every proposal of that kind — a held public key for
+verifying, for ECDH, for combining — is here rather than in the
+proposal:
 
 > what an object saves is the cost of *rebuilding, from octets, whatever
 > it holds*. It earns its state when that cost is arithmetic, and does
 > not when it is a parse.
+
+`musig`'s three do not answer to this rule, and are not measured against
+it below: there is no octets form of a keyagg cache, a session or a
+secret nonce to rebuild from in the first place, `musig.py`'s own module
+docstring saying why. What decides *that* exception is #87's own test —
+"a handle is a lifetime someone has to own and invalidate" — which
+`ssa.Signer` and `keys.PubkeyTweakChain` never had to pass, holding an
+object this package could equally have handed back as bytes.
 
 The saving is not merely bounded by that cost; it *is* that cost, and by
 construction rather than by measurement. `ssa.sign` builds the keypair,
@@ -454,12 +464,12 @@ held holds it — `keys.parse` hands back the object and the private
 halves take it, which is what "the private halves above hand one object
 from a call to the next" already promised. What a class would add there
 is a name, not a saving. The second is the other side of the ledger:
-this package is [stateless by construction](#design), which is also why
-MuSig2 is not wrapped, so an object is an exception to that, with an
-owner and an invalidation and a threading story, and the rule is what
-the exception has to be paid for with. What it does not weigh is
-ergonomics — the line a caller does not have to write is real, and
-belongs in btclib along with the lifetimes.
+this package is [stateless by construction](#design), and
+`musig.KeyAggCache` and `musig.Session` are its exception, each an
+object with an owner and an invalidation and, [Thread safety](#thread-safety)
+says, its own answer to sharing one across threads. What the rule above
+does not weigh is ergonomics — the line a caller does not have to write
+is real, and belongs in btclib along with the lifetimes.
 
 So the numbers **confirm** the rule rather than establish it, and it is
 worth being clear which of them would survive a different machine. Not
@@ -674,7 +684,7 @@ Microseconds per signature. The finding is the gap between the two
 increments: 19.5 for ECDSA against 12.7 for BIP340, and the 6.8 between
 them is the multiplication `secp256k1_ec_pubkey_create` does and
 `secp256k1_keypair_xonly_pub` does not — the keypair holds the point
-already, which is the same 7.55 the [signer](#two-outposts-past-the-boundary)
+already, which is the same 7.55 the [signer](#outposts-past-the-boundary)
 hoists. So the step the specification prescribes is also the cheaper of
 the two, and a `Signer` pays it at the same price as a bare `ssa.sign`.
 
@@ -911,7 +921,7 @@ declarations are available through the `lib` and `ffi` cffi objects:
 | `recovery`          | `recovery`                                |
 | `extrakeys`         | `xonly`, used by `ssa`                    |
 | `schnorrsig`        | `ssa`                                     |
-| `musig`             | raw `lib` bindings, by decision           |
+| `musig`             | `musig` (BIP327)                          |
 | `ellswift`          | `ellswift` (BIP324)                       |
 | `silentpayments`    | `silentpayments` (BIP352)                 |
 
@@ -1011,35 +1021,51 @@ unreachable through these bindings and what it would be is a way to make
 them slow. It remains available through `lib` for a caller who has a C
 function pointer to give it.
 
-MuSig2 has no binding module, by decision. What its two-round protocol
-needs is a session whose secret nonce cannot be reused, and that is a
-property of an object's lifetime rather than of a function: only whoever
-owns the session can invalidate it. This package is stateless by
-construction, every function being one libsecp256k1 call with its
-arguments validated, so the place to enforce it is where the signing
-state already lives, in [btclib](https://github.com/btclib-org/btclib):
-its PSBT is the multi-party signing machinery MuSig2 plugs into, and the
-specifications say the same (BIP327 the protocol, BIP373 its PSBT
-fields, BIP328 its descriptors). That place already holds the session:
-`btclib.ecc.musig2.sign` zeroes the secret nonce it consumes, so a
-second call with it fails before a second signature exists, and
-`btclib.psbt.musig2.partial_sign` carries the same guarantee into a PSBT
-round.
+MuSig2 is wrapped, in `musig`. What its two-round protocol needs is a
+session whose secret nonce cannot be reused, and that is a property of
+an object's lifetime rather than of a function: only whoever owns the
+session can invalidate it. This package is otherwise stateless by
+construction, every other function being one libsecp256k1 call with its
+arguments validated, and `musig.KeyAggCache` and `musig.Session` are its
+exception -- the *Outposts past the boundary* section above says why the
+existing rule for holding an object does not reach them, and `musig.py`'s
+own module docstring records the decision to take the exception rather
+than to leave the state to whoever calls this package, `KeyAggCache` and
+`Session` having no serialization to hand back regardless.
 
-What MuSig2 needs from here is what has no state, and it is all present:
-`keys.pubkey_sort` for the key ordering and `keys.pubkey_combine` for
-aggregation, `xonly.tweak_add` for the taproot output,
-`hashes.tagged_sha256`, and `ssa.verify`, an aggregate MuSig2 signature
-being a plain BIP340 signature. The 17 `musig` entry points remain
-available through `lib`, and `tests/test_modules.py` drives a complete
-2-of-2 signing session with them.
+`musig.SecretNonce` is the object that carries the secret: `nonce_gen`
+and `nonce_gen_counter` return one, `partial_sign` wipes it whether it
+signs or is refused, and a session abandoned before that -- the case
+libsecp256k1 itself cannot see -- is `wipe`, or the `with` statement that
+calls it on the way out. `ssa.Signer` is the model this follows, and
+SECURITY.md records both as the buffers in this package whose zeroing is
+asked for rather than done.
 
-A call made through `lib` has no argument validation in front of it, so
-libsecp256k1 is the only thing checking its preconditions: it reports a
-violated one through a callback of the context and returns 0, leaving
-nothing in the return value to say what happened. `context.check()`
-raises what was reported, the failed precondition verbatim, and is meant
-to follow such a call:
+[btclib](https://github.com/btclib-org/btclib) still carries its own
+MuSig2 signing state, independent of the C library's: its PSBT is the
+multi-party signing machinery MuSig2 plugs into, and the specifications
+say so too (BIP327 the protocol, BIP373 its PSBT fields, BIP328 its
+descriptors). `btclib.ecc.musig2.sign` zeroes the secret nonce it
+consumes and `btclib.psbt.musig2.partial_sign` carries the same
+guarantee into a PSBT round, in a pure-python implementation of BIP327
+that is a different thing from wrapping libsecp256k1's own session --
+`musig` is what btclib can now check that implementation against,
+rather than only against published vectors.
+
+The aggregate signature `Session.partial_sig_agg` answers is a plain
+BIP340 signature, over the aggregate key `KeyAggCache.pubkey_get` or
+`agg_pubkey` names: `ssa.verify` is what checks it, and nothing in
+`musig` duplicates that call. `keys.pubkey_sort` is BIP327's key
+ordering, applied before `KeyAggCache` if the signers have not agreed on
+another one.
+
+A call made through `lib` directly -- which `musig`'s own functions are,
+underneath, and which a caller reaching past them is free to make too --
+has no argument validation in front of it, so libsecp256k1 is the only
+thing checking its preconditions: it reports a violated one through a
+callback of the context and returns 0, leaving nothing in the return
+value to say what happened. `context.check()` raises what was reported,
+the failed precondition verbatim, and is meant to follow such a call:
 
 ```python
 if not lib.secp256k1_musig_partial_sign(ctx, psig, secnonce, ...):
@@ -1047,13 +1073,15 @@ if not lib.secp256k1_musig_partial_sign(ctx, psig, secnonce, ...):
 ```
 
 That example is the one that matters: partial signing zeroes the secret
-nonce, so signing twice with it is refused, and this is how a session
-learns why. The entry points taking octets need none of it, validating
-their arguments before calling; the private halves taking an object need
-exactly it, for the reason *Parsing the key once* gives. Either way the
-abort()ing libsecp256k1 defaults are replaced by do-nothing stubs in the
-vendored build, so no illegal argument can take the hosting process
-down.
+nonce, so signing twice with it is refused, and this is how a caller
+reaching `lib` directly learns why -- `musig.SecretNonce.partial_sign`
+answers its own `ValueError` for the same case instead, its callers
+having no callback to read. The entry points taking octets need none of
+it, validating their arguments before calling; the private halves taking
+an object need exactly it, for the reason *Parsing the key once* gives.
+Either way the abort()ing libsecp256k1 defaults are replaced by
+do-nothing stubs in the vendored build, so no illegal argument can take
+the hosting process down.
 
 ## Thread safety
 
@@ -1067,13 +1095,17 @@ This matters on a free-threaded interpreter, for which a wheel is built
 (`cp314t`), where those calls are no longer serialized;
 `tests/test_concurrency.py` exercises it.
 
-The two outposts above are what hold a buffer across calls, and they
-answer differently. `ssa.Signer` does not cost that guarantee:
-libsecp256k1 takes a keypair const, so several threads may sign through
-one signer. What is theirs to order is the wipe, which overwrites the
-very memory a concurrent signature is reading — the same shape of race as
+The outposts above are what hold a buffer across calls, and they answer
+differently. `ssa.Signer` does not cost that guarantee: libsecp256k1
+takes a keypair const, so several threads may sign through one signer.
+What is theirs to order is the wipe, which overwrites the very memory a
+concurrent signature is reading — the same shape of race as
 re-randomizing the context below, and the reason the `with` block ends
-where the threads have joined.
+where the threads have joined. `musig.Session` reads the same way: every
+call that takes one — `SecretNonce.partial_sign`, `partial_sig_verify`,
+`partial_sig_agg` — takes it const, `secp256k1_musig_session` never
+being written to after `Session.__init__` builds it, so several threads
+may verify or sign through one session at once.
 
 `keys.PubkeyTweakChain` is the exception, and by construction:
 `secp256k1_ec_pubkey_tweak_add` takes its key as *in and out*, so every
@@ -1081,7 +1113,18 @@ where the threads have joined.
 thread, and a path is a sequence in any case — two threads sharing one
 are not two walkers of it but two writers of the same point. Each thread
 that wants one builds its own, which costs the parse the chain exists to
-pay once.
+pay once. `musig.KeyAggCache` is the same shape: `pubkey_ec_tweak_add`
+and `pubkey_xonly_tweak_add` write the cache in place, so two threads
+tweaking one race, where two threads only ever *reading* it — through
+`nonce_gen`, `Session.__init__`, `partial_sign` — do not, none of those
+calls writing to it.
+
+`musig.SecretNonce` costs no guarantee of its own to state, being
+narrower than either: `partial_sign` consumes it exactly once, by
+design, so a second call from any thread is already refused before
+concurrency is the question — the ordering that matters is the one
+`wipe` and `partial_sign` already impose on a single nonce, not one
+between threads.
 
 The one way to lose that guarantee is to re-randomize the shared context
 while it is in use. `context._randomize(context.ctx)` is there for a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,16 @@ a tag is generated from.
 
 ## v0.8.0.4 (work in progress, not released yet)
 
+Non-breaking. `musig` is new: it wraps MuSig2 (BIP327), previously
+reachable only through the raw `lib` bindings this package also exports.
+`musig.KeyAggCache` aggregates signers' public keys and applies the
+BIP32 and BIP341 tweaks; `musig.nonce_gen` (or `nonce_gen_counter`)
+starts a signing round and returns a `musig.SecretNonce`, wiped whether
+`partial_sign` signs with it or is refused, and refusing a second use of
+the same one even from a different thread; `musig.Session`, opened from
+the signers' aggregate nonce, verifies and aggregates the resulting
+partial signatures into a plain BIP340 signature `ssa.verify` checks.
+
 ## v0.8.0.3
 
 **Breaking: one module is gone, and every other break is a rename.**

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -231,8 +231,10 @@ because that document, and not this one, is where the rule lives.
   typecheck a module which exists only after a build.
 - A new module: is it more than one call of another? `mult` was exactly
   that, and was folded into `keys`. And is it one the README's Design
-  section says belongs here at all — MuSig2 is deliberately not wrapped,
-  its two-round session belonging where the signing state is.
+  section says belongs here at all — `musig.KeyAggCache` and
+  `musig.Session` are the one place this package holds a libsecp256k1
+  object with no serialization to be one, and the reasoning for taking
+  that exception is in `musig.py`'s own module docstring.
 - A check added to a workflow: is it in `.pre-commit-config.yaml`
   instead? `CLAUDE.md` states that file as the single definition of
   clean, and a check discovered by CI after a push is a check in the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,17 +116,20 @@ These are known and inherent, not vulnerabilities:
         prvkey[:] = bytes(32)     # the caller's wipe, and only theirs
     ```
 
-- the one buffer whose zeroing is the caller's to ask for is
-    `ssa.Signer`'s. Everything above is wiped inside the call that made
-    it — read out and zeroed in the one operation, or wiped in a
-    `finally` where it is a keypair; a signer holds its
-    `secp256k1_keypair` across calls, which is what it is for, and wipes
-    it when told — `wipe`, or the `with` statement that calls it on the
-    way out of the block. A signer told neither is dropped with the
-    keypair still holding the private key, and cffi frees that memory
-    without overwriting it. There is no finalizer behind it on purpose:
-    one would run at a time nothing specifies, which reads as a guarantee
-    and is not one. `with` is the guarantee
+- the two buffers whose zeroing is the caller's to ask for are
+    `ssa.Signer`'s keypair and `musig.SecretNonce`'s secret nonce.
+    Everything above is wiped inside the call that made it — read out and
+    zeroed in the one operation, or wiped in a `finally` where it is a
+    keypair; a signer holds its `secp256k1_keypair` across calls, which is
+    what it is for, and a `SecretNonce` holds a `secp256k1_musig_secnonce`
+    between `musig.nonce_gen` and `partial_sign` for the same reason.
+    `partial_sign` wipes it as the last thing it does with it, whatever
+    that call answers; short of that, both wipe when told — `wipe`, or the
+    `with` statement that calls it on the way out of the block. Either one
+    told neither is dropped with the secret still in it, and cffi frees
+    that memory without overwriting it. There is no finalizer behind
+    either on purpose: one would run at a time nothing specifies, which
+    reads as a guarantee and is not one. `with` is the guarantee
 - a nonce is the private key, given the signature it made. The two nonce
     entry points exist so that an implementation of RFC6979 or of BIP340's
     derivation can be checked against libsecp256k1's own, and what they

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -12,8 +12,8 @@ The final signature this protocol produces is a plain BIP340 one, over
 the aggregate (and possibly tweaked) key `pubkey_agg` computes:
 `ssa.verify` is what checks it, and nothing here duplicates that call.
 
-**Two of the five libsecp256k1 objects this module wraps have no
-serialization.** `secp256k1_musig_keyagg_cache` and `secp256k1_musig_session`
+**`secp256k1_musig_keyagg_cache` and `secp256k1_musig_session` have no
+serialization**, unlike every other object this module wraps. They
 are, in the header's own words, structures with "no serialization and
 parsing functions (yet)", so they cannot cross this package's boundary as
 octets -- which is the rule the package docstring states for everything

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -70,6 +70,7 @@ loop that found it already knew it.
 from __future__ import annotations
 
 import secrets
+import threading
 from collections.abc import Sequence
 from types import TracebackType
 
@@ -643,6 +644,22 @@ class SecretNonce:
     the second buffer in this package whose zeroing is asked for rather
     than done.
 
+    Signing at most once is the whole reason this class exists, and on
+    a free-threaded interpreter that has to be true of two threads
+    calling `partial_sign` on the same object, not only of one: reading
+    `self._secnonce` and then clearing it are two statements, and two
+    threads each passing the read before either reaches the clear would
+    both go on to drive `secp256k1_musig_partial_sign` over the same
+    native secnonce at once, an unsynchronized concurrent access on the
+    exact memory a nonce-reuse leak comes from. `_take` is where the
+    read and the clear become one statement instead of two, under a
+    lock private to this instance -- there being no reason for two
+    `SecretNonce` objects to serialize on each other's locks, unlike the
+    one shared libsecp256k1 context. Thread safety here is that lock,
+    not the constness `ssa.Signer`'s relies on: this is the one buffer
+    in the package meant to be read exactly once, where a keypair is
+    meant to be read any number of times.
+
     Args:
         secnonce: the libsecp256k1 secret nonce object `nonce_gen` or
             `nonce_gen_counter` built.
@@ -665,6 +682,10 @@ class SecretNonce:
         self._pubnonce = pubnonce
         self._pubkey = pubkey
         self.pubnonce = pubnonce_serialize(pubnonce)
+        # private to this instance: what it orders is one SecretNonce's
+        # own check-and-clear, not calls into libsecp256k1, so it is not
+        # the shared context's lock and does not compete with it
+        self._lock = threading.Lock()
 
     def partial_sign(
         self,
@@ -707,7 +728,12 @@ class SecretNonce:
                 not verify, which no input reaching this far can make
                 happen.
         """
-        secnonce = self._held()
+        # _take, not _held: it clears self._secnonce as the one
+        # statement that reads it, which is what keeps two threads
+        # calling this on the same object from both passing a check and
+        # both going on to sign -- the class docstring says why that
+        # race is the one this class exists to rule out
+        secnonce = self._take()
         keypair_obj: CData | None = None
         partial_sig = ffi.new("secp256k1_musig_partial_sig *")
         try:
@@ -736,11 +762,12 @@ class SecretNonce:
             # so this wipes it here too, unconditionally, rather than
             # trust a C side effect that this exception proves did not
             # run. Wiping twice is not a problem, so which of the two
-            # happened is not asked
+            # happened is not asked. self._secnonce is already cleared,
+            # by _take above, before this thread did anything else with
+            # the object it returned
             if keypair_obj is not None:
                 wipe(keypair_obj)
             wipe(secnonce)
-            self._secnonce = None
         if not signed:
             msg = (
                 "the private key, key aggregation cache or session do not"
@@ -766,11 +793,18 @@ class SecretNonce:
         Signing afterwards raises rather than signing with the zeros
         left behind, and there is no reviving it: nothing here keeps the
         nonce anywhere else, so a session abandoned this way is
-        restarted with a fresh `nonce_gen` rather than resumed.
+        restarted with a fresh `nonce_gen` rather than resumed. Takes
+        the same lock `partial_sign` does, so a `wipe` racing a
+        `partial_sign` call on another thread cannot see the buffer
+        between the two: whichever of them clears `self._secnonce`
+        first is the one that goes on to act on it, and the other finds
+        nothing left to take.
         """
-        if self._secnonce is not None:
-            wipe(self._secnonce)
+        with self._lock:
+            secnonce = self._secnonce
             self._secnonce = None
+        if secnonce is not None:
+            wipe(secnonce)
 
     # PYI034 asks for `typing.Self` here, and that is 3.11 while this
     # package supports 3.10, as ssa.Signer's own comment says
@@ -799,19 +833,32 @@ class SecretNonce:
         """
         self.wipe()
 
-    def _held(self) -> CData:
-        """Return the secret nonce, or refuse if it is gone.
+    def _take(self) -> CData:
+        """Read the secret nonce and clear it, as one atomic step.
+
+        The private half of the guarantee `partial_sign` and `wipe`
+        both make: "is there a secret nonce" and "take it" have to be
+        one operation, under `self._lock`, or two threads calling
+        `partial_sign` on the same object could each pass the read
+        before either reaches the clear, and both go on to sign with
+        it -- the class docstring says what that race would cost.
 
         Returns:
-            The libsecp256k1 secret nonce object.
+            The libsecp256k1 secret nonce object. `self._secnonce` is
+            already `None` by the time this returns it, so no other
+            call -- from any thread -- can receive the same object
+            again.
 
         Raises:
             ValueError: if `wipe` or a previous `partial_sign` has
-                already overwritten it.
+                already taken it.
         """
-        if self._secnonce is None:
+        with self._lock:
+            secnonce = self._secnonce
+            self._secnonce = None
+        if secnonce is None:
             raise ValueError("this secret nonce has been wiped or already spent")
-        return self._secnonce
+        return secnonce
 
 
 class Session:

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -708,9 +708,15 @@ class SecretNonce:
                 happen.
         """
         secnonce = self._held()
-        keypair_obj = keypair(prvkey)
+        keypair_obj: CData | None = None
         partial_sig = ffi.new("secp256k1_musig_partial_sig *")
         try:
+            # keypair(prvkey) is inside the try on purpose: it is the
+            # one fallible step here that runs before libsecp256k1 ever
+            # sees secnonce, and the docstring's guarantee -- the secret
+            # nonce does not survive the call, whatever the outcome --
+            # has to hold even when this raises before that call is made
+            keypair_obj = keypair(prvkey)
             signed = lib.secp256k1_musig_partial_sign(
                 ctx,
                 partial_sig,
@@ -721,10 +727,19 @@ class SecretNonce:
             )
         finally:
             # the keypair carries the private key, wiped as ssa.sign
-            # wipes its own; the secret nonce is spent by the call above
-            # regardless of its outcome -- libsecp256k1 zeroes it right
-            # after loading it and before any of its own checks can fail
-            wipe(keypair_obj)
+            # wipes its own -- and only if it was built at all, a
+            # private key `keypair` refused never having become one.
+            # The secret nonce is spent regardless: libsecp256k1
+            # zeroes it once its own call is made, right after loading
+            # it and before any of its other checks can fail, but a
+            # keypair that failed to build never reaches that call --
+            # so this wipes it here too, unconditionally, rather than
+            # trust a C side effect that this exception proves did not
+            # run. Wiping twice is not a problem, so which of the two
+            # happened is not asked
+            if keypair_obj is not None:
+                wipe(keypair_obj)
+            wipe(secnonce)
             self._secnonce = None
         if not signed:
             msg = (

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -1,0 +1,951 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""MuSig2, a two-round multi-signature scheme for BIP340 keys.
+
+According to BIP327:
+https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki
+
+The final signature this protocol produces is a plain BIP340 one, over
+the aggregate (and possibly tweaked) key `pubkey_agg` computes:
+`ssa.verify` is what checks it, and nothing here duplicates that call.
+
+**Two of the five libsecp256k1 objects this module wraps have no
+serialization.** `secp256k1_musig_keyagg_cache` and `secp256k1_musig_session`
+are, in the header's own words, structures with "no serialization and
+parsing functions (yet)", so they cannot cross this package's boundary as
+octets -- which is the rule the package docstring states for everything
+else. #87 declined an opaque *handle* for the reason that "a handle is a
+lifetime someone has to own and invalidate", and `_secret.py` records the
+clause that reopens it: the handle "belongs where the signing state
+lives". A MuSig2 session is exactly that, so `KeyAggCache` and `Session`
+below are that exception, taken rather than refused -- refusing it would
+leave this module unable to do anything a caller could not already do
+through the raw `lib`. Neither object is secret: a keyagg cache is
+aggregated *public* keys, and the header says of a session that it "is
+not required to be kept secret for the signing protocol to be secure".
+So the two are ordinary held state, the third outpost past the boundary
+alongside `ssa.Signer` and `keys.PubkeyTweakChain` -- and, unlike either
+of those, one this module cannot build any other way.
+
+**A third object, the secret nonce, is the one that must be wiped, and
+`SecretNonce` is the model `ssa.Signer` already set for a held secret:**
+a `with` statement that overwrites it on the way out, whether the block
+ended in a signature or in an exception, and a wiped object that refuses
+to sign rather than signing with the zeros left behind. libsecp256k1
+already zeroes a secnonce inside `partial_sign` -- "overwrites the given
+secnonce with zeros and will abort if given a secnonce that is all
+zeros" -- which covers a session that runs to completion. What `wipe` and
+the `with` statement add is the session that does not: one abandoned
+between `nonce_gen` and `partial_sign`, which the C side never sees and
+so never overwrites. SECURITY.md records this as the second buffer in
+this package whose zeroing is asked for rather than done, `ssa.Signer`'s
+keypair being the first.
+
+**`partial_sign` verifies the partial signature it produces, by
+default.** `secp256k1_musig_partial_sign` "does not verify the output
+partial signature, deviating from the BIP 327 specification", and its
+header recommends verifying it with `secp256k1_musig_partial_sig_verify`
+"to prevent random or adversarially provoked computation errors" --
+which is BIP340's own argument for `ssa.sign`'s `verify`, on a signature
+made from more moving parts than a solo one. `verify=True` is the
+default for the same reason it is there: the cost is a verification
+against a nonce and a key already in hand, and BIP327 recommends paying
+it.
+
+**A parse failure and a tweak failure both tell this package nothing.**
+Verified against `secp256k1_musig_pubnonce_parse`: a refusal answers a
+bare `0`, through an empty illegal callback, with no message for
+`context.check` to raise. `pubkey_agg`, `nonce_agg` and `partial_sig_agg`
+all take arrays of already-parsed objects, which the C API's own
+calling convention already asks a caller to build -- so `KeyAggCache`,
+`nonce_agg` and `Session.partial_sig_agg` each parse their array one
+contribution at a time rather than handing a comprehension to the array
+helper, and the index that failed is in the `ValueError` because the
+loop that found it already knew it.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Sequence
+from types import TracebackType
+
+from . import BytesLike, CData, ffi, keys, lib, xonly
+from ._cdata import array
+from ._scalar import in_range, octets, scalar
+from ._secret import keypair, wipe
+from .context import ctx
+
+# the three serializations this module has fixed widths for: BIP327's own
+# for a public and an aggregate nonce (33 octets per point, two points
+# each), and libsecp256k1's compact 32-byte partial signature -- s alone,
+# the nonce and the key both being implied by the session. The aggregate
+# signature `Session.partial_sig_agg` answers is a plain BIP340 one, whose
+# width `ssa.py` already states
+_PUBNONCE_SIZE = 66
+_AGGNONCE_SIZE = 66
+_PARTIAL_SIG_SIZE = 32
+_SIGNATURE_SIZE = 64
+
+_PUBNONCE_BUFFER_TYPE = ffi.typeof(f"char[{_PUBNONCE_SIZE}]")
+_AGGNONCE_BUFFER_TYPE = ffi.typeof(f"char[{_AGGNONCE_SIZE}]")
+_PARTIAL_SIG_BUFFER_TYPE = ffi.typeof(f"char[{_PARTIAL_SIG_SIZE}]")
+_SIGNATURE_BUFFER_TYPE = ffi.typeof(f"char[{_SIGNATURE_SIZE}]")
+
+
+def pubnonce_parse(pubnonce_bytes: BytesLike, name: str = "public nonce") -> CData:
+    """Parse a signer's public nonce into its internal representation.
+
+    Args:
+        pubnonce_bytes: the public nonce, 66 bytes, as `nonce_gen` or
+            `nonce_gen_counter` answered it through the `SecretNonce`
+            they built.
+        name: what the nonce is, as the exception should call it, for a
+            caller parsing more than one array of them.
+
+    Returns:
+        The libsecp256k1 public nonce object.
+
+    Raises:
+        ValueError: if it is not 66 bytes, or not one BIP327 defines.
+    """
+    pubnonce_bytes = octets(pubnonce_bytes, name, _PUBNONCE_SIZE)
+    pubnonce = ffi.new("secp256k1_musig_pubnonce *")
+    if not lib.secp256k1_musig_pubnonce_parse(ctx, pubnonce, pubnonce_bytes):
+        raise ValueError(f"invalid {name}")
+    return pubnonce
+
+
+def pubnonce_serialize(pubnonce: CData) -> bytes:
+    """Serialize a parsed public nonce.
+
+    Args:
+        pubnonce: the libsecp256k1 public nonce object, as `pubnonce_parse`
+            returns.
+
+    Returns:
+        Its 66 bytes.
+
+    Raises:
+        RuntimeError: if libsecp256k1 refuses the object, which one it
+            produced cannot make it do.
+    """
+    output = ffi.new(_PUBNONCE_BUFFER_TYPE)
+    if not lib.secp256k1_musig_pubnonce_serialize(ctx, output, pubnonce):
+        raise RuntimeError("public nonce serialization failed")
+    return ffi.unpack(output, _PUBNONCE_SIZE)
+
+
+def aggnonce_parse(aggnonce_bytes: BytesLike, name: str = "aggregate nonce") -> CData:
+    """Parse an aggregate public nonce into its internal representation.
+
+    Args:
+        aggnonce_bytes: the aggregate nonce, 66 bytes, as `nonce_agg`
+            answered it.
+        name: what the nonce is, as the exception should call it.
+
+    Returns:
+        The libsecp256k1 aggregate nonce object.
+
+    Raises:
+        ValueError: if it is not 66 bytes, or not one BIP327 defines.
+    """
+    aggnonce_bytes = octets(aggnonce_bytes, name, _AGGNONCE_SIZE)
+    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
+    if not lib.secp256k1_musig_aggnonce_parse(ctx, aggnonce, aggnonce_bytes):
+        raise ValueError(f"invalid {name}")
+    return aggnonce
+
+
+def aggnonce_serialize(aggnonce: CData) -> bytes:
+    """Serialize a parsed aggregate public nonce.
+
+    Args:
+        aggnonce: the libsecp256k1 aggregate nonce object, as
+            `aggnonce_parse` returns.
+
+    Returns:
+        Its 66 bytes.
+
+    Raises:
+        RuntimeError: if libsecp256k1 refuses the object, which one it
+            produced cannot make it do.
+    """
+    output = ffi.new(_AGGNONCE_BUFFER_TYPE)
+    if not lib.secp256k1_musig_aggnonce_serialize(ctx, output, aggnonce):
+        raise RuntimeError("aggregate nonce serialization failed")
+    return ffi.unpack(output, _AGGNONCE_SIZE)
+
+
+def partial_sig_parse(
+    partial_sig_bytes: BytesLike, name: str = "partial signature"
+) -> CData:
+    """Parse a partial signature into its internal representation.
+
+    Args:
+        partial_sig_bytes: the partial signature, 32 bytes, as
+            `SecretNonce.partial_sign` answered it.
+        name: what the signature is, as the exception should call it.
+
+    Returns:
+        The libsecp256k1 partial signature object.
+
+    Raises:
+        ValueError: if it is not 32 bytes, or not one below the curve
+            order.
+    """
+    partial_sig_bytes = octets(partial_sig_bytes, name, _PARTIAL_SIG_SIZE)
+    partial_sig = ffi.new("secp256k1_musig_partial_sig *")
+    if not lib.secp256k1_musig_partial_sig_parse(ctx, partial_sig, partial_sig_bytes):
+        raise ValueError(f"invalid {name}")
+    return partial_sig
+
+
+def partial_sig_serialize(partial_sig: CData) -> bytes:
+    """Serialize a parsed partial signature.
+
+    Args:
+        partial_sig: the libsecp256k1 partial signature object, as
+            `partial_sig_parse` returns.
+
+    Returns:
+        Its 32 bytes.
+
+    Raises:
+        RuntimeError: if libsecp256k1 refuses the object, which one it
+            produced cannot make it do.
+    """
+    output = ffi.new(_PARTIAL_SIG_BUFFER_TYPE)
+    if not lib.secp256k1_musig_partial_sig_serialize(ctx, output, partial_sig):
+        raise RuntimeError("partial signature serialization failed")
+    return ffi.unpack(output, _PARTIAL_SIG_SIZE)
+
+
+def nonce_agg(pubnonces_bytes: Sequence[BytesLike]) -> bytes:
+    """Aggregate the signers' public nonces into one, for `Session`.
+
+    Any party can do this, trusted or not: an aggregate nonce computed
+    wrong makes the final signature invalid rather than makes it forge,
+    so BIP327 lets an untrusted coordinator collect the round-one
+    nonces and hand every signer this one value back instead of every
+    other signer's.
+
+    Args:
+        pubnonces_bytes: the signers' public nonces, 66 bytes each, in
+            the order `Session.partial_sig_agg` will later take their
+            partial signatures. At least one is required.
+
+    Returns:
+        The 66-byte aggregate nonce.
+
+    Raises:
+        ValueError: if the sequence is empty, or if one of the nonces is
+            not 66 bytes or not one BIP327 defines -- named by its
+            position in the sequence, `pubnonces_bytes[0]` being "public
+            nonce at index 0".
+        RuntimeError: if libsecp256k1 fails to aggregate or serialize the
+            result, which no valid input can make it do.
+    """
+    if not pubnonces_bytes:
+        raise ValueError("at least one public nonce is required")
+    # a per-contribution parse loop, not a comprehension calling
+    # `pubnonce_parse` with its default name: the array this is built
+    # into is what secp256k1_musig_nonce_agg takes, and a bare 0 back
+    # from it says nothing about which contribution was bad -- the index
+    # has to come from parsing each one under its own name, which is
+    # what the module docstring's "a parse failure ... tells this
+    # package nothing" is about
+    pubnonces = [
+        pubnonce_parse(pubnonce_bytes, f"public nonce at index {index}")
+        for index, pubnonce_bytes in enumerate(pubnonces_bytes)
+    ]
+    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
+    if not lib.secp256k1_musig_nonce_agg(
+        ctx, aggnonce, array("secp256k1_musig_pubnonce *[]", pubnonces), len(pubnonces)
+    ):
+        raise RuntimeError("nonce aggregation failed")
+    return aggnonce_serialize(aggnonce)
+
+
+class KeyAggCache:
+    """The aggregate of a set of signers' public keys, and its tweaks.
+
+    What `secp256k1_musig_keyagg_cache` holds: the aggregate public key
+    BIP327 calls `Q`, the per-signer coefficients it is built from, and
+    the running sum of any tweak applied since. It has no serialization,
+    which the module docstring explains, and holding it here rather than
+    parsing it back from octets on every call is not an optimization
+    over some other spelling -- there is no other spelling, a cache
+    built once being the only way `nonce_gen`, `Session` and
+    `SecretNonce.partial_sign` can be handed the aggregation they need.
+
+    Building one is `secp256k1_musig_pubkey_agg`, which orders the keys
+    exactly as given: `keys.pubkey_sort` first is BIP327's own rule for
+    reaching one aggregate key independently of the order the signers'
+    public keys arrived in, and is the caller's to apply, this taking
+    the sequence as it stands.
+
+    Args:
+        pubkeys_bytes: the signers' public keys, 33 or 65 bytes each, in
+            aggregation order. At least one is required.
+
+    Raises:
+        ValueError: if the sequence is empty, or if one of the keys is
+            not a valid point -- named by its position in the sequence,
+            `pubkeys_bytes[0]` being "public key at index 0".
+        RuntimeError: if libsecp256k1 fails to aggregate or serialize the
+            result, which no valid input can make it do.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, musig
+        >>> pubkeys = [keys.pubkey_from_prvkey(1), keys.pubkey_from_prvkey(2)]
+        >>> cache = musig.KeyAggCache(pubkeys)
+        >>> len(cache.agg_pubkey)
+        32
+    """
+
+    # pydoclint (DOC301) asks that this carry no docstring of its own,
+    # the class docstring above being where the constructor is documented
+    def __init__(self, pubkeys_bytes: Sequence[BytesLike]) -> None:  # noqa: D107
+        if not pubkeys_bytes:
+            raise ValueError("at least one public key is required")
+        # a per-contribution parse loop, for the reason nonce_agg's has
+        pubkeys = [
+            keys.parse(pubkey_bytes, f"public key at index {index}")
+            for index, pubkey_bytes in enumerate(pubkeys_bytes)
+        ]
+        cache = ffi.new("secp256k1_musig_keyagg_cache *")
+        agg_pk = ffi.new("secp256k1_xonly_pubkey *")
+        if not lib.secp256k1_musig_pubkey_agg(
+            ctx, agg_pk, cache, array("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
+        ):
+            raise RuntimeError("key aggregation failed")
+        self._cache = cache
+        # BIP327's Q, before any tweak: pubkey_agg is the only call that
+        # answers it, so it is captured now or not at all -- pubkey_get
+        # below answers the *current*, possibly tweaked aggregate instead
+        self.agg_pubkey = xonly.serialize(agg_pk)
+
+    def pubkey_get(self, compressed: bool = True) -> bytes:
+        """Return the current aggregate public key, tweaks included.
+
+        Useful for the non-xonly form of the aggregate key -- plain
+        tweaking, or batch-verifying more than one key aggregation, which
+        libsecp256k1 does not implement -- where `agg_pubkey` is the
+        x-only one and BIP341 taproot tweaking wants the full point.
+
+        Args:
+            compressed: whether to return 33 bytes rather than 65.
+
+        Returns:
+            The serialized aggregate public key, as it stands after
+            every `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add`
+            made so far.
+
+        Raises:
+            RuntimeError: if libsecp256k1 fails to read or serialize it,
+                which a cache this built cannot make it do.
+        """
+        agg_pk = ffi.new("secp256k1_pubkey *")
+        if not lib.secp256k1_musig_pubkey_get(ctx, agg_pk, self._cache):
+            raise RuntimeError("aggregate public key extraction failed")
+        return keys.serialize(agg_pk, compressed)
+
+    def pubkey_ec_tweak_add(
+        self, tweak: BytesLike | int, compressed: bool = True
+    ) -> bytes:
+        """Add a plain EC tweak to the aggregate key, e.g. a BIP32 step.
+
+        The MuSig2 counterpart of `keys.pubkey_tweak_add`: the tweaking
+        method is the same, and what differs is that it is applied to
+        this cache's running aggregate rather than to an argument, so
+        that signing for the tweaked key is `SecretNonce.partial_sign`
+        against the cache afterwards rather than against a key nobody
+        holds the private share of directly.
+
+        Args:
+            tweak: the tweak, 32 bytes or an int below 2**256. Callers
+                are responsible for deriving it in a way that does not
+                reduce MuSig2's security, BIP32 being such a way.
+            compressed: whether to return 33 bytes rather than 65.
+
+        Returns:
+            The serialized tweaked aggregate public key.
+
+        Raises:
+            ValueError: if the tweak is not 32 bytes or does not fit in
+                them, or if the tweak or the resulting key is invalid.
+            RuntimeError: if libsecp256k1 fails to serialize the result,
+                which no valid input can make it do.
+        """
+        return self._tweak_add(
+            lib.secp256k1_musig_pubkey_ec_tweak_add, tweak, compressed
+        )
+
+    def pubkey_xonly_tweak_add(
+        self, tweak: BytesLike | int, compressed: bool = True
+    ) -> bytes:
+        """Add a BIP341 x-only tweak to the aggregate key, for a taproot output.
+
+        `xonly.tweak_add`'s equation, applied to this cache instead of
+        to a bare argument: `xonly.tweak_add_check` on the x-only form of
+        what this returns, `agg_pubkey` and the same tweak, holds exactly
+        as it does for a solo taproot key. This is required, rather than
+        `xonly.tweak_add` on `agg_pubkey` directly, wherever a signature
+        is wanted for the tweaked key: `xonly.tweak_add` leaves this
+        cache untweaked, so a later `SecretNonce.partial_sign` would sign
+        for the untweaked aggregate instead.
+
+        Args:
+            tweak: the tweak, 32 bytes or an int below 2**256. Callers
+                are responsible for deriving it in a way that does not
+                reduce MuSig2's security, BIP341 being such a way.
+            compressed: whether to return 33 bytes rather than 65.
+
+        Returns:
+            The serialized tweaked aggregate public key.
+
+        Raises:
+            ValueError: if the tweak is not 32 bytes or does not fit in
+                them, or if the tweak or the resulting key is invalid.
+            RuntimeError: if libsecp256k1 fails to serialize the result,
+                which no valid input can make it do.
+        """
+        return self._tweak_add(
+            lib.secp256k1_musig_pubkey_xonly_tweak_add, tweak, compressed
+        )
+
+    def _tweak_add(
+        self, tweak_add: CData, tweak: BytesLike | int, compressed: bool
+    ) -> bytes:
+        """Apply the tweak both public methods share, told apart by the C call.
+
+        Args:
+            tweak_add: `secp256k1_musig_pubkey_ec_tweak_add` or
+                `secp256k1_musig_pubkey_xonly_tweak_add`, already bound.
+            tweak: the tweak, 32 bytes or an int below 2**256.
+            compressed: whether to return 33 bytes rather than 65.
+
+        Returns:
+            The serialized tweaked aggregate public key.
+
+        Raises:
+            ValueError: if the tweak is not 32 bytes or does not fit in
+                them, or if the tweak or the resulting key is invalid.
+            RuntimeError: if libsecp256k1 fails to serialize the result,
+                which no valid input can make it do.
+        """
+        tweak_bytes = scalar(tweak, "tweak")
+        output = ffi.new("secp256k1_pubkey *")
+        if not tweak_add(ctx, output, self._cache, tweak_bytes):
+            raise ValueError("invalid tweak or resulting public key")
+        return keys.serialize(output, compressed)
+
+    def _cache_(self) -> CData:
+        """Return the libsecp256k1 keyagg cache object this holds.
+
+        The private half every other entry point of this module reaches
+        for: `nonce_gen`, `nonce_gen_counter`, `Session.__init__` and
+        `SecretNonce.partial_sign` all take a `KeyAggCache` and read it
+        through this rather than through a public attribute, so that
+        nothing outside this class can replace what it points at.
+
+        Returns:
+            The libsecp256k1 keyagg cache object, mutated in place by
+            `pubkey_ec_tweak_add` and `pubkey_xonly_tweak_add`.
+        """
+        return self._cache
+
+
+def nonce_gen(
+    pubkey_bytes: BytesLike,
+    prvkey: BytesLike | int | None = None,
+    msg32: BytesLike | None = None,
+    keyagg_cache: KeyAggCache | None = None,
+    extra_input32: BytesLike | None = None,
+) -> SecretNonce:
+    """Start a signing session by generating a nonce.
+
+    Round one of BIP327: the public nonce this answers is sent to every
+    other signer, or to whoever aggregates them, and the secret nonce is
+    kept -- held by the `SecretNonce` this returns, until a matching
+    `Session` exists to call its `partial_sign`.
+
+    The 32 bytes of session randomness BIP327 requires, unique to this
+    call and never reused, is not a parameter: it is generated here with
+    `secrets.token_bytes`, the same source the rest of this package's
+    randomness comes from, because the one thing a caller could do with
+    it -- supply their own -- is the one thing the header warns against
+    doing twice.
+
+    Args:
+        pubkey_bytes: the public key of the signer this nonce is for, 33
+            or 65 bytes. The secnonce this answers can only sign for a
+            keypair matching it, which `SecretNonce.partial_sign` asks
+            libsecp256k1 to check.
+        prvkey: this signer's private key, 32 bytes or an int below
+            2**256, if already known. Optional, and folded into the
+            nonce derivation to increase misuse-resistance where given;
+            using the same private key across several MuSig2 sessions is
+            fine.
+        msg32: the 32-byte message this session will sign, if already
+            known. Optional, for the same reason.
+        keyagg_cache: the key aggregation this session signs under, if
+            already known. Optional, for the same reason.
+        extra_input32: 32 bytes that do not repeat in normal use, such as
+            the current time, folded into the derivation alongside the
+            above. Optional, and no substitute for the session
+            randomness above, which is what carries the uniqueness
+            requirement.
+
+    Returns:
+        The secret nonce, held rather than returned as octets: the
+        module docstring says why, and `SecretNonce` is what a caller
+        wipes if this session is abandoned before `partial_sign`.
+
+    Raises:
+        ValueError: if the public key is not a valid point, if the
+            private key is given and is not 32 bytes, does not fit in
+            them, or is not in [1, n-1], or if `msg32` or
+            `extra_input32` is given and is not 32 bytes.
+    """
+    pubkey = keys.parse(pubkey_bytes, "public key")
+    prvkey_bytes = None if prvkey is None else scalar(prvkey, "private key")
+    msg_bytes = None if msg32 is None else octets(msg32, "message", 32)
+    extra_bytes = (
+        None if extra_input32 is None else octets(extra_input32, "extra_input32", 32)
+    )
+    cache = ffi.NULL if keyagg_cache is None else keyagg_cache._cache_()
+
+    secnonce = ffi.new("secp256k1_musig_secnonce *")
+    pubnonce = ffi.new("secp256k1_musig_pubnonce *")
+    session_secrand = ffi.new("unsigned char[32]", secrets.token_bytes(32))
+    try:
+        generated = lib.secp256k1_musig_nonce_gen(
+            ctx,
+            secnonce,
+            pubnonce,
+            session_secrand,
+            ffi.NULL if prvkey_bytes is None else prvkey_bytes,
+            pubkey,
+            ffi.NULL if msg_bytes is None else msg_bytes,
+            cache,
+            ffi.NULL if extra_bytes is None else extra_bytes,
+        )
+    finally:
+        # this package's own scratch randomness, owed a wipe whether the
+        # call used it or refused it first -- libsecp256k1 only zeroes it
+        # itself on success, see the header of secp256k1_musig_nonce_gen
+        wipe(session_secrand)
+    if not generated:
+        raise ValueError("invalid private key: not in [1, n-1]")
+    return SecretNonce(secnonce, pubnonce, pubkey)
+
+
+def nonce_gen_counter(
+    prvkey: BytesLike | int,
+    nonrepeating_cnt: int,
+    msg32: BytesLike | None = None,
+    keyagg_cache: KeyAggCache | None = None,
+    extra_input32: BytesLike | None = None,
+) -> SecretNonce:
+    """Start a signing session, deriving the nonce from a counter instead.
+
+    The alternative to `nonce_gen` for a signer with a non-repeating
+    counter rather than good randomness available -- a hardware signer
+    keeping one in place of an RNG it does not trust, which is what this
+    exists for. The counter must never repeat for this private key: two
+    calls with the same keypair and the same `nonrepeating_cnt`, on any
+    device signing with that key, reuse the nonce.
+
+    Args:
+        prvkey: this signer's private key, 32 bytes or an int below
+            2**256. Mandatory here, where `nonce_gen`'s is optional: the
+            counter's uniqueness is a property of the key it counts for.
+        nonrepeating_cnt: the counter value, an int in [0, 2**64 - 1],
+            unique to this call for this private key.
+        msg32: the 32-byte message this session will sign, if already
+            known.
+        keyagg_cache: the key aggregation this session signs under, if
+            already known.
+        extra_input32: 32 bytes that do not repeat in normal use, folded
+            into the derivation alongside the above.
+
+    Returns:
+        The secret nonce, as `nonce_gen` returns it.
+
+    Raises:
+        TypeError: if `nonrepeating_cnt` is not an int.
+        ValueError: if the private key is not 32 bytes, does not fit in
+            them, or is not in [1, n-1], if `nonrepeating_cnt` is out of
+            range, if `extra_input32` is given and is not 32 bytes, or if
+            `msg32` is given and is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to extract the public key or
+            to generate the nonce, which a private key already verified
+            cannot make it do.
+    """
+    nonrepeating_cnt = in_range(nonrepeating_cnt, "nonrepeating_cnt", 2**64 - 1)
+    msg_bytes = None if msg32 is None else octets(msg32, "message", 32)
+    extra_bytes = (
+        None if extra_input32 is None else octets(extra_input32, "extra_input32", 32)
+    )
+    cache = ffi.NULL if keyagg_cache is None else keyagg_cache._cache_()
+
+    keypair_obj = keypair(prvkey)
+    try:
+        pubkey = ffi.new("secp256k1_pubkey *")
+        if not lib.secp256k1_keypair_pub(ctx, pubkey, keypair_obj):
+            raise RuntimeError("public key extraction failed")
+
+        secnonce = ffi.new("secp256k1_musig_secnonce *")
+        pubnonce = ffi.new("secp256k1_musig_pubnonce *")
+        generated = lib.secp256k1_musig_nonce_gen_counter(
+            ctx,
+            secnonce,
+            pubnonce,
+            nonrepeating_cnt,
+            keypair_obj,
+            ffi.NULL if msg_bytes is None else msg_bytes,
+            cache,
+            ffi.NULL if extra_bytes is None else extra_bytes,
+        )
+    finally:
+        # the keypair carries the private key: overwrite it whether the
+        # nonce was made or refused, as ssa.sign does with its own
+        wipe(keypair_obj)
+    if not generated:
+        raise RuntimeError("nonce generation failed")
+    return SecretNonce(secnonce, pubnonce, pubkey)
+
+
+class SecretNonce:
+    """A signer's secret nonce, held between `nonce_gen` and `partial_sign`.
+
+    `nonce_gen` and `nonce_gen_counter` are the two ways to obtain one --
+    this is never built from octets, there being no parser for a secret
+    nonce by design: "Avoid copying (or serializing) the secnonce. This
+    reduces the possibility that it is used more than once for signing",
+    the header says, and a parser is exactly a way to make a copy.
+
+    What `ssa.Signer` documents about holding a keypair holds here for
+    the same reason: `wipe`, or the `with` statement that calls it on the
+    way out of the block, overwrites the secret nonce whether the block
+    produced a signature or raised. `partial_sign` also wipes it, being
+    the call whose whole point is to consume it -- so a nonce used once is
+    already gone by the time `wipe` might run again, and wiping a second
+    time is not an error, exactly as `ssa.Signer.wipe` is not either.
+
+    A `SecretNonce` told neither is dropped holding the secret, cffi
+    freeing the memory without overwriting it: SECURITY.md names this as
+    the second buffer in this package whose zeroing is asked for rather
+    than done.
+
+    Args:
+        secnonce: the libsecp256k1 secret nonce object `nonce_gen` or
+            `nonce_gen_counter` built.
+        pubnonce: the matching public nonce object, already parsed.
+        pubkey: the signer's already-parsed public key, kept for
+            `partial_sign`'s own `verify`.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, musig
+        >>> prvkey, pubkey = 1, keys.pubkey_from_prvkey(1)
+        >>> with musig.nonce_gen(pubkey, prvkey) as secnonce:
+        ...     len(secnonce.pubnonce)
+        66
+    """
+
+    # pydoclint (DOC301) asks that this carry no docstring of its own,
+    # the class docstring above being where the constructor is documented
+    def __init__(self, secnonce: CData, pubnonce: CData, pubkey: CData) -> None:  # noqa: D107
+        self._secnonce: CData | None = secnonce
+        self._pubnonce = pubnonce
+        self._pubkey = pubkey
+        self.pubnonce = pubnonce_serialize(pubnonce)
+
+    def partial_sign(
+        self,
+        prvkey: BytesLike | int,
+        keyagg_cache: KeyAggCache,
+        session: Session,
+        *,
+        verify: bool = True,
+    ) -> bytes:
+        """Produce this signer's partial signature, and wipe the secret nonce.
+
+        Whatever the outcome -- a signature, a refusal or an exception --
+        the secret nonce this holds does not survive the call: `wipe`
+        below is not needed afterwards, and calling it anyway is not an
+        error, as the class docstring says.
+
+        Args:
+            prvkey: this signer's private key, 32 bytes or an int below
+                2**256, matching the public key `nonce_gen` or
+                `nonce_gen_counter` built this nonce for.
+            keyagg_cache: the key aggregation this session signs under,
+                the same one the nonce was generated against if one was.
+            session: the session `Session.__init__` built from the
+                aggregate nonce this signer's public nonce contributed
+                to.
+            verify: whether to check the partial signature against this
+                signer's public nonce and public key before returning
+                it, as the module docstring explains and BIP327's own
+                header recommends.
+
+        Returns:
+            The 32-byte partial signature.
+
+        Raises:
+            ValueError: if this secret nonce has already been spent or
+                wiped, if the private key is not 32 bytes, does not fit
+                in them, or is not in [1, n-1], or if it does not match
+                this secret nonce, or `keyagg_cache` or `session` do not.
+            RuntimeError: if `verify` asks and the partial signature does
+                not verify, which no input reaching this far can make
+                happen.
+        """
+        secnonce = self._held()
+        keypair_obj = keypair(prvkey)
+        partial_sig = ffi.new("secp256k1_musig_partial_sig *")
+        try:
+            signed = lib.secp256k1_musig_partial_sign(
+                ctx,
+                partial_sig,
+                secnonce,
+                keypair_obj,
+                keyagg_cache._cache_(),
+                session._session_(),
+            )
+        finally:
+            # the keypair carries the private key, wiped as ssa.sign
+            # wipes its own; the secret nonce is spent by the call above
+            # regardless of its outcome -- libsecp256k1 zeroes it right
+            # after loading it and before any of its own checks can fail
+            wipe(keypair_obj)
+            self._secnonce = None
+        if not signed:
+            msg = (
+                "the private key, key aggregation cache or session do not"
+                " match this secret nonce"
+            )
+            raise ValueError(msg)
+        if verify and not lib.secp256k1_musig_partial_sig_verify(
+            ctx,
+            partial_sig,
+            self._pubnonce,
+            self._pubkey,
+            keyagg_cache._cache_(),
+            session._session_(),
+        ):
+            raise RuntimeError(
+                "partial signing produced a signature that does not verify"
+            )
+        return partial_sig_serialize(partial_sig)
+
+    def wipe(self) -> None:
+        """Overwrite the secret nonce, ending what this can sign.
+
+        Signing afterwards raises rather than signing with the zeros
+        left behind, and there is no reviving it: nothing here keeps the
+        nonce anywhere else, so a session abandoned this way is
+        restarted with a fresh `nonce_gen` rather than resumed.
+        """
+        if self._secnonce is not None:
+            wipe(self._secnonce)
+            self._secnonce = None
+
+    # PYI034 asks for `typing.Self` here, and that is 3.11 while this
+    # package supports 3.10, as ssa.Signer's own comment says
+    def __enter__(self) -> SecretNonce:  # noqa: PYI034
+        """Return this secret nonce, for the `with` block that wipes it.
+
+        Returns:
+            This object, nothing being built here that the constructor
+            did not already build.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Wipe the secret nonce, whatever ended the block.
+
+        Args:
+            exc_type: the class of the exception ending the block, if
+                one is.
+            exc_value: that exception.
+            traceback: its traceback.
+        """
+        self.wipe()
+
+    def _held(self) -> CData:
+        """Return the secret nonce, or refuse if it is gone.
+
+        Returns:
+            The libsecp256k1 secret nonce object.
+
+        Raises:
+            ValueError: if `wipe` or a previous `partial_sign` has
+                already overwritten it.
+        """
+        if self._secnonce is None:
+            raise ValueError("this secret nonce has been wiped or already spent")
+        return self._secnonce
+
+
+class Session:
+    """A MuSig2 signing session, opened from the signers' aggregate nonce.
+
+    What `secp256k1_musig_nonce_process` produces: the message, the
+    aggregate nonce and the key aggregation are fixed into it, and
+    `SecretNonce.partial_sign`, `partial_sig_verify` and
+    `partial_sig_agg` all read the session rather than those three
+    again. Like `KeyAggCache`, this has no serialization -- the module
+    docstring explains why that is taken as an exception here -- and,
+    also like it, holds nothing secret: the header says a session "is
+    not required to be kept secret for the signing protocol to be
+    secure".
+
+    Args:
+        aggnonce_bytes: the aggregate of the signers' public nonces, 66
+            bytes, as `nonce_agg` answered it.
+        msg32: the 32-byte message this session signs.
+        keyagg_cache: the key aggregation this session signs under.
+
+    Raises:
+        ValueError: if `aggnonce_bytes` is not 66 bytes or not one
+            BIP327 defines, or if the message is not 32 bytes.
+        RuntimeError: if libsecp256k1 fails to build the session, which
+            no valid input can make it do.
+
+    Example:
+        >>> from btclib_secp256k1 import keys, musig
+        >>> pubkeys = [keys.pubkey_from_prvkey(1), keys.pubkey_from_prvkey(2)]
+        >>> cache = musig.KeyAggCache(pubkeys)
+        >>> secnonces = [
+        ...     musig.nonce_gen(pk, i + 1) for i, pk in enumerate(pubkeys)
+        ... ]
+        >>> pubnonces = [s.pubnonce for s in secnonces]
+        >>> aggnonce = musig.nonce_agg(pubnonces)
+        >>> session = musig.Session(aggnonce, bytes(32), cache)
+    """
+
+    # pydoclint (DOC301) asks that this carry no docstring of its own,
+    # the class docstring above being where the constructor is documented
+    def __init__(  # noqa: D107
+        self, aggnonce_bytes: BytesLike, msg32: BytesLike, keyagg_cache: KeyAggCache
+    ) -> None:
+        aggnonce = aggnonce_parse(aggnonce_bytes)
+        msg_bytes = octets(msg32, "message", 32)
+        session = ffi.new("secp256k1_musig_session *")
+        if not lib.secp256k1_musig_nonce_process(
+            ctx, session, aggnonce, msg_bytes, keyagg_cache._cache_()
+        ):
+            raise RuntimeError("nonce processing failed")
+        self._session = session
+
+    def partial_sig_verify(
+        self,
+        partial_sig_bytes: BytesLike,
+        pubnonce_bytes: BytesLike,
+        pubkey_bytes: BytesLike,
+        keyagg_cache: KeyAggCache,
+    ) -> bool:
+        """Verify one signer's partial signature, within this session.
+
+        Not required in a regular session: an aggregate signature that
+        fails `ssa.verify` was made from at least one bad partial
+        signature, but does not say which. This is the call that finds
+        out, at the cost of one verification per signer instead of one
+        for the aggregate.
+
+        Args:
+            partial_sig_bytes: the partial signature to verify, 32 bytes.
+            pubnonce_bytes: the public nonce of the signer it is
+                attributed to, 66 bytes, exactly as it went into
+                `nonce_agg`.
+            pubkey_bytes: the public key of that signer, 33 or 65 bytes,
+                exactly as it went into the `KeyAggCache` this session's
+                key aggregation came from.
+            keyagg_cache: that key aggregation.
+
+        Returns:
+            True if the partial signature is valid for that signer's
+            nonce and key, within this session.
+
+        Raises:
+            ValueError: if any of the three byte arguments is not the
+                right length or not one libsecp256k1 will read.
+        """
+        partial_sig = partial_sig_parse(partial_sig_bytes)
+        pubnonce = pubnonce_parse(pubnonce_bytes)
+        pubkey = keys.parse(pubkey_bytes, "public key")
+        return bool(
+            lib.secp256k1_musig_partial_sig_verify(
+                ctx,
+                partial_sig,
+                pubnonce,
+                pubkey,
+                keyagg_cache._cache_(),
+                self._session,
+            )
+        )
+
+    def partial_sig_agg(self, partial_sigs_bytes: Sequence[BytesLike]) -> bytes:
+        """Aggregate the signers' partial signatures into the final one.
+
+        The result is a plain BIP340 signature -- `ssa.verify` against
+        the key aggregation's `pubkey_get` (or its x-only form,
+        `agg_pubkey`, where no tweak was applied) is how a caller checks
+        it, this answering 1 "which does NOT mean the resulting
+        signature verifies", in the header's own words.
+
+        Args:
+            partial_sigs_bytes: the signers' partial signatures, 32
+                bytes each, one per signer of this session. At least
+                one is required.
+
+        Returns:
+            The 64-byte aggregate signature.
+
+        Raises:
+            ValueError: if the sequence is empty, or if one of the
+                partial signatures is not 32 bytes or not one below the
+                curve order -- named by its position in the sequence,
+                `partial_sigs_bytes[0]` being "partial signature at
+                index 0".
+            RuntimeError: if libsecp256k1 fails to aggregate the result,
+                which no valid input can make it do.
+        """
+        if not partial_sigs_bytes:
+            raise ValueError("at least one partial signature is required")
+        # a per-contribution parse loop, for the reason nonce_agg's has
+        partial_sigs = [
+            partial_sig_parse(partial_sig_bytes, f"partial signature at index {index}")
+            for index, partial_sig_bytes in enumerate(partial_sigs_bytes)
+        ]
+        signature = ffi.new(_SIGNATURE_BUFFER_TYPE)
+        if not lib.secp256k1_musig_partial_sig_agg(
+            ctx,
+            signature,
+            self._session,
+            array("secp256k1_musig_partial_sig *[]", partial_sigs),
+            len(partial_sigs),
+        ):
+            raise RuntimeError("partial signature aggregation failed")
+        return ffi.unpack(signature, _SIGNATURE_SIZE)
+
+    def _session_(self) -> CData:
+        """Return the libsecp256k1 session object this holds.
+
+        Returns:
+            The libsecp256k1 session object, read by
+            `SecretNonce.partial_sign` and by this class's own methods.
+        """
+        return self._session

--- a/docs/source/btclib_secp256k1.rst
+++ b/docs/source/btclib_secp256k1.rst
@@ -46,6 +46,13 @@ btclib\_secp256k1.keys module
    :members:
    :show-inheritance:
 
+btclib\_secp256k1.musig module
+------------------------------
+
+.. automodule:: btclib_secp256k1.musig
+   :members:
+   :show-inheritance:
+
 btclib\_secp256k1.recovery module
 ---------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,12 @@ authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 # is well short of. Lowercase throughout, a GitHub topic being lowercase
 # or not a topic, so that one spelling serves both lists.
 #
-# Two of them name what is reachable rather than what is wrapped, and the
-# difference is worth knowing before either is trusted. musig2 has no
-# module of its own -- the two-round protocol needs a session whose secret
-# nonce cannot be reused, which belongs where the signing state lives --
-# but the vendored library is built with SECP256K1_ENABLE_MODULE_MUSIG and
-# secp256k1_musig.h is among the headers the cdef is made of, so the whole
-# of that api is reachable through the `lib` this package exposes. bip324
-# is the ellswift module beside it: the encoding and the x-only ECDH that
-# BIP's handshake needs of its keys, and not its transport, which is a
-# cipher and a framing layer this package has no part of.
+# One of them names what is reachable rather than what is wrapped, and the
+# difference is worth knowing before it is trusted. bip324 is the ellswift
+# module: the encoding and the x-only ECDH that BIP's handshake needs of
+# its keys, and not its transport, which is a cipher and a framing layer
+# this package has no part of. musig2 is wrapped, in `musig`, and needs no
+# such note.
 #
 # elliptic-curves stays out: this is one curve, and secp256k1 names it.
 keywords = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,7 +170,9 @@ behind  0 revisions; that commit is the tip of the path
 
 Verdict: **identical**. Every case, the tweaked ones included: the
 aggregate signature is compared with the published value and then
-verified as a plain BIP340 signature of the tweaked aggregate key.
+verified as a plain BIP340 signature of the tweaked aggregate key; the
+error ones are all refused at the parse of the partial signature, which
+is where libsecp256k1 puts that check.
 
 Not vendored from `bip-0327/vectors/`: `key_sort_vectors.json`,
 `nonce_gen_vectors.json`, `tweak_vectors.json` and

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -25,11 +25,21 @@ tested as if it were: `secp256k1_ec_pubkey_tweak_add` takes its key as
 in and out, so every `tweak_add` writes the point the chain holds, and
 one chain belongs to one thread. What is tested of it here is that a
 chain per thread answers what a chain alone answers.
+
+`musig.SecretNonce` is neither of those two shapes. It is not const, like
+a keypair, and it is not one-thread-per-object by convention, like a
+chain: it is meant to be read exactly once, from whichever thread gets
+there first, and refused everywhere else -- the invariant the whole class
+exists to hold, a secnonce driving `secp256k1_musig_partial_sign` twice
+being how MuSig2 leaks the private key. `SecretNonce._take` makes the
+read and the clear one atomic step under a lock private to the instance,
+and the last test here is what that buys: `WORKERS` threads racing one
+`SecretNonce`, of which exactly one may ever sign.
 """
 
 from concurrent.futures import ThreadPoolExecutor
 
-from btclib_secp256k1 import dsa, ecdh, keys, ssa, xonly
+from btclib_secp256k1 import dsa, ecdh, keys, musig, ssa, xonly
 
 prvkey = 0xB7331FE4A9F79F4A2B79A5BEE4CCA2C6A0A9DCE05C4EB77C1C8AA1CC1EE47ADD
 tweak = 0x3F2B1C7D8E9F0A1B2C3D4E5F60718293A4B5C6D7E8F901A2B3C4D5E6F708192A
@@ -132,3 +142,40 @@ def test_a_chain_per_thread_walks_the_same_path() -> None:
 
     with ThreadPoolExecutor(max_workers=WORKERS) as pool:
         list(pool.map(walk, range(WORKERS * ROUNDS)))
+
+
+def test_exactly_one_thread_signs_a_shared_secret_nonce() -> None:
+    """`WORKERS` threads race one `SecretNonce`, and exactly one signs it.
+
+    Every other thread has to find the secret nonce already gone: not
+    "usually", the way a race is normally read, but always, because
+    `SecretNonce._take` makes the check and the clearing one operation
+    under a lock rather than two racing statements. So this is not a
+    flaky detector of the bug -- it is what the fix makes true on every
+    run, on the GIL-enabled interpreter this suite runs under as much as
+    on `cp314t`, and it would fail deterministically on the read of
+    `self._secnonce` followed by a separate clear that the fix replaces.
+
+    A single round rather than `ROUNDS`: a secret nonce is spent by the
+    first thread to reach it, `ROUNDS` more attempts on the same one
+    only exercising the refusal `test_a_wiped_secret_nonce_refuses_to
+    _sign` already covers in `tests/test_musig.py`.
+    """
+    pubkey_bytes = keys.pubkey_from_prvkey(prvkey)
+    cache = musig.KeyAggCache([pubkey_bytes])
+    secnonce = musig.nonce_gen(pubkey_bytes, prvkey)
+    aggnonce = musig.nonce_agg([secnonce.pubnonce])
+    session = musig.Session(aggnonce, msg, cache)
+
+    def race(_: int) -> bytes | None:
+        try:
+            return secnonce.partial_sign(prvkey, cache, session)
+        except ValueError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        results = list(pool.map(race, range(WORKERS)))
+
+    signed = [result for result in results if result is not None]
+    assert len(signed) == 1
+    assert results.count(None) == WORKERS - 1

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -3,18 +3,17 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the ecdh, recovery, ellswift, and musig libsecp256k1 modules.
+"""Tests for the ecdh, recovery and ellswift libsecp256k1 modules.
 
 Wherever possible the results are cross-checked against the other
 bindings (dsa, ssa, keys) instead of against vendored constants: the
-ECDH secret is recomputed from the shared point, the recoverable
-signature is compared with the deterministic ECDSA one, and the
-MuSig2 aggregate signature is verified as a plain BIP340 signature.
+ECDH secret is recomputed from the shared point, and the recoverable
+signature is compared with the deterministic ECDSA one.
 
-MuSig2 has no wrapper module, by decision, its two-round protocol
-belonging where the signing state lives: it is exercised through the raw
-cffi bindings, and this test doubles as the usage example the README
-points at.
+`musig` has its own tests, in `tests/test_musig.py`: it is the one
+module here that holds state across calls, which is a different shape
+of test from the other three, one call each against an equation checked
+another way.
 """
 
 from __future__ import annotations
@@ -25,19 +24,16 @@ import pytest
 
 from btclib_secp256k1 import (
     _secret,
-    context,
     dsa,
     ecdh,
     ellswift,
     ffi,
     keys,
-    lib,
     recovery,
     silentpayments,
     ssa,
     xonly,
 )
-from btclib_secp256k1.context import ctx
 
 msg = hashlib.sha256(b"btclib_secp256k1").digest()
 
@@ -223,93 +219,6 @@ def test_ellswift_invalid_inputs() -> None:
         ellswift.xdh(ell, ell, 11, 2)
     with pytest.raises(ValueError, match="private key"):
         ellswift.xdh(ell, ell, 0, 0)
-
-
-def test_musig() -> None:
-    """Run a 2-of-2 MuSig2 signing session, then verify it with ssa."""
-    prvkeys = [(1).to_bytes(32, "big"), (2).to_bytes(32, "big")]
-
-    keypairs, pubkeys = [], []
-    for prvkey in prvkeys:
-        keypair = ffi.new("secp256k1_keypair *")
-        assert lib.secp256k1_keypair_create(ctx, keypair, prvkey)
-        pubkey = ffi.new("secp256k1_pubkey *")
-        assert lib.secp256k1_keypair_pub(ctx, pubkey, keypair)
-        keypairs.append(keypair)
-        pubkeys.append(pubkey)
-
-    # key aggregation
-    keyagg_cache = ffi.new("secp256k1_musig_keyagg_cache *")
-    agg_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    assert lib.secp256k1_musig_pubkey_agg(
-        ctx, agg_pubkey, keyagg_cache, ffi.new("secp256k1_pubkey *[]", pubkeys), 2
-    )
-
-    # nonce generation, first round
-    secnonces, pubnonces = [], []
-    for i, prvkey in enumerate(prvkeys):
-        secnonce = ffi.new("secp256k1_musig_secnonce *")
-        pubnonce = ffi.new("secp256k1_musig_pubnonce *")
-        # the session randomness is zeroed by the call
-        session_secrand = ffi.new("char[32]", bytes([i + 10]) * 32)
-        assert lib.secp256k1_musig_nonce_gen(
-            ctx,
-            secnonce,
-            pubnonce,
-            session_secrand,
-            prvkey,
-            pubkeys[i],
-            msg,
-            keyagg_cache,
-            ffi.NULL,
-        )
-        secnonces.append(secnonce)
-        pubnonces.append(pubnonce)
-
-    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
-    assert lib.secp256k1_musig_nonce_agg(
-        ctx, aggnonce, ffi.new("secp256k1_musig_pubnonce *[]", pubnonces), 2
-    )
-
-    # partial signatures, second round
-    session = ffi.new("secp256k1_musig_session *")
-    assert lib.secp256k1_musig_nonce_process(ctx, session, aggnonce, msg, keyagg_cache)
-
-    partial_sigs = []
-    for i in range(2):
-        partial_sig = ffi.new("secp256k1_musig_partial_sig *")
-        assert lib.secp256k1_musig_partial_sign(
-            ctx, partial_sig, secnonces[i], keypairs[i], keyagg_cache, session
-        )
-        assert lib.secp256k1_musig_partial_sig_verify(
-            ctx, partial_sig, pubnonces[i], pubkeys[i], keyagg_cache, session
-        )
-        partial_sigs.append(partial_sig)
-
-    sig = ffi.new("char[64]")
-    assert lib.secp256k1_musig_partial_sig_agg(
-        ctx,
-        sig,
-        session,
-        ffi.new("secp256k1_musig_partial_sig *[]", partial_sigs),
-        2,
-    )
-
-    # the aggregate signature is a plain BIP340 one, for the aggregate key
-    xonly_bytes = ffi.new("char[32]")
-    assert lib.secp256k1_xonly_pubkey_serialize(ctx, xonly_bytes, agg_pubkey)
-    pubkey_bytes = ffi.unpack(xonly_bytes, 32)
-    assert ssa.verify(msg, pubkey_bytes, ffi.unpack(sig, 64))
-
-    # signing zeroed the secret nonces, so signing again with one of them
-    # is refused: the whole point of the session, and the reason a call
-    # made through lib is worth following with context.check(), which
-    # turns the bare 0 into what libsecp256k1 has to say about it
-    assert not lib.secp256k1_musig_partial_sign(
-        ctx, partial_sigs[0], secnonces[0], keypairs[0], keyagg_cache, session
-    )
-    with pytest.raises(ValueError, match="secnonce_magic"):
-        context.check()
 
 
 def test_size_checks_refuse_both_sides() -> None:

--- a/tests/test_musig.py
+++ b/tests/test_musig.py
@@ -1,0 +1,415 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""`musig` holds state, which is the one thing the other modules do not.
+
+`tests/test_vectors.py` holds `musig` to BIP327's own vectors, case by
+case; what is left for this file is what a vector cannot state, the same
+split `tests/test_signer.py` makes for `ssa.Signer`: the lifetime the
+three classes hand the caller. `KeyAggCache` and `Session` hold nothing
+secret, so what is asserted of them here is the shape of a session end
+to end, and that a bad contribution to `pubkey_agg`, `nonce_agg` or
+`partial_sig_agg` is named by its position. `SecretNonce` does hold a
+secret, and what is asserted of it is `wipe`'s cases -- overwritten,
+consumed by `partial_sign`, wiped twice, dropped -- the same shape
+`tests/test_signer.py` holds `ssa.Signer` to, and for the reason
+SECURITY.md gives: this is the second buffer in the package whose
+zeroing is asked for rather than done.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+
+import pytest
+
+from btclib_secp256k1 import ffi, keys, lib, musig, ssa
+from btclib_secp256k1.context import check, ctx
+
+PRVKEYS = [(1).to_bytes(32, "big"), (2).to_bytes(32, "big")]
+PUBKEYS = [keys.pubkey_from_prvkey(prvkey) for prvkey in PRVKEYS]
+MSG = hashlib.sha256(b"btclib_secp256k1 musig").digest()
+
+
+def secnonce_memory(secnonce: musig.SecretNonce) -> bytes:
+    """Return the octets of the secret nonce a `SecretNonce` holds.
+
+    Reaching into the object is the only way to ask, exactly as
+    `tests/test_signer.py`'s `keypair_memory` does for `ssa.Signer`.
+
+    Args:
+        secnonce: the secret nonce to look inside.
+
+    Returns:
+        The 132 octets of the `secp256k1_musig_secnonce`, or an empty
+        bytes once it has been wiped or spent.
+    """
+    held = secnonce._secnonce
+    return b"" if held is None else bytes(ffi.buffer(held))
+
+
+def two_of_two_session() -> tuple[
+    musig.KeyAggCache, list[musig.SecretNonce], musig.Session
+]:
+    """Build a 2-of-2 key aggregation, nonces and session, up to round two.
+
+    Returns:
+        The key aggregation, one `SecretNonce` per signer in `PRVKEYS`
+        order, and the session `partial_sign` and `partial_sig_verify`
+        are checked against.
+    """
+    cache = musig.KeyAggCache(PUBKEYS)
+    secnonces = [
+        musig.nonce_gen(pubkey, prvkey, msg32=MSG, keyagg_cache=cache)
+        for prvkey, pubkey in zip(PRVKEYS, PUBKEYS, strict=True)
+    ]
+    aggnonce = musig.nonce_agg([secnonce.pubnonce for secnonce in secnonces])
+    session = musig.Session(aggnonce, MSG, cache)
+    return cache, secnonces, session
+
+
+def test_a_2_of_2_session_signs_and_verifies() -> None:
+    """The usage example: aggregate, two rounds, and a plain BIP340 check.
+
+    Every partial signature is checked with `partial_sig_verify` before
+    aggregating, which a regular session does not need -- the module
+    docstring says why it is worth doing anyway -- and the aggregate
+    verifies under `KeyAggCache.agg_pubkey` exactly as BIP327 says it
+    must, `ssa.verify` being the whole of the check: nothing in `musig`
+    reimplements it.
+    """
+    cache, secnonces, session = two_of_two_session()
+    pubnonces = [secnonce.pubnonce for secnonce in secnonces]
+
+    partial_sigs = [
+        secnonce.partial_sign(prvkey, cache, session)
+        for secnonce, prvkey in zip(secnonces, PRVKEYS, strict=True)
+    ]
+    for partial_sig, pubnonce, pubkey in zip(
+        partial_sigs, pubnonces, PUBKEYS, strict=True
+    ):
+        assert session.partial_sig_verify(partial_sig, pubnonce, pubkey, cache)
+
+    signature = session.partial_sig_agg(partial_sigs)
+    assert len(signature) == 64
+    assert ssa.verify(MSG, cache.agg_pubkey, signature)
+
+
+def test_partial_sign_without_verify_answers_the_same_signature() -> None:
+    """`verify=False` skips the check and not the arithmetic.
+
+    `secp256k1_musig_partial_sign` does not verify on its own -- the
+    module docstring quotes the header on it -- so what `verify=True`
+    adds on top is a call and not a different signature: the same
+    secnonce, signed unverified, answers what `nonce_process` over the
+    same aggregate nonce and message always would.
+    """
+    cache, secnonces, session = two_of_two_session()
+    unverified = secnonces[0].partial_sign(PRVKEYS[0], cache, session, verify=False)
+    assert session.partial_sig_verify(
+        unverified, secnonces[0].pubnonce, PUBKEYS[0], cache
+    )
+
+
+def test_key_agg_cache_requires_at_least_one_key() -> None:
+    """An empty sequence has no aggregate to compute."""
+    with pytest.raises(ValueError, match="at least one public key"):
+        musig.KeyAggCache([])
+
+
+def test_key_agg_cache_reports_which_key_failed_to_parse() -> None:
+    """The index of the bad key, not just that the aggregation failed.
+
+    `secp256k1_musig_pubkey_agg` answers a bare 0 for it, the module
+    docstring's own point about a parse failure telling this package
+    nothing: the index is only available because `KeyAggCache` parses
+    each contribution itself, under its own name.
+    """
+    with pytest.raises(ValueError, match="public key at index 1"):
+        musig.KeyAggCache([PUBKEYS[0], b"\x00" * 33])
+
+
+def test_nonce_agg_requires_at_least_one_pubnonce() -> None:
+    """An empty sequence has no aggregate to compute."""
+    with pytest.raises(ValueError, match="at least one public nonce"):
+        musig.nonce_agg([])
+
+
+def test_nonce_agg_reports_which_pubnonce_failed_to_parse() -> None:
+    """The index of the bad nonce, as the key aggregation test has above."""
+    _cache, secnonces, _session = two_of_two_session()
+    with pytest.raises(ValueError, match="public nonce at index 1"):
+        musig.nonce_agg([secnonces[0].pubnonce, bytes(66)])
+
+
+def test_partial_sig_agg_requires_at_least_one_signature() -> None:
+    """An empty sequence has no signature to aggregate."""
+    _cache, _secnonces, session = two_of_two_session()
+    with pytest.raises(ValueError, match="at least one partial signature"):
+        session.partial_sig_agg([])
+
+
+def test_partial_sig_agg_reports_which_signature_failed_to_parse() -> None:
+    """The index of the bad signature, for the reason the two tests above have.
+
+    32 octets above the curve order are what `partial_sig_parse` refuses:
+    zero, and every other value below the order, parses fine and is
+    caught only by `partial_sig_verify`, if at all.
+    """
+    cache, secnonces, session = two_of_two_session()
+    good = secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+    with pytest.raises(ValueError, match="partial signature at index 1"):
+        session.partial_sig_agg([good, b"\xff" * 32])
+
+
+def test_key_agg_cache_tweaks_leave_agg_pubkey_alone() -> None:
+    """`agg_pubkey` is BIP327's `Q`, fixed at construction, tweaks or not.
+
+    `pubkey_get` is the current state instead, so the two answer
+    differently once a tweak lands.
+    """
+    tweak = hashlib.sha256(b"btclib_secp256k1 musig tweak").digest()
+    ec_cache = musig.KeyAggCache(PUBKEYS)
+    before = ec_cache.agg_pubkey
+    untweaked = ec_cache.pubkey_get()
+
+    ec_tweaked = ec_cache.pubkey_ec_tweak_add(tweak)
+    assert ec_cache.agg_pubkey == before
+    assert ec_cache.pubkey_get() == ec_tweaked
+    assert ec_tweaked != untweaked
+
+    xonly_cache = musig.KeyAggCache(PUBKEYS)
+    xonly_tweaked = xonly_cache.pubkey_xonly_tweak_add(tweak)
+    assert xonly_cache.agg_pubkey == before
+    assert xonly_tweaked != untweaked
+
+
+def test_key_agg_cache_tweak_add_refuses_an_invalid_tweak() -> None:
+    """A tweak that is the wrong length, or does not fit in 32 bytes."""
+    cache = musig.KeyAggCache(PUBKEYS)
+    with pytest.raises(ValueError, match="32 bytes"):
+        cache.pubkey_ec_tweak_add(b"\x01" * 31)
+    # 2**256 - 1, above the curve order: not a valid scalar
+    with pytest.raises(ValueError, match="invalid tweak"):
+        cache.pubkey_xonly_tweak_add(b"\xff" * 32)
+
+
+def test_session_refuses_an_invalid_aggregate_nonce() -> None:
+    """A wrong-length or unparsable aggregate nonce is refused at the parse."""
+    cache = musig.KeyAggCache(PUBKEYS)
+    with pytest.raises(ValueError, match="66 bytes"):
+        musig.Session(bytes(65), MSG, cache)
+    # 0x02 names no valid point at x = 0
+    with pytest.raises(ValueError, match="invalid aggregate nonce"):
+        musig.Session(b"\x02" + bytes(65), MSG, cache)
+
+
+def test_session_refuses_a_message_of_the_wrong_length() -> None:
+    """`nonce_process` signs a 32-byte message, `msg32` being its own name."""
+    cache, secnonces, _session = two_of_two_session()
+    aggnonce = musig.nonce_agg([secnonce.pubnonce for secnonce in secnonces])
+    with pytest.raises(ValueError, match="message"):
+        musig.Session(aggnonce, MSG + b"\x00", cache)
+
+
+def test_partial_sig_verify_answers_false_for_a_wrong_signature() -> None:
+    """A partial signature attributed to the wrong signer does not verify.
+
+    Not required in a regular session, the module docstring's own words:
+    what this checks is that a caller who does ask gets a verdict rather
+    than an exception for octets that parse fine and simply are not the
+    right answer.
+    """
+    cache, secnonces, session = two_of_two_session()
+    sig0 = secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+    assert not session.partial_sig_verify(
+        sig0, secnonces[1].pubnonce, PUBKEYS[1], cache
+    )
+
+
+def test_partial_sign_refuses_a_mismatched_private_key() -> None:
+    """A secnonce signs only for the keypair `nonce_gen` built it for.
+
+    libsecp256k1 checks the match through an ARG_CHECK and reports a
+    bare 0 for it, which is conflated here with every other reason
+    `partial_sign` can fail -- the module docstring's own point about a
+    wrapper unable to tell them apart. What is asserted is that it is
+    refused, and that the secret nonce is spent regardless, as it is for
+    a signature that succeeds.
+    """
+    cache, secnonces, session = two_of_two_session()
+    with pytest.raises(ValueError, match="do not match this secret nonce"):
+        secnonces[0].partial_sign(PRVKEYS[1], cache, session)
+    assert secnonce_memory(secnonces[0]) == b""
+    # the mismatch is an ARG_CHECK, so it recorded an illegal argument on
+    # this thread that nothing here read: drained so it is not raised by
+    # a later, unrelated call to context.check(), as its own docstring
+    # asks of a caller reaching an ARG_CHECK through anything but `lib`
+    with pytest.raises(ValueError, match="secp256k1_fe_equal"):
+        check()
+    check()  # and now the thread is clean
+
+
+def test_a_wiped_secret_nonce_refuses_to_sign() -> None:
+    """Rather than signing with the zeros the wipe left."""
+    cache, secnonces, session = two_of_two_session()
+    secnonces[0].wipe()
+    with pytest.raises(ValueError, match="wiped or already spent"):
+        secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+
+
+def test_wipe_overwrites_the_secret_nonce() -> None:
+    """The secret is in there until `wipe`, and gone after it."""
+    secnonce = musig.nonce_gen(PUBKEYS[0], PRVKEYS[0])
+    assert secnonce_memory(secnonce) != b""
+
+    secnonce.wipe()
+    assert secnonce_memory(secnonce) == b""
+
+
+def test_partial_sign_wipes_the_secret_nonce_it_spends() -> None:
+    """`partial_sign` wipes on the way out, whether it signs or is refused."""
+    cache, secnonces, session = two_of_two_session()
+    secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+    assert secnonce_memory(secnonces[0]) == b""
+
+
+def test_the_with_block_wipes_whatever_ended_it() -> None:
+    """A signature, and an exception, leave the same wiped secret nonce."""
+    cache, secnonces, session = two_of_two_session()
+    with secnonces[0] as secnonce:
+        secnonce.partial_sign(PRVKEYS[0], cache, session)
+    assert secnonce_memory(secnonces[0]) == b""
+
+    raising = musig.nonce_gen(PUBKEYS[0], PRVKEYS[0])
+    with pytest.raises(ValueError, match="what the block raised"), raising:
+        raise ValueError("what the block raised")
+    assert secnonce_memory(raising) == b""
+
+
+def test_wiping_twice_is_not_an_error() -> None:
+    """Signing consumes it, and wiping afterwards is not a mistake to report."""
+    cache, secnonces, session = two_of_two_session()
+    with secnonces[0] as secnonce:
+        secnonce.partial_sign(PRVKEYS[0], cache, session)
+    secnonces[0].wipe()
+    assert secnonce_memory(secnonces[0]) == b""
+
+
+def test_a_dropped_secret_nonce_leaves_the_memory_as_it_was() -> None:
+    """Nothing wipes behind a caller who neither wipes nor uses `with`.
+
+    SECURITY.md names this as the second buffer of the package whose
+    zeroing is asked for rather than done, and this is that sentence as
+    an assertion, matching `tests/test_signer.py`'s own for `ssa.Signer`.
+    """
+    secnonce = musig.nonce_gen(PUBKEYS[0], PRVKEYS[0])
+    # kept alive here, and by nothing else once the secnonce is dropped
+    held = secnonce._secnonce
+    assert held is not None
+    before = bytes(ffi.buffer(held))
+    assert before != bytes(len(before))
+
+    del secnonce
+    gc.collect()  # refcounting has dropped it already; PyPy needs asking
+
+    assert bytes(ffi.buffer(held)) == before
+
+
+def test_nonce_gen_needs_only_a_public_key() -> None:
+    """Every other argument is optional, and folds into the derivation."""
+    secnonce = musig.nonce_gen(PUBKEYS[0])
+    assert len(secnonce.pubnonce) == 66
+    secnonce.wipe()
+
+
+def test_nonce_gen_refuses_an_invalid_public_key() -> None:
+    """The public key is parsed before any secret is generated."""
+    with pytest.raises(ValueError, match="public key"):
+        musig.nonce_gen(bytes(33))
+
+
+# secp256k1 group order
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+@pytest.mark.parametrize("prvkey", [0, N])
+def test_nonce_gen_refuses_a_private_key_out_of_range(prvkey: int) -> None:
+    """The one way `secp256k1_musig_nonce_gen` can fail given valid octets.
+
+    The public key, the message and the key aggregation cache are all
+    already-proved objects by the time they reach it; the private key,
+    given as octets rather than parsed, is the one argument libsecp256k1
+    still checks for itself, `secp256k1_scalar_set_b32_seckey` rejecting
+    zero and the group order the same way `keys.prvkey_verify` does.
+    """
+    with pytest.raises(ValueError, match="private key"):
+        musig.nonce_gen(PUBKEYS[0], prvkey)
+
+
+def test_nonce_gen_counter_needs_a_private_key_and_a_counter() -> None:
+    """The alternative to `nonce_gen`, for a signer counting instead of asking.
+
+    Unlike `nonce_gen`, the private key is mandatory here: the counter's
+    uniqueness is a property of the key it counts for.
+    """
+    secnonce = musig.nonce_gen_counter(PRVKEYS[0], 0)
+    assert len(secnonce.pubnonce) == 66
+    secnonce.wipe()
+
+    # a second call with the same key and counter is exactly what the
+    # counter exists to prevent, and nothing here can catch it: this
+    # package validates arguments, not the caller's bookkeeping. What is
+    # checked is only the bound on the counter itself
+    with pytest.raises(ValueError, match="nonrepeating_cnt"):
+        musig.nonce_gen_counter(PRVKEYS[0], -1)
+    with pytest.raises(ValueError, match="nonrepeating_cnt"):
+        musig.nonce_gen_counter(PRVKEYS[0], 2**64)
+    with pytest.raises(TypeError, match="nonrepeating_cnt"):
+        musig.nonce_gen_counter(PRVKEYS[0], 1.0)  # type: ignore[arg-type]
+
+
+def test_pubnonce_aggnonce_and_partial_sig_round_trip() -> None:
+    """`parse` and `serialize` answer each other, for all three types."""
+    cache, secnonces, session = two_of_two_session()
+    pubnonce = musig.pubnonce_parse(secnonces[0].pubnonce)
+    assert musig.pubnonce_serialize(pubnonce) == secnonces[0].pubnonce
+
+    aggnonce_bytes = musig.nonce_agg([s.pubnonce for s in secnonces])
+    aggnonce = musig.aggnonce_parse(aggnonce_bytes)
+    assert musig.aggnonce_serialize(aggnonce) == aggnonce_bytes
+
+    partial_sig_bytes = secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+    partial_sig = musig.partial_sig_parse(partial_sig_bytes)
+    assert musig.partial_sig_serialize(partial_sig) == partial_sig_bytes
+
+
+def test_a_call_made_through_lib_reports_through_context_check() -> None:
+    """The raw path the README documents beside `musig`'s own wrapping.
+
+    `musig.SecretNonce.partial_sign` answers its own `ValueError` for a
+    reused secret nonce, having no illegal callback to read; a caller
+    reaching `lib` directly instead gets a bare 0 and reads why with
+    `context.check()`, which is what this reproduces.
+    """
+    cache, secnonces, session = two_of_two_session()
+    secnonce = secnonces[0]._secnonce
+    keypair = ffi.new("secp256k1_keypair *")
+    assert lib.secp256k1_keypair_create(ctx, keypair, PRVKEYS[0])
+    partial_sig = ffi.new("secp256k1_musig_partial_sig *")
+    assert lib.secp256k1_musig_partial_sign(
+        ctx, partial_sig, secnonce, keypair, cache._cache_(), session._session_()
+    )
+    secnonces[0]._secnonce = None  # the C call already zeroed it
+
+    # signing again with the same (now zeroed) secnonce is refused, and
+    # named: this is the failed magic check context.py's own docstring
+    # names as the example
+    assert not lib.secp256k1_musig_partial_sign(
+        ctx, partial_sig, secnonce, keypair, cache._cache_(), session._session_()
+    )
+    with pytest.raises(ValueError, match="secnonce_magic"):
+        check()

--- a/tests/test_musig.py
+++ b/tests/test_musig.py
@@ -253,6 +253,29 @@ def test_partial_sign_refuses_a_mismatched_private_key() -> None:
     check()  # and now the thread is clean
 
 
+def test_partial_sign_wipes_the_secret_nonce_even_when_keypair_raises() -> None:
+    """A private key `keypair` refuses spends the nonce just the same.
+
+    `keypair(prvkey)` is the one fallible step of `partial_sign` that
+    runs before libsecp256k1 ever sees the secret nonce -- an ordinary,
+    documented failure, a caller's malformed or out-of-range private key
+    -- and the class docstring's guarantee does not carve out an
+    exception for it: "whatever the outcome... the secret nonce this
+    holds does not survive the call." What is asserted is that same
+    triple as the mismatch test above, for a refusal that happens before
+    the C call rather than inside it: the exception, the zeroed memory,
+    and a `SecretNonce` that refuses to sign again rather than being
+    retried with a corrected key -- which is the nonce reuse this class
+    exists to refuse in the first place.
+    """
+    cache, secnonces, session = two_of_two_session()
+    with pytest.raises(ValueError, match="private key"):
+        secnonces[0].partial_sign(0, cache, session)
+    assert secnonce_memory(secnonces[0]) == b""
+    with pytest.raises(ValueError, match="wiped or already spent"):
+        secnonces[0].partial_sign(PRVKEYS[0], cache, session)
+
+
 def test_a_wiped_secret_nonce_refuses_to_sign() -> None:
     """Rather than signing with the zeros the wipe left."""
     cache, secnonces, session = two_of_two_session()

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -56,17 +56,15 @@ from typing import Any
 import pytest
 
 from btclib_secp256k1 import (
-    CData,
     dsa,
     ellswift,
-    ffi,
     keys,
-    lib,
+    musig,
     recovery,
     silentpayments,
     ssa,
+    xonly,
 )
-from btclib_secp256k1.context import ctx
 
 # secp256k1 group order
 N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
@@ -271,66 +269,32 @@ def bip327_vectors(name: str) -> dict[str, Any]:
         return loaded
 
 
-def musig_pubkey(serialized: str) -> CData | None:
-    """Parse a public key of a BIP327 vector, None where it is refused."""
-    pubkey = ffi.new("secp256k1_pubkey *")
-    data = bytes.fromhex(serialized)
-    if not lib.secp256k1_ec_pubkey_parse(ctx, pubkey, data, len(data)):
-        return None
-    return pubkey
-
-
-def musig_pubnonce(serialized: str) -> CData | None:
-    """Parse a 66-byte public nonce, None where it is refused."""
-    pubnonce = ffi.new("secp256k1_musig_pubnonce *")
-    if not lib.secp256k1_musig_pubnonce_parse(ctx, pubnonce, bytes.fromhex(serialized)):
-        return None
-    return pubnonce
-
-
-def musig_partial_sig(serialized: str) -> CData | None:
-    """Parse a 32-byte partial signature, None where it is refused."""
-    partial_sig = ffi.new("secp256k1_musig_partial_sig *")
-    data = bytes.fromhex(serialized)
-    if not lib.secp256k1_musig_partial_sig_parse(ctx, partial_sig, data):
-        return None
-    return partial_sig
-
-
 def musig_keyagg(
-    pubkeys: list[CData], tweaks: list[tuple[bytes, bool]]
-) -> CData | None:
+    pubkeys_hex: list[str], tweaks: list[tuple[bytes, bool]]
+) -> musig.KeyAggCache | None:
     """Aggregate keys and apply the tweaks, None where a step is refused.
 
-    Returns the keyagg cache, which is what every later call reads.
+    Returns the key aggregation, which is what every later call reads.
+    A vector's own error cases do not say which step failed -- an
+    unparsable key or an out-of-range tweak are one refusal in the
+    reference implementation -- so neither is told apart here either.
     """
-    cache = ffi.new("secp256k1_musig_keyagg_cache *")
-    aggregate = ffi.new("secp256k1_xonly_pubkey *")
-    if not lib.secp256k1_musig_pubkey_agg(
-        ctx, aggregate, cache, ffi.new("secp256k1_pubkey *[]", pubkeys), len(pubkeys)
-    ):
+    try:
+        cache = musig.KeyAggCache([bytes.fromhex(pubkey) for pubkey in pubkeys_hex])
+        for tweak, is_xonly in tweaks:
+            if is_xonly:
+                cache.pubkey_xonly_tweak_add(tweak)
+            else:
+                cache.pubkey_ec_tweak_add(tweak)
+    except ValueError:
         return None
-    for tweak, is_xonly in tweaks:
-        tweak_add = (
-            lib.secp256k1_musig_pubkey_xonly_tweak_add
-            if is_xonly
-            else lib.secp256k1_musig_pubkey_ec_tweak_add
-        )
-        if not tweak_add(ctx, ffi.NULL, cache, tweak):
-            return None
     return cache
 
 
-def musig_xonly(cache: CData) -> str:
+def musig_xonly(cache: musig.KeyAggCache) -> str:
     """Serialize the aggregate key of a cache, as BIP327 writes it."""
-    pubkey = ffi.new("secp256k1_pubkey *")
-    assert lib.secp256k1_musig_pubkey_get(ctx, pubkey, cache)
-    xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
-    parity = ffi.new("int *")
-    assert lib.secp256k1_xonly_pubkey_from_pubkey(ctx, xonly_pubkey, parity, pubkey)
-    output = ffi.new("char[32]")
-    assert lib.secp256k1_xonly_pubkey_serialize(ctx, output, xonly_pubkey)
-    return ffi.unpack(output, 32).hex().upper()
+    pubkey_bytes = cache.pubkey_get(compressed=False)
+    return xonly.from_pubkey(pubkey_bytes)[0].hex().upper()
 
 
 def musig_tweaks(
@@ -343,14 +307,6 @@ def musig_tweaks(
             case.get("tweak_indices", []), case.get("is_xonly", []), strict=True
         )
     ]
-
-
-def musig_session(cache: CData, aggnonce: CData, msg: bytes) -> CData:
-    """Start the signing session a partial signature is made or checked in."""
-    assert len(msg) == 32, "libsecp256k1 signs a 32-byte message"
-    session = ffi.new("secp256k1_musig_session *")
-    assert lib.secp256k1_musig_nonce_process(ctx, session, aggnonce, msg, cache)
-    return session
 
 
 KEY_AGG = bip327_vectors("key_agg")
@@ -375,15 +331,16 @@ SIGNABLE = [
 def test_bip327_key_agg_vector(case: dict[str, Any]) -> None:
     """Aggregate the keys of one BIP327 vector into the key it publishes.
 
-    The MuSig2 test in test_modules.py verifies an aggregate signature
-    against an aggregate key these bindings computed, which is a round
-    trip: a wrong-but-self-consistent aggregation passes it. This is the
+    `tests/test_musig.py` verifies an aggregate signature against an
+    aggregate key `musig.KeyAggCache` computed, which is a round trip: a
+    wrong-but-self-consistent aggregation passes it. This is the
     aggregation itself, against the published value -- the coefficients,
     the ordering, and the second-key special case among them.
     """
-    pubkeys = [musig_pubkey(KEY_AGG["pubkeys"][i]) for i in case["key_indices"]]
-    assert None not in pubkeys
-    cache = musig_keyagg(pubkeys, musig_tweaks(KEY_AGG, case))
+    cache = musig_keyagg(
+        [KEY_AGG["pubkeys"][i] for i in case["key_indices"]],
+        musig_tweaks(KEY_AGG, case),
+    )
     assert cache is not None
     assert musig_xonly(cache) == case["expected"]
 
@@ -399,10 +356,13 @@ def test_bip327_key_agg_error_vector(case: dict[str, Any]) -> None:
     implementation reports both as one error. What is pinned is that
     nothing comes out the other end.
     """
-    pubkeys = [musig_pubkey(KEY_AGG["pubkeys"][i]) for i in case["key_indices"]]
-    if None in pubkeys:
-        return
-    assert musig_keyagg(pubkeys, musig_tweaks(KEY_AGG, case)) is None
+    assert (
+        musig_keyagg(
+            [KEY_AGG["pubkeys"][i] for i in case["key_indices"]],
+            musig_tweaks(KEY_AGG, case),
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -410,21 +370,8 @@ def test_bip327_key_agg_error_vector(case: dict[str, Any]) -> None:
 )
 def test_bip327_nonce_agg_vector(case: dict[str, Any]) -> None:
     """Aggregate public nonces into the 66 bytes BIP327 publishes."""
-    pubnonces = [
-        musig_pubnonce(NONCE_AGG["pnonces"][i]) for i in case["pnonce_indices"]
-    ]
-    assert None not in pubnonces
-
-    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
-    assert lib.secp256k1_musig_nonce_agg(
-        ctx,
-        aggnonce,
-        ffi.new("secp256k1_musig_pubnonce *[]", pubnonces),
-        len(pubnonces),
-    )
-    serialized = ffi.new("char[66]")
-    assert lib.secp256k1_musig_aggnonce_serialize(ctx, serialized, aggnonce)
-    assert ffi.unpack(serialized, 66).hex().upper() == case["expected"]
+    pubnonces = [bytes.fromhex(NONCE_AGG["pnonces"][i]) for i in case["pnonce_indices"]]
+    assert musig.nonce_agg(pubnonces).hex().upper() == case["expected"]
 
 
 @pytest.mark.parametrize(
@@ -432,10 +379,9 @@ def test_bip327_nonce_agg_vector(case: dict[str, Any]) -> None:
 )
 def test_bip327_nonce_agg_error_vector(case: dict[str, Any]) -> None:
     """Refuse a public nonce BIP327 says is invalid, at the parse."""
-    pubnonces = [
-        musig_pubnonce(NONCE_AGG["pnonces"][i]) for i in case["pnonce_indices"]
-    ]
-    assert None in pubnonces
+    pubnonces = [bytes.fromhex(NONCE_AGG["pnonces"][i]) for i in case["pnonce_indices"]]
+    with pytest.raises(ValueError, match="public nonce"):
+        musig.nonce_agg(pubnonces)
 
 
 @pytest.mark.parametrize("case", SIGNABLE, ids=lambda c: c["expected"][:8])
@@ -451,22 +397,21 @@ def test_bip327_partial_sig_verify_vector(case: dict[str, Any]) -> None:
     nonce and public key only if the coefficients, the aggregate nonce
     and the challenge are the ones BIP327 defines.
     """
-    pubkeys = [musig_pubkey(SIGN_VERIFY["pubkeys"][i]) for i in case["key_indices"]]
-    assert None not in pubkeys
+    pubkeys = [SIGN_VERIFY["pubkeys"][i] for i in case["key_indices"]]
     cache = musig_keyagg(pubkeys, [])
     assert cache is not None
 
-    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
     aggnonce_bytes = bytes.fromhex(SIGN_VERIFY["aggnonces"][case["aggnonce_index"]])
-    assert lib.secp256k1_musig_aggnonce_parse(ctx, aggnonce, aggnonce_bytes)
     msg = bytes.fromhex(SIGN_VERIFY["msgs"][case["msg_index"]])
-    session = musig_session(cache, aggnonce, msg)
+    session = musig.Session(aggnonce_bytes, msg, cache)
 
     signer = case["signer_index"]
-    pubnonce = musig_pubnonce(SIGN_VERIFY["pnonces"][case["nonce_indices"][signer]])
-    partial_sig = musig_partial_sig(case["expected"])
-    assert lib.secp256k1_musig_partial_sig_verify(
-        ctx, partial_sig, pubnonce, pubkeys[signer], cache, session
+    pubnonce_bytes = bytes.fromhex(
+        SIGN_VERIFY["pnonces"][case["nonce_indices"][signer]]
+    )
+    partial_sig_bytes = bytes.fromhex(case["expected"])
+    assert session.partial_sig_verify(
+        partial_sig_bytes, pubnonce_bytes, bytes.fromhex(pubkeys[signer]), cache
     )
 
 
@@ -475,32 +420,30 @@ def test_bip327_partial_sig_verify_vector(case: dict[str, Any]) -> None:
 )
 def test_bip327_partial_sig_verify_fail_vector(case: dict[str, Any]) -> None:
     """Refuse a partial signature BIP327 says does not verify."""
-    pubkeys = [musig_pubkey(SIGN_VERIFY["pubkeys"][i]) for i in case["key_indices"]]
-    assert None not in pubkeys
+    pubkeys = [SIGN_VERIFY["pubkeys"][i] for i in case["key_indices"]]
     cache = musig_keyagg(pubkeys, [])
     assert cache is not None
 
     pubnonces = [
-        musig_pubnonce(SIGN_VERIFY["pnonces"][i]) for i in case["nonce_indices"]
+        bytes.fromhex(SIGN_VERIFY["pnonces"][i]) for i in case["nonce_indices"]
     ]
-    assert None not in pubnonces
-    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
-    assert lib.secp256k1_musig_nonce_agg(
-        ctx,
-        aggnonce,
-        ffi.new("secp256k1_musig_pubnonce *[]", pubnonces),
-        len(pubnonces),
-    )
+    aggnonce = musig.nonce_agg(pubnonces)
     msg = bytes.fromhex(SIGN_VERIFY["msgs"][case["msg_index"]])
-    session = musig_session(cache, aggnonce, msg)
+    session = musig.Session(aggnonce, msg, cache)
 
     signer = case["signer_index"]
-    partial_sig = musig_partial_sig(case["sig"])
     # a signature out of range is refused by the parse; one in range and
     # wrong, by the verification
-    assert partial_sig is None or not lib.secp256k1_musig_partial_sig_verify(
-        ctx, partial_sig, pubnonces[signer], pubkeys[signer], cache, session
-    )
+    try:
+        verified = session.partial_sig_verify(
+            bytes.fromhex(case["sig"]),
+            pubnonces[signer],
+            bytes.fromhex(pubkeys[signer]),
+            cache,
+        )
+    except ValueError:
+        return
+    assert not verified
 
 
 @pytest.mark.parametrize(
@@ -514,45 +457,40 @@ def test_bip327_sig_agg_vector(case: dict[str, Any]) -> None:
     aggregate signature through the session, and an aggregation that got
     it wrong would still produce something self-consistent.
     """
-    pubkeys = [musig_pubkey(SIG_AGG["pubkeys"][i]) for i in case["key_indices"]]
-    assert None not in pubkeys
-    cache = musig_keyagg(pubkeys, musig_tweaks(SIG_AGG, case))
+    cache = musig_keyagg(
+        [SIG_AGG["pubkeys"][i] for i in case["key_indices"]],
+        musig_tweaks(SIG_AGG, case),
+    )
     assert cache is not None
 
-    aggnonce = ffi.new("secp256k1_musig_aggnonce *")
-    assert lib.secp256k1_musig_aggnonce_parse(
-        ctx, aggnonce, bytes.fromhex(case["aggnonce"])
-    )
+    aggnonce_bytes = bytes.fromhex(case["aggnonce"])
     msg = bytes.fromhex(SIG_AGG["msg"])
-    session = musig_session(cache, aggnonce, msg)
+    session = musig.Session(aggnonce_bytes, msg, cache)
 
-    partial_sigs = [
-        musig_partial_sig(SIG_AGG["psigs"][i]) for i in case["psig_indices"]
-    ]
-    assert None not in partial_sigs
-    signature = ffi.new("char[64]")
-    assert lib.secp256k1_musig_partial_sig_agg(
-        ctx,
-        signature,
-        session,
-        ffi.new("secp256k1_musig_partial_sig *[]", partial_sigs),
-        len(partial_sigs),
-    )
-    aggregate = ffi.unpack(signature, 64)
-    assert aggregate.hex().upper() == case["expected"]
+    partial_sigs = [bytes.fromhex(SIG_AGG["psigs"][i]) for i in case["psig_indices"]]
+    signature = session.partial_sig_agg(partial_sigs)
+    assert signature.hex().upper() == case["expected"]
     # and it is a BIP340 signature of the aggregate key, tweaks included
-    assert ssa.verify(msg, bytes.fromhex(musig_xonly(cache)), aggregate)
+    assert ssa.verify(msg, bytes.fromhex(musig_xonly(cache)), signature)
 
 
 @pytest.mark.parametrize(
     "case", SIG_AGG["error_test_cases"], ids=lambda c: c["comment"]
 )
 def test_bip327_sig_agg_error_vector(case: dict[str, Any]) -> None:
-    """Refuse a partial signature BIP327 says cannot be aggregated."""
-    partial_sigs = [
-        musig_partial_sig(SIG_AGG["psigs"][i]) for i in case["psig_indices"]
-    ]
-    assert None in partial_sigs
+    """Refuse a partial signature BIP327 says cannot be aggregated.
+
+    Every error case of this vector is a signature that fails to parse,
+    which `tests/README.md` records; a session is not built to check it,
+    the parse failure being independent of which one it would have been.
+    """
+    refused = 0
+    for i in case["psig_indices"]:
+        try:
+            musig.partial_sig_parse(bytes.fromhex(SIG_AGG["psigs"][i]))
+        except ValueError:
+            refused += 1
+    assert refused > 0
 
 
 def bip352_vectors() -> list[dict[str, Any]]:


### PR DESCRIPTION
Closes #282.

**Held deliberately: do not merge.** A btclib-secp256k1 release is being
cut right now, and this lands after it, not before. The maintainer
clears it for landing; nothing here should be merged, auto-merged, or
squashed by reflex just because CI goes green and review acks it.

## What this adds

`btclib_secp256k1/musig.py`, wrapping all 17 `musig` entry points:

- parse/serialize for `pubnonce`, `aggnonce`, `partial_sig`
- key aggregation: `pubkey_agg`, `pubkey_get`, `pubkey_ec_tweak_add`,
  `pubkey_xonly_tweak_add` — behind `KeyAggCache`
- round 1: `nonce_gen`, `nonce_gen_counter`, `nonce_agg`
- round 2: `nonce_process`, `partial_sign`, `partial_sig_verify`,
  `partial_sig_agg` — `nonce_process` and the two `partial_sig_*` behind
  `Session`, `nonce_gen`/`nonce_gen_counter`/`partial_sign` behind
  `SecretNonce`

## The two design decisions

**1. The opaque handles — reopening what #87 declined, on purpose, and
here is the case for why this is a different shape of request.**

*What #87 asked for.* A `SecretKey` handle wrapping a private key
buffer, kept alive across a chain of sign/derive/tweak calls instead of
being read out and wiped after each one — so that
`SecretKey.from_bytes(b)` could feed `sign`, then `tweak_add`, then
`sign` again, without a `bytes` round-trip through Python in between.

*Why it was declined, in the issue's own words.* The analysis found the
entry and exit sides added nothing over what already existed:
`SecretKey.from_bytes(b)` "still starts from a `bytes`/`int` the caller
already produced and holds," so copying it into a native buffer "buys
nothing over what `prvkey_tweak_add` already does on the way in," and
the exit side, "an explicit, opt-in extraction operation," is
`_secret.take`, "already written." That left exactly one thing the
handle would add: "holding the buffer open across several calls under
one owner, rather than one call each." And that piece was declined
because it is "a stateful object whose lifetime someone has to own and
invalidate" — this package being "stateless by construction, every
function being one libsecp256k1 call with its arguments validated" — so
"the place to enforce it is where the signing state already lives, in
btclib." The issue was closed not planned: "the current wrappers already
wipe native-owned temporary buffers, while an opaque handle would add
state and cannot eliminate the Python-side copies at import/export."

*What is actually different about `KeyAggCache` and `Session`, checked
against the header rather than asserted.* `secp256k1_musig_keyagg_cache`
is 197 bytes and `secp256k1_musig_session` is 133, and the header says
of both, in identical words, "No serialization and parsing functions
(yet)" — verified against `include/secp256k1_musig.h` in the vendored
submodule, and against the whole file for any `_serialize`/`_parse`
pair naming either type: there is none. That is the structural
difference from #87's `SecretKey`, not a rhetorical one. A private key
already has an octets form that is how every function communicates with
it today — the declined handle would only have made an *existing* path
faster by skipping a `bytes` round-trip, and #87's analysis is explicit
that this is all a handle could add. `secp256k1_musig_keyagg_cache` and
`secp256k1_musig_session` have no octets form to round-trip through at
all: `nonce_gen`, `nonce_process`, `partial_sign` and
`partial_sig_verify` each take a keyagg cache or a session as a C
struct passed by pointer, upstream itself provides no
`secp256k1_musig_keyagg_cache_serialize` to turn one into bytes between
calls, and no `_parse` to read one back. So the choice here is not
"hold an object, or round-trip through bytes as before" — it is "hold
the object, or these entry points cannot be composed into a session at
all," which is the state issue #282 exists to fix (its own text:
"refusing it means this module cannot exist in any useful form").
Declining the exception here does not leave a working octets-based
alternative in place the way declining #87 did; it leaves MuSig2 wrapped
only as far as its stateless calls reach, i.e. not usable for an actual
signing session, which is the status quo before this PR.

*And neither object is the kind of thing #87 was declining custody of.*
`#87`'s `SecretKey` would have held a private key — the exact secret
`ssa.Signer`'s keypair already holds, whose lifetime is a real risk to
own. `KeyAggCache` holds aggregated *public* keys and their tweak
coefficients; `Session` holds a finalized nonce, a challenge, and a
tweak accumulator — the header says outright that a session "is not
required to be kept secret for the signing protocol to be secure." So
the "lifetime someone has to own and invalidate" objection in #87 — the
one that matters, an unwiped secret — does not describe either of these
two classes. It does describe `SecretNonce`, the third class this PR
adds, which is why that one is modelled on `ssa.Signer` — an *existing*,
already-accepted pattern for exactly this shape of object — rather than
on the general-purpose `SecretKey` #87 declined.

`_secret.py`'s own module docstring is where this reading comes from,
not an invention for this PR: it already names the clause that reopens
#87 — a handle "belongs where the signing state lives," and a MuSig2
session is that place — and #282 itself, opened by the same maintainer
who declined #87, frames this issue as exactly where that exception "is
either taken or refused." Taking it is this PR's proposal, not a
foregone conclusion; the case above is what a reviewer or the maintainer
has to find wrong to prefer refusing it instead.

`KeyAggCache` and `Session` are, either way, held state beside
`ssa.Signer` and `keys.PubkeyTweakChain`, but for a different reason
than either — the README's *Outposts past the boundary* section states
the existing rule for holding an object (it earns its state when what
it saves is arithmetic, not a parse) and explains why that rule doesn't
reach these two, since there is no octets form to rebuild from in the
first place.

**2. The secnonce wipe.** `SecretNonce` is the third class, and the one
that holds a secret. `ssa.Signer` is the model: a `with` statement
overwrites it on the way out whether the block signs or raises, and a
wiped object refuses to sign rather than signing with the zeros left
behind. libsecp256k1 already zeroes a secnonce inside `partial_sign` —
"overwrites the given secnonce with zeros and will abort if given a
secnonce that is all zeros" — which covers a session that runs to
completion. What `SecretNonce.wipe` (and the `with` block) add is the
wipe for a session *abandoned* between `nonce_gen` and `partial_sign`,
which the C side never sees. SECURITY.md now names two such buffers
instead of one.

**A third question the issue asks:** whether the wrapper verifies its own
output, as `ssa.sign` does with `verify`. `secp256k1_musig_partial_sign`
"does not verify the output partial signature, deviating from the BIP
327 specification," and its header recommends verifying with
`partial_sig_verify` "to prevent random or adversarially provoked
computation errors" — BIP340's own argument for `ssa.sign`'s `verify`,
on a signature assembled from more moving parts than a solo one.
`SecretNonce.partial_sign(..., verify=True)` defaults to on, for the
same reason.

## What the wrapper reports

`pubkey_agg`, `nonce_agg` and `partial_sig_agg` each take arrays of
already-parsed objects, and libsecp256k1 answers a bare `0` for either a
parse failure or a semantic one, with nothing on the thread for
`context.check` to raise. So `KeyAggCache.__init__`, `nonce_agg` and
`Session.partial_sig_agg` each parse their array one contribution at a
time, under a name that includes its position, rather than handing a
comprehension to the array builder — a bad contribution is reported as
"public key at index 2" rather than a refusal that could be any of them.

Reading through every C code path that can produce the aggregate-level
`0` (not the per-contribution parse), several turned out unreachable
given already-parsed, already-proved objects — `pubkey_agg`'s own
aggregation (upstream's own comment: would need an `ecmult_multi_var`
callback that can fail, which none does), `nonce_agg`'s,
`nonce_process`'s, and `partial_sig_agg`'s. Those are `RuntimeError`
rather than `ValueError`, matching the distinction
`pyproject.toml`'s `exclude_also = ["raise RuntimeError"]` already
draws between the two exceptions this package raises ("a `ValueError`
reports an argument out of the domain, and every one of them is
exercised, while a `RuntimeError` reports a libsecp256k1 call failing
where no input can make it fail, and none of them can be"). The one
genuinely reachable failure of that shape is `nonce_gen`'s private key
range check, which stays a `ValueError` and is tested.

## Thread safety, found and fixed during review

`SecretNonce` is meant to be read exactly once, from whichever thread
gets there first, and refused everywhere else. That is not `ssa.Signer`'s
shape (a keypair is `const` to libsecp256k1, so any number of threads may
read it any number of times) and it is not `keys.PubkeyTweakChain`'s
either (one chain belongs to one thread, by convention, since every
`tweak_add` writes it) — it is closer to a single-writer handoff, and an
earlier version of this PR only ordered it by sequential program order:
the check (`self._secnonce is not None`) and the clearing
(`self._secnonce = None`) were two separate statements, and nothing
stopped two threads from both passing the check before either reached
the clear, both then driving `secp256k1_musig_partial_sign` over the
same native secnonce at once — an unsynchronized concurrent access on
native memory that, for MuSig2, reproduces the exact nonce-reuse
condition this class exists to prevent, the worst failure the module
has. Review caught this; it's fixed now.

A `threading.Lock` private to each `SecretNonce` instance is what makes
the check and the clear one atomic step (`SecretNonce._take`, replacing
`_held`), chosen over the alternatives — a module-level lock, or piggy-
backing on the shared libsecp256k1 context's own synchronization story —
because what needs ordering is one instance's own state, not a call into
libsecp256k1 itself: two different `SecretNonce` objects have no reason
to serialize on each other, so a per-instance lock is both the narrowest
correct scope and the cheapest one, adding no contention between
unrelated signing sessions. `wipe()` takes the same lock, so it resolves
the same way against a concurrent `partial_sign`.

`tests/test_concurrency.py` now races `WORKERS` threads on one shared
`SecretNonce` and asserts exactly one signs — deterministically, since
the lock enforces mutual exclusion structurally rather than by timing
luck, so the test holds under the GIL as much as under `cp314t`, and it
would fail on the read-then-separately-clear pattern the fix replaces.
README.md's Thread safety section is corrected to match: it had
asserted this guarantee before the code provided it, which is also
fixed.

## Tests

- `tests/test_musig.py` is new: the lifetime the three classes hand the
  caller (the wipe cases `tests/test_signer.py` already holds
  `ssa.Signer` to), the index-in-message behaviour, a full 2-of-2 session
  as the usage example, and a wiped-on-every-exit-path test for
  `partial_sign` (including a private key that makes `keypair()` raise
  before libsecp256k1 is ever reached).
- `tests/test_concurrency.py` gains
  `test_exactly_one_thread_signs_a_shared_secret_nonce`, racing `WORKERS`
  threads on one `SecretNonce`.
- `tests/test_vectors.py`'s BIP327 cases (`key_agg`, `nonce_agg`,
  `sign_verify`, `sig_agg`) now drive `musig.py` itself instead of the
  raw bindings underneath it.
- Every doctest (`uv run pytest tests/test_examples.py`) and the sphinx
  build (`-W --keep-going`) are green.

## Docs

README's *Wrapped modules*, *Design*, *Outposts past the boundary* (now
titled without "Two", since there are more than two) and *Thread safety*
sections; REVIEWING.md's own checklist line about MuSig2 not being
wrapped; SECURITY.md's "one buffer" sentence, now two; `pyproject.toml`'s
keywords comment; `docs/source/btclib_secp256k1.rst` gains the module's
stanza. CHANGELOG.md's musig entry no longer states "the 17 entry
points" as a lead count — review asked whether that was the CONTRIBUTING.md
dated-measurement exception, and it wasn't (no command or fixed external
reference beside it to re-derive it from), so it is now "every `musig`
entry point," with the full enumerated list right after it doing the
same job without asserting a total that could drift.

## Gates

```
uv run pytest            # 765 passed, 100.00% coverage
uv run pre-commit run --all-files   # all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wrap the complete MuSig2 protocol with stateful key aggregation and session APIs, securely manage single-use secret nonces, and validate the implementation against BIP327 vectors and concurrency scenarios.

New Features:
- Add a public MuSig2 (BIP327) wrapper covering key aggregation, nonce generation and aggregation, session processing, partial signing and verification, signature aggregation, and related parsing and serialization.
- Provide stateful KeyAggCache and Session objects plus a single-use SecretNonce with explicit wiping and context-manager support.
- Verify partial signatures by default before returning them and provide descriptive validation errors for invalid contributions.

Bug Fixes:
- Prevent concurrent reuse of a shared SecretNonce by atomically claiming it under a per-instance lock.
- Ensure secret nonces are wiped when signing fails, including failures before libsecp256k1 processes the nonce.

Enhancements:
- Expose MuSig2 state and lifecycle semantics through documented Python APIs while retaining raw lib access for lower-level callers.

Documentation:
- Document the MuSig2 wrapper, secret-buffer handling, lifecycle and thread-safety guarantees, and its public API in the README, release notes, changelog, security guidance, review checklist, and API documentation.

Tests:
- Add dedicated MuSig2 lifecycle, end-to-end signing, validation, wiping, and serialization tests.
- Run BIP327 vector tests through the new wrapper instead of raw bindings.
- Add concurrency coverage ensuring exactly one thread can consume a shared secret nonce.

Chores:
- Update module listings and test documentation to reflect that MuSig2 is now wrapped.


