### PR TITLE
Key latest.yml's cache on the runner image, and record the token-permissions status

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -161,12 +161,38 @@ jobs:
         with:
           enable-cache: true
 
-      # keyed on the config file: the hook environments are the slow
-      # part, and the upgrade below does not touch them
+      # ImageOS is set by the runner image, not by this workflow, so the
+      # env context holds nothing for it and a shell is where it is read.
+      # lint.yml's step of this name carries the rest of that reasoning,
+      # ImageVersion included
+      - name: Identify the runner image
+        id: image
+        run: echo "os=${ImageOS:-unknown}" >> "$GITHUB_OUTPUT"
+
+      # the hook environments are the slow part and the upgrade below
+      # does not touch them, which is why they are cached here at all.
+      # The key carries the runner image and the interpreter as well as
+      # the config hash because what is cached is virtualenvs: on the
+      # config hash alone an ubuntu-latest rotation is not a graceful
+      # miss but a hit, handing the job environments built on the
+      # previous image. This is the job that can least afford one -- it
+      # runs to report what a new release of a dependency breaks, so a
+      # failure the cache caused is read as the thing this workflow was
+      # watching for and chased in the tree instead.
+      # That is the key lint.yml uses, deliberately rather than by
+      # coincidence, and
+      #   git grep -n 'pre-commit-\${{' -- .github/workflows/
+      # is what re-reads the two together: they are meant to agree
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: >-
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-${{
+            hashFiles('.pre-commit-config.yaml', '.python-version') }}
+          # a prefix that still names the image, so a partial restore
+          # cannot cross an image boundary either
+          restore-keys: |
+            pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-
 
       - name: Upgrade every dependency to its latest release
         run: uv lock --upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,23 @@ release-notes length in the first place, and are still in
   It leaves the entry above where it was. The gates exercise what the
   tree already held, so what a diff decides with has been run by nothing
   whether they ran or not, and a review runs that either way.
