### PR TITLE
Rely on a gate run on this sha rather than repeating it

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -131,12 +131,11 @@ jobs:
             about this tree a review has to know, and CONTRIBUTING.md the
             rules a finding cites.
 
-            One deviation from REVIEWING.md, because this is CI and not a
-            session: do not run the gates. They are running beside you on
-            this same sha, in test.yml, lint.yml and docs.yml, and a
-            second run of them here would buy nothing and cost a slot.
-            Review everything else the standard asks for, and say in the
-            summary that the gates were left to those workflows.
+            Do not run the gates. They are running beside you on this
+            same sha, which is the reliance REVIEWING.md provides for and
+            CLAUDE.md makes sound. Review everything else the standard
+            asks for, and say in the summary that no gates were run by
+            this job and that those runs are what stands.
 
             Do not file issues from here: a collateral finding goes in the
             summary comment, under a line saying it is not a finding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,31 @@ release-notes length in the first place, and are still in
   names `REVIEWING.md` rather than restating it, so the standard moves
   without the workflow being edited.
 
+- **`REVIEWING.md` says when a gate already run is relied on rather than
+  repeated, and `CLAUDE.md` says which checks a pull request is gated
+  on.** The condition is the sha and the record: where the gates have
+  been run on this very commit — the required checks running beside a
+  review, or an author handing over a branch they gated and stated the
+  result of — the review relies on that run and names whose it is, and
+  where there is no such run it runs them itself. A run on another tree
+  is not a run on this one, so a rebase voids it, the branch having been
+  gated before the tree moved under the gate.
+
+  What earned it is `claude-review.yml`'s prompt, whose reason for not
+  running the gates was that a second run of them would cost a runner
+  slot. That is an argument about price, and a reviewer reading it
+  generalizes it into "running costs, so do not run" — which is the
+  disposition that acked the `local-link-prefix` pattern of the entry
+  above without running it. The prompt now carries the instruction and
+  points at `CLAUDE.md` for why the reliance is sound, which is also
+  what keeps its hunk small: a pull request editing that file cannot be
+  reviewed at all, the action refusing to run under a workflow differing
+  from the default branch's copy (btclib-org/.github#58).
+
+  It leaves the entry above where it was. The gates exercise what the
+  tree already held, so what a diff decides with has been run by nothing
+  whether they ran or not, and a review runs that either way.
+
 ### CI
 
 - **`[tool.uv]`'s `required-version` comment stated the wrong reason**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,13 @@ uvx --from detect-secrets detect-secrets scan --slim \
 
 ## The workflows that gate, and the ones that do not
 
+The suite's aggregate, the lint job and the documentation build are the
+required checks on a pull request, and `REPOSITORY.md` reads the rule
+back from the endpoint rather than asserting it. So code does not reach a
+review without having passed them or passing them beside it on the same
+sha, and a reviewer may rely on that rather than establishing it again;
+`REVIEWING.md` has what the reliance takes.
+
 `lint`, `docs`, `test` and `codeql` are the gate, and `release` reuses the
 first three. It does not reuse `codeql`, and does not have to: a tag is an
 ancestor of `main` before the matrix builds anything (`version-check` in

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -247,8 +247,30 @@ the gates are, and the two ways a run of them lies, is `CLAUDE.md`: a
 suite run over a subset is not the coverage gate, and `pre-commit`
 passing is not the lint gate, sphinx being a job of its own.
 
-A gate that fails locally is the strongest finding available. A gate
-that passes is not evidence that the diff is right.
+**Unless they have already been run on this sha and that run is on the
+record.** Then rely on it, and say whose it is. Two runs qualify: the
+workflows of the required checks, running beside a review on the same
+commit — `CLAUDE.md` names which checks those are — and an author handing
+over a branch they gated themselves and said so. What is relied on is
+that those gates run and hold the merge, not the colour of a check, which
+stays none of a reviewer's business for the reason below.
+
+The sha is the whole of the condition: a run on another tree is not a run
+on this one, so a rebase voids it — the branch was gated, and then the
+tree moved under the gate. Naming the run is not a disclaimer but the
+evidence's provenance, "no gates were run by this job, the workflows on
+this sha are what stands" and "the author's statement of what they ran is
+what stands" being the two forms it takes, and it is what lets a reader
+tell a gate relied on from one nobody looked at. A pull request picked up
+with no such run in front of you is the other case, and there they are
+run.
+
+Relying on them settles nothing about what the diff decides with: the
+gates exercise what the tree already held, and the section above is what
+runs the rest.
+
+A gate that fails is the strongest finding available. A gate that passes
+is not evidence that the diff is right.
 
 **CI is not the reviewer's concern.** Do not wait for a workflow run, do
 not read one, do not report a check as a finding, do not withhold a


### PR DESCRIPTION
`REVIEWING.md` told a reviewer to run the gates and said nothing about
the case where they have already been run on that very commit, so a
review either repeated them or skipped them on a reason of its own. This
states the condition: **the sha and the record.**

Where the gates have been run on this sha and that run is on the record
— the required checks running beside a review on the same commit, or an
author handing over a branch they gated themselves and said what they
ran — the review relies on that run and **names whose it is**; where
there is no such run, it runs them. A run on another tree is not a run on
this one, so a rebase voids it: the branch was gated, and then the tree
moved under the gate.

Naming the run is not a disclaimer. It is the evidence's provenance, and
it is what lets a reader tell a gate relied on from one nobody looked at.

`CLAUDE.md` gains the fact the reliance rests on — which checks are
required here, read back from the endpoint rather than copied from a
sibling — so the reliance is sound in this repository and not merely
asserted.

`claude-review.yml`'s prompt stops calling this a deviation, because it
no longer is. Its previous reason for not running the gates was that a
second run would cost a runner slot: an argument about price, which a
reviewer reading it generalizes into "running costs, so do not run" —
the disposition that acked a regex without executing it.

Relying on a gate settles nothing about what the diff decides with. The
gates exercise what the tree already held; a pattern, a script or a query
the diff *adds* has been run by nothing, and the review runs it either
way.

---

**No ack of record is obtainable for this pull request.** It edits
`.github/workflows/claude-review.yml`, and the action refuses to run
under a workflow file differing from the default branch's copy
(btclib-org/.github#58). The gates below were run by hand on this sha
before the push, and the required checks run on it here.

**Gates on `922168b`:** `uv run pytest --cov` 0, `pre-commit run --all-files` 0, sphinx `-W --keep-going` 0.

## Summary by Sourcery

Allow reviews to rely on documented gate results for the exact commit while preserving independent review of changes introduced by the diff.

Enhancements:
- Define when reviews may rely on recorded gate runs for the exact commit instead of rerunning them, while requiring the run's provenance to be named and invalidating it after a rebase.
- Document the pull request's required checks and clarify that relying on existing gates does not replace running checks for behavior introduced by the diff.

CI:
- Update the Claude review workflow to rely on required checks running on the same commit and explicitly report that this job did not rerun them.

Documentation:
- Update review guidance and project instructions with the commit-and-record condition for relying on gate runs.

Chores:
- Record the review-policy changes in the changelog.