### PR TITLE
Key lint.yml's pre-commit cache on the runner image and interpreter

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -151,8 +151,8 @@ jobs:
         with:
           enable-cache: true
 
-      # keyed on the config file, as in lint.yml: the hook environments are
-      # the slow part, and the upgrade below does not touch them
+      # keyed on the config file: the hook environments are the slow
+      # part, and the upgrade below does not touch them
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,12 +132,43 @@ jobs:
         with:
           python-version: "3.14"
 
+      # what the cache key has to distinguish, and why a step computes it.
+      # ImageOS is set by the runner image ("ubuntu24"), not by this
+      # workflow, and the env context holds only what a workflow, job or
+      # step declares -- so "${{ env.ImageOS }}" in the key below would
+      # interpolate to the empty string and the comment claiming otherwise
+      # would be the only thing distinguishing the images. Read here, in a
+      # shell, where it is an ordinary environment variable.
+      # ImageOS and not ImageVersion: the version moves every week or two
+      # for patches no hook environment depends on, and putting it in the
+      # key would mean rebuilding all of them that often
+      - name: Identify the runner image
+        id: image
+        run: echo "os=${ImageOS:-unknown}" >> "$GITHUB_OUTPUT"
+
       # the hook environments are the slow part; they only change when
-      # the pinned revisions in .pre-commit-config.yaml change
+      # the pinned revisions in .pre-commit-config.yaml change.
+      # The key carries the runner image and the interpreter as well as
+      # that file, because what is cached is virtualenvs: a hook
+      # environment is built against whatever Python pre-commit runs
+      # under, which here is the one .python-version pins, and against
+      # the runner's node and go. The config hash alone would survive an
+      # ubuntu-latest rotation -- 22.04 to 24.04, and the next one -- and
+      # restore environments built on the previous image under the same
+      # key.
+      # restore-keys then makes a revision bump cheap rather than a cold
+      # start: pre-commit rebuilds the hooks whose rev moved and reuses
+      # the rest, and it health-checks each restored environment against
+      # the interpreter it finds, so a stale one is rebuilt rather than
+      # run -- which is what makes a partial restore safe to want
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: >-
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-${{
+            hashFiles('.pre-commit-config.yaml', '.python-version') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,20 @@ release-notes length in the first place, and are still in
   `0.12.1` still clears `0.12.0`, so the floor itself does not move here
   -- only the comment does.
 
+- **`lint.yml`'s pre-commit cache key now carries the runner image and
+  the interpreter, not only `.pre-commit-config.yaml`'s hash** (#296).
+  What the cache holds is compiled artifacts and interpreter-linked
+  virtualenvs, so restoring one built on a different runner image is not
+  a graceful miss but a hit that hands the run a broken environment, the
+  failure surfacing as whichever hook touches it first -- the config
+  hash alone would have survived an `ubuntu-latest` rotation, 22.04 to
+  24.04 and the next one, and kept restoring an environment built on the
+  image before it. Both siblings already key on `runner.os`, the
+  `ImageOS` environment variable read by a new `Identify the runner
+  image` step, and `.python-version`'s hash alongside the config's; this
+  repository's file is now the same, `restore-keys` included so a
+  revision bump in the config stays a warm start rather than a cold one.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for


### PR DESCRIPTION
## Summary

- `lint.yml`'s pre-commit cache was keyed on
  `hashFiles('.pre-commit-config.yaml')` alone, which a runner-image
  rotation survives: what the cache holds is compiled hook
  environments built against the image's own Python, node and go, so
  restoring one built on a previous image under the same key is a hit
  that hands the run a broken environment, surfacing as whichever hook
  touches it first.
- A new `Identify the runner image` step reads `ImageOS` from the
  environment (the `env` context only holds what the workflow
  declares, so `${{ env.ImageOS }}` in the key would have resolved to
  nothing), and the key now also hashes `.python-version`, which this
  repository has and which pins the interpreter pre-commit runs under.
  `restore-keys` keeps a config revision bump a warm start rather than
  a cold one — pre-commit health-checks a restored environment against
  the interpreter it finds, so a stale one is rebuilt rather than run.
- Both siblings (btclib, bitcoin-core-rpc) already carry this, and are
  byte-identical to each other in the cache-key block (the `Identify
  the runner image` step through the `Cache the pre-commit hook
  environments` step, comments included), so there was no drift
  between them to reconcile — this repository's file now matches.
  Verified with:

  ```shell
  gh api repos/btclib-org/btclib/contents/.github/workflows/lint.yml \
      --jq .content | base64 -d > /tmp/btclib_lint.yml
  gh api repos/btclib-org/bitcoin-core-rpc/contents/.github/workflows/lint.yml \
      --jq .content | base64 -d > /tmp/bcr_lint.yml
  diff /tmp/btclib_lint.yml /tmp/bcr_lint.yml
  ```

  The full-file `diff` does show a handful of hunks (a concurrency-group
  comment reworded, `astral-sh/setup-uv` pinned to a different patch
  release), none of them touching the cache-key block, which appears
  identically in both `diff` outputs' unchanged context.
- `latest.yml`'s `lint-latest` job comment said "keyed on the config
  file, as in `lint.yml`"; that comparison stopped being true the
  moment `lint.yml`'s key changed here, so it is dropped, keeping the
  reason that is still true (the hook environments are the slow part
  and the dependency upgrade in that job does not touch them).
  `latest.yml`'s own cache key is unchanged and out of scope: it has
  the identical runner-image-rotation problem, but that is one defect
  across `btclib-secp256k1`, `btclib` and `bitcoin-core-rpc` alike (the
  latter two's `latest.yml` carries the same bare key and the same
  now-false comment already, `lint.yml` there having been fixed
  earlier), filed once in `btclib-org/.github` rather than three times
  here.

Closes #296.

## Test plan

- [x] `uv run pre-commit run --all-files` — exit 0, no unexpected file
      changes
- [x] `uv run pytest --cov` — 765 passed, 100.00% coverage
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` — build
      succeeded
- [x] this branch's own `lint.yml` run: cache miss on the new key as
      expected (`Cache not found for input keys:
      pre-commit-Linux-ubuntu24-<hash>, pre-commit-Linux-ubuntu24-`),
      hooks ran and passed, `Cache saved with key:
      pre-commit-Linux-ubuntu24-<hash>` at job end — job took 2m4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align the lint workflow's pre-commit cache with the runner image and interpreter to avoid reusing incompatible hook environments.

Bug Fixes:
- Prevent stale pre-commit hook environments from being restored after runner-image or interpreter changes.

Enhancements:
- Include the runner operating system, runner image, and pinned Python interpreter in the pre-commit cache key while retaining partial restores for configuration revisions.

Chores:
- Record the pre-commit cache keying change in the changelog.
