### PR TITLE
CLAUDE.md's roster of the gate names only what gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,24 @@ release-notes length in the first place, and are still in
 
 ### The gate
 
+- **`CLAUDE.md`'s roster of the gate names only what gates** (issue
+  #323). It said "`lint`, `docs`, `test` and `codeql` are the gate", and
+  `codeql` is none of it: the endpoint returns three contexts, and the
+  workflow has no `pull_request` trigger at all, so there is nothing for
+  a branch rule to require and nothing a merge could wait on. The claim
+  sat a few lines under the paragraph stating the required checks
+  correctly, and that adjacency is what made it worth fixing rather than
+  leaving: `REVIEWING.md` now has a reviewer *rely* on those runs where
+  they are on the record, so a file naming a fourth one turns a
+  documented reliance into a wrong one — a reviewer waiting for a run
+  that will not come, or acking on one that holds nothing. It is also
+  wrong in the direction nobody audits, claiming more is gated than is.
+  What replaces it says where `codeql` does run, the push to `main` a
+  merge creates and the weekly cron, which is what its own `on:` block
+  argues at length. The `release` half of the sentence was sound and
+  keeps its reasoning, with "the merge gate has already scanned"
+  corrected to the analysis that actually reads that tree.
+
 - **Coverage measures `tests/` as well as the package**
   (btclib-org/.github#7). `[tool.coverage.run] source` named
   `btclib_secp256k1` alone, so the one thing the 100% ratchet said

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,17 +220,21 @@ review without having passed them or passing them beside it on the same
 sha, and a reviewer may rely on that rather than establishing it again;
 `REVIEWING.md` has what the reliance takes.
 
-`lint`, `docs`, `test` and `codeql` are the gate, and `release` reuses the
-first three. It does not reuse `codeql`, and does not have to: a tag is an
-ancestor of `main` before the matrix builds anything (`version-check` in
-`release.yml`), so the tree it publishes is one the merge gate has already
-scanned — and `codeql` is weekly besides, which is what covers the code
-nobody touched. The rest are sentinels: each is a workflow of its own, has
-no aggregate job, is named by no branch rule, and opens no issue on failure
-(`vendored-vectors` excepted, for the reason its own header gives). That is
-deliberate in every case — each is expected to go red for a reason no pull
-request introduced, and a red check nobody can act on from a branch is
-noise. Their crons are spread out, because sentinels landing in one inbox
+`lint`, `docs` and `test` are the gate, and `release` reuses all three.
+`codeql` is not one of them and holds nothing: no branch rule names its
+aggregate, and it has no `pull_request` trigger at all, so a merge never
+waits on it. It runs on the push to `main` that a merge creates — its
+own `on:` block says what that trade bought and what it defers — and
+weekly besides, which is what covers the code nobody touched. `release`
+does not reuse it and does not have to: a tag is an ancestor of `main`
+before the matrix builds anything (`version-check` in `release.yml`), so
+the tree it publishes is one that push-triggered analysis has already
+read. The rest are sentinels: each is a workflow of its own, has no
+aggregate job, is named by no branch rule, and opens no issue on failure
+(`vendored-vectors` excepted, for the reason its own header gives). That
+is deliberate in every case — each is expected to go red for a reason no
+pull request introduced, and a red check nobody can act on from a branch
+is noise. Their crons are spread out, because sentinels landing in one inbox
 on one morning are one sentinel, and `codeql` keeps a morning of its own
 for the same reason. Two pairs share a morning even so. `macos` and
 `latest` do it deliberately, and both cron comments say why: half an hour


### PR DESCRIPTION
`CLAUDE.md` said:

> `lint`, `docs`, `test` and `codeql` are the gate, and `release` reuses
> the first three.

**`codeql` is not the gate and never holds a merge.** Two independent
reasons, either one sufficient:

```shell
gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
  --jq '.required_status_checks.checks[].context'
# Lint and type-check
# Build the documentation
# test: every job passed
```

and `codeql.yml` has no `pull_request` trigger at all — `push:
branches: [main]`, a Tuesday cron and `workflow_dispatch` — so there is
no check for a rule to require and nothing for a merge to wait on.

`REPOSITORY.md` and `CONTRIBUTING.md` both already say this correctly
(`git grep -in codeql` is what shows it). `CLAUDE.md` was the one file
the change that dropped the context left behind — and it is the file the
review prompt reads.

**Why it matters more than it did.** The sentence sits a few lines below
the paragraph that states the required checks correctly, which is now
what a reviewer is told to *rely on*: where the gates ran on this sha and
the run is on the record, the review relies on it rather than repeating
it. Two adjacent statements disagreeing about which runs those are is
exactly how a documented reliance becomes a wrong one — a reviewer
waiting for a run that will never arrive, or acking on one that holds
nothing. It is also wrong in the direction nobody audits: *more* gated
than really is reads as caution.

The `release` half was sound and keeps its reasoning; "the merge gate has
already scanned" is corrected to the push-triggered analysis that
actually reads that tree.

Closes #323

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0. The
suite, the lint job and the documentation build run beside this review on
this same sha.

## Summary by Sourcery

Correct the documented CI gate names and explain CodeQL’s actual analysis schedule.

Bug Fixes:
- Correct the documented merge-gate roster by removing CodeQL from the required pull-request checks and clarifying its push-to-main and scheduled execution.
- Update the release rationale to reflect that CodeQL analyzes the merged tree after the push to main rather than as part of the merge gate.

Documentation:
- Align CLAUDE.md’s gate documentation with the repository’s actual branch protection rules and workflow triggers.

Chores:
- Record the documentation correction in the changelog.