### PR TITLE
docs.yml's unresolved-link grep carries both known shapes (issue #1157)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,9 +122,10 @@ jobs:
       # same claim made about the artifact rather than about the
       # configuration, and what would catch a suppression added back.
       #
-      # Two greps, not one (issue #1157). This repository's root files do
-      # not settle on one spelling: CONTRIBUTING.md and SECURITY.md link
-      # by bare name ("SECURITY.md" -> href="#SECURITY.md" if it broke,
+      # Two greps, not one (issue btclib-org/btclib#1157). This
+      # repository's root files do not settle on one spelling:
+      # CONTRIBUTING.md and SECURITY.md link by bare name
+      # ("SECURITY.md" -> href="#SECURITY.md" if it broke,
       # the second grep below), but CONTRIBUTING.md's own link to
       # REVIEWING.md and CHANGELOG.md's to RELEASE_NOTES.md are written
       # "./REVIEWING.md" and "./RELEASE_NOTES.md" -- the first grep, and

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -116,16 +116,31 @@ jobs:
 
       # the one defect the build above cannot report on itself, matching
       # btclib's own second step and the reasoning in its docs/source/conf.py:
-      # a relative link myst cannot resolve becomes an anchor on the page it
-      # is already on -- href="#SECURITY.md", an id nothing has -- rather
-      # than a warning, which conf.py's RootFileLinks transform exists to
-      # prevent. This is the same claim made about the artifact rather than
-      # about the configuration, and what would catch a suppression added
-      # back. No "./" prefix in the pattern, unlike btclib's: the root files
-      # here link to each other by bare name ("SECURITY.md"), never "./SECURITY.md"
+      # a link myst cannot resolve becomes an anchor on the page it is
+      # already on -- an id nothing has -- rather than a warning, which
+      # conf.py's RootFileLinks transform exists to prevent. This is the
+      # same claim made about the artifact rather than about the
+      # configuration, and what would catch a suppression added back.
+      #
+      # Two greps, not one (issue #1157). This repository's root files do
+      # not settle on one spelling: CONTRIBUTING.md and SECURITY.md link
+      # by bare name ("SECURITY.md" -> href="#SECURITY.md" if it broke,
+      # the second grep below), but CONTRIBUTING.md's own link to
+      # REVIEWING.md and CHANGELOG.md's to RELEASE_NOTES.md are written
+      # "./REVIEWING.md" and "./RELEASE_NOTES.md" -- the first grep, and
+      # the one a single-pattern check here used to leave uncovered. A
+      # survey of the other two repositories in this organization, and of
+      # every link these root files carry, found no third shape, so two
+      # greps is the union rather than a guess at how far to generalize.
       - name: Check the built pages for unresolved links
         run: |
-          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page"
-            exit 1
+          status=0
+          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page (unresolved relative path)"
+            status=1
           fi
+          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page (unresolved bare .md target)"
+            status=1
+          fi
+          exit $status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,22 @@ release-notes length in the first place, and are still in
   failed with `tool_version_not_supported` before a single one started.
   `0.12.1` still clears `0.12.0`, so the floor itself does not move here
   -- only the comment does.
+- **`docs.yml`'s unresolved-link grep now carries both known shapes**,
+  closing btclib-org/btclib#1157. MyST renders a link its
+  `RootFileLinks` transform cannot resolve as `href="#<target>"`
+  verbatim, so what the grep matches depends on how the target was
+  written -- `href="#[A-Za-z0-9_.-]*\.md"` for a bare `SECURITY.md` with
+  no `./`, most of this package's own root-file links, and `href="#\./`
+  for `./REVIEWING.md` and `./RELEASE_NOTES.md`, which CONTRIBUTING.md
+  and CHANGELOG.md write with the `./` the rest of this package's links
+  omit -- the same shape the comment this replaces claimed the package
+  never used. This job ran only the bare-name grep, which is blind to
+  either of those two live links breaking. Built the documentation with
+  a deliberately unresolved link of each shape and confirmed the added
+  grep reports it before removing it; `sphinx-build -W --keep-going`
+  passes on both unchanged, since neither is the broken *reference* `-W`
+  already catches -- a link myst resolves happily and is dead anyway is
+  the whole reason this second check exists.
 
 ## v0.8.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,8 @@ release-notes length in the first place, and are still in
   `0.12.1` still clears `0.12.0`, so the floor itself does not move here
   -- only the comment does.
 - **`docs.yml`'s unresolved-link grep now carries both known shapes**,
