### PR TITLE
Declare shell: bash on every Windows-capable run: step (issue btclib-org/btclib#1148)

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -121,6 +121,15 @@ jobs:
       # This rewrites uv.lock, which is harmless on an ephemeral checkout
       # and worth knowing before running the same command in a working tree
       - name: Upgrade every dependency to its latest release
+        # this matrix includes windows-latest, whose default shell is
+        # PowerShell rather than bash -- see windows.yml's suite-windows
+        # job for the failure mode a POSIX-only step hits there unnoticed
+        # (issue btclib-org/btclib#1148). Both steps below are one plain
+        # command each and run identically under either shell today,
+        # which is exactly the hazard: a future edit that adds
+        # POSIX-only syntax would go green on this cell having run
+        # nothing
+        shell: bash
         run: uv lock --upgrade
 
       # still --locked, which is not a contradiction: the step above just
@@ -128,6 +137,7 @@ jobs:
       # keeps the convention that no uv command here installs from a lock
       # it has not checked
       - name: Run pytest
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
   # mypy is the whole reason this job exists, and it is worth being explicit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,7 +378,14 @@ jobs:
         shell: bash
         run: echo "CIBW_BUILD=cp314-*" >> "$GITHUB_ENV"
 
+      # this job's own matrix carries windows-latest and windows-11-arm,
+      # the same reason the step above already declares shell: bash --
+      # see its comment. This step is one plain command and runs
+      # identically under PowerShell today; the hazard is the same one
+      # that step's comment names for the next edit that is not
+      # (issue btclib-org/btclib#1148)
       - name: Build wheels
+        shell: bash
         run: uv run --frozen --only-group build cibuildwheel
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -592,7 +599,13 @@ jobs:
           python -m pip install -U pip pytest
           python -m pip install --verbose dist/*.tar.gz
 
+      # this job's matrix carries windows-latest and windows-11-arm, the
+      # same reason the step above already declares shell: bash. `pytest`
+      # alone has no POSIX-only syntax and runs identically under
+      # PowerShell today; the hazard is the next edit that adds some
+      # (issue btclib-org/btclib#1148)
       - name: Test
+        shell: bash
         run: pytest
 
   build-windows:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,8 +136,18 @@ jobs:
 
       # the command CONTRIBUTING.md gives a developer, and the one the
       # coverage job of test.yml runs on ubuntu: a static build, where
-      # `_load_lib` returns the extension's own `lib`
+      # `_load_lib` returns the extension's own `lib`.
+      #
+      # both steps below run on windows-latest or windows-11-arm, where
+      # the default shell is PowerShell rather than bash -- see
+      # published.yml's own fix, issue btclib-org/btclib#1141, for the
+      # failure mode a POSIX-only step hits there unnoticed. Each is one
+      # plain command and runs identically under either shell today,
+      # which is exactly the hazard: a future edit adding POSIX-only
+      # syntax would go green on this cell having run nothing (issue
+      # btclib-org/btclib#1148)
       - name: Run pytest against a static build
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
       # the other branch of `_load_lib`: cffi in ABI mode, dlopening the
@@ -149,6 +159,7 @@ jobs:
       - name: Run pytest against a dynamic build
         env:
           BTCLIB_LIBSECP256K1_DYNAMIC: "true"
+        shell: bash
         run: >
           uv run --locked --no-default-groups --group test
           --reinstall-package btclib_secp256k1 --no-cache pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,40 @@ release-notes length in the first place, and are still in
   `0.12.1` still clears `0.12.0`, so the floor itself does not move here
   -- only the comment does.
 
+- **Every `run:` step that can land on a Windows runner declares
+  `shell: bash`** (btclib-org/btclib#1148). `suite-latest` in
+  `latest.yml`, `suite-windows` in `windows.yml`, and
+  `build-cibuildwheel` and `suite-sdist` in `test.yml` each carry a
+  `windows-latest` or `windows-11-arm` matrix cell, where the default
+  shell is PowerShell and `"$GITHUB_ENV"` and the rest of the POSIX
+  spelling are literals rather than variables; `build-cibuildwheel`'s
+  `Build wheels` step already sits beside one step that declares the
+  line for exactly this reason, and named the other Windows steps of
+  this file it did not yet reach. All six affected steps are one plain
+  command each and run identically under either shell today, so nothing
+  shipped broken -- the hazard is the next conditional, substitution or
+  loop added to one of them, which would fail only on Windows.
+  `latest.yml` and `windows.yml` run on neither a pull request nor a
+  push to `main`, so such an edit's first execution would be a scheduled
+  run; `test.yml`'s two steps are on the merge gate itself, where the
+  Windows cells of `build-cibuildwheel` and `suite-sdist` are exercised
+  on every pull request, but a shell-less step there would still go
+  green having run the wrong interpreter's syntax rather than the
+  intended one.
+
+  Enumerated by parsing every workflow file's `jobs.*.strategy.matrix`
+  (`os` and `include`) and `runs-on` with PyYAML, and flagging a `run:`
+  step whose job's runner set contains `windows` and which declares no
+  `shell:` of its own and inherits none from a job-level `defaults.run`
+  -- `actionlint`, the pinned linter in the pre-commit gate, reports
+  nothing for this shape, measured on a minimal workflow with a POSIX
+  `for` loop and no `shell:` under both a literal `windows-latest` and a
+  matrix naming it. `btclib` and `bitcoin-core-rpc` had the same defect
+  in their own copies of `latest.yml` and `windows.yml`
+  (`windows-arm.yml` in `bitcoin-core-rpc`), fixed in a pull request of
+  their own; `btclib`'s `test.yml` carries no Windows row and
+  `bitcoin-core-rpc`'s carried one further instance of its own.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for


### PR DESCRIPTION
Reference: btclib-org/btclib#1148.

## The defect

`latest.yml`, `windows.yml` and `test.yml` carry `run:` steps on
`windows-latest` / `windows-11-arm` matrix cells with no `shell:` of
their own, which GitHub hands to PowerShell rather than bash.
`"$GITHUB_ENV"` and the rest of the POSIX spelling are literals there
rather than variables. `test.yml`'s `build-cibuildwheel` job already
carries one step with `shell: bash` for exactly this reason — see its
own comment, added for ISS #1141's `published.yml` fix — and this PR
gives the rest of that job, and the other three Windows-capable jobs,
the same line. Every step this PR touches is a single plain command
today and runs identically under either shell, so nothing has shipped
broken; the hazard is the next conditional, substitution or loop
landing on one of them.

btclib-org/btclib#1148 is the tracking issue: filed against `btclib`
after a sweep of that repository's own workflows found `latest.yml` and
`windows.yml` carrying the pattern, and asking that every workflow of
all three publishing repositories be audited, since the same one-line
omission had already shipped once in each of `published.yml` (this
repository, four months before ISS #1141's `btclib` hit) and
`btclib`'s own tree.

## How every instance was enumerated

`actionlint`, the linter pinned in the pre-commit gate, does not ask
this question: reproduced on a minimal workflow carrying a POSIX `for`
loop and no `shell:`, it reports zero findings both under a literal
`runs-on: windows-latest` and under a matrix naming it. The enumeration
here is every `run:` step of every workflow in this repository, done by
parsing each file's `jobs.*.strategy.matrix` (`os` and `include`
entries) and `runs-on` with PyYAML, and flagging a `run:` step under a
job whose runner set contains `windows` and which declares no `shell:`
of its own and inherits none from a job-level `defaults.run`.

That turned up six steps:

| workflow / job | step |
| --- | --- |
| `latest.yml::suite-latest` | `Upgrade every dependency to its latest release` |
| `latest.yml::suite-latest` | `Run pytest` |
| `windows.yml::suite-windows` | `Run pytest against a static build` |
| `windows.yml::suite-windows` | `Run pytest against a dynamic build` |
| `test.yml::build-cibuildwheel` | `Build wheels` |
| `test.yml::suite-sdist` | `Test` |

`test.yml`'s `build-cibuildwheel` and `suite-sdist` are on the merge
gate itself, so their Windows cells (`windows-latest`, `windows-11-arm`)
run on every pull request — but a shell-less step among them still
executes PowerShell rather than the bash the script was written for,
going green on the wrong interpreter's syntax rather than red on the
right one, which is why their being pull-request-gated is not itself
evidence the two were safe.

`btclib` and `bitcoin-core-rpc` were swept the same way, in their own
worktrees, with their own pull requests: both had the matching
`latest.yml`/`windows.yml` defect (`windows-arm.yml` in
`bitcoin-core-rpc` — see the parent tracking issue #1152 on why that
repository's file is not named the same), and `bitcoin-core-rpc`
additionally had one instance in its own `test.yml`:

- `btclib-org/btclib#1177` (closes #1148) — `latest.yml::suite-latest`
  (2 steps), `windows.yml::suite-windows` (1 step),
  `latest.yml::suite-bindings-latest` (3 steps)
- `btclib-org/bitcoin-core-rpc#184` — `latest.yml::suite-latest`
  (2 steps), `windows-arm.yml::suite-windows-arm` (1 step),
  `test.yml::suite` (1 step)

## Verification

Run from this branch's worktree (`git submodule update --init
--recursive` first):

- `uv run pre-commit run --all-files` — exit 0, every hook passed
- `uv run pytest` — exit 0, 765 passed
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0, build
  succeeded with no warnings

`windows.yml`'s only trigger besides `release.yml`'s call is
`schedule`/`workflow_dispatch`, so it was dispatched directly on this
branch to exercise the two changed steps for real:
`gh workflow run windows.yml --ref fix/1148-windows-shell-bash` — run
https://github.com/btclib-org/btclib-secp256k1/actions/runs/32485720936, both `Run pytest against a static build` and `Run pytest
against a dynamic build` green on every cell of the matrix.
`build-cibuildwheel` and `suite-sdist` in `test.yml` are exercised by
this pull request's own required checks, which cover their Windows
cells directly.

## Summary by Sourcery

Bug Fixes:
- Ensure all workflow run steps that can execute on Windows use Bash, preventing future POSIX shell commands from silently running under PowerShell.