### PR TITLE
RELEASING.md records why no SBOM is attached here

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ release-notes length in the first place, and are still in
   of one the same bytes — the compiler, its version and the toolchain
   the runner happened to have are inputs nothing here pins.
 
+- **`RELEASING.md` records why no CycloneDX bill of materials is
+  attached to this repository's releases**, unlike btclib's. This
+  package's `Requires-Dist` names only `cffi`; the dependency it
+  actually wraps, the vendored libsecp256k1 C library at its
+  pinned commit, does not appear there, for either wheel this
+  package ships — statically linked into the extension in a
+  static build, a shared object beside it in a dynamic (ABI-mode)
+  one. btclib's `RELEASING.md` carries the reasoning; see its
+  "Read the bill of materials attached to the release" step and
+  btclib-org/btclib#1159 for the evaluation.
+
 ### CI
 
 - **`[tool.uv]`'s `required-version` comment stated the wrong reason**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,10 +13,14 @@ the index's attestation says nothing about.
 
 **No CycloneDX bill of materials is attached, on purpose**, unlike
 btclib's release. This package's `Requires-Dist` names only `cffi` —
-the dependency it actually wraps, the vendored, statically-linked
-libsecp256k1 C library pinned by commit in the `secp256k1` submodule
-and compiled directly into the wheel, does not appear there and so is
-invisible to the generator btclib uses. btclib's `RELEASING.md` (the
+the dependency it actually wraps, the vendored libsecp256k1 C
+library at its pinned commit in the `secp256k1` submodule, does not
+appear there and so is invisible to the generator btclib uses. That
+holds for both wheels this package ships, not only the static one:
+a static build links the library into the extension, a dynamic
+(ABI-mode) build ships it as a shared object beside the extension
+instead (see CLAUDE.md's Architecture section) — `Requires-Dist`
+says nothing about the pin either way. btclib's `RELEASING.md` (the
 "Read the bill of materials attached to the release" step) has the
 full reasoning, and issue
 [btclib-org/btclib#1159](https://github.com/btclib-org/btclib/issues/1159)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,22 @@ The `attest` job then signs a build provenance statement for the sdist,
 which is the file the GitHub release attaches and therefore the one copy
 the index's attestation says nothing about.
 
+**No CycloneDX bill of materials is attached, on purpose**, unlike
+btclib's release. A bill of materials built the way btclib's is would
+read `Requires-Dist` off the wheel's metadata, which names only `cffi`
+— the dependency this package actually wraps is the vendored,
+statically-linked libsecp256k1 C library, pinned by commit in the
+`secp256k1` submodule and compiled directly into the wheel, and no
+Python metadata says so. Describing that pin correctly needs a
+component the existing generator does not build, sourced from the same
+pin `check_submodule_pin.py` already checks rather than from
+`Requires-Dist` — a design question of its own, not a copy of btclib's
+workflow step. Shipping the naive version now would name the least
+interesting dependency and omit the one worth auditing, which is worse
+than attaching nothing. See issue
+[btclib-org/btclib#1159](https://github.com/btclib-org/btclib/issues/1159)
+for the evaluation and what would change it.
+
 The version published is the one in `pyproject.toml`; the tag only
 decides which index is reached. The `version-check` job cross-checks
 them, and runs before anything is built: a `v0.7.1` tag on a tree still

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,20 +12,15 @@ which is the file the GitHub release attaches and therefore the one copy
 the index's attestation says nothing about.
 
 **No CycloneDX bill of materials is attached, on purpose**, unlike
-btclib's release. A bill of materials built the way btclib's is would
-read `Requires-Dist` off the wheel's metadata, which names only `cffi`
-— the dependency this package actually wraps is the vendored,
-statically-linked libsecp256k1 C library, pinned by commit in the
-`secp256k1` submodule and compiled directly into the wheel, and no
-Python metadata says so. Describing that pin correctly needs a
-component the existing generator does not build, sourced from the same
-pin `check_submodule_pin.py` already checks rather than from
-`Requires-Dist` — a design question of its own, not a copy of btclib's
-workflow step. Shipping the naive version now would name the least
-interesting dependency and omit the one worth auditing, which is worse
-than attaching nothing. See issue
+btclib's release. This package's `Requires-Dist` names only `cffi` —
+the dependency it actually wraps, the vendored, statically-linked
+libsecp256k1 C library pinned by commit in the `secp256k1` submodule
+and compiled directly into the wheel, does not appear there and so is
+invisible to the generator btclib uses. btclib's `RELEASING.md` (the
+"Read the bill of materials attached to the release" step) has the
+full reasoning, and issue
 [btclib-org/btclib#1159](https://github.com/btclib-org/btclib/issues/1159)
-for the evaluation and what would change it.
+has the evaluation behind it.
 
 The version published is the one in `pyproject.toml`; the tag only
 decides which index is reached. The `version-check` job cross-checks


### PR DESCRIPTION
## What

Documents, in `RELEASING.md`, that this repository not attaching a
CycloneDX bill of materials to its releases is a decision rather than
drift from btclib, which does.

## Why

btclib-org/btclib#1159 asked whether the SBOM step is a
three-repository property or a btclib one. Evidence (full detail on
that issue): a bill of materials generated for this repository's
current `main` (built wheel + sdist, `generate_sbom.py` borrowed from
btclib) names `cffi` three times -- once per environment-marker split
-- and nothing else. The dependency this package actually wraps, the
vendored/statically-linked libsecp256k1 C library pinned by commit in
the `secp256k1` submodule and compiled directly into the wheel, does
not appear in `Requires-Dist` and so is invisible to a generator that
reads only that. Attaching the naive output would name the least
interesting dependency and omit the one worth auditing.

Making the bill of materials say something true about the vendored
pin needs a new component sourced from the same pin
`check_submodule_pin.py` already reads, not a copy of btclib's
workflow step -- a design question of its own. This repository also
lacks the `SOURCE_DATE_EPOCH`/reproducibility prerequisite btclib's
generator depends on for its "a rebuild writes the same bytes"
guarantee (tracked separately as divergence #8 on
btclib-org/btclib#1152).

Recommendation on #1159 is to keep the asymmetry and write it down.
This PR is that write-down for this repository. It does not close
#1159 -- that is btclib-org/btclib#1169.

Reference: btclib-org/btclib#1159

## Verification

```
$ uv run --locked pre-commit run --files RELEASING.md   # exit 0, all hooks passed
```

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Document the intentional decision not to attach CycloneDX SBOMs to this repository’s releases.

Enhancements:
- Document why CycloneDX SBOMs are intentionally omitted from this repository’s releases because the generated dependency data would not represent the vendored libsecp256k1 dependency.

Documentation:
- Explain the release SBOM decision and link to the related btclib evaluation.

Chores:
- Record the release-documentation change in the changelog.