-  closing btclib-org/btclib#1157. MyST renders a link its
+  one of two companion fixes for btclib-org/btclib#1157, which
+  btclib-org/btclib's own PR closes. MyST renders a link its
   `RootFileLinks` transform cannot resolve as `href="#<target>"`
   verbatim, so what the grep matches depends on how the target was
   written -- `href="#[A-Za-z0-9_.-]*\.md"` for a bare `SECURITY.md` with


### PR DESCRIPTION
## What

`docs.yml`'s unresolved-link grep now runs both known patterns, not
only the bare-`.md` one. Companion to btclib-org/btclib#1157 and to
btclib-org/bitcoin-core-rpc's own PR; does not close #1157 itself —
that is btclib-org/btclib's PR.

## Why this repository was blind, concretely

`docs/source/conf.py`'s `RootFileLinks` transform resolves every
repository-relative link the included root files (README,
CONTRIBUTING, SECURITY, HISTORY) carry; what it cannot resolve MyST
renders as `href="#<target>"` verbatim rather than as a `-W`-visible
warning. The comment this PR replaces claimed "the root files here
link to each other by bare name ... never `./SECURITY.md`" — checked
against the actual files rather than trusted:

```
$ grep -n '](\./' README.md CONTRIBUTING.md CHANGELOG.md
CONTRIBUTING.md:617:[REVIEWING.md](./REVIEWING.md) is the standard...
CHANGELOG.md:15:[RELEASE_NOTES.md](./RELEASE_NOTES.md) has the...
CHANGELOG.md:21:[RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than...
```

`CONTRIBUTING.md` and `CHANGELOG.md` are both included pages, and both
carry a `./`-prefixed link the previous single grep
(`href="#[A-Za-z0-9_.-]*\.md"`) cannot match — its character class
excludes `/`, so `href="#./REVIEWING.md"` never matches it. If either
link broke, this job would report nothing.

## The other shape, and why btclib/bitcoin-core-rpc were blind too

Those two repositories run `href="#\./`, which matches a `./`-prefixed
target of any extension but not a bare `SECURITY.md`-style target —
the shape most of this package's own root-file links use. Two distinct
MyST failure modes, `# 1157`'s tracking issue naming the fix as
**neither repository alone**.

## Verification

Built the documentation with a deliberately unresolved link of each
shape appended to a scratch `CONTRIBUTING.md`
(`./DOES_NOT_EXIST.md` and `DOES_NOT_EXIST.md`), confirmed both new
greps report it, then reverted:

```shell
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
build succeeded.
$ uv run pre-commit run --all-files
... all hooks Passed, exit 0
```

`docs.yml` dispatched on this branch: https://github.com/btclib-org/btclib-secp256k1/actions/runs/32486359594, job green.

Also checked, and filed rather than fixed here since nothing in this
package's own root files currently writes it: a link with no leading
`./` and no `.md` extension, or a nested path with no leading `./`,
reaches the same MyST fallback and neither grep catches it —
btclib-org/btclib#1175.

Reference: btclib-org/btclib#1157

## Summary by Sourcery

Improve documentation CI coverage for unresolved relative links.

Bug Fixes:
- Update the documentation workflow to detect unresolved links using both bare `.md` and `./`-prefixed target patterns.

CI:
- Make unresolved-link checks report all matching failures while preserving a combined failing status.

Documentation:
- Document the expanded unresolved-link coverage in the changelog.