### PR TITLE
CONTRIBUTING.md sends a contributor to the organization standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`CONTRIBUTING.md` sends a contributor to the organization standard**
+  (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
+  the toolchain, the lint gate, the workflow set and the branch rules
+  once for this repository and its siblings, and it claims to be linked
+  from each repository's `CONTRIBUTING.md`. Nothing here named it: the
+  only mentions of that repository in this tree were `CHANGELOG.md` and
+  `RELEASING.md` citing issue numbers filed there, so a contributor
+  following `CONTRIBUTING.md` to `REPOSITORY.md` to `CLAUDE.md` was
+  never told a document above them existed — and a rule stated only
+  there was one they could not find. The pointer is in the opening
+  rather than in `REPOSITORY.md` or `CLAUDE.md`: the audit and the
+  normalizing checklist that standard carries are performed *holding*
+  it, so the reader who arrives without it is the contributor, and this
+  is the file that reader is already in — and the one of the three the
+  documentation build renders, `docs/source/contributing_link.md`
+  including it. Hence the absolute github.com url, the shape a sibling
+  repository is linked with elsewhere here: a relative destination
+  resolves against the rendered site.
+
 - **`CONTRIBUTING.md` and `CLAUDE.md` catch up with `test.yml`'s
   `--frozen`** (btclib-org/.github#8). The organization standard's
   `--locked`, never `--frozen` rule is stated flatly, and the wheel-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,12 @@ release-notes length in the first place, and are still in
   the toolchain, the lint gate, the workflow set and the branch rules
   once for this repository and its siblings, and it claims to be linked
   from each repository's `CONTRIBUTING.md`. Nothing here named it: the
-  only mentions of that repository in this tree were `CHANGELOG.md` and
-  `RELEASING.md` citing issue numbers filed there, so a contributor
+  mentions of that repository in this tree were every one of them an
+  issue-number citation — in a workflow comment, a hook comment,
+  `CHANGELOG.md` and `RELEASING.md` — and not one of them a pointer
+  to the standard. `git grep -n 'btclib-org/\.github'` is what re-derives
+  them, a list here going stale the next time one is cited. So a
+  contributor
   following `CONTRIBUTING.md` to `REPOSITORY.md` to `CLAUDE.md` was
   never told a document above them existed — and a rule stated only
   there was one they could not find. The pointer is in the opening

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,15 @@ here.
 
 Please read the [Code of Conduct](./CODE_OF_CONDUCT.md) too.
 
+What this repository holds in common with its siblings — the toolchain,
+the lint gate, the tool tables behind it, the workflow set and the branch
+rules — is stated once in the
+[btclib-org repository standard](https://github.com/btclib-org/.github/blob/main/README.md),
+each rule with the alternative it was decided against. It binds this
+repository, so a change departing from it is a divergence, and one filed
+as an issue in that repository rather than here: a difference between two
+repositories belongs to neither of them.
+
 ## Which project is this
 
 These are thin python bindings to


### PR DESCRIPTION
The organization standard — `README.md` in `btclib-org/.github` — states
the toolchain, the lint gate, the tool tables behind it, the workflow set
and the branch rules once for this repository and its siblings, each rule
with the alternative it was decided against. **Nothing in this tree named
it.** The only mentions of that repository were `CHANGELOG.md` and
`RELEASING.md` citing issue numbers filed there, so a contributor
following `CONTRIBUTING.md` → `REPOSITORY.md` → `CLAUDE.md` was never
told a document above them existed. A rule stated only there was a rule
they could not find, and a divergence they introduce is one nothing here
warned them about.

**The pointer goes in `CONTRIBUTING.md`, and nowhere else.** The
standard's three readers are not equally in need of it: §15's audit and
§16's checklists are performed *holding* the standard — that is what
makes their commands runnable — so the only reader who reaches a
btclib-org tree without it is the contributor, and `CONTRIBUTING.md` is
the file that reader is already in.

Three things settled it rather than left it a preference:

- The standard already claims exactly this — "linked from each
  repository's `CONTRIBUTING.md`, rather than a copy per repository" — so
  a pointer in `REPOSITORY.md` or `CLAUDE.md` would have left that
  sentence false.
- `CONTRIBUTING.md` is the only one of the three the documentation build
  renders: `docs/source/contributing_link.md` `{include}`s it and `index`
  lists it, while `REPOSITORY.md` and `CLAUDE.md` are in no toctree.
- Each repository's own *one fact in one place* rule argues against five
  pointers where one carries it.

The destination is an absolute `https://github.com/…` url, the shape
every cross-repository link here already takes: a `./`-relative one
resolves against btclib.org or the Read the Docs site and reaches
nothing. `local-link-prefix`'s lookahead exempts a scheme, so the hook is
unaffected, and the rendered `href` was checked in the built html.

`btclib-org/.github#52` **stays open**: btclib-node is inside its
measurement and outside this work.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite and the documentation
build run beside this review on this same sha.

## Summary by Sourcery

Point contributors to the shared organization standard from CONTRIBUTING.md.

Enhancements:
- Link contributors from CONTRIBUTING.md to the shared btclib organization repository standard for common tooling, linting, workflows, and branch rules.

Documentation:
- Document the organization-wide repository standard in the changelog.