### PR TITLE
Document the zero-jobs startup_failure v0.8.0.3 hit

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -228,7 +228,28 @@ Then:
 
    `git push --tags` would push whatever other local tags happen to
    exist. The workflow then builds and tests every artifact the release
-   ships and stops at the `pypi` environment
+   ships and stops at the `pypi` environment.
+
+   A run that comes back `startup_failure` with **zero jobs
+   scheduled** -- not even `version-check`, which has no dependencies
+   at all -- is not the matrix failing to build; `release.yml` itself
+   was refused before a single job started, and the REST API says
+   nothing more than a generic "workflow file issue": the actual error
+   is on the run page alone, not in anything `gh run view` or
+   `gh api .../runs/<id>/jobs` prints. `v0.8.0.3` hit this on three tag
+   pushes and a `workflow_dispatch`, all identical and independent of
+   the trigger, because a called workflow's jobs are capped at what
+   the *caller* grants, not at what the called workflow's own
+   top-level default declares -- `test.yml`'s `changes` job (#189)
+   asks for `pull-requests: read`, and `release.yml` granted only
+   `contents: read`. Retagging does not help here the way it does for
+   `invalid-publisher` below: nothing had been built yet either way,
+   but this is a structural defect in the workflow file, not a
+   transient one, and a freshly re-signed tag on the same commit failed
+   the same way two hours later. What answered it was the missing
+   permission, granted on the calling job (#281) -- confirmed with a
+   `workflow_dispatch` rehearsal on the fix branch before retagging,
+   scheduling dozens of jobs where the unfixed commit scheduled none
 1. approve the `pypi` deployment when the run pauses for review. Up to
    here nothing is public and the tag can still be deleted; the upload
    that follows is the point of no return — the upload, and not the


### PR DESCRIPTION
RELEASING.md's tagging step already documents real incidents with
their facts and fixes: `invalid-publisher` (0.7.1's rehearsal and
0.7.1.2's real one), the CDN lag on 0.8.0, `github-release` skipping a
real release three times over. This adds `v0.8.0.3`'s: three tag
pushes and a `workflow_dispatch` all came back `startup_failure` with
**zero jobs scheduled**, the REST API surfacing nothing beyond a
generic "workflow file issue" — the actual error only shows on the run
page. Root cause and fix are [btclib-secp256k1#281](https://github.com/btclib-org/btclib-secp256k1/pull/281):
a called workflow's jobs are capped at what the caller grants, and
`release.yml` granted `test.yml`'s `changes` job (#189) less than it
asked for.

The other thing this adds explicitly: retagging alone does not recover
from this the way it does from `invalid-publisher`. Nothing had been
built either way, but `invalid-publisher` is transient (a stale
registration) where this is a structural defect in the workflow file —
a freshly re-signed tag on the same commit failed the same way two
hours later, and only the permission fix (confirmed with a
`workflow_dispatch` rehearsal before retagging) resolved it.

No code change, no version bump — documentation only.

## Summary by Sourcery

Document the v0.8.0.3 release workflow startup failure and clarify that correcting the workflow permissions, rather than retagging alone, is required for recovery.

Enhancements:
- Document the v0.8.0.3 zero-job startup failure, including its workflow-permission root cause and the need to fix the caller before retagging.

Documentation:
- Expand the release guide with diagnostic and recovery guidance for workflow startup failures that schedule no jobs.