### PR TITLE
0.8.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
-## v0.8.0.4 (work in progress, not released yet)
+## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
-## v0.8.0.4 (work in progress, not released yet)
+## v0.8.0.4
 
 Non-breaking. `musig` is new: it wraps MuSig2 (BIP327), previously
 reachable only through the raw `lib` bindings this package also exports.


### PR DESCRIPTION
Non-breaking. `musig` is new: it wraps MuSig2 (BIP327), previously
reachable only through the raw `lib` bindings this package also exports.
`musig.KeyAggCache` aggregates signers' public keys and applies the
BIP32 and BIP341 tweaks; `musig.nonce_gen` (or `nonce_gen_counter`)
starts a signing round and returns a `musig.SecretNonce`, wiped whether
`partial_sign` signs with it or is refused, and refusing a second use of
the same one even from a different thread; `musig.Session`, opened from
the signers' aggregate nonce, verifies and aggregates the resulting
partial signatures into a plain BIP340 signature `ssa.verify` checks.

The vendored libsecp256k1 has not moved since v0.8.0.3, so this is a
bindings-only release: the fourth number was already open, `uv.lock`
already matched, and nothing else needed renumbering.

`latest` dispatched on `main` and came back red, as it gates nothing:
https://github.com/btclib-org/btclib-secp256k1/actions/runs/32449057938
failed only at `uv-lock`, resolving newer ruff (0.16.3→0.16.4),
stevedore (5.9.0→5.9.1) and pygments than what `uv.lock` pins — the
next dependency bump is going to be work, not a release blocker.