### PR TITLE
Say what each .readthedocs.yaml is true of, and stop copying what it is not

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,37 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 #
 # The dotted name is the canonical one; readthedocs.yml is honored too,
-# but documented as deprecated.
+# but documented as deprecated. btclib's copy of this line goes on to
+# say that "include *.yml" would drag the file into the sdist; there is
+# no MANIFEST.in here and no site served from this root for that clause
+# to be about.
+#
+# What this file cannot say is *which* versions run it, and here that is
+# where the defect is rather than a footnote. `latest`, `stable` and each
+# release tag are versions on read the docs' side, and an automation rule
+# is what activates a new tag there. This project has no such rule, so
+# every build of this file has been `latest`, which follows main, or
+# `stable`, which read the docs moves to the highest release tag and
+# rebuilds by itself. No version named for a release has ever been built,
+# v0.8.0.4 included, and `/en/v<version>/` is therefore a 404 here where
+# both siblings serve it -- the permanent URL a reader is given wherever
+# a version is named. What is *not* broken is the build: `stable` runs
+# this file against a release tag's tree and succeeds, so the missing
+# thing is the URL and not an untested build.
+#
+# The slug is the other half. The project is served under
+# `btclib-libsecp256k1`, which the rename never followed, while
+# README.md's badge and link name `btclib-secp256k1`; the read the docs
+# project's own *name* has been renamed and its slug has not.
+#
+# Both halves are dashboard actions rather than anything a pull request
+# reaches: issue #302 for the slug, btclib-org/.github#26 for the rule
+# and for the commands that re-derive all of this, and issue #295 for
+# the release check that reads the rendered tag URL, which stays blocked
+# while there is no such URL to read. That check would be reachable only
+# on a tag, the shape btclib-org/.github#49 is about, which is a reason
+# to order it after the URL exists rather than before; nothing here
+# settles btclib-org/.github#49.
 
 # Required
 version: 2
@@ -30,7 +60,15 @@ build:
   # build.commands rather than the sphinx: and python: keys, which cannot
   # express installing this package's own dependency group and are
   # rejected when it is present. uv installs the docs group from
-  # uv.lock, which is why there is no docs/requirements.txt.
+  # uv.lock, which is why there is no docs/requirements.txt: the group in
+  # pyproject.toml is the single declaration and the lock pins it, where
+  # a requirements file would be unpinned and kept in step by a header
+  # asking a human to do it.
+  # uv itself is not pinned, deliberately: no dependabot ecosystem
+  # watches this file, so a pin here is a version nobody bumps, and
+  # --locked makes the uv version irrelevant to what gets installed --
+  # uv.lock decides that, and a uv too old to read the lock fails loudly
+  # rather than resolving something else.
   # -W turns a failed import into a failed build, which is the point of
   # the whole file; --keep-going comes first so one broken module
   # reports every other problem in the same run instead of one per push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,43 @@ release-notes length in the first place, and are still in
   organization standard for why no endpoint can answer it. Documentation
   only: nothing was set, and the read-back is the same object before and
   after.
