### PR TITLE
Drop the Slack badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **The Slack badge is gone from `README.md` and `CONTRIBUTING.md`.**
+  The badge block's own comment states the criterion — a badge reports
+  state, which is why "we use ruff" is not one — and this badge reported
+  a route instead, to a channel of the course workspace btclib was first
+  taught in. What answers a question here is the issue tracker and a
+  pull request, which leave the answer where the next reader of these
+  files can find it, and a chat message does not. The badge stood alone
+  in both files, with no prose sending a contributor there, so each
+  block loses a line and nothing else changes. Both siblings do the
+  same, so that the badge goes everywhere it is rather than in one
+  place, and the organization profile no longer names Slack either.
+
 - **`RELEASING.md` checks the breaking-changes list against the API
   itself, with griffe** (#292, closing #291). Both sibling repositories
   already had this step; `v0.8.0.2` to `v0.8.0.3` is what makes it not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ libsecp256k1 release rather than the calendar. -->
 [![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
 [![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
-[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 Thank you for investing your time in this project. What follows is how to
 build and test these bindings, and what this repository

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ bitcoin-core-rpc carry the same three lines. -->
 [![documentation build](https://readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
-[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---
 


### PR DESCRIPTION
## What this changes

The Slack badge goes from `README.md` and `CONTRIBUTING.md`.

The badge block's own comment states the criterion — a badge reports
state, which is why "we use ruff" is not one. This badge reported a
route rather than state, to a channel of the course workspace btclib was
first taught in.

What answers a question here is the issue tracker and a pull request.
The difference is not the medium: a question asked in an issue leaves an
answer the next reader of these files can find, where a chat message
leaves one only for whoever was in the channel.

The badge stood alone in both files, with no prose sending a contributor
there, so each block loses a line and nothing else changes.

## How it was verified

```text
uv run pre-commit run --all-files                    exit 0
uv run pytest                                        exit 0
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html \
    docs/source docs/build/html                      exit 0
```

`README.md` is what `pyproject.toml` declares as the long description,
so the packaging hooks in the gate above read the edited file.

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry, under `### Documentation`. Nothing a
      user has to act on

## Anything the reviewer should know

The last of three: btclib-org/btclib#1161 and
btclib-org/bitcoin-core-rpc#163 remove the same badge from the same two
files, and btclib-org/.github's organization profile does not name Slack.
Removing it from one repository and not the others would have left the
badge saying the channel is where to go, from wherever it survived.

## Summary by Sourcery

Remove Slack badges from the project documentation and record the documentation cleanup in the changelog.

Enhancements:
- Remove the obsolete Slack badges from the README and contributor guide.

Documentation:
- Document the removal of Slack badges from the project documentation.