### PR TITLE
Fix the required-version comment: the floor tracks Dependabot, not the hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ release-notes length in the first place, and are still in
   baseline sizes, one of which had already drifted:
   `.secrets.baseline`'s documented 53 findings against the actual 54.
 
+### CI
+
+- **`[tool.uv]`'s `required-version` comment stated the wrong reason**
+  (#299): it read as though the floor were the version the uv-lock hook
+  of `.pre-commit-config.yaml` pins, but that hook pins `0.12.5` while
+  the floor reads `>=0.12.0` -- the two numbers were never the same
+  one. The real constraint is Dependabot's own uv-ecosystem updater: it
+  runs `uv lock` with exactly the uv it bundles
+  (`dependabot/dependabot-core`'s `uv/Dockerfile`, `0.12.1` at the time
+  of writing) and refuses instead of upgrading itself when that uv
+  falls short of this key. btclib's issue #485 is what a floor ahead of
+  it costs: every lock update it attempted, security ones included,
+  failed with `tool_version_not_supported` before a single one started.
+  `0.12.1` still clears `0.12.0`, so the floor itself does not move here
+  -- only the comment does.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,16 +243,21 @@ dev = [
 ]
 
 [tool.uv]
-# the oldest uv allowed to touch uv.lock, and it is the version the
-# uv-lock hook of .pre-commit-config.yaml pins: that hook is what
-# regenerates the file, and its rev is something pre-commit.ci moves.
-# Declared here the floor holds for every uv command rather than for the
-# hook alone, so an older uv on a developer's machine says so instead of
-# rewriting the lock in a format the runners then fail to read — uv is
-# pre-1.0 and changes that format. It also reaches CI without a second
-# pin: setup-uv, given no version input, reads this key, and a bare
-# minimum specifier makes it install the latest uv, so the runners are
-# never behind the floor and there is nothing here to go stale
+# the oldest uv allowed to touch uv.lock -- not the version the uv-lock
+# hook of .pre-commit-config.yaml pins, which is newer and moves on its
+# own schedule under pre-commit.ci; a floor here has to stay at or below
+# whatever Dependabot's own uv-ecosystem updater bundles instead. That
+# updater runs `uv lock` with exactly the uv it bundles regardless of
+# this key, and refuses rather than upgrading itself when it falls short
+# of the key, so raising this past what it bundles silently stops every
+# lock update it attempts, including security ones. Declared here the
+# floor still holds for every uv command rather than for that one
+# updater alone, so an older uv on a developer's machine says so instead
+# of rewriting the lock in a format the runners then fail to read — uv
+# is pre-1.0 and changes that format. It also reaches CI without a
+# second pin: setup-uv, given no version input, reads this key, and a
+# bare minimum specifier makes it install the latest uv, so the runners
+# are never behind the floor and there is nothing here to go stale
 required-version = ">=0.12.0"
 
 [tool.mypy]


### PR DESCRIPTION
## Summary
- The `[tool.uv]` comment above `required-version` claimed the floor was
  the version the uv-lock hook of `.pre-commit-config.yaml` pins. It
  never was: the hook pins `0.12.5` while the floor reads `>=0.12.0`.
- The real constraint is Dependabot's own uv-ecosystem updater: it runs
  `uv lock` with exactly the uv it bundles regardless of this key, and
  refuses instead of upgrading itself when that uv falls short of the
  key. Checked against `dependabot/dependabot-core`'s `uv/Dockerfile`
  (bundled uv currently `0.12.1`, last bumped in PR #15770) and against
  btclib's issue #485, where a floor ahead of Dependabot's bundled uv
  failed every lock update -- security updates included -- with
  `tool_version_not_supported` before a single one started.
- `0.12.1` still clears this repository's `0.12.0` floor, so the floor
  itself is not raised or lowered here -- only the comment, which now
  states the actual reason instead of a number that was never true.

Closes #299

## Test plan
- [x] `git submodule update --init && uv sync --locked`
- [x] `uv run pre-commit run --all-files` (exit 0)
- [x] `uv run pytest` (765 passed)
- [x] `uv run pytest --cov` (100.00% coverage, gate satisfied)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` (build succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNzuzag82WGhvznByjFDH

## Summary by Sourcery

Clarify that the uv version floor must remain compatible with Dependabot's bundled uv rather than tracking the pre-commit hook version.

Bug Fixes:
- Correct the `[tool.uv]` `required-version` comment to accurately describe Dependabot's bundled uv as the constraint on the version floor.

Documentation:
- Document the corrected rationale for the uv version floor in the changelog.