+- **`.readthedocs.yaml` records that no release of this package has ever
+  been built under a name of its own** (btclib-org/.github#26). Read the
+  docs activates a new tag from an automation rule of its own; this
+  project has none, so every build of this file has been `latest`, which
+  follows `main`, or `stable`, which read the docs moves to the highest
+  release tag and rebuilds by itself. No version named for a release has
+  ever been built, v0.8.0.4 included, and `/en/v<version>/` is therefore
+  a 404 here where both siblings serve it — that URL being what a reader
+  is given wherever a version is named. What is *not* broken is the
+  build: `stable` runs this file against a release tag's tree and
+  succeeds, so what is missing is the URL and not an untested build. The
+  comment says exactly that, a reader of the file otherwise having
+  nowhere in this tree to learn it — `REPOSITORY.md` has no Read the
+  Docs section, where btclib's does.
+
+  The slug is the other half and is #302's. The documentation is served
+  under `btclib-libsecp256k1`, which the rename never followed, while
+  `README.md`'s badge and the link behind it name `btclib-secp256k1`;
+  the read the docs project's *name* has been renamed and only its slug
+  has not, which is a finer reading than #302 records. Both halves are
+  dashboard actions rather than anything a pull request reaches, so what
+  lands here is the record beside the file: #302 for the slug, #295 for
+  the release check that reads the rendered tag URL and stays blocked
+  while there is none, and btclib-org/.github#26 for the commands that
+  re-derive all of it. That check would be reachable only on a tag, the
+  shape btclib-org/.github#49 is about — a reason to order it after the
+  URL exists rather than a change to what that issue asks.
+
+- **The same file carries the reasoning its siblings give for leaving uv
+  unpinned.** Nothing about this repository made it different: no
+  dependabot ecosystem watches this file, so a pin here is a version
+  nobody bumps, and `--locked` makes the uv version irrelevant to what
+  gets installed — `uv.lock` decides that, and a uv too old to read the
+  lock fails loudly rather than resolving something else. The
+  `docs/requirements.txt` sentence gains the half that says why the
+  group and the lock are the single declaration, which was the argument
+  for having no such file and had been left out.
 
 ### CI
 


### PR DESCRIPTION
`btclib-org/.github#26` asks whether Read the Docs is wired the same way
in the three publishing repositories. The question underneath it is
whether it *should* be: **a difference that follows from what a
repository publishes is not drift; one nobody chose is.** Each difference
was judged on that, and most were left alone.

Left alone, because they follow from the repository:
`btclib-secp256k1`'s `submodules:` block, which every `automodule` there
needs to compile; plural against singular in the autodoc paragraph, which
follows from what each publishes; and the shared mechanism — `version`,
`build.os`, the interpreter, `pip install uv`, `uv sync --locked`,
`sphinx-build -W --keep-going` — identical in all four for the same
reason in each.

**The file that was most identical was the most wrong.**
`btclib-benchmarks/.readthedocs.yaml` was byte-for-byte identical to
`btclib`'s — `diff -u` empty — which is how a repository that publishes
no API came to declare an autodoc build of a package it does not install,
and to carry a Jekyll `include *.yml` clause with no `_config.yml` and no
`MANIFEST.in` to record it. Its command is now the one `docs.yml` really
runs: `--only-group docs`, not the sibling form. Measured — the sibling
form exits 1 building secp256k1 on 3.14, because the comparands *are*
this project's dependencies and coincurve publishes no cp314 wheel. A
divergence that follows from what the repository publishes.

Fixed as drift: the Jekyll clause copied into repositories that have
neither file; the uv-not-pinned reasoning missing from
`btclib-secp256k1` alone for no reason; and the fact that **no file said
which versions run it**, now recorded in each with a pointer to where the
answer lives.

`btclib`'s stated counts — "15 bare module titles", "89 signatures" — are
gone. Its own `CONTRIBUTING.md` forbids them, its `CLAUDE.md` claims
nothing states a count, and re-derivation shows the numbers were stale.
The command replaces them.

**The brief's premise about the never-built tag was wrong, and the issue
is stale with it.** `versions/stable/` reports `ref: v0.8.0.4`,
`type: tag`, `built: true`, with repeated successful builds from tag
commits. So `.readthedocs.yaml` *is* exercised against a release tag's
tree and succeeds. What has never existed is a version **named** for a
release: every tag-type version other than `stable` is inactive, so
`/en/<version>/` 404s where both siblings serve it. The missing thing is
the permanent per-release URL, not an untested build — written that way
because the weaker reading sends the next reader hunting in the tree.

`btclib-org/.github#26` **stays open**: every box it carries is an action
on `app.readthedocs.org`, and none is reachable from a tree.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0 after the
rebase onto current `main`. The suite and the documentation build run
beside this review on this same sha.

## Summary by Sourcery

Bring the Read the Docs configuration and related documentation up to date with this repository’s actual publishing behavior and known dashboard-side limitations.

Enhancements:
- Document the Read the Docs configuration’s repository-specific behavior, release-version limitations, project slug mismatch, and intentionally unpinned uv rationale.
- Replace stale documentation-build statistics with the project’s current contribution guidance and build behavior.

Documentation:
- Clarify how Read the Docs builds and versions this repository, including the distinction between successful tag builds and unavailable permanent release URLs.
- Remove inaccurate autodoc count claims and record the rationale for the repository’s documentation dependency setup.