### PR TITLE
Stop stating counts nothing checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ release-notes length in the first place, and are still in
   builds the C extension, and that build does not exist to check yet in
   a fresh clone. The new step uses `--isolated --no-project -s .`
   instead, griffe reading only Python source.
+- **Prose stops stating counts nothing checks** (#293, #294): a
+  cross-reference by "step N" into RELEASING.md's numbered list, which
+  the list itself proved fragile by moving once this cycle (#292);
+  GitHub's own platform limits (concurrent jobs, the plan table,
+  artifact retention), dated rather than removed, since they are
+  someone else's settings and can move without notice; and counts of
+  this repository's own growing things — a `.dev<run><attempt>` worked
+  example, a redundant entry-point count, and two `detect-secrets`
+  baseline sizes, one of which had already drifted:
+  `.secrets.baseline`'s documented 53 findings against the actual 54.
 
 ## v0.8.0.4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,8 @@ kill rate, which is the one failure mode that looks like good news.
   releases are cut by a maintainer, and the release workflow checks the
   tag against it. The one bump that is not a release is the fourth number
   opened straight after one, so that the tree stops claiming the version
-  it shipped: step 10 of RELEASING.md, and the reason it is a step
+  it shipped: RELEASING.md's step that opens the next version, and the
+  reason that step exists
 - **the `secp256k1` submodule moves in a change of its own,** with the
   version named in `README.md` and `RELEASE_NOTES.md` moved with it
 - **`main` is the only long-lived branch**, so a pull request targets it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,10 +196,11 @@ read by every checkout of this repository.
 The first two rows are what a merge waits for.
 
 What the rows below them have in common is one number: GitHub Free gives an
-organization twenty concurrent jobs, shared across every repository in it.
-A commit here asked for seventy-three, one in btclib for thirty-nine and one
-in bitcoin-core-rpc for forty-four, so a pull request in any of the three
-spent its wall clock waiting for a slot. A platform therefore earns a place
+organization twenty concurrent jobs (as of 2026-08-21), shared across every
+repository in it. A commit here, in btclib and in bitcoin-core-rpc each ask
+for more jobs than that ceiling alone allows, so a pull request in any of
+the three spent its wall clock waiting for a slot. A platform therefore
+earns a place
 before a review only if it is cheap to wait for, and neither of these is:
 macOS runners queue for tens of minutes rather than for two, and the
 twenty-one Windows suite cells were 27.3 of a run's 112.9 runner-minutes,
@@ -489,9 +490,12 @@ targets and where every change lands; a tag on `main` is a release.
   manual" in its own words. A scan into a file has no old baseline to
   merge, so those marks go back to their defaults, and slim output prints
   no `is_secret` at all when it is unset: the loss shows up as a diff of
-  nothing. Nothing is lost today, all 53 and all 466 findings being
-  unverified and none carrying `is_secret`, but an audit's marks want
-  saving elsewhere or re-applying after the next regeneration.
+  nothing. `jq '[.results[][]] | length' .secrets.baseline` (and the
+  same against `.secrets.vectors.baseline`) is how to check whether
+  there is anything to lose — every finding in either file being
+  unverified and none carrying `is_secret` means there isn't, today —
+  but an audit's marks want saving elsewhere or re-applying after the
+  next regeneration.
 
   read the diff before committing it, which is the whole point of a
   baseline: what appears there is what nobody has looked at yet

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,8 +31,9 @@ hand. Telling them apart is most of what can go wrong:
   published, on either index, and the only one a human edits
 - **`0.7.1.1`**, a fourth number on an already-final version, plays two
   roles this list would otherwise leave out: right after 0.7.1 ships,
-  step 11 opens the tree on it as a placeholder, nothing having moved the
-  submodule since to renumber it; and if 0.7.1 itself shipped broken,
+  the step that opens the next version puts the tree on it as a
+  placeholder, nothing having moved the submodule since to renumber
+  it; and if 0.7.1 itself shipped broken,
   "When a release turns out to be broken" ships the very same string
   as the fix, tagged. Both are typed by hand, like `0.7.1` above, and
   both read the same way — "the same libsecp256k1, one change since" —
@@ -47,9 +48,11 @@ hand. Telling them apart is most of what can go wrong:
   ever carries it
 - **`0.7.1.dev1`** is what the earlier `.dev<run number>` template
   produced the first time this workflow was dispatched, rehearsing
-  0.7.1: `0.7.1` from `pyproject.toml`, and run number 1. Today the same
-  run would produce `0.7.1.dev101`. `github.run_number` counts the runs
-  of `release.yml` alone, not of the repository, so it started at one
+  0.7.1: `0.7.1` from `pyproject.toml`, and run number 1. A later
+  dispatch's suffix is whatever the formula above computes for it then,
+  not a value worth writing down here, since it moves with every
+  dispatch. `github.run_number` counts the runs of `release.yml` alone,
+  not of the repository, so it started at one
   and rises by one per dispatch; `github.run_attempt` starts at one and
   rises with each re-run of a single dispatch, which is what a run
   number alone could not tell apart. Between them every attempt of every
@@ -111,7 +114,8 @@ Then:
    it into `uv.lock`. Version numbers track the wrapped libsecp256k1,
    with a fourth number for a release of the bindings alone: see the
    Versioning section of [README.md](README.md). The previous release
-   left a fourth number open, by step 11 below, so this is often a matter
+   left a fourth number open, by the step that opens the next version
+   below, so this is often a matter
    of confirming what is already declared, or of renumbering it if the
    submodule has moved since
 1. check the breaking-changes list against the API itself, which
@@ -151,7 +155,7 @@ Then:
    written as each change lands, not here, so what is left is to read
    the open section of both against `git log`, drop the `(work in
    progress, not released yet)` from each heading, and renumber them
-   if step 1 renumbered the version. `version-check` refuses a tag
+   if the version bump above renumbered it. `version-check` refuses a tag
    whose section in either file is missing, empty, or still carrying
    anything after the version in its heading, so a forgotten retitle
    stops the release before the matrix builds anything. Dropping those
@@ -179,10 +183,11 @@ Then:
    ```
 
    and against the open sections of `CHANGELOG.md` and
-   `RELEASE_NOTES.md`, which step 3 has just closed and which are
-   where each change was described as it landed. `latest`'s result and
-   step 2's griffe findings belong here too, a line rather than a
-   screenshot: neither gates anything, and a pull request that never
+   `RELEASE_NOTES.md`, which closing the release notes above has just
+   closed and which are where each change was described as it landed.
+   `latest`'s result and the breaking-changes check's griffe findings
+   belong here too, a line rather than a screenshot: neither gates
+   anything, and a pull request that never
    mentions them having run reads exactly like one that skipped them.
 
    A deliberate skip and an item nobody has gotten to yet are different
@@ -446,7 +451,8 @@ Then:
 1. open the next version, in a pull request of its own and before
     anything else lands: bump `pyproject.toml` to a fourth number over
     what was just published — `0.7.1.1` after `0.7.1` — and run `uv
-    lock`. It is a placeholder, and step 1 renumbers it if the submodule
+    lock`. It is a placeholder, and the version-bump step renumbers it if
+    the submodule
     moves before the next release; what it buys is a tree that no longer
     claims to be a version it is not. `__version__` reads installed
     metadata, so a checkout a developer installed stops reporting itself
@@ -461,9 +467,10 @@ Then:
     section for it in `CHANGELOG.md` and in `RELEASE_NOTES.md` at the
     same time, headed `## v<version> (work in progress, not released yet)`
     and empty: what lands next then has somewhere to be written down as
-    it lands, which is the whole of step 3 — and, with one branch and no
-    long-lived release pull request to hold a body, the whole of what
-    step 4 reads the cycle off at the end of it
+    it lands, which is the whole of closing the release notes — and,
+    with one branch and no long-lived release pull request to hold a
+    body, the whole of what giving the pull request its title and body
+    reads the cycle off at the end of it
 
 ## Rehearsing on TestPyPI
 
@@ -504,8 +511,9 @@ without rebuilding anything.
    alone against the artifacts already built, instead of an hour of
    matrix again. That is what published 0.7.1.dev1, three minutes after
    a registration was corrected, and it holds for as long as the
-   artifacts do: ninety days, this repository not having narrowed the
-   retention. Note that a re-run rebuilding the matrix now carries the
+   artifacts do: ninety days (as of 2026-08-21, GitHub's own default),
+   this repository not having narrowed the retention. Note that a
+   re-run rebuilding the matrix now carries the
    attempt in its version, so what it uploads is not what the first
    attempt built under a different name.
    Never tag a rehearsal: the trigger is what picks the index, so a

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -619,16 +619,16 @@ GitHub free to move the numbers without notice):
 twenty is what `windows.yml`'s header measured against, and paying for
 Team would triple it; the five is what `macos.yml`'s header measured
 against, and Team does not move it at all. A macOS column that queued for
-tens of minutes was thirty-five jobs asking for five slots, and only
-Enterprise changes that arithmetic. So the split that took those cells
-out of the merge gate is not a workaround for a plan — on this repository
-it is the answer, and the plan below Enterprise that would undo it does
-not exist.
+tens of minutes was far more jobs than five slots could clear at once,
+and only Enterprise changes that arithmetic. So the split that took those
+cells out of the merge gate is not a workaround for a plan — on this
+repository it is the answer, and the plan below Enterprise that would
+undo it does not exist.
 
 What Team would buy is the rest: the Linux and Windows crowding, and the
-contention with the other repositories of the organization, `btclib`
-asking for thirty-nine jobs a commit and `bitcoin-core-rpc` for
-forty-four. Whether that is worth three seats is a question for whoever
+contention with the other repositories of the organization, `btclib` and
+`bitcoin-core-rpc` each asking for well more than the twenty on their own
+commits too. Whether that is worth three seats is a question for whoever
 pays for them, and it is recorded here so that it is asked with the
 second column in view.
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -38,10 +38,10 @@ gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
 
 `codeql: every job passed` is not among them, and that is the one place a
 check was traded for the slots it held. GitHub Free gives an organization
-twenty concurrent jobs, shared across every repository in it: this one asked
-for seventy-three on every commit, btclib for thirty-nine and
-bitcoin-core-rpc for forty-four, so a pull request in any of the three
-waited for a slot rather than for the work. `codeql.yml` now runs on `main`
+twenty concurrent jobs (as of 2026-08-21), shared across every repository
+in it: this one, btclib and bitcoin-core-rpc each ask for more jobs than
+that on every commit, so a pull request in any of the three waited for a
+slot rather than for the work. `codeql.yml` now runs on `main`
 and on its Tuesday schedule, the analysis landing on the merge commit rather
 than ahead of it, and it still produces that aggregate — the name is
 available, so requiring it again is a patch to the rule and nothing in the
@@ -246,9 +246,9 @@ gh api -X PATCH repos/btclib-org/btclib-secp256k1/code-quality/setup \
 What decided it is the ceiling the section above already trades against,
 not the queries. `Analyze (python)` ran on every pull request and every
 push to `main` — `Code Quality: PR #N` in the run list — for some 52
-seconds of a slot each time, and the twenty concurrent jobs are shared
-with every other repository in the organization, where the same setting
-was on.
+seconds of a slot each time, and the twenty concurrent jobs (as of
+2026-08-21) are shared with every other repository in the organization,
+where the same setting was on.
 
 What it produced in exchange cannot be read from outside a browser. There
 is no `code-quality/alerts` and no `code-quality/analyses`, both 404, and
@@ -605,7 +605,8 @@ gh api orgs/btclib-org --jq .plan.name        # free
 ```
 
 [GitHub's own table](https://docs.github.com/en/actions/reference/limits)
-is the authority, and two of its columns matter here:
+is the authority, and two of its columns matter here (as of 2026-08-21,
+GitHub free to move the numbers without notice):
 
 | plan | concurrent jobs | of which macOS |
 | --- | --- | --- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,7 +84,7 @@ These are known and inherent, not vulnerabilities:
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
 - **`into` moves that last copy somewhere the caller can overwrite,**
-    and is the whole of what it does. Eight entry points take a
+    and is the whole of what it does. A named set of entry points take a
     keyword-only `into` — a writable buffer of exactly the secret's
     length, contiguous and one octet an item, `bytearray` and
     `memoryview` and `mmap` and `array.array("B")` alike — write the
@@ -92,8 +92,8 @@ These are known and inherent, not vulnerabilities:
     That breadth is the run time's: the annotation is a `bytearray` or a
     `memoryview`, `collections.abc.Buffer` being python 3.12 where the
     floor here is 3.10, so a caller running `mypy --strict` passes
-    anything else as `memoryview(x)`, which copies nothing. The eight
-    are `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
+    anything else as `memoryview(x)`, which copies nothing. They are
+    `keys.prvkey_negate`, `keys.prvkey_tweak_add`,
     `keys.prvkey_tweak_mul`, `xonly.prvkey_tweak_add`,
     `ecdh.shared_secret`, `ellswift.xdh`, `dsa.nonce_rfc6979` and
     `ssa.nonce_bip340`. **The two secrets `silentpayments` answers do

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,7 +84,7 @@ These are known and inherent, not vulnerabilities:
     not safety: the `bytes` handed to the caller holds the same secret
     and cannot be overwritten
 - **`into` moves that last copy somewhere the caller can overwrite,**
-    and is the whole of what it does. A named set of entry points take a
+    and is the whole of what it does. The entry points that take a
     keyword-only `into` — a writable buffer of exactly the secret's
     length, contiguous and one octet an item, `bytearray` and
     `memoryview` and `mmap` and `array.array("B")` alike — write the


### PR DESCRIPTION
Closes #293.

Three shapes of unchecked numbers, fixed differently:

- **"step N" cross-references** into RELEASING.md's numbered "Then:"
  list (CLAUDE.md:293, RELEASING.md's version-string section and every
  step that pointed at another by position) — replaced with what each
  step does rather than where it sits. The list itself already proved
  this fragile once this cycle: #292 inserted a step and pushed seven
  cross-references out of date.
- **GitHub's own platform limits** — twenty concurrent jobs, the
  plan-limit table, ninety-day artifact retention — dated
  `(as of 2026-08-21)` rather than removed: true facts about someone
  else's settings, not this repository's, and GitHub can move them
  without notice.
- **This repository's own growing counts**, removed or replaced with a
  live command: a `.dev<run><attempt>` worked example that goes wrong
  every dispatch, a redundant entry-point count sitting right next to
  the list it duplicates, and two `detect-secrets` baseline sizes —
  checked while writing this: `.secrets.baseline` is at 54 findings now,
  not the 53 documented, already stale.

A fifth finding the issue's census turned up — a stale "17 `musig`
entry points" claim in README.md — turned out to already be gone,
rewritten when `musig` was wrapped (#285), so nothing to do there.

## Summary by Sourcery

Make documentation resilient to changing workflow positions, repository counts, and GitHub platform limits.

Enhancements:
- Replace fragile numbered-step cross-references with descriptions of the referenced release activities.
- Remove repository-specific counts and volatile worked examples, using live commands or qualitative descriptions where appropriate.
- Date GitHub platform limits and plan information to clarify that they are externally controlled and may change.

Documentation:
- Update repository, contribution, release, security, and maintainer documentation to avoid stale counts and positional references.