### PR TITLE
Point what would reopen the SBOM decision at an issue that is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ release-notes length in the first place, and are still in
   "Read the bill of materials attached to the release" step and
   btclib-org/btclib#1159 for the evaluation.
 
+- **`RELEASING.md` says what would reopen that decision**
+  (btclib-org/.github#24). Stating a limitation is not the same as
+  stating that it can lift: what keeps the vendored library out of the
+  document is what the generator reads, so a generator that learned to
+  describe a submodule pin as a component would make the question worth
+  asking again, and the section gave a reader no reason to expect the
+  answer ever to change. It now carries that trigger and names the
+  issue holding it, which is open — btclib-org/btclib#1159, cited
+  beside it for the evaluation, is not, and watches nothing.
+
 ### CI
 
 - **`[tool.uv]`'s `required-version` comment stated the wrong reason**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,12 @@ says nothing about the pin either way. btclib's `RELEASING.md` (the
 "Read the bill of materials attached to the release" step) has the
 full reasoning, and issue
 [btclib-org/btclib#1159](https://github.com/btclib-org/btclib/issues/1159)
-has the evaluation behind it.
+has the evaluation behind it. The limit is the generator's rather than
+this package's, so the decision is conditional: if the generator ever
+learns to describe a submodule pin as a component, it reopens.
+[btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24)
+records that trigger and stays open; an issue no longer open watches
+nothing.
 
 The version published is the one in `pyproject.toml`; the tag only
 decides which index is reached. The `version-check` job cross-checks


### PR DESCRIPTION
`btclib-org/btclib#1159` — "Decide whether a release SBOM is a three-repository
property or a btclib one" — closed at `2026-08-21T13:15:39Z`. All three
`RELEASING.md` files still send the reader who asks "why is no bill of
materials attached here?" to that issue, and none names
[btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24), which
is the open successor holding the conditional half of the decision.

A completed evaluation cited at a closed issue is a legitimate record. A
condition that would reopen the decision, pointing at a closed issue, is a
decision quietly becoming permanent — which is what `.github#24` was opened to
prevent, and its third box is exactly this: the trigger written down.

So the evaluation still points where it happened, and what would reopen it now
points somewhere a person is watching. The three sentences are not identical
prose: each paragraph sits in a different argument, and this repository's says
what is its own. What is true in all three afterwards is the same.

This does **not** close `.github#24` — that issue has boxes these changes do
not satisfy.

Gates: `pre-commit run --all-files`, the suite with its coverage gate, and
`sphinx-build -W --keep-going`, each exit 0.

## Summary by Sourcery

Clarify where the SBOM decision is recorded and what future generator capability would prompt its reconsideration.

Enhancements:
- Update the release documentation to identify the open issue and condition that would reopen the SBOM decision while retaining the closed issue as the evaluation record.

Documentation:
- Document the SBOM decision’s reopening trigger and distinguish the active tracking issue from the completed evaluation issue.