### PR TITLE
Open 0.8.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
+## v0.8.0.4 (work in progress, not released yet)
+
 ## v0.8.0.3
 
 ### A tag-integrity ruleset closes the last unsigned link in the release chain

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
+## v0.8.0.4 (work in progress, not released yet)
+
 ## v0.8.0.3
 
 **Breaking: one module is gone, and every other break is a rename.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btclib_secp256k1"
-version = "0.8.0.3"
+version = "0.8.0.4"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "btclib-secp256k1"
-version = "0.8.0.3"
+version = "0.8.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
Step 10 of RELEASING.md, right after 0.8.0.3 shipped ([v0.8.0.3](https://github.com/btclib-org/btclib-secp256k1/releases/tag/v0.8.0.3)): a placeholder fourth number, so the tree stops claiming a version it already published. The submodule has not moved since 0.8.0, so this stays 0.8.0.4 unless a submodule bump renumbers it before the next release.

## Summary by Sourcery

Open the 0.8.0.4 development version after the 0.8.0.3 release.

Enhancements:
- Advance the project version to 0.8.0.4 and add unreleased placeholders to the changelog and release notes.

Build:
- Update the lockfile to reflect version 0.8.0.4.