### PR TITLE
Open 0.8.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
+## v0.8.0.5 (work in progress, not released yet)
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
 has to act on and what a user gains, and it is what the GitHub release of
 a tag is generated from.
 
+## v0.8.0.5 (work in progress, not released yet)
+
 ## v0.8.0.4
 
 Non-breaking. `musig` is new: it wraps MuSig2 (BIP327), previously

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btclib_secp256k1"
-version = "0.8.0.4"
+version = "0.8.0.5"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "btclib-secp256k1"
-version = "0.8.0.4"
+version = "0.8.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
Placeholder over v0.8.0.4, per RELEASING.md step 10: bumps `pyproject.toml`
and `uv.lock` to a fourth number over what was just published (the
submodule hasn't moved), and opens the `CHANGELOG.md`/`RELEASE_NOTES.md`
sections for what lands next.

## Summary by Sourcery

Open the unreleased v0.8.0.5 development version and prepare its release documentation.

Enhancements:
- Open the v0.8.0.5 release sections for upcoming changes.

Build:
- Bump the package and lockfile versions to 0.8.0.5.