### PR TITLE
Justify the mutation config's location without a tool this repository lacks

### DIFF
--- a/.github/mutation/bindings.toml
+++ b/.github/mutation/bindings.toml
@@ -86,9 +86,13 @@
 #
 # Here rather than at the repository root: cosmic-ray takes the path of its
 # configuration as an argument, so nothing forces a name or a place, and
-# .github/ is a directory check-manifest already ignores -- a root file
-# would need an entry in [tool.check-wheel-contents] or the sdist to say
-# what its location says here.
+# this repository runs no check-manifest to make a root file's placement
+# something that needs recording. What that tool would ask -- whether the
+# sdist carries what a build from it needs -- is answered here instead by
+# suite-sdist in test.yml, which installs from the built sdist and compiles
+# the vendored library on every platform its matrix covers; this file plays
+# no part in that build, so where it sits does not bear on the question.
+# .github/ is simply where the rest of the CI configuration already lives.
 #
 # One file where btclib has two, and the asymmetry that makes it want two is
 # absent: there the two halves of the scope cost 1.1 s and 7.2 s of cpu per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,19 @@ release-notes length in the first place, and are still in
   answer ever to change. It now carries that trigger and names the
   issue holding it, which is open — btclib-org/btclib#1159, cited
   beside it for the evaluation, is not, and watches nothing.
+- **`.github/mutation/bindings.toml`'s comment on why the mutation config
+  lives under `.github/` no longer cites a tool this repository does not
+  run** (#314). The reasoning had been carried across from btclib, where
+  check-manifest gates a pull request and treats `.github/` as a directory
+  already safe to leave out of the sdist; nothing here runs check-manifest,
+  so a reader checking the claim found a tool never wired into this tree
+  and could not tell whether the placement was still right or the tool had
+  gone missing. The comment now names what answers the same question here
+  instead: `suite-sdist` in `test.yml`, which installs from the built sdist
+  and compiles the vendored library across its matrix, and would fail were
+  anything a build needs missing from it. The placement itself is unchanged
+  — cosmic-ray takes its configuration's path as an argument, so nothing
+  forces a name or a place — only the reason given for it.
 
 ### CI
 


### PR DESCRIPTION
`.github/mutation/bindings.toml` justified the cosmic-ray configuration's
location by saying `.github/` is "a directory check-manifest already ignores".
This repository runs no `check-manifest` — that comment was its only occurrence
in the tree, the reasoning having been carried across from `btclib`, where the
hook does run.

The sentence changes; the placement does not. What `check-manifest` would ask
— whether the sdist carries what a build from it needs — is answered here by
`suite-sdist`, which installs from the built sdist and compiles the vendored
library across its matrix, and this file plays no part in that build. So the
placement is still right and now says why in terms that hold in this
repository.

Gates: `uv sync --locked` and the whole `pre-commit` gate, each exit 0, with
no file rewritten by a hook afterwards.

Closes #314.

## Summary by Sourcery

Clarify the mutation configuration’s placement rationale without changing its location.

Enhancements:
- Clarify why the cosmic-ray mutation configuration remains under `.github/` using this repository’s sdist validation rather than an unavailable `check-manifest` hook.

Documentation:
- Document the corrected rationale for the mutation configuration’s location in the changelog.