### PR TITLE
Enforce the link-destination rule where the link is written

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,26 +122,27 @@ jobs:
       # same claim made about the artifact rather than about the
       # configuration, and what would catch a suppression added back.
       #
-      # Two greps, not one (issue btclib-org/btclib#1157). This
-      # repository's root files do not settle on one spelling:
-      # CONTRIBUTING.md and SECURITY.md link by bare name
-      # ("SECURITY.md" -> href="#SECURITY.md" if it broke,
-      # the second grep below), but CONTRIBUTING.md's own link to
-      # REVIEWING.md and CHANGELOG.md's to RELEASE_NOTES.md are written
-      # "./REVIEWING.md" and "./RELEASE_NOTES.md" -- the first grep, and
-      # the one a single-pattern check here used to leave uncovered. A
-      # survey of the other two repositories in this organization, and of
-      # every link these root files carry, found no third shape, so two
-      # greps is the union rather than a guess at how far to generalize.
+      # One grep, because there is one spelling to look for. myst's
+      # fallback renders the destination verbatim, so what this can match
+      # is decided upstream of here, in how the link was written -- and
+      # the local-link-prefix hook in .pre-commit-config.yaml refuses a
+      # local destination that does not begin "./", in the commit that
+      # writes it. Every destination the included root files carry
+      # therefore renders "#./<destination>" when it breaks, anchor,
+      # extension and nested path alike, which this pattern catches
+      # whole (issue btclib-org/.github#20; the hook's own comment has
+      # the measurement).
+      #
+      # Not a second grep for a bare destination beside it. It would be
+      # unreachable with the hook in place, and it is no superset of this
+      # one even without: a character class of name characters stops at
+      # the "#" of an anchor, so "#README.md#build" is a shape both
+      # patterns pass over. That is the whole argument for the hook. A
+      # check downstream of the rendering has to anticipate every way a
+      # link can be written; a rule upstream of it permits one.
       - name: Check the built pages for unresolved links
         run: |
-          status=0
           if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
             echo "::error::the links above resolve to no page (unresolved relative path)"
-            status=1
+            exit 1
           fi
-          if grep -rn 'href="#[A-Za-z0-9_.-]*\.md"' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page (unresolved bare .md target)"
-            status=1
-          fi
-          exit $status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -244,6 +244,70 @@ repos:
       - id: markdownlint-cli2
         name: markdownlint-cli2 (in place fixes)
         args: [--fix]
+  # how a link destination is spelled, which markdownlint has no rule for
+  # and the documentation build turns out to depend on. docs.yml greps the
+  # built html for `href="#./`: that is what myst renders in place of a
+  # link the RootFileLinks transform in docs/source/conf.py cannot
+  # resolve -- an anchor to an id no page has, which -W reports today and
+  # would stop reporting the day a suppression went back into conf.py. A
+  # grep can key on one spelling only, so the destinations are spelled one
+  # way and this hook is what keeps them that way.
+  #
+  # Measured, by building this repository's documentation with an
+  # unresolvable link written each way: a destination beginning "./"
+  # renders `#./<destination>` verbatim -- with an anchor after it, with
+  # another extension, with a directory in front of it -- so the one grep
+  # sees each of them. Drop the "./" and the same links render
+  # `#<destination>`, which that grep cannot see, and no single pattern
+  # covers those without also matching the autodoc anchors these pages
+  # carry (btclib-org/btclib#1175 has the attempt and why it was set
+  # aside).
+  #
+  # The rule is therefore the prefix and not the extension, and that
+  # issue's table is what decides it: "DOES_NOT_EXIST.txt",
+  # "sub/DOES_NOT_EXIST.md", "DOES_NOT_EXIST" and "../DOES_NOT_EXIST.md"
+  # each reach myst's fallback, and each is missed by the union of both
+  # greps a repository ran. An ".md"-scoped rule leaves all four
+  # writable; a prefix refuses all four where they are written, which is
+  # a pattern per shape fewer.
+  #
+  # "../" is the row with nothing downstream behind it at all, which is
+  # why it is refused here rather than allowed as an ordinary relative
+  # path: the transform declines a target that normalizes above the
+  # repository root -- nothing above the root is a document this build
+  # can answer for -- so that shape reaches myst's fallback by design
+  # rather than by a gap in the transform, and renders
+  # href="#../page.md", which the grep in docs.yml does not match and
+  # should not be widened to. This hook is the only place it can be
+  # caught. No link here climbs out of the root.
+  #
+  # pygrep, and the same hook in every repository of this organization
+  # (btclib-org/.github#20): there is no shared hook repository to put it
+  # in, and `pinned-rev` above is that same arrangement already. The
+  # pattern asks for a whole `[text](destination)` whose "[" is not
+  # preceded by a backtick, which is what lets prose quote the refused
+  # shape in a code span; grep output of the form `FILE.md:21:](x.md)`
+  # carries no "[" and is not matched either.
+  #
+  # A reference definition is a link too, and the second branch is for
+  # it: "[label]: page.md" renders the same fallback as the inline form
+  # -- measured on the built html -- and carries no "(", so the first
+  # branch cannot see it. That branch is anchored at the start of the
+  # line, which is what keeps it off a *use* site: "[label][ref]: the"
+  # is prose in a sibling repository's changelog, and an unanchored
+  # pattern reported it. At most three leading spaces, four making the
+  # line an indented code block rather than a definition.
+  #
+  # What pygrep cannot see is a fenced block, being line based -- an
+  # example of the refused shape inside one fails this hook, and the
+  # code span is the way round it
+  - repo: local
+    hooks:
+      - id: local-link-prefix
+        name: a local markdown link destination begins with ./
+        language: pygrep
+        entry: '(?<!`)(?:\[[^]]*\]\(|^ {0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]'
+        types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint above
   # in effect and not in order -- pre-commit runs this file top to bottom, so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -281,13 +281,28 @@ repos:
   # should not be widened to. This hook is the only place it can be
   # caught. No link here climbs out of the root.
   #
+  # The first branch steps over a nested image, and it has to: a badge is
+  # "[![alt](src)](href)", and link text written "[^]]*" stops at the "]"
+  # that closes the alt text -- so a scan anchored on it checks the image
+  # src and never reaches the badge's own destination. That was this
+  # hook's first shape, and it left every badge href unchecked; the link
+  # text is now "(?:[^]]|\]\([^)]*\))*", a character that is not "]" or a
+  # whole "](...)" group, which steps over the image and, by
+  # backtracking, still checks the src on the way. Measured: a badge href
+  # renders exactly what a plain href renders, so every row of the table
+  # above can be written as a badge destination and only the "./" one is
+  # caught downstream.
+  #
   # pygrep, and the same hook in every repository of this organization
   # (btclib-org/.github#20): there is no shared hook repository to put it
   # in, and `pinned-rev` above is that same arrangement already. The
-  # pattern asks for a whole `[text](destination)` whose "[" is not
-  # preceded by a backtick, which is what lets prose quote the refused
-  # shape in a code span; grep output of the form `FILE.md:21:](x.md)`
-  # carries no "[" and is not matched either.
+  # pattern asks for a whole `[text](destination)`, so grep output of the
+  # form `FILE.md:21:](x.md)` carries no "[" and is not matched. The
+  # lookbehind refuses a "[" preceded by a backtick, which is what lets
+  # prose quote the refused shape in a code span -- and one preceded by
+  # "!" or "[" as well, so that a *quoted* badge is escaped whole rather
+  # than re-entered at the image inside it. The leading "!?" is what
+  # keeps a standalone image's own src checked despite that.
   #
   # A reference definition is a link too, and the second branch is for
   # it: "[label]: page.md" renders the same fallback as the inline form
@@ -306,7 +321,14 @@ repos:
       - id: local-link-prefix
         name: a local markdown link destination begins with ./
         language: pygrep
-        entry: '(?<!`)(?:\[[^]]*\]\(|^ {0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]'
+        # one line, and no literal space in it -- "\x20" is the space the
+        # reference branch allows -- so yamllint reads the value as a
+        # single unbreakable word and its 100-column rule exempts it. A
+        # block scalar rather than a quoted one for the same reason a
+        # folded scalar was rejected: folding joins lines with a space,
+        # which would land inside the regex
+        entry: |-
+          (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,10 +342,22 @@ release-notes length in the first place, and are still in
   render `#./` followed by the destination, so the one grep sees them
   all; the same destinations without the `./` render the destination
   alone, which no pattern reaches without also matching the autodoc
-  anchors these pages carry. `CONTRIBUTING.md`'s link to the README's Build
-  section was a live instance of the gap -- an anchor after a bare name, where
-  the bare-name grep's character class stops. `uvx pre-commit run local-link-
-  prefix --all-files` re-derives the whole of it.
+  anchors these pages carry. `CONTRIBUTING.md`'s link to the README's
+  Build section was a live instance of the gap -- an anchor after a bare
+  name, where the bare-name grep's character class stops.
+
+  A badge, `[![alt](src)](href)`, needed the pattern's link text to step
+  over the image inside it: written `[^]]*` it stops at the `]` closing
+  the alt text, so the scan checked the image `src` and never the
+  badge's own destination -- measured on the built html, where a badge
+  href renders exactly what a plain href renders. Link text is
+  therefore `(?:[^]]|\]\([^)]*\))*`, which reaches the destination
+  behind the image and still checks the `src` by backtracking. This
+  repository's `README.md` and `CONTRIBUTING.md` carry badge links, none
+  of them violating the rule.
+
+  `uvx pre-commit run local-link-prefix --all-files` re-derives the
+  whole of it.
 
 ## v0.8.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,15 @@ release-notes length in the first place, and are still in
   (`windows-arm.yml` in `bitcoin-core-rpc`), fixed in a pull request of
   their own; `btclib`'s `test.yml` carries no Windows row and
   `bitcoin-core-rpc`'s carried one further instance of its own.
+- **`docs.yml`'s unresolved-link check is one grep again**
+  (btclib-org/.github#20). The second pattern, for a bare destination ending
+  `.md`, has nothing left to catch now that the `local-link-prefix` hook
+  refuses that spelling, and it was no superset of the first even before: a
+  character class of name characters stops at the `#` of an anchor, so
+  `#README.md#build` is a shape both patterns pass over -- and that is what
+  this repository's own `CONTRIBUTING.md` would have rendered. The step's
+  comment carries the reasoning. What is left is `href="#\./`, and the hook is
+  what makes it sufficient rather than merely first.
 
 ### The gate
 
@@ -296,6 +305,47 @@ release-notes length in the first place, and are still in
   and modelling the members the vendored `secp256k1/` submodule alone
   contributes would be an allowlist nobody could maintain for a
   question `exclude` already answers by construction.
+- **A `local-link-prefix` hook refuses a local markdown link
+  destination that does not begin with `./`, and every link here now
+  begins with one** (btclib-org/.github#20). `docs.yml` greps the built
+  html for `href="#./`, which is what myst renders in place of a link
+  `docs/source/conf.py`'s `RootFileLinks` transform cannot resolve. One
+  pattern can key on one spelling, and this repository wrote two:
+  `CHANGELOG.md`, `RELEASE_NOTES.md`, `REVIEWING.md` and one line of
+  `CONTRIBUTING.md` wrote `./REVIEWING.md`, while the rest of
+  `CONTRIBUTING.md` and all of `CLAUDE.md`, `RELEASING.md` and
+  `REPOSITORY.md` wrote the bare name -- so a link of the second kind
+  breaking rendered an anchor the grep was not looking for. Rewriting
+  those is the smaller half of this; the hook is what keeps the drift
+  from coming back, and it is the same hook in every repository of the
+  organization, `pinned-rev`'s arrangement rather than a shared hook
+  repository that does not exist.
+
+  The rule is the prefix and not the extension, and the table in
+  btclib-org/btclib#1175 is what decides that: `DOES_NOT_EXIST.txt`,
+  `sub/DOES_NOT_EXIST.md`, `DOES_NOT_EXIST` and `../DOES_NOT_EXIST.md`
+  each reach MyST's fallback and each is missed by the union of both
+  greps, so an `.md`-scoped rule would leave all four writable. `../`
+  is the row with nothing downstream behind it at all: the transform
+  *declines* a target normalizing above the repository root, so that
+  shape reaches the fallback by design and renders `href="#../X.md"`,
+  which the surviving grep does not match and should not be widened to
+  reach — the hook is the only place it can be caught. A link reference
+  definition, `[label]: page.md`, renders the same fallback and carries
+  no `(`, so the pattern has a second branch for it, anchored at the
+  start of a line so that a reference *use* followed by a colon is not
+  mistaken for one.
+
+  Measured here too, by building this documentation with an
+  unresolvable link written each way: `./page.md`, `./page.md#anchor`,
+  `./page.txt`, `./sub/page.md` and an extensionless `./page` each
+  render `#./` followed by the destination, so the one grep sees them
+  all; the same destinations without the `./` render the destination
+  alone, which no pattern reaches without also matching the autodoc
+  anchors these pages carry. `CONTRIBUTING.md`'s link to the README's Build
+  section was a live instance of the gap -- an anchor after a bare name, where
+  the bare-name grep's character class stops. `uvx pre-commit run local-link-
+  prefix --all-files` re-derives the whole of it.
 
 ## v0.8.0.4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Working on btclib_secp256k1
 
-Python bindings to a vendored [libsecp256k1](secp256k1/), built from
+Python bindings to a vendored [libsecp256k1](./secp256k1/), built from
 source. The package is thin: the cryptography is upstream, and what lives
 here is the wrapping, the argument validation at the cffi boundary, and
 the packaging — one wheel per platform and linkage, which is where most of
@@ -11,23 +11,23 @@ fail when it was not edited.
 
 Repository configuration — branch protection, required checks, token
 permissions, publishing environments, Dependabot, secret scanning — is in
-[REPOSITORY.md](REPOSITORY.md). Read that file before changing a workflow,
+[REPOSITORY.md](./REPOSITORY.md). Read that file before changing a workflow,
 a branch rule or a repository setting. Writing code does not need it.
 
 Reviewing a pull request — what a review establishes before it gives
 an ack, what a finding must contain, and why everything it notices
 that the diff is not about becomes an issue rather than a comment — is
-[REVIEWING.md](REVIEWING.md), and `/review` is that file as a command.
+[REVIEWING.md](./REVIEWING.md), and `/review` is that file as a command.
 
 This file is for what is not written down elsewhere. The documentation is,
 and stays, in:
 
-- [README.md](README.md) — design, wrapped modules, build, and the
+- [README.md](./README.md) — design, wrapped modules, build, and the
   static/dynamic/sdist distinction
-- [CONTRIBUTING.md](CONTRIBUTING.md) — how to build and test
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — how to build and test
   locally, how to reproduce each CI job, and what a change has to satisfy
-- [RELEASING.md](RELEASING.md) — the release, and the rehearsal
-- [scripts/README.md](scripts/README.md) — the build backend, one file at
+- [RELEASING.md](./RELEASING.md) — the release, and the rehearsal
+- [scripts/README.md](./scripts/README.md) — the build backend, one file at
   a time
 - the comments in `.github/workflows/*.yml` and `pyproject.toml`, which
   carry the reasoning behind their choices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ libsecp256k1 release rather than the calendar. -->
 Thank you for investing your time in this project. What follows is how to
 build and test these bindings, and what this repository
 expects of a change. What the build itself does on each platform is in
-the [Build](README.md#build) section of the README, which is not repeated
+the [Build](./README.md#build) section of the README, which is not repeated
 here.
 
-Please read the [Code of Conduct](CODE_OF_CONDUCT.md) too.
+Please read the [Code of Conduct](./CODE_OF_CONDUCT.md) too.
 
 ## Which project is this
 
@@ -44,7 +44,7 @@ to route:
   wheels
 
 A vulnerability is never an issue: see the
-[security policy](SECURITY.md).
+[security policy](./SECURITY.md).
 
 ## Opening an issue
 
@@ -593,7 +593,7 @@ exception, and it is dated for exactly that reason.
 
 **One fact in one place.** Two files stating the same thing become two
 files disagreeing about it; the second one points at the first. That is
-why [REPOSITORY.md](REPOSITORY.md) holds the repository settings and
+why [REPOSITORY.md](./REPOSITORY.md) holds the repository settings and
 CLAUDE.md points at it.
 
 **No history in the prose.** Comments and docstrings say why the code is
@@ -602,7 +602,7 @@ to be. "This is here rather than X because X breaks Y" stays, whatever
 prompted it; "this used to be X, until Z" goes — unless the old spelling
 is something a caller can still encounter, in which case it is not history
 but the present. History has a file of its own,
-[RELEASE_NOTES.md](RELEASE_NOTES.md), and the commit messages.
+[RELEASE_NOTES.md](./RELEASE_NOTES.md), and the commit messages.
 
 ## Pull requests
 
@@ -680,7 +680,7 @@ branch never carried. GitHub only offers it while something is still
 pending, and it merges nothing the branch rule would not have let
 through by hand.
 
-Releases are cut by a maintainer, following [RELEASING.md](RELEASING.md);
+Releases are cut by a maintainer, following [RELEASING.md](./RELEASING.md);
 nothing about a version needs to be touched in a pull request.
 
 Once merged, your contribution is visible on the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,7 +133,7 @@ Then:
 1. bump the version in `pyproject.toml` and run `uv lock`, which carries
    it into `uv.lock`. Version numbers track the wrapped libsecp256k1,
    with a fourth number for a release of the bindings alone: see the
-   Versioning section of [README.md](README.md). The previous release
+   Versioning section of [README.md](./README.md). The previous release
    left a fourth number open, by the step that opens the next version
    below, so this is often a matter
    of confirming what is already declared, or of renumbering it if the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -1,7 +1,7 @@
 # Repository configuration
 
 Read this before changing a workflow, a branch rule or a repository
-setting; writing code does not need it. [CLAUDE.md](CLAUDE.md) points here
+setting; writing code does not need it. [CLAUDE.md](./CLAUDE.md) points here
 rather than carrying it, so that a session fixing a wrapper does not hold
 it in context.
 
@@ -550,7 +550,7 @@ What that rule constrains is the *name* of the ref and nothing else. A
 commit satisfies it exactly as the release tag does, so it is not the
 check that a release is a release: the `version-check` job of
 `release.yml` fails a tag that is not an ancestor of `main`, before the
-matrix builds anything. [RELEASING.md](RELEASING.md) has the rest,
+matrix builds anything. [RELEASING.md](./RELEASING.md) has the rest,
 including what a mismatched trusted publisher looks like and why
 self-review stays allowed.
 


### PR DESCRIPTION
A local destination written without a `./` prefix is not a style question in
these repositories: it is the shape that breaks silently. MyST's fallback
renders whatever string the link carried, so an unresolvable target becomes an
`href="#<target>"` anchor rather than a warning `-W` can fail on, and the
greps in `docs.yml` see only two of the shapes that fallback can take.

The rule is now enforced where the link is written. `local-link-prefix` is a
pygrep hook over markdown that refuses a link destination which is neither
`./`-prefixed, an anchor, nor a scheme — covering both the inline form and a
link reference definition, whose bare destination renders the identical
fallback and which the first draft of the pattern could not see.

**The prefix, not the extension.** `btclib-org/btclib#1175` measured six
shapes reaching that fallback, and the union of both greps catches two of
them: a bare `.txt`, a nested path with no leading `./`, an extensionless
name and a `../` climb are all invisible downstream. An `.md`-scoped rule
would leave every one of them writable.

**`../` in particular has no downstream check at all.** `conf.py`'s
`RootFileLinks` transform declines, by design, to resolve a target that
normalizes above the repository root — nothing above the root is a document
that build can answer for — so that shape reaches the fallback deliberately
and neither grep can see it. The source is the only place it can be caught.

The `href="#[A-Za-z0-9_.-]*\.md"` grep goes with it: what it answers is now
unwritable, and it never covered `X.md#fragment`, which is the shape one of
these repositories actually carried.

Stated rather than solved: pygrep is line based and cannot see a fenced block,
so a bare link inside one is reported. An inline code span is the escape
hatch, which is already the house style for quoting markup.

Gates: `pre-commit`, `sphinx-build -E -W --keep-going`, the surviving link
step run verbatim, and the suite at its coverage gate, each exit 0.

Part of `btclib-org/.github#20`, which no single branch here satisfies.

## Summary by Sourcery

Enforce a consistent `./` prefix for local Markdown links at authoring time and align the documentation checks with that rule.

New Features:
- Add a pre-commit hook that requires local Markdown link destinations to use a `./` prefix while allowing anchors and external schemes.
- Cover both inline links and link reference definitions, including links nested in badges.

Bug Fixes:
- Prevent unresolved local links from rendering as silent fallback anchors that evade the documentation workflow's checks.
- Update existing repository documentation links to comply with the enforced local-link format.

Enhancements:
- Simplify the built-document unresolved-link check to a single pattern made reliable by source-level validation.

Documentation:
- Document the local-link rule and its rationale in the changelog.