### PR TITLE
CONTRIBUTING.md and CLAUDE.md catch up with test.yml's --frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`CONTRIBUTING.md` and `CLAUDE.md` catch up with `test.yml`'s
+  `--frozen`** (btclib-org/.github#8). The organization standard's
+  `--locked`, never `--frozen` rule is stated flatly, and the wheel-build
+  steps of `test.yml` (`build-cibuildwheel`, `build-dynamic`,
+  `build-sdist`, the Windows cross-build) have used `--frozen` since
+  `test.yml` was first written, with a comment beside the first of them:
+  they run after the `dev-version` action has rewritten `pyproject.toml`
+  on the rehearsal path, and `--locked` refuses exactly that
+  disagreement, `uv sync --locked` measured to fail there with "The
+  lockfile at `uv.lock` needs to be updated" where `--frozen` measured to
+  pass. The rule was not a copy nobody examined; two other files were
+  stale. `CONTRIBUTING.md`'s `Build wheels on <os>` reproduction command
+  had dropped the flag, so it no longer matched the step it claims to
+  reproduce, and `CLAUDE.md`'s "uv commands pass `--locked`, never
+  `--frozen`" line stated the rule with no exception, which is wrong
+  about a job it also documents elsewhere. Every other repository of the
+  organization was checked the same way (`grep -rn -- '--frozen'
+  .github/workflows/` in `btclib`, `bitcoin-core-rpc` and
+  `btclib-benchmarks`): each hit there is inside a comment explaining why
+  the flag is *not* used, and no `run:` step passes it.
+
 - **The Slack badge is gone from `README.md` and `CONTRIBUTING.md`.**
   The badge block's own comment states the criterion — a badge reports
   state, which is why "we use ruff" is not one — and this badge reported

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,8 +331,13 @@ findings.
   branch, and one cancels the other
 - `actions/checkout` passes `persist-credentials: false`, so the token
   does not stay in `.git/config` where an artifact upload could carry it
-- uv commands pass `--locked`, never `--frozen`: the second takes
-  `uv.lock` as it finds it and never checks it
+- uv commands pass `--locked`, never `--frozen` — except the wheel-build
+  steps of `test.yml` (`build-cibuildwheel`, `build-dynamic`,
+  `build-sdist`, the Windows cross-build), which run after the
+  `dev-version` action has rewritten `pyproject.toml` on the rehearsal
+  path; `--locked` refuses exactly that disagreement, so those steps use
+  `--frozen`, and the comment above `build-cibuildwheel`'s `Build wheels`
+  step has the reasoning in full
 - the packaging tools come from the pinned `check` group, not from `uvx`,
   which would fetch whatever the index holds when the job runs
 - a hook that needs a tool carries it in `additional_dependencies`, with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,11 +294,13 @@ command at all, for the reason above, and no longer gates.
 - `Build wheels on <os>`, for this platform only
 
   ```shell
-  uv run --only-group build cibuildwheel
+  uv run --frozen --only-group build cibuildwheel
   ```
 
-  the Linux wheels of that job are built in a manylinux container, so
-  reproducing them needs a container runtime (`colima` on macOS)
+  `--frozen`, not `--locked`: `test.yml` has the reason, next to the step
+  itself. The Linux wheels of that job are built in a manylinux
+  container, so reproducing them needs a container runtime (`colima` on
+  macOS)
 
 - `Build dynamic wheel on <os>`
 


### PR DESCRIPTION
## Summary

btclib-org/.github#8 asks whether `test.yml`'s wheel-build `--frozen`
is a copy nobody examined or a decision, since the organization
standard states `--locked`, never `--frozen`, flatly.

It is a decision, and it is already commented where it was made:
`build-cibuildwheel`, `build-dynamic`, `build-sdist` and the Windows
cross-build all run after the `dev-version` action rewrites the
version in `pyproject.toml` on the rehearsal path, and `--locked`
refuses exactly that disagreement. Measured in a worktree, after the
same rewrite: `uv sync --locked` fails with `The lockfile at
uv.lock needs to be updated`, where `uv sync --frozen` succeeds.

What was missing was in two other files. `CONTRIBUTING.md`'s local
reproduction of the `cibuildwheel` step had dropped the flag, so the
documented command no longer matched the workflow step it claims to
reproduce verbatim (the standard: "a workflow change that does not
update it makes that file wrong rather than merely stale"). `CLAUDE.md`'s
summary of workflow conventions stated the rule with no exception,
wrong about a job the same file documents elsewhere. Both now point at
the reasoning that is already beside the flag in `test.yml`, rather than
repeating it.

The other three repositories of the organization were checked the same
way: `grep -rn -- '--frozen' .github/workflows/` in `btclib`,
`bitcoin-core-rpc` and `btclib-benchmarks` returns only comments arguing
*against* the flag; no `run:` step in any of them passes it.

This PR changes no workflow behavior — the wheel-build steps keep
`--frozen`, correctly.

## Verification

Run from a worktree, submodule initialized, `uv sync --locked`:

```
uv run pre-commit run --all-files   # exit 0, actionlint and zizmor
                                     # both at zero findings
uv run --locked --no-default-groups --group test pytest --cov
                                     # exit 0, 765 passed, 100.00% coverage
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
                                     # exit 0, build succeeded
```

The wheel jobs themselves only run in CI; watching this PR's `test.yml`
run for the build-cibuildwheel / build-dynamic / build-sdist / Windows
cross-build steps going green next.

Refs btclib-org/.github#8.

## Test plan

- [x] `uv run pre-commit run --all-files` — exit 0
- [x] `uv run --locked --no-default-groups --group test pytest --cov` —
      exit 0, 100.00% coverage
- [x] sphinx build — exit 0
- [ ] CI's wheel-build steps go green on this PR

## Summary by Sourcery

Update project documentation to accurately reflect the existing `--frozen` usage in test workflow wheel builds without changing workflow behavior.

Enhancements:
- Align the contribution and workflow-convention documentation with the existing wheel-build exception that requires `uv --frozen`.
- Document the rationale for the exception by referring contributors to the workflow’s existing explanation.

Documentation:
- Correct the documented cibuildwheel reproduction command to include `--frozen` and update the workflow guidance in `CLAUDE.md` to describe the exception to the usual `--locked` rule.