### PR TITLE
Coverage measures tests/, and the shebang pair is guarded

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,12 +68,28 @@ repos:
         exclude: ^tests/bip3(40|24)_.*\.csv$
       - id: check-case-conflict
       # off, and measured rather than assumed: nothing tracked here carries
-      # the execute bit and no python file opens with a shebang, so both of
-      # these apply to no file at all. check-hooks-apply below is what would
-      # report them, a hook matching nothing being a rule that has stopped
-      # running rather than a rule that passes
+      # the execute bit -- `git ls-files -s` reports mode 100644 for every
+      # path, the submodule gitlink aside -- and this hook selects on
+      # types [text, executable], so it applies to no file at all.
+      # check-hooks-apply below is what would report that, a hook matching
+      # nothing being a rule that has stopped running rather than a rule
+      # that passes
       # - id: check-executables-have-shebangs
-      # - id: check-shebang-scripts-are-executable
+      # its converse is on, the same measurement reading the other way.
+      # This one selects on types [text] alone, so it matches every file
+      # here whether or not any carries a shebang: what it enforces is the
+      # pair, and the day a file needs one it also needs chmod +x. Nothing
+      # needs one today, which is a fact about how these scripts are
+      # invoked rather than an omission -- a shebang is read by the kernel
+      # only when a file is exec'd directly, and none is. hatchling
+      # `exec()`s scripts/hatch_build.py and scripts/cffi_build.py from
+      # inside the build, `uv run python scripts/cffi_build.py` is how
+      # scripts/README.md gives the in-place build, and the three under
+      # .github/scripts/ are run as `python .github/scripts/<name>.py` by
+      # this file and by the workflows. In each the interpreter is named
+      # by the caller, so a shebang would announce one nothing consults --
+      # and, unpaired, would cost this guard
+      - id: check-shebang-scripts-are-executable
       # finds nothing today, and stops an editor on another platform from
       # adding three bytes tomorrow
       - id: fix-byte-order-marker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,67 @@ release-notes length in the first place, and are still in
   their own; `btclib`'s `test.yml` carries no Windows row and
   `bitcoin-core-rpc`'s carried one further instance of its own.
 
+### The gate
+
+- **Coverage measures `tests/` as well as the package**
+  (btclib-org/.github#7). `[tool.coverage.run] source` named
+  `btclib_secp256k1` alone, so the one thing the 100% ratchet said
+  nothing about was the suite enforcing it: a helper no test calls and a
+  branch no fixture takes are dead code carrying the authority of a
+  test. `source = ["btclib_secp256k1", "tests"]` is what the sibling
+  repositories already name, and it found four gaps here rather than
+  none.
+
+  Two are closed by a test that had been missing. `point_add` in
+  `test_vectors.py` is the independent arithmetic the recovery id 2 and
+  3 fixture is built against, and its only caller, `point_mul`, never
+  hands it the identity on the right nor two points that cancel -- so
+  the group law's two special cases were reference code nothing
+  exercised, and a reference that is wrong is wrong in a way no vector
+  reports. `_calls` in `test_secret.py` reads a call whose function is
+  neither a name nor an attribute and answers nothing for it, which is
+  precisely the blind spot the population of
+  `test_every_function_that_takes_a_secret_out_offers_into` is defined
+  by: a producer invoked as `table[key]()` is not in it. The new test
+  runs the helper as well as reading it, so the pair of assertions is a
+  finding -- the secret does come out, and the walk reports no call --
+  rather than a restatement of the code. It is a module-level function
+  for a reason worth recording: `inspect.getsource` of a nested one
+  answers an indented block, which `ast.parse` refuses outright.
+
+  The other two are `raise AssertionError`, in the stubs
+  `test_submodule_pin.py` and `test_verified_signing.py` substitute to
+  prove a path is never taken. No test can cover those lines, and the
+  reason is stronger than reachability: executing one is the run in
+  which the suite is red, so a green run cannot reach it and no amount
+  of testing would. They join `raise RuntimeError` in `exclude_also`,
+  which is the same argument the entry above them already makes. The
+  package raises no `AssertionError`, so nothing shipped is excluded by
+  it. `# pragma: no cover` twice was the alternative, and it records the
+  decision once per occurrence instead of once.
+
+- **`check-shebang-scripts-are-executable` is on** (btclib-org/.github#7).
+  It sat commented out beside `check-executables-have-shebangs` under
+  one comment covering both, and that comment was right about one of
+  them: `git ls-files -s` reports mode 100644 for every path here, so a
+  hook selecting on `types: [text, executable]` matches nothing and
+  `check-hooks-apply` would say so. Its converse selects on
+  `types: [text]` alone and matches every file in the tree whether or
+  not any carries a shebang, so the same measurement enables it rather
+  than excluding it -- what it enforces is the pair, and the day a file
+  needs a shebang it also needs `chmod +x`.
+
+  That no file has one today is a fact about how these scripts are
+  invoked, not an omission: hatchling `exec()`s `scripts/hatch_build.py`
+  and `scripts/cffi_build.py` from inside the build,
+  `scripts/README.md` gives the in-place build as `uv run python
+  scripts/cffi_build.py`, and the three under `.github/scripts/` run as
+  `python .github/scripts/<name>.py` from `.pre-commit-config.yaml` and
+  the workflows. The caller names the interpreter every time, so a
+  shebang would announce one nothing consults -- and, unpaired with the
+  execute bit, would cost this guard. `fix-byte-order-marker`, the
+  entry of the same shape, was already on.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -584,7 +584,13 @@ filterwarnings = ["error"]
 xfail_strict = true
 
 [tool.coverage.run]
-source = ["btclib_secp256k1"]
+# both trees are named, rather than left to --cov's default of "whatever
+# got imported": a module no test imports is then reported at 0% instead
+# of being absent from the table, which is the miss worth catching. tests
+# is measured for the same reason it is written -- a helper nothing calls
+# and a fixture branch nothing takes are dead code carrying the authority
+# of a test, and only a measured suite says so
+source = ["btclib_secp256k1", "tests"]
 # the interesting misses are the guard clauses of a wrapper: statement
 # coverage alone would call a half-tested if fully covered
 branch = true
@@ -603,8 +609,14 @@ precision = 2
 # reports an argument out of the domain, and every one of them is
 # exercised, while a RuntimeError reports a libsecp256k1 call failing
 # where no input can make it fail, and none of them can be. Excluding
-# the latter leaves a number that only untested code can lower
-exclude_also = ["raise RuntimeError"]
+# the latter leaves a number that only untested code can lower.
+# `raise AssertionError` joins it now that tests are measured, and for a
+# stronger reason than reachability: it is how a stub substituted to
+# prove a path is never taken reports being called, so executing that
+# line is the run in which the suite is red. A green run cannot cover
+# it, and no amount of testing would. The package raises none, so the
+# entry reaches the two stubs in tests/ and nothing shipped
+exclude_also = ["raise RuntimeError", "raise AssertionError"]
 # with those excluded the suite reaches every line and every branch, so
 # the ratchet can be the only value that fails on a single new untested
 # one. It assumes the static extension the coverage job builds: on a

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -21,6 +21,7 @@ import inspect
 import mmap
 import pkgutil
 from types import FunctionType
+from typing import Any
 
 import pytest
 
@@ -66,6 +67,23 @@ def _calls(function: FunctionType) -> set[str]:
             elif isinstance(node.func, ast.Name):
                 names.add(node.func.id)
     return names
+
+
+def _take_through_a_table(buffer: Any) -> Any:
+    """Read a secret out through a subscript, which names no function.
+
+    Parsed and never run, and at module level because that is the only
+    source `_calls` can read: `inspect.getsource` of a nested function
+    answers its indented block, which `ast.parse` refuses outright.
+
+    Args:
+        buffer: whatever `_secret.take` would have been handed.
+
+    Returns:
+        Whatever `_secret.take` would have answered.
+    """
+    table = {"take": _secret.take}
+    return table["take"](buffer)
 
 
 def test_take_reads_the_secret_out_and_zeroes_the_buffer() -> None:
@@ -216,6 +234,30 @@ def test_take_refuses_a_view_of_wider_items() -> None:
     with pytest.raises(TypeError, match="not of 4-byte items"):
         _secret.take(buffer, into=wide)
     assert ffi.unpack(buffer, ffi.sizeof(buffer)) == bytes(ffi.sizeof(buffer))
+
+
+def test_calls_reads_nothing_from_a_call_that_names_no_function() -> None:
+    """A call reached through an expression contributes no name.
+
+    The population of the test below is the names `_calls` answers, so
+    what it cannot name it cannot include: a producer invoked as
+    `table[key]()` leaves that walk reporting no call site at all rather
+    than reporting a wrong one. The helper is run as well as read, which
+    is what makes the pair of assertions a finding and not a definition
+    -- it does take a secret out, and the walk says it calls nothing.
+    That is a blind spot of the same kind SECURITY.md records for a
+    secret that never passes through `take`, and it is measured here
+    rather than assumed, a walk having no other way to report which of
+    its two readings it took.
+    """
+    buffer = ffi.new("char[32]", SECRET)
+
+    assert _take_through_a_table(buffer) == SECRET
+    # the same narrowing the walk below reaches its population through:
+    # a bare `def` is a `Callable` to mypy, and `_calls` takes the
+    # `FunctionType` `inspect.isfunction` answers for
+    assert inspect.isfunction(_take_through_a_table)
+    assert _calls(_take_through_a_table) == set()
 
 
 def test_every_function_that_takes_a_secret_out_offers_into() -> None:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -72,8 +72,11 @@ def _calls(function: FunctionType) -> set[str]:
 def _take_through_a_table(buffer: Any) -> Any:
     """Read a secret out through a subscript, which names no function.
 
-    Parsed and never run, and at module level because that is the only
-    source `_calls` can read: `inspect.getsource` of a nested function
+    Two things read this. `_calls` parses it below, to see that a call
+    reached as `table["take"](buffer)` contributes no name; the test
+    that follows also runs it, on a real secret, to check that the
+    secret still comes out through the subscript. It is at module level
+    for the first of those: `inspect.getsource` of a nested function
     answers its indented block, which `ast.parse` refuses outright.
 
     Args:

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -134,6 +134,28 @@ def compressed(point: Point) -> bytes:
     return bytes([2 + (point[1] & 1)]) + point[0].to_bytes(32, "big")
 
 
+def test_point_add_at_infinity() -> None:
+    """The two cases the vectors below never reach, driven directly.
+
+    `point_mul` is the only caller here, and it never hands `point_add`
+    a second operand of None nor two points that cancel: it doubles and
+    adds a generator by scalars that are group elements. So the identity
+    on the right and the inverse are the arithmetic this file compares
+    the bindings against, and are exercised by nothing that compares
+    anything -- which is the shape a test of the reference itself exists
+    for, the reference being wrong in a way no vector would report.
+    """
+    assert point_add(G, None) == G
+    assert point_add(None, G) == G
+    assert point_add(None, None) is None
+    # -G is G mirrored across the x axis, and G + (-G) is the point at
+    # infinity: the one sum of two affine points that has no affine value
+    assert point_add(G, (G[0], P - G[1])) is None
+    # a point and itself is doubling and not cancellation, which is the
+    # distinction the first coordinate alone cannot make
+    assert point_add(G, G) == point_mul(2, G)
+
+
 def bip340_vectors() -> list[dict[str, str]]:
     """Read the BIP340 vector csv, vendored from bitcoin/bips."""
     path = pathlib.Path(__file__).parent / "bip340_test_vectors.csv"


### PR DESCRIPTION
Part of btclib-org/.github#7, "Adopt the practices the audit sent back
into the standard". This repository already had branch coverage,
`exclude_also` and pydoclint; it owed the two below.

## `tests` added to `[tool.coverage.run] source`

`source = ["btclib_secp256k1", "tests"]`, matching the sibling
repositories. The suite enforcing the 100% ratchet was the one thing the
ratchet said nothing about. Measuring it found four gaps, none of them
cosmetic:

- **`point_add`'s identity and inverse cases** (`tests/test_vectors.py`
  108, 110). It is the independent arithmetic the recovery id 2 and 3
  fixture is built against, and its only caller, `point_mul`, never
  hands it `None` on the right nor two points that cancel. Closed by
  `test_point_add_at_infinity`, a real test: a reference implementation
  that is wrong here is wrong in a way no vector would report.
- **`_calls`' second reading** (`tests/test_secret.py`, partial branch
  67->63): a call whose function is neither a name nor an attribute
  contributes no name, which is exactly the blind spot the population of
  `test_every_function_that_takes_a_secret_out_offers_into` is defined
  by — a producer invoked as `table[key]()` is not in it. Closed by
  `test_calls_reads_nothing_from_a_call_that_names_no_function`, which
  runs the helper as well as reading it, so the two assertions are a
  finding (the secret does come out; the walk reports no call) rather
  than a restatement. The helper is module-level because
  `inspect.getsource` of a nested function answers an indented block
  that `ast.parse` refuses.
- **two `raise AssertionError` lines** (`tests/test_submodule_pin.py`
  206, `tests/test_verified_signing.py` 246), in stubs substituted to
  prove a path is never taken. No test can cover them, and for a reason
  stronger than reachability: executing one is the run in which the
  suite is red, so a green run cannot reach it and no amount of testing
  would. They join `raise RuntimeError` in `exclude_also`, with the
  reasoning beside it. The package raises no `AssertionError`, so
  nothing shipped is excluded. Two `# pragma: no cover` was the
  alternative, and it records the decision once per occurrence.

Coverage is back at 100.00% with `tests/` in scope.

## `check-shebang-scripts-are-executable`

It was not merely absent: it sat commented out beside
`check-executables-have-shebangs` under a single comment covering both.
That comment was right about the latter — `git ls-files -s` reports mode
100644 for every path here (the submodule gitlink aside), and that hook
selects on `types: [text, executable]`, so it matches no file and
`check-hooks-apply` would say so. It was wrong about the former, which
selects on `types: [text]` alone and therefore matches every file in the
tree whether or not any carries a shebang. So the same measurement
enables one and keeps the other off, and the comment is split in two.

What the hook found: nothing. `grep -l '^#!' scripts/*.py
.github/scripts/*.py` matches nothing and no tracked file carries the
execute bit — as it should be, given how these are invoked. hatchling
`exec()`s `scripts/hatch_build.py` and `scripts/cffi_build.py` from
inside the build, `scripts/README.md` gives the in-place build as
`uv run python scripts/cffi_build.py`, and the three under
`.github/scripts/` run as `python .github/scripts/<name>.py` from
`.pre-commit-config.yaml` and the workflows. The caller names the
interpreter every time, so a shebang would announce one nothing
consults — and, unpaired with the execute bit, would cost this guard.
`fix-byte-order-marker`, the entry of the same shape, was already on and
is not duplicated.

## Verification

Setup: `git submodule update --init --recursive` then `uv sync --locked`,
both exit 0.

| command | exit code |
| --- | --- |
| `uv run pre-commit run --all-files` | 0 |
| `uv run pytest` | 0 (767 passed) |
| `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` | 0 |

`uv run pytest --cov` also exits 0, at 100.00% with `tests/` measured.
The sphinx command is CONTRIBUTING.md's own, which differs from the
plain `uv run sphinx-build` form.

## Summary by Sourcery

Strengthen quality gates by measuring test coverage comprehensively and enforcing consistent shebang and executable permissions.

New Features:
- Enable the shebang/executable pairing pre-commit check to prevent future script permission mismatches.

Bug Fixes:
- Add coverage for elliptic-curve point-at-infinity and inverse cases and for secret extraction through dynamically selected calls.

Enhancements:
- Measure the tests alongside the package for complete coverage enforcement and exclude intentionally unreachable assertion failures from the coverage calculation.

Documentation:
- Document the expanded coverage gate and shebang-check policy in the changelog.

Tests:
- Extend tests to cover previously unmeasured arithmetic and AST-walking edge cases.