### PR TITLE
check-dist gains a wheel-content check

### DIFF
--- a/.github/scripts/verify_wheel_contents.py
+++ b/.github/scripts/verify_wheel_contents.py
@@ -1,0 +1,277 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+r"""Check a built wheel against an allowlist of its members.
+
+`twine check`, `check-wheel-contents` and `pyroma` read the *metadata* of
+a wheel: whether it is syntactically valid, whether the long description
+renders, whether the classifiers a package should declare are there.
+None of them reads every member, and what is in the archive is what a
+user installs.
+
+`check-wheel-contents --package btclib_secp256k1`, configured in
+`pyproject.toml` for `btclib`, is the closest built-in answer, and it
+does not fit here: it diffs the wheel's whole library against the one
+named package tree, and this package's wheel is not one package tree.
+Every wheel this project ships also carries a compiled artifact at the
+wheel's own root, beside `btclib_secp256k1/` rather than inside it -- the
+extension module for a static wheel, that module's ABI-mode source and
+the shared `libsecp256k1` for a dynamic one -- which `--package` reports
+as "files not in package tree" whether or not they are the ones this
+project intends. `[tool.check-wheel-contents]` keeps `ignore = ["W003",
+"W009"]` for the same reason, on the dynamic wheel specifically: the
+checks those codes name are about a *non-package* file at the top level,
+which for this project's dynamic wheel is not a mistake but the shared
+library.
+
+Three questions, and what answers them:
+
+**Which top-level artifact must be there.** A wheel's tag says whether it
+is static (an `infer_tag`ed `cpNN-...`, one compiled extension) or
+dynamic (`py3-none-<platform>`, an ABI-mode module and the shared library
+beside it) -- `scripts/hatch_build.py`'s own distinction, and this reads
+the same tag it writes. Which artifacts a wheel of that kind must carry,
+and refusing an extra one -- a stray file that is not part of
+`btclib_secp256k1/` and not one of them -- is what `--package` cannot
+phrase without also refusing the artifact that belongs.
+
+**Whether the artifact is really there**, and not a zero-byte member a
+half-finished build step left behind: `scripts/cffi_build.py` raises when
+it cannot find one to copy, not when it copies an empty one, so an empty
+file is a shape that check has no report for. `toplevel_reason` below
+checks the kind-appropriate artifact for size as well as presence, which
+none of `check-wheel-contents`'s codes do for any member.
+
+**Whether `btclib_secp256k1/` itself is complete.** Everything under
+that directory in the wheel has to be everything the checkout has under
+it -- source, `py.typed`, nothing more and nothing less -- which is
+`--package`'s own question, asked here by hand rather than through a
+flag that would also judge the sibling artifact.
+
+The sdist is not this script's subject. `btclib`'s sibling script checks
+it because `MANIFEST.in` there is an *include* list -- a file the tree
+gains and MANIFEST.in does not name is a file the sdist silently drops,
+which is the failure this whole class of check exists for.
+`[tool.hatch.build.targets.sdist] exclude` here is the opposite shape: a
+file the tree gains ships by default, and has to be named to be left
+out, so the failure mode is an sdist too wide rather than one silently
+narrow. What that leaves unchecked -- an exclude pattern that lists a
+file this build still needs -- is a build failure, not a silent gap,
+which is a different question with a different check to answer it.
+
+Run it against one built wheel:
+
+    uv run --no-project --python 3.14 \\
+        .github/scripts/verify_wheel_contents.py dist/*.whl
+
+`test.yml`'s `check-dist` job runs it on every wheel it downloads --
+`build-cibuildwheel`, `build-dynamic` and `build-windows` between them --
+which are the artifacts `release.yml`'s own `test` job produces and the
+publish jobs upload: one build, checked and shipped, so this judges the
+files this project actually publishes rather than a copy of them.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+# the package this repository ships, read fresh from the checkout rather
+# than hard-coded: a module added to it is a module the next wheel has to
+# carry, and a copy of the file list here would drift the day one is
+# added or removed without anybody editing this script to match
+PACKAGE_DIR = Path(__file__).parents[2] / "btclib_secp256k1"
+
+# no member of this wheel carries any of these, whichever top-level
+# artifact the kind below admits: a `.pth` executes at interpreter
+# startup, before the first import; a `.pyc` is a compiled module nobody
+# reviewed; an archive inside an archive is a second package installing
+# with the first. Checked against `btclib_secp256k1/` and the
+# top-level artifact -- not against `.dist-info`, which is already
+# validated member by member, against its own allowlist, above
+FORBIDDEN_SUFFIXES = (".egg", ".pth", ".pyc", ".tar.gz", ".whl", ".zip")
+FORBIDDEN_NAMES = ("sitecustomize.py", "usercustomize.py")
+
+# what hatchling writes into `.dist-info`, and no more. No
+# `top_level.txt`: that is a setuptools file, and this build backend is
+# hatchling
+WHEEL_METADATA_FILES = frozenset({"METADATA", "RECORD", "WHEEL"})
+# `license-files` in pyproject.toml, copied into `licenses/` verbatim
+WHEEL_LICENSE_FILES = frozenset({"AUTHORS.md", "COPYRIGHT", "LICENSE"})
+
+# suffixes a compiled extension module carries, keyed by platform: cffi's
+# static path compiles one of these, named `_btclib_secp256k1` with an
+# ABI tag before the suffix on POSIX (cffi's own convention) and without
+# one on Windows -- `scripts/cffi_build.py`'s MSVC path names the
+# extension `_btclib_secp256k1.pyd` outright
+EXTENSION_SUFFIXES = (".so", ".pyd")
+# the shared library a dynamic wheel carries beside the ABI-mode module,
+# by the platform suffix `shared_library_extension` in cffi_build.py
+# names for it. No version suffix: the same function skips a candidate
+# with more than one, which is the symlink chain's own name and not the
+# file CMake just built
+SHARED_LIBRARY_SUFFIXES = (".dll", ".dylib", ".so")
+
+
+def wheel_kind(name: str) -> str:
+    """Return "static" or "dynamic" for the wheel named `name`.
+
+    The python tag is the second-to-last dash-separated field before the
+    platform tag in a three-tag wheel name, and it is what
+    scripts/hatch_build.py itself sets: `py3-none-<platform>` for a
+    dynamic wheel, an inferred `cpNN-cpNN-<platform>` for a static one.
+    Reading the filename rather than the `WHEEL` file's Root-Is-Purelib
+    line: that line is `false` for both kinds here, since the build hook
+    clears `pure_python` before either is tagged.
+    """
+    tags = name[: -len(".whl")].split("-")
+    return "dynamic" if tags[-3] == "py3" else "static"
+
+
+def toplevel_reason(members: set[str], kind: str) -> str | None:
+    """Say why the wheel's top-level artifact does not match `kind`.
+
+    Returns None if it does. `members` is every member outside
+    `btclib_secp256k1/` and the `.dist-info` directory.
+    """
+    if kind == "static":
+        matches = [
+            m
+            for m in members
+            if m.startswith("_btclib_secp256k1") and m.endswith(EXTENSION_SUFFIXES)
+        ]
+        rest = members - set(matches)
+        if len(matches) != 1 or rest:
+            return (
+                "a static wheel carries exactly one _btclib_secp256k1 extension "
+                f"module and nothing else at its root; found {sorted(members)}"
+            )
+        return None
+    py_module = "_btclib_secp256k1.py"
+    libs = [
+        m
+        for m in members
+        if m.startswith("libsecp256k1") and m.endswith(SHARED_LIBRARY_SUFFIXES)
+    ]
+    rest = members - {py_module, *libs}
+    if py_module not in members or len(libs) != 1 or rest:
+        return (
+            "a dynamic wheel carries _btclib_secp256k1.py and one "
+            f"libsecp256k1 shared library and nothing else at its root; "
+            f"found {sorted(members)}"
+        )
+    return None
+
+
+def forbidden_reason(path: str) -> str | None:
+    """Say why this member may never be in the wheel, or None."""
+    name = path.rsplit("/", 1)[-1]
+    if name in FORBIDDEN_NAMES:
+        return f"is {name}, which Python imports at startup"
+    for suffix in FORBIDDEN_SUFFIXES:
+        if path.endswith(suffix):
+            return f"carries the forbidden suffix {suffix}"
+    if "__pycache__" in path.split("/"):
+        return "is under __pycache__"
+    return None
+
+
+def package_payload_complaints(members: set[str]) -> list[str]:
+    """Diff the wheel's `btclib_secp256k1/` against this checkout's.
+
+    What `check-wheel-contents --package btclib_secp256k1` would report,
+    asked directly instead: every check against the checkout beside this
+    tree, and so every complaint this function returns, applies equally
+    to a wheel judged in the sdist-install jobs, which have no compiled
+    artifact for `toplevel_reason` to be right or wrong about.
+    """
+    on_disk = {
+        f"btclib_secp256k1/{path.relative_to(PACKAGE_DIR)}"
+        for path in PACKAGE_DIR.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    }
+    missing = on_disk - members
+    extra = members - on_disk
+    complaints = [f"btclib_secp256k1/ is missing {name}" for name in sorted(missing)]
+    complaints += [
+        f"wheel carries {name}, not in the checkout" for name in sorted(extra)
+    ]
+    return complaints
+
+
+def verify_wheel(wheel: Path) -> list[str]:
+    """Return every complaint about the wheel at `wheel`."""
+    kind = wheel_kind(wheel.name)
+    distribution, version = wheel.name.split("-")[:2]
+    dist_info = f"{distribution}-{version}.dist-info"
+
+    with zipfile.ZipFile(wheel) as archive:
+        infos = [info for info in archive.infolist() if not info.filename.endswith("/")]
+        sizes = {info.filename: info.file_size for info in infos}
+    members = set(sizes)
+
+    complaints = []
+
+    dist_info_members = {m for m in members if m.startswith(f"{dist_info}/")}
+    package_members = {m for m in members if m.startswith("btclib_secp256k1/")}
+    toplevel_members = members - dist_info_members - package_members
+
+    for name in dist_info_members:
+        relative = name[len(dist_info) + 1 :]
+        if relative in WHEEL_METADATA_FILES:
+            continue
+        if relative.startswith("licenses/") and relative[len("licenses/") :] in (
+            WHEEL_LICENSE_FILES
+        ):
+            continue
+        complaints.append(f"{name} is under {dist_info}/ and is not one of its files")
+    required_dist_info = WHEEL_METADATA_FILES | {
+        f"licenses/{name}" for name in WHEEL_LICENSE_FILES
+    }
+    complaints += [
+        f"{dist_info}/{name} is missing"
+        for name in sorted(
+            required_dist_info - {m[len(dist_info) + 1 :] for m in dist_info_members}
+        )
+    ]
+
+    for name in package_members | toplevel_members:
+        reason = forbidden_reason(name)
+        if reason is not None:
+            complaints.append(f"{name} {reason}")
+
+    complaints += package_payload_complaints(package_members)
+
+    toplevel_error = toplevel_reason(toplevel_members, kind)
+    if toplevel_error is not None:
+        complaints.append(toplevel_error)
+    else:
+        for name in toplevel_members:
+            if sizes[name] == 0:
+                complaints.append(f"{name} is present and empty")
+
+    return [f"{wheel.name}: {c}" for c in complaints]
+
+
+def main(argv: list[str]) -> int:
+    """Verify every wheel named on the command line."""
+    if len(argv) < 2:
+        print(f"usage: {argv[0]} <wheel> [<wheel> ...]", file=sys.stderr)
+        return 2
+
+    complaints = [c for arg in argv[1:] for c in verify_wheel(Path(arg))]
+    for complaint in complaints:
+        # the workflow annotation, so a failure is readable from the run
+        # summary rather than only from the log
+        print(f"::error::{complaint}", file=sys.stderr)
+    if not complaints:
+        for arg in argv[1:]:
+            print(f"{Path(arg).name}: carries what it may and no more")
+    return 1 if complaints else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -706,6 +706,17 @@ jobs:
       - name: Check wheel contents
         run: uv run --locked --only-group check check-wheel-contents dist/*.whl
 
+      # what check-wheel-contents cannot phrase without also refusing the
+      # compiled artifact this project's wheels legitimately carry outside
+      # any package tree: docs/source/package-content-policy.md has the
+      # three questions this answers and why check-wheel-contents --package
+      # is not one flag away from asking them here. --no-project, so it
+      # runs on the interpreter uv already fetched and installs nothing
+      - name: Check what the wheels contain
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/verify_wheel_contents.py dist/*.whl
+
       # the wheel test jobs install cffi by hand and then the wheel with
       # --no-index, which resolves nothing: what the metadata declares is
       # only ever checked against a cffi that is already installed, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,32 @@ release-notes length in the first place, and are still in
   shebang would announce one nothing consults -- and, unpaired with the
   execute bit, would cost this guard. `fix-byte-order-marker`, the
   entry of the same shape, was already on.
+- **`check-dist` gains a wheel-content check**,
+  `.github/scripts/verify_wheel_contents.py`, closing this repository's
+  half of btclib-org/btclib#1160: `check-wheel-contents`, configured
+  here since `ignore = ["W003", "W009"]` entered `pyproject.toml`, reads
+  metadata and a wheel's declared top level; it has no way to say a
+  member is present and zero bytes, and `--package btclib_secp256k1`
+  -- the flag that would diff the wheel's package tree against this
+  checkout's -- reports the compiled artifact every wheel this project
+  ships as "not in package tree" whether or not it belongs, since that
+  artifact sits beside `btclib_secp256k1/` rather than inside it. The
+  new script asks both questions by hand instead: that
+  `btclib_secp256k1/` in the wheel is exactly what this checkout's own
+  directory has, and that the kind-appropriate top-level artifact -- one
+  compiled extension for a static wheel, the ABI-mode module and the
+  shared `libsecp256k1` for a dynamic one -- is there and not empty.
+  `docs/source/package-content-policy.md` states the policy in prose,
+  and `tests/test_wheel_contents.py` compares it against the script's
+  own constants in both directions, the same pairing `btclib`'s sibling
+  script and page keep. The sdist is not this script's subject:
+  `[tool.hatch.build.targets.sdist] exclude` here is an exclude list
+  rather than `btclib`'s include one, so the failure `btclib`'s own
+  script answers for -- a file the tree gains and the manifest does not
+  name, silently absent from the archive -- does not arise the same way,
+  and modelling the members the vendored `secp256k1/` submodule alone
+  contributes would be an allowlist nobody could maintain for a
+  question `exclude` already answers by construction.
 
 ## v0.8.0.4
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ btclib_secp256k1 documentation
    CONTRIBUTING <contributing_link.md>
    REVIEWING <reviewing_link.md>
    SECURITY <security_link.md>
+   PACKAGE CONTENT POLICY <package-content-policy.md>
    RELEASE NOTES <release_notes_link.md>
    CHANGELOG <changelog_link.md>
 

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -1,0 +1,117 @@
+# The package-content policy
+
+A release publishes wheels of two kinds and one sdist. This page states
+what a wheel may hold, what it may never hold, and what has to be there;
+`.github/scripts/verify_wheel_contents.py` enforces every rule down to
+the last section, and `tests/test_wheel_contents.py` compares the two in
+both directions, so this page cannot state a rule the script does not
+have, and the script cannot grow a rule this page does not state. The
+prose around the lists is prose, and is checked by nobody.
+
+`test.yml`'s `check-dist` job runs the script on every wheel it
+downloads from `build-cibuildwheel`, `build-dynamic` and `build-windows`
+— the artifacts `release.yml`'s own `test` job produces and the publish
+jobs upload, so this judges the files that actually reach PyPI rather
+than a copy of them.
+
+## Two kinds of wheel
+
+`scripts/hatch_build.py` builds one or the other, never both, and tags
+each so the difference is legible from the file name: a **static**
+wheel carries one compiled extension, `_btclib_secp256k1`, linked
+against libsecp256k1 and tagged for the interpreter that built it
+(`cpNN-cpNN-<platform>`); a **dynamic** wheel compiles no C at all,
+carries the ABI-mode module `_btclib_secp256k1.py` and the shared
+`libsecp256k1` library it `dlopen`s at import, and is tagged
+`py3-none-<platform>` because neither file is interpreter-specific. The
+script reads the wheel's own file name to tell them apart — the same
+distinction `scripts/hatch_build.py` draws when it writes the tag in the
+first place.
+
+## What may never be in the wheel
+
+Checked against every member of `btclib_secp256k1/` and the top-level
+artifact, not against `.dist-info` — already validated member by
+member, against its own allowlist, above: `FORBIDDEN_SUFFIXES` and
+`FORBIDDEN_NAMES`.
+
+- `.pth` — executed at interpreter startup, before the first import
+- `.pyc` — a compiled module whose source nobody reviewed
+- `.egg`, `.tar.gz`, `.whl`, `.zip` — an archive inside an archive, that
+  is, a second package installing with the first
+- `sitecustomize.py`, `usercustomize.py` — the two names Python imports
+  for their side effects alone, at startup, from the root of
+  site-packages
+
+A `__pycache__` directory is refused too, by name rather than by suffix.
+
+## What the wheel may hold
+
+Three regions, and nothing outside them.
+
+Under `btclib_secp256k1-<version>.dist-info/` — `WHEEL_METADATA_FILES`
+and, under `licenses/`, `WHEEL_LICENSE_FILES`:
+
+- `METADATA`, `RECORD`, `WHEEL` — what hatchling writes for a package
+  configured as this one is. No `top_level.txt`: that file is
+  setuptools's, and this build backend is hatchling
+- `AUTHORS.md`, `COPYRIGHT`, `LICENSE` — `project.license-files` in
+  `pyproject.toml`, copied into `licenses/` verbatim
+
+Under `btclib_secp256k1/` — exactly the files this checkout's own
+`btclib_secp256k1/` directory has, source and `py.typed` alike. The
+script reads that directory fresh rather than carrying a copy of its
+file list, which is what `check-wheel-contents --package
+btclib_secp256k1` would check too, asked here by hand instead of
+through that flag: the flag also judges the third region below, which is
+not part of any package tree and is not a mistake for being outside one.
+
+At the wheel's own root, one artifact set per kind, and nothing else — a
+second extension, a stray file, a test package shipped by accident, all
+fail, whichever kind the wheel is.
+
+A static wheel: exactly one file whose name starts with
+`_btclib_secp256k1` and ends in a compiled-extension suffix,
+`EXTENSION_SUFFIXES`:
+
+- `.so` — Linux and macOS
+- `.pyd` — Windows
+
+A dynamic wheel: exactly `_btclib_secp256k1.py`, the ABI-mode module
+`scripts/cffi_build.py` emits, and exactly one file whose name starts
+with `libsecp256k1` and ends in a shared-library suffix,
+`SHARED_LIBRARY_SUFFIXES`:
+
+- `.so` — Linux
+- `.dylib` — macOS
+- `.dll` — Windows
+
+Never a versioned name from the symlink chain CMake also leaves behind,
+such as `libsecp256k1.so.2` — `scripts/cffi_build.py` itself skips those
+when it copies the artifact into the wheel, keeping to one shared
+library rather than the chain of names one file on disk can answer to.
+
+## What has to be in there
+
+Every file `btclib_secp256k1/` may hold, per the diff above, and the
+kind-appropriate top-level artifact, checked for size as well as
+presence: an artifact `scripts/cffi_build.py` failed to finish copying
+would still be a member of the archive, at zero bytes, and no other
+check here or in `check-wheel-contents` reads a member's size at all.
+
+## The sdist is not this policy's subject
+
+`btclib`'s sibling script checks the sdist because `MANIFEST.in` there
+is an *include* list: a file the tree gains and `MANIFEST.in` does not
+name is a file the sdist silently drops, which is the failure this whole
+class of check exists for. `[tool.hatch.build.targets.sdist] exclude` in
+this repository's `pyproject.toml` is the opposite shape — a file the
+tree gains ships by default, and has to be named to be left out — so the
+failure mode here is an sdist too wide rather than one silently narrow,
+and modelling the members the vendored `secp256k1/` submodule and this
+repository's own tooling contribute would be an allowlist nobody could
+read, let alone maintain, for a question the `exclude` list itself
+already answers by construction. What that leaves
+unchecked — an exclude pattern naming a file a build still needs — fails
+the build outright rather than shipping silently, which is a different
+question with a different check to answer it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -551,6 +551,11 @@ max-complexity = 10
 # else: what it prints is what pre-commit shows the developer whose
 # commit it just refused, and stderr is where all of that goes
 ".github/scripts/check_submodule_pin.py" = ["print"]
+# the wheel-content check, whose complaints are `::error::` workflow
+# annotations on stderr and whose all-clear line on stdout is what a
+# green run of check-dist shows in its own log: same exemption, same
+# reason as the two scripts above
+".github/scripts/verify_wheel_contents.py" = ["print"]
 
 [tool.ruff.lint.flake8-copyright]
 # notice-rgx is COPYRIGHT's text as one regex, anchored with ^ so a

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -1,0 +1,425 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the wheel-content check of `.github/scripts`.
+
+What CI can show is that a real build passes: `test.yml`'s `check-dist`
+job runs the script on every wheel it downloads. What CI cannot show is
+that anything *fails* -- a wheel with a second compiled extension in it
+is not something a workflow can produce on purpose -- so the archives
+here are synthetic, one member planted per rule, and the assertion is
+the complaint.
+
+The last two tests ask a different question: whether
+`docs/source/package-content-policy.md` states the same policy. A page
+beside a script is a second copy of one list, and two copies are one
+that can be wrong -- the page saying `.so` is a shared-library suffix
+while the script's tuple does not carry it, with nothing to notice.
+Those two compare the page against the script's own constants in both
+directions, the same way `btclib`'s own
+`tests/verify_dist_contents_test.py` does; the parsing helpers below are
+copied from there rather than written twice, the two pages having the
+same "list stated by the paragraph naming it" shape.
+
+The script is loaded by path, `.github/scripts` being no package, as
+`test_submodule_pin.py` loads its own subject.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import runpy
+import sys
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "verify_wheel_contents.py"
+_PAGE = Path(__file__).parents[1] / "docs" / "source" / "package-content-policy.md"
+
+_VERSION = "0.8.0.5"
+_DIST_INFO = f"btclib_secp256k1-{_VERSION}.dist-info"
+
+# the smallest static wheel that passes: the package, its typed marker,
+# the compiled extension, and the metadata hatchling writes
+_PACKAGE = ("btclib_secp256k1/__init__.py", "btclib_secp256k1/py.typed")
+_DIST_INFO_MEMBERS = (
+    f"{_DIST_INFO}/METADATA",
+    f"{_DIST_INFO}/RECORD",
+    f"{_DIST_INFO}/WHEEL",
+    f"{_DIST_INFO}/licenses/AUTHORS.md",
+    f"{_DIST_INFO}/licenses/COPYRIGHT",
+    f"{_DIST_INFO}/licenses/LICENSE",
+)
+
+
+@pytest.fixture
+def script(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> ModuleType:
+    """Return the script, imported by path, reading a fake checkout.
+
+    `PACKAGE_DIR` is a module-level constant computed from `__file__` at
+    import time, so it is patched after the fact rather than by
+    controlling where the script is loaded from -- the script itself
+    stays at its real path, which is what the pairing tests below read
+    the source of.
+    """
+    spec = importlib.util.spec_from_file_location("verify_wheel_contents", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    package_dir = tmp_path / "btclib_secp256k1"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "py.typed").write_text("", encoding="utf-8")
+    monkeypatch.setattr(module, "PACKAGE_DIR", package_dir)
+    return module
+
+
+def write_wheel(
+    path: Path,
+    *,
+    kind: str = "static",
+    extra: tuple[str, ...] = (),
+    omit: tuple[str, ...] = (),
+    empty: tuple[str, ...] = (),
+) -> Path:
+    """Write a wheel at `path` and return it.
+
+    `kind` selects the tag and the top-level artifact a clean wheel of
+    that kind carries; `extra`, `omit` and `empty` perturb the member
+    set from there, `empty` writing a zero-byte member instead of one
+    with content.
+    """
+    toplevel = (
+        ("_btclib_secp256k1.cpython-314-darwin.so",)
+        if kind == "static"
+        else ("_btclib_secp256k1.py", "libsecp256k1.dylib")
+    )
+    members = {*_PACKAGE, *_DIST_INFO_MEMBERS, *toplevel, *extra} - set(omit)
+
+    with zipfile.ZipFile(path, "w") as archive:
+        for member in sorted(members):
+            archive.writestr(member, b"" if member in empty else b"x")
+    return path
+
+
+def test_a_clean_static_wheel_has_no_complaints(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The smallest passing static wheel is accepted."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl"
+    )
+    assert script.verify_wheel(wheel) == []
+
+
+def test_a_clean_dynamic_wheel_has_no_complaints(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The smallest passing dynamic wheel is accepted."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-py3-none-any.whl", kind="dynamic"
+    )
+    assert script.verify_wheel(wheel) == []
+
+
+@pytest.mark.parametrize("member", ["btclib_secp256k1/x.pth", "btclib_secp256k1/x.egg"])
+def test_a_forbidden_suffix_under_the_package_is_refused(
+    script: ModuleType, tmp_path: Path, member: str
+) -> None:
+    """Every suffix `FORBIDDEN_SUFFIXES` names is refused."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=(member,),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any(member in c for c in complaints)
+
+
+def test_a_forbidden_name_under_the_package_is_refused(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`sitecustomize.py` under the package is refused by name."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=("btclib_secp256k1/sitecustomize.py",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("sitecustomize.py" in c for c in complaints)
+
+
+def test_pycache_is_refused_by_name(script: ModuleType, tmp_path: Path) -> None:
+    """A `__pycache__` member fails, whether or not it carries a `.pyc`."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=("btclib_secp256k1/__pycache__/x",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("__pycache__" in c for c in complaints)
+
+
+def test_a_dist_info_member_outside_the_allowlist_is_refused(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`entry_points.txt` under `.dist-info` is not one of its files."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=(f"{_DIST_INFO}/entry_points.txt",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("entry_points.txt" in c for c in complaints)
+
+
+def test_a_missing_dist_info_file_is_reported(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A wheel with no `RECORD` says so."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        omit=(f"{_DIST_INFO}/RECORD",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("RECORD" in c and "missing" in c for c in complaints)
+
+
+def test_a_missing_package_file_is_reported(script: ModuleType, tmp_path: Path) -> None:
+    """`py.typed` dropped from the wheel is caught against the checkout."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        omit=("btclib_secp256k1/py.typed",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("py.typed" in c and "missing" in c for c in complaints)
+
+
+def test_an_untracked_package_file_is_reported(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A package member the checkout does not have is caught too."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=("btclib_secp256k1/stray.py",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("stray.py" in c and "not in the checkout" in c for c in complaints)
+
+
+def test_a_second_static_extension_is_refused(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A second top-level compiled extension fails a static wheel."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        extra=("_btclib_secp256k1_second.so",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("exactly one" in c for c in complaints)
+
+
+def test_a_missing_shared_library_fails_a_dynamic_wheel(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The dynamic wheel's shared library is required, not just allowed."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-py3-none-any.whl",
+        kind="dynamic",
+        omit=("libsecp256k1.dylib",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("dynamic wheel carries" in c for c in complaints)
+
+
+def test_a_versioned_shared_library_name_is_not_the_expected_one(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`libsecp256k1.so.2`, alone, does not satisfy the shared-library rule.
+
+    `scripts/cffi_build.py` itself skips a candidate with more than one
+    suffix when it copies the artifact into the wheel -- this is the
+    versioned name that skip exists to leave behind, and if one reached
+    the wheel regardless it would not read as the shared library the
+    dynamic wheel is required to carry.
+    """
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-py3-none-any.whl",
+        kind="dynamic",
+        omit=("libsecp256k1.dylib",),
+        extra=("libsecp256k1.so.2",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("dynamic wheel carries" in c for c in complaints)
+
+
+def test_an_empty_toplevel_artifact_is_reported(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A zero-byte extension is a member, and a broken one."""
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl",
+        empty=("_btclib_secp256k1.cpython-314-darwin.so",),
+    )
+    complaints = script.verify_wheel(wheel)
+    assert any("empty" in c for c in complaints)
+
+
+@pytest.mark.parametrize(
+    "name,kind",
+    [
+        ("btclib_secp256k1-0.8.0.5-cp314-cp314-macosx_11_0_arm64.whl", "static"),
+        ("btclib_secp256k1-0.8.0.5-py3-none-macosx_11_0_arm64.whl", "dynamic"),
+    ],
+)
+def test_wheel_kind_reads_the_python_tag(
+    script: ModuleType, name: str, kind: str
+) -> None:
+    """`py3` in the python-tag position means dynamic, anything else static."""
+    assert script.wheel_kind(name) == kind
+
+
+def test_main_reports_every_argument(script: ModuleType, tmp_path: Path) -> None:
+    """`main` checks every wheel named on the line, not just the first."""
+    clean = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl"
+    )
+    broken = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-py3-none-any.whl",
+        kind="dynamic",
+        omit=("btclib_secp256k1/py.typed",),
+    )
+    assert script.main(["prog", str(clean), str(broken)]) == 1
+
+
+def test_main_needs_at_least_one_wheel(script: ModuleType) -> None:
+    """No argument is a usage error, not a silent pass."""
+    assert script.main(["prog"]) == 2
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    This project collects no coverage from a child interpreter, so a
+    real subprocess would leave the guard as uncovered as it is
+    elsewhere in `.github/scripts`. `runpy.run_path` executes the file
+    fresh with `__name__` set to `"__main__"` in this one, against the
+    real `btclib_secp256k1/` of this checkout, which the fixture above
+    does not patch here since nothing constructs this module through it.
+    """
+    wheel = write_wheel(
+        tmp_path / f"btclib_secp256k1-{_VERSION}-cp314-cp314-macosx_11_0_arm64.whl"
+    )
+    monkeypatch.setattr(sys, "argv", ["prog", str(wheel)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    # the real package tree, not the fixture's empty one: __init__.py
+    # alone is missing every other module this checkout's package has,
+    # so this run is expected to complain and only its exit status --
+    # nonzero rather than a crash -- is what this test is about
+    assert excinfo.value.code == 1
+
+
+# --- the page states the script's constants, and no more ------------------
+
+_CONSTANT = re.compile(r"`([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)`")
+_CODE_SPAN = re.compile(r"`([^`]+)`")
+_REASON = " \N{EM DASH} "
+
+
+def _rules(text: str) -> list[tuple[set[str], set[str]]]:
+    """Pair every rule list of the page with the constants above it.
+
+    A list introduced by a paragraph naming no constant is not a rule
+    list and is skipped. Each item contributes the code spans before its
+    dash.
+    """
+    rules: list[tuple[set[str], set[str]]] = []
+    paragraph: list[str] = []
+    lead: list[str] = []
+    items: list[str] = []
+    for line in (*text.splitlines(), ""):
+        if line.startswith("- "):
+            items.append(line[2:])
+        elif items and line.startswith("  "):
+            items[-1] += " " + line.strip()
+        elif items:
+            named = set(_CONSTANT.findall(" ".join(lead)))
+            if named:
+                rules.append((named, _stated(items)))
+            items, lead = [], []
+        elif line.strip():
+            paragraph.append(line)
+        elif paragraph:
+            lead, paragraph = paragraph, []
+    return rules
+
+
+def _stated(items: list[str]) -> set[str]:
+    """Every code span a rule list states, before each item's reason."""
+    spans: set[str] = set()
+    for item in items:
+        rule, dash, _ = item.partition(_REASON)
+        assert dash, f"a rule with no reason after it: {item}"
+        spans.update(_CODE_SPAN.findall(rule))
+    return spans
+
+
+def test_rules_skips_a_list_whose_paragraph_names_no_constant() -> None:
+    """A list is a rule list only once its lead paragraph names one.
+
+    `_rules` is exercised directly, on synthetic text, because
+    `docs/source/package-content-policy.md` -- the only text the other
+    two tests parse -- never carries a stray list of this shape, and
+    planting one there to cover a helper would leave the page
+    misstating its own policy.
+    """
+    text = "Prose that names nothing in backticks.\n\n- one \N{EM DASH} reason\n"
+    assert _rules(text) == []
+
+
+def test_rules_treats_consecutive_blank_lines_as_one_gap() -> None:
+    """A blank line with no paragraph pending starts nothing.
+
+    Two blank lines ahead of the first paragraph -- the page's own
+    opening never has the second -- are what the first exercises.
+    """
+    text = "\n\nParagraph naming `A_CONSTANT`.\n\n- `one` \N{EM DASH} reason\n"
+    assert _rules(text) == [({"A_CONSTANT"}, {"one"})]
+
+
+def _policy_constants(
+    script: ModuleType,
+) -> dict[str, tuple[str, ...] | frozenset[str]]:
+    """Every constant of the script that is a list of members."""
+    return {
+        name: value
+        for name, value in vars(script).items()
+        if name.isupper() and isinstance(value, (tuple, frozenset))
+    }
+
+
+def test_the_page_states_what_the_script_enforces(script: ModuleType) -> None:
+    """Every rule list on the page is its constants, exactly."""
+    constants = _policy_constants(script)
+
+    for named, stated in _rules(_PAGE.read_text(encoding="utf-8")):
+        expected = {value for name in named for value in constants.get(name, ())}
+        assert stated == expected, sorted(named)
+
+
+def test_the_page_states_every_rule_the_script_has(script: ModuleType) -> None:
+    """And no constant is left off the page, or stated twice."""
+    named = [
+        name for names, _ in _rules(_PAGE.read_text(encoding="utf-8")) for name in names
+    ]
+
+    assert sorted(named) == sorted(_policy_constants(script))


### PR DESCRIPTION
## Summary

btclib-org/btclib#1160 surveys two half-measures for one question,
across the organization's three publishing repositories: `btclib`
runs a hand-written script (`verify_dist_contents.py`) comparing a
built wheel and sdist, member for member, against an allowlist; this
repository configures `check-wheel-contents` (`ignore = ["W003",
"W009"]`, for the shared library a dynamic wheel ships beside the
package) but has no script of its own; `bitcoin-core-rpc` had neither.

## Current state (established before deciding)

| repository | member-listing script | configured `check-wheel-contents` | runs on |
| --- | --- | --- | --- |
| `btclib` | `verify_dist_contents.py`, paired with `docs/source/package-content-policy.md` via a test comparing the two | not configured (defaults) | `test.yml`'s `dist` job **and** `release.yml`'s `build` job — the exact files it uploads |
| `btclib-secp256k1` (this repository, before this PR) | none | `ignore = ["W003", "W009"]` | `test.yml`'s `check-dist` job, which `release.yml`'s `test` job calls and whose artifacts the publish jobs upload — the exact files it uploads |
| `bitcoin-core-rpc` | none (as of this PR: `check-wheel-contents --package`, see PR #178) | not configured, before #178 | `test.yml`'s `dist` job only |

This repository already has the better artifact story of the three
(divergence #9 of btclib-org/btclib#1152): no separate rebuild in
`release.yml`, so `check-dist` inspects the same wheels the publish
jobs upload. What it lacked is any check of what a member actually
*is*.

## What check-wheel-contents cannot phrase here, measured

`--package btclib_secp256k1` is the flag that would do for this
repository what PR #178 does for `bitcoin-core-rpc`: diff the wheel's
package tree against the checkout's. It does not work here, and I
measured why before writing anything else. Every wheel this project
ships carries a compiled artifact at the wheel's own root, beside
`btclib_secp256k1/` rather than inside it — the extension module for a
static wheel, or the ABI-mode module and the shared `libsecp256k1` for
a dynamic one. Running `check-wheel-contents --package
btclib_secp256k1 --ignore W003,W009` against a real static wheel:

```
W102: Wheel library contains files not in package tree:
  _btclib_secp256k1.cpython-314-darwin.so
```

against the compiled extension this build is *supposed* to carry.
`--package` has no way to name a second, legitimate top-level entry
outside the tree it diffs, so the flag cannot be configured into
correctness here the way it was for `bitcoin-core-rpc`.

Unconfigured `check-wheel-contents` (today's state) also does not
catch a dropped `py.typed`: built a wheel with it stripped out and
`RECORD` edited to match, `check-wheel-contents` (with or without the
`ignore` this repository already carries) reports `OK`.

## Decision: a script, tailored to two wheel kinds, wheel-only

`.github/scripts/verify_wheel_contents.py` asks the two questions
`--package` cannot phrase without a false positive: that
`btclib_secp256k1/` in the wheel is exactly what this checkout's own
directory has (read fresh via `PACKAGE_DIR.rglob`, not a copy of the
file list — a module added to the package is a module the next wheel
has to carry, with nothing here to edit to match), and that the
kind-appropriate top-level artifact is present *and not empty* — a
question no `check-wheel-contents` code answers for any member, static
or dynamic wheel alike. The wheel's own filename tag (`py3-none-...`
vs `cpNN-...`) is read to tell the two kinds apart, the same
distinction `scripts/hatch_build.py` draws when it writes the tag.

`docs/source/package-content-policy.md` states the policy in prose,
wired into the toctree beside `btclib`'s own page.
`tests/test_wheel_contents.py` compares the page against the script's
six constants in both directions — the pairing mechanism `btclib`
carries, ported here rather than the constants themselves, which
describe a different wheel shape. 21 tests, one failure mode planted
per rule (a forbidden suffix, a forbidden name, `__pycache__`, an
undeclared `.dist-info` member, a missing dist-info file, a dropped
package file, an untracked package file, a second static extension, a
missing dynamic shared library, a versioned shared-library name, an
empty top-level artifact) plus the two pairing tests and CLI-level
tests, all passing against real wheels built both static and dynamic.

**The sdist is out of scope**, and says so in both the script's
docstring and the policy page: `[tool.hatch.build.targets.sdist]
exclude` here is an *exclude* list, the opposite shape from `btclib`'s
*include* `MANIFEST.in` — a file the tree gains ships by default here,
rather than silently not shipping — so the failure `btclib`'s script
exists for does not arise the same way. This repository's sdist has
roughly three hundred members, most of them the vendored `secp256k1/`
submodule; modelling that as an allowlist would be exactly what the
issue warns against — "a check whose allowlist nobody can read is a
check nobody maintains" — for a question `exclude` already answers by
construction. Also noted, out of scope for this PR: unlike `btclib`
and `bitcoin-core-rpc`, this repository has no `check-manifest` hook
at all, so nothing here answers "does the sdist match the tracked
tree" independently of the `exclude` list's own correctness — a
different, narrower question than this PR's, and a candidate for its
own issue if it turns out to matter given the `exclude` shape.

Wired into `test.yml`'s `check-dist` job, right after the existing
`check-wheel-contents` step, over the same `dist/*.whl` this job
already downloads from `build-cibuildwheel`, `build-dynamic` and
`build-windows`.

This PR leaves btclib-org/btclib#1160 open: the issue lives in
`btclib`, and its own pull request is where the decision documented
here gets closed out.

## Verification

- `uv run --locked --only-group lint pre-commit run --all-files`:
  exit 0 (36 hooks, no `check-manifest` hook in this repository — see
  above)
- `uv run --locked --no-default-groups --group test pytest --cov
  --cov-report=term-missing:skip-covered`: exit 0, 786 passed, 100%
  coverage
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`: exit 0,
  `package-content-policy` renders

`check-dist`'s own commands, from CONTRIBUTING.md, run by hand against
a real static wheel, a real dynamic wheel (`BTCLIB_LIBSECP256K1_DYNAMIC=true`,
`MACOSX_DEPLOYMENT_TARGET=11.0`) and a real sdist, all three built
from this branch:

- `uv build --wheel` (static), `BTCLIB_LIBSECP256K1_DYNAMIC=true uv
  build --wheel` (dynamic), `uv build --sdist`: exit 0 each
- `uv run --locked --only-group check twine check --strict dist/*`:
  exit 0, `PASSED` on all three files
- `uv run --locked --only-group check check-wheel-contents
  dist/*.whl`: exit 0, `OK` on both wheels
- `uv run --no-project --python 3.14
  .github/scripts/verify_wheel_contents.py dist/*.whl`: exit 0,
  "carries what it may and no more" on both wheels
- `uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz`:
  exit 0, 10/10
- installed the static wheel alone, isolated, from an empty directory,
  and ran `import btclib_secp256k1 as m; print(m.__version__,
  m.lib)`: exit 0, `0.8.0.5 <Lib object for '_btclib_secp256k1'>`

Re-ran pre-commit and pytest after rebasing onto origin/main: both
exit 0, 786 passed.

## Summary by Sourcery

Validate published wheels against the repository package-content policy for both static and dynamic builds.

New Features:
- Add a wheel-content validation script that verifies package completeness, metadata members, permitted top-level artifacts, forbidden files, and non-empty compiled artifacts for both static and dynamic wheels.

Bug Fixes:
- Prevent incomplete, unexpected, or malformed wheel contents from reaching published distributions.

Enhancements:
- Document the wheel package-content policy and explicitly scope sdist validation out of this check.

CI:
- Run the wheel-content validation in the check-dist job against the same wheels used for release publishing.

Documentation:
- Add the package-content policy to the documentation to describe allowed and required wheel members.

Tests:
- Add comprehensive tests covering valid static and dynamic wheels, invalid members, missing files, artifact variants, CLI behavior, and policy/script consistency.

Chores:
- Record the new wheel-content validation in the changelog.