+- **`REPOSITORY.md` reads the whole workflow-permissions object back and
+  says the value is untested against the organization default**
+  (btclib-org/.github#23). The read-back was there, but as
+  `--jq '.default_workflow_permissions'`, which drops
+  `can_approve_pull_request_reviews` — the field that decides whether a
+  run can approve a pull request, and so whether the one rule saying
+  somebody other than the author approves has a way around it. It reads
+  back `false`. What the section did not say at all is which side of the
+  organization default this repository is on: it already held `read`
+  when that default moved there on 21 August 2026, so it was never
+  observed following the move, and an override set before that day is
+  indistinguishable from an inheritance. That is recorded as untested
+  rather than known good, with the `PUT` that moves this repository by
+  hand the next time the organization default moves, and a link to the
+  organization standard for why no endpoint can answer it. Documentation
+  only: nothing was set, and the read-back is the same object before and
+  after.
 
 ### CI
 
@@ -271,6 +288,27 @@ release-notes length in the first place, and are still in
   this repository's own `CONTRIBUTING.md` would have rendered. The step's
   comment carries the reasoning. What is left is `href="#\./`, and the hook is
   what makes it sufficient rather than merely first.
+
+- **`latest.yml`'s pre-commit cache is keyed on the runner image and the
+  interpreter rather than on the config hash alone**
+  (btclib-org/.github#25). #296 put those segments into `lint.yml`'s key
+  and #309 corrected this file's comment, which had claimed the bare key
+  was "as in `lint.yml`"; the key itself was out of that pull request's
+  scope and is what changes here. What the cache holds is virtualenvs,
+  so the config hash alone survives an `ubuntu-latest` rotation and
+  restores environments built on the previous image — not a graceful
+  miss but a hit, surfacing as whichever hook touches the broken
+  environment first. `lint-latest` is the job with the most to lose from
+  that: it runs to report what a new release of a dependency breaks, so
+  a failure the cache caused arrives looking exactly like the one the
+  workflow exists to find, and is chased in the tree. The `Identify the
+  runner image` step reading `ImageOS` from a shell, the key over
+  `runner.os`, that output and `hashFiles` of `.pre-commit-config.yaml`
+  and `.python-version`, and `restore-keys` still naming the image so a
+  partial restore cannot cross an image boundary, are all `lint.yml`'s.
+  The comment now carries this job's own reason for the key, with
+  `git grep -n 'pre-commit-\${{' -- .github/workflows/` beside it as the
+  command that re-reads both keys together.
 
 ### The gate
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -508,9 +508,15 @@ gh pr view <n> --json autoMergeRequest
 needing more declares it:
 
 ```shell
-gh api repos/btclib-org/btclib-secp256k1/actions/permissions/workflow \
-  --jq '.default_workflow_permissions'   # "read"
+gh api repos/btclib-org/btclib-secp256k1/actions/permissions/workflow
+# {"default_workflow_permissions":"read",
+#  "can_approve_pull_request_reviews":false}
 ```
+
+The whole object rather than one field of it: a run that can approve a
+pull request is a way around the rule that somebody other than the
+author approves, so `can_approve_pull_request_reviews` is read back
+beside the token's own scope and not left to be assumed.
 
 Only `release.yml` asks for more: `contents: write` on `github-release`,
 `id-token: write` on the two publish jobs, which is what Trusted
@@ -519,6 +525,32 @@ Publishing exchanges, and `id-token: write` with `attestations: write` on
 releases holds no OIDC token, and the job that signs writes no release.
 The workflow-level `permissions: contents: read` in every file is belt and
 braces; keep it, it is what makes the intent readable where the job is.
+
+What the call above cannot say is whether either value is this
+repository's own or the organization's, no endpoint reporting an
+override and none clearing one: [the standard's tokens
+section](https://github.com/btclib-org/.github/blob/main/README.md#tokens-publishing-scanning)
+is where that is argued, and what this file adds is which of the two
+states this repository is in.
+
+It is **untested**, and the date is what makes it so: this repository
+already held `read` when the organization default moved there on
+21 August 2026, so it was not among the ones that could be *seen*
+following the move, and an override set before that day reads back
+exactly like an inheritance does. Nobody has recorded setting one here,
+which is weaker than knowing there is none — `bitcoin-core-rpc` is the
+repository where one was found, by that same move, and its
+`REPOSITORY.md` records it as pinned.
+
+So whoever moves the organization default reads this repository back
+afterwards rather than assuming it followed, and moves it by hand where
+it did not:
+
+```shell
+gh api -X PUT repos/btclib-org/btclib-secp256k1/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+```
 
 ## Publishing
 


### PR DESCRIPTION
**`latest.yml`'s pre-commit cache was keyed on the config hash alone**,
under a comment claiming the key was `lint.yml`'s — which it was not.
What the cache holds is hook virtualenvs: compiled artifacts and
interpreter-linked binaries. On the config hash alone an `ubuntu-latest`
rotation is not a graceful miss but a **hit**, handing the job
environments built on the previous image, and surfacing as whichever
hook touches one first.

`lint-latest` is the job least able to absorb that. Its only product is a
signal about the outside world — *a new release of something broke this
tree* — so a cache-induced failure there is indistinguishable from the
finding the workflow exists to produce, and gets chased in the tree
rather than in the cache, on a schedule nobody is watching. Trimming the
comment to match the bare key would have made the file honest and left
that failure mode in place; the key changes instead, to `lint.yml`'s:
`Identify the runner image` reading `ImageOS` from a shell, a key over
`runner.os` + that output + `hashFiles` of `.pre-commit-config.yaml` and
`.python-version`, and `restore-keys` whose prefix still carries the
image so a partial restore cannot cross an image boundary. The cost is
one cold rebuild per rotation, which `lint.yml` already pays.

The comment no longer *justifies* the key by pointing at the sibling —
this job's own reason stands on its own — and carries the command that
re-reads both keys together, since nothing automated compares them:
`git grep -n 'pre-commit-\${{' -- .github/workflows/`.

**The workflow-token default is recorded as untested, not as inherited.**
No endpoint distinguishes an override from an inheritance, `PUT` takes
only `read`/`write`, and the org audit log answers 404 on this plan. Each
repository already held `read` before the organization default moved
there on 21 August 2026, so none could have been *observed* following the
move. `REPOSITORY.md` records the measured object — `read`, with
`can_approve_pull_request_reviews` false, the field that decides whether
a run can approve a pull request and so whether the one rule requiring
somebody other than the author has a way around it — the command that
produced it, and the by-hand `PUT` for the next time the default moves.

---

Neither `btclib-org/.github#23` nor `#25` is closed by this: each spans repositories that land separately, so no single commit answers either in full.

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run after the rebase onto current `main`. The suite and the documentation build run beside this review on this same sha — `REVIEWING.md` is what that reliance takes.

## Summary by Sourcery

Make dependency-lint caching safe across runner image changes and document the workflow-token permission status without assuming organization-level inheritance.

Bug Fixes:
- Prevent stale pre-commit hook environments from being restored after runner image rotations by including the runner image and Python version in the cache key and restore prefix.

Enhancements:
- Record the complete workflow-token permissions object and explicitly classify the repository’s relationship to the organization default as untested, including guidance for verifying or updating it.

CI:
- Align the latest dependency-lint workflow cache behavior with the runner image-aware cache strategy.

Documentation:
- Update repository documentation and changelog entries with the measured workflow permissions, their limitations, and the manual update procedure.