### PR TITLE
.yamllint.yaml keeps the default rule set on, and drops one tree's claims

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,11 +202,13 @@ repos:
     hooks:
       - id: check-dependabot
       - id: check-readthedocs
-  # the shape of the workflows, which actionlint and zizmor do not read:
-  # the first says whether one is valid, the second whether it is safe,
-  # and neither says whether a line has grown to 118 columns. The limit is
-  # 100 rather than the 80 the prose gets, and .yamllint.yaml carries the
-  # arithmetic behind that
+  # the shape of the yaml itself, which actionlint and zizmor do not read:
+  # the first says whether a workflow is valid, the second whether it is
+  # safe, and neither says whether a line has grown to 118 columns, a key
+  # is written twice, or a block is indented under nothing. yamllint's
+  # default rule set, less the two .yamllint.yaml disables by name, with
+  # the width at 100 rather than the 80 the prose gets -- that file
+  # carries the arithmetic behind both
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -4,16 +4,24 @@
 # which for a pre-commit hook is the repository root, so the hook needs no
 # flag.
 #
+# This file is the same in every repository of the organization,
+# deliberately, so nothing written here may be true of one tree only. Which
+# toml files a repository actually has is that repository's own
+# .pre-commit-config.yaml to name, beside the hook that runs this.
+#
 # What is *not* set matters as much: reorder_keys stays at its default of
 # false, the order of a table here being an argument rather than an accident
-# -- [project] reads top to bottom, and the ruff rule sets are grouped by
-# what they cover rather than sorted.
+# -- a table meant to be read top to bottom, or grouped by what its keys
+# cover rather than by how they are spelled, says something that sorting
+# would throw away.
 [formatting]
-# four spaces, which is what pyproject.toml already uses and what
-# ruff-format writes in the Python beside it; taplo's own default is two
+# four spaces, and not taplo's own default of two: one indent for every toml
+# in the organization is the point of having a formatter at all, and four is
+# what a pyproject.toml's arrays are already written with wherever there is
+# one, ruff-format writing the same four in the Python beside them
 indent_string = "    "
 # an array that is exploded stays exploded: one entry per line is what makes
-# adding a rule set, or a module to the mutation session, a one-line diff,
-# and the default would collapse a short array onto one line and expand it
-# again when it outgrows the width -- churn driven by a column count
+# adding an entry a one-line diff, and the default would collapse a short
+# array onto one line and expand it again when it outgrows the width -- churn
+# driven by a column count
 array_auto_collapse = false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -11,21 +11,31 @@
 # below, asked in the tree that wants the answer, rather than a number
 # recorded here and carried into repositories nobody re-measured it in.
 #
-# Enabled: the width of a line, which nothing else here measures for
-# yaml, and the marker that opens a document. The rest of the default set
-# is off, reporting a convention rather than a defect:
-#   - comments wants two spaces before a trailing comment where one is
-#     written. Dependabot writes one when it bumps a
-#     "uses: action@sha # v1.2.3" pin, so the rule would report the bot's
-#     own output on every update
-#   - truthy reports the "on:" that opens a workflow: yaml 1.1 reads that
-#     key as the boolean true, so what the rule objects to is the
-#     spelling GitHub Actions requires, one per workflow by construction
-# What the default set says about this tree today:
+# The default set, minus two rules and with one width changed. extends is
+# what carries the rest: yamllint enables no rule a configuration does
+# not name, so a file that lists rules and extends nothing runs those
+# rules alone -- indentation, trailing whitespace, duplicate keys and the
+# rest silently off, with a lint gate that still passes because a check
+# nobody runs cannot fail. The two exceptions are named under rules
+# below, where a reader can see them, rather than left to be inferred
+# from what is missing.
+#
+# What the whole default set says about this tree today, the two
+# exceptions included, is a question for the tree that is asking:
 #
 #   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
 #     -d '{extends: default, rules: {line-length: {max: 100}}}'
+extends: default
+
 rules:
+  # two spaces before a trailing comment where one is written. Dependabot
+  # writes one when it bumps a "uses: action@sha # v1.2.3" pin, so the
+  # rule reports the bot's own output on every update
+  comments: disable
+  # the "on:" that opens a workflow: yaml 1.1 reads that key as the
+  # boolean true, so what the rule objects to is the spelling GitHub
+  # Actions requires, one per workflow by construction
+  truthy: disable
   line-length:
     # 100, where markdown is held to 80 and any Python beside it to the
     # same, and the difference is the pinning convention. An action

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,40 +1,54 @@
 ---
-# the third width gate, beside markdownlint on the prose and ruff on the
-# python: the workflows were the one place a line could grow with nothing
-# to say so. actionlint answers whether a workflow is valid and zizmor
-# whether it is safe; neither reads its shape.
-
-extends: default
-
+# yamllint's configuration, in a file of its own because the reasoning
+# below needs more room than a hook argument has, and because a
+# repository with no pyproject.toml has nowhere else to keep it. yamllint
+# finds this file by name in the directory it runs from, which for a
+# pre-commit hook is the repository root, so the hook needs no -c.
+#
+# This file is the same in every repository of the organization,
+# deliberately, so nothing written here may be true of one tree only.
+# What the default set reports is therefore a question for the command
+# below, asked in the tree that wants the answer, rather than a number
+# recorded here and carried into repositories nobody re-measured it in.
+#
+# Enabled: the width of a line, which nothing else here measures for
+# yaml, and the marker that opens a document. The rest of the default set
+# is off, reporting a convention rather than a defect:
+#   - comments wants two spaces before a trailing comment where one is
+#     written. Dependabot writes one when it bumps a
+#     "uses: action@sha # v1.2.3" pin, so the rule would report the bot's
+#     own output on every update
+#   - truthy reports the "on:" that opens a workflow: yaml 1.1 reads that
+#     key as the boolean true, so what the rule objects to is the
+#     spelling GitHub Actions requires, one per workflow by construction
+# What the default set says about this tree today:
+#
+#   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
+#     -d '{extends: default, rules: {line-length: {max: 100}}}'
 rules:
-  # 100 and not the 80 the markdown and the python comments get, for an
-  # arithmetic this repository cannot argue with: an action pinned to a
-  # 40-character commit SHA with its tag in a trailing comment starts at
-  # 77 columns before the name of the action is written. Measured on this
-  # tree, 80 reports 62 lines against 8 at 100, and buying the difference
-  # would take a `yamllint disable-line` on every pin -- a width rule does
-  # not get to break the pinning rule. 100 also clears today's longest pin
-  # by enough that an action with a longer name cannot turn a dependabot
-  # pull request red for having no defect in it
   line-length:
+    # 100, where markdown is held to 80 and any Python beside it to the
+    # same, and the difference is the pinning convention. An action
+    # pinned to a 40-character commit SHA with its tag in a trailing
+    # comment has spent most of an 80-column line before the name of the
+    # action is written, so a limit of 80 reports the pins and buys its
+    # 80 with a "yamllint disable-line" on each. A width rule does not
+    # get to break a security one. 100 clears today's longest pin with
+    # room for an action whose name is longer, so a dependabot pull
+    # request cannot go red for having no defect in it; what the rule is
+    # left guarding is prose, the one thing here that can be rewrapped.
+    # What 80 would cost, in the tree that is asking:
+    #
+    #   git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
+    #     -d '{rules: {line-length: {max: 80}}}'
     max: 100
-
-  # off, at 46 findings, every one of them a pin: dependabot and
-  # pre-commit.ci write one space before the trailing `#` where the rule
-  # wants two, and those two bots are what keeps the pins moving. A rule
-  # that turns every bot pull request red is a rule that gets ignored
-  comments:
-    require-starting-space: true
-    min-spaces-from-content: 1
-
-  # off, at 4 findings, all of them the `on:` that opens a workflow: in
-  # yaml 1.1 that key *is* the boolean true, so the rule is reporting the
-  # spelling GitHub Actions requires
-  truthy: disable
-
-  # the "---" every yaml file here already opens with, matching btclib's
-  # own .yamllint.yaml: `extends: default` carries the rule already, but
-  # only as a warning, which .readthedocs.yaml's own missing one passed
-  # unnoticed until measured -- enable is what turns it into the same
-  # question a review can fail on
+    # allow-non-breakable-words stays at its default, true: a line that
+    # is one long token has nowhere to break, which is the exemption
+    # MD013 already makes for a bare URL
+  # the "---" every yaml file here opens with, which is yamllint's
+  # default and one line each. What it buys is that the files answer the
+  # question the same way instead of each beginning however its author
+  # left it, and that the default set carries one exemption fewer to
+  # justify. On line 1, above the header comment rather than below it, so
+  # there is no second place to look for it
   document-start: enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,7 +284,10 @@ release-notes length in the first place, and are still in
   the shared file unchanged would have turned the set off here too; the
   shared file gains it back instead, with the two exceptions named under
   `rules:` where a reader can see them rather than inferred from what is
-  missing. Nothing new is reported in this tree:
+  missing. `.pre-commit-config.yaml`'s comment above the hook follows:
+  it described a width check, which is what the hook was, and now names
+  what actionlint and zizmor still do not read -- a key written twice, a
+  block indented under nothing. Nothing new is reported in this tree:
   `git ls-files '*.yml' '*.yaml' | xargs uvx yamllint` is clean before
   and after.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,27 +261,43 @@ release-notes length in the first place, and are still in
 
 ### CI
 
-- **`.yamllint.yaml` and `.taplo.toml` stop carrying one tree's claims**
-  (btclib-org/.github#40). Both files are shared byte-for-byte across
-  the organization's repositories, deliberately, and both had been
-  written as though they lived in one: `.yamllint.yaml` recorded the
-  findings of a survey run somewhere else -- "62 lines against 8 at
-  100" -- as settled fact, and `.taplo.toml` justified `reorder_keys`
-  and `array_auto_collapse` by naming this tree's furniture, "the ruff
-  rule sets", "a module to the mutation session". A number measured in
-  another repository and copied here is not a measurement of this one,
-  and the reader who checks it has no way to learn that from the file.
+- **`.yamllint.yaml` keeps the default rule set on, and stops carrying
+  one tree's claims** (btclib-org/.github#40, and the shared file's own
+  defect found reviewing that change). Two things, one file.
 
-  Both are now the copies `btclib`, `bitcoin-core-rpc` and
-  `btclib-benchmarks` already carry, which state the rule and the
-  command that re-derives the numbers in whichever tree is asking,
-  rather than the answers. Each also says outright that it is shared and
-  that nothing in it may be true of one tree only, which is what makes
-  the next edit to any copy answerable. The settings themselves do not
-  move: `max: 100`, `document-start: enable`, four-space indent,
-  `array_auto_collapse = false` -- `diff` against a sibling is what shows
-  the files are identical, and the gate passing unchanged is what shows
-  the configuration did not.
+  The claims first: the file recorded the findings of a survey run
+  somewhere else — "80 reports 62 lines against 8 at 100" — as settled
+  fact, in a file shared byte-for-byte across the organization's
+  repositories. A number measured in another tree and copied here is not
+  a measurement of this one, and nothing in the file told the reader who
+  checked it so. It now states the rule and the command that re-derives
+  the numbers in whichever tree is asking.
+
+  The defect that came with the shared copy is `extends: default`.
+  yamllint enables no rule a configuration does not name, so a file that
+  lists `line-length` and `document-start` and extends nothing runs those
+  two alone: indentation, trailing whitespace, duplicate keys and the
+  rest of the default set silently off, while the file's own prose said
+  only `comments` and `truthy` were. A lint gate passes either way — a
+  check nobody runs cannot fail — which is why the copy travelled. This
+  repository was the one still carrying `extends: default`, so adopting
+  the shared file unchanged would have turned the set off here too; the
+  shared file gains it back instead, with the two exceptions named under
+  `rules:` where a reader can see them rather than inferred from what is
+  missing. Nothing new is reported in this tree:
+  `git ls-files '*.yml' '*.yaml' | xargs uvx yamllint` is clean before
+  and after.
+
+- **`.taplo.toml` stops carrying one tree's furniture**
+  (btclib-org/.github#40). It justified `reorder_keys` and
+  `array_auto_collapse` by naming things that are one tree's — "the ruff
+  rule sets", "a module to the mutation session" — where the reasons are
+  that a table's order is an argument rather than an accident, and that
+  one indent across every toml in the organization is the point of having
+  a formatter. It is now the copy the sibling repositories carry, which
+  argues from the rule and says outright that nothing in it may be true
+  of one tree only. `indent_string` and `array_auto_collapse` do not
+  move, which taplo rewriting nothing here is what shows.
 
 - **`[tool.uv]`'s `required-version` comment stated the wrong reason**
   (#299): it read as though the floor were the version the uv-lock hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,28 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`.yamllint.yaml` and `.taplo.toml` stop carrying one tree's claims**
+  (btclib-org/.github#40). Both files are shared byte-for-byte across
+  the organization's repositories, deliberately, and both had been
+  written as though they lived in one: `.yamllint.yaml` recorded the
+  findings of a survey run somewhere else -- "62 lines against 8 at
+  100" -- as settled fact, and `.taplo.toml` justified `reorder_keys`
+  and `array_auto_collapse` by naming this tree's furniture, "the ruff
+  rule sets", "a module to the mutation session". A number measured in
+  another repository and copied here is not a measurement of this one,
+  and the reader who checks it has no way to learn that from the file.
+
+  Both are now the copies `btclib`, `bitcoin-core-rpc` and
+  `btclib-benchmarks` already carry, which state the rule and the
+  command that re-derives the numbers in whichever tree is asking,
+  rather than the answers. Each also says outright that it is shared and
+  that nothing in it may be true of one tree only, which is what makes
+  the next edit to any copy answerable. The settings themselves do not
+  move: `max: 100`, `document-start: enable`, four-space indent,
+  `array_auto_collapse = false` -- `diff` against a sibling is what shows
+  the files are identical, and the gate passing unchanged is what shows
+  the configuration did not.
+
 - **`[tool.uv]`'s `required-version` comment stated the wrong reason**
   (#299): it read as though the floor were the version the uv-lock hook
   of `.pre-commit-config.yaml` pins, but that hook pins `0.12.5` while


### PR DESCRIPTION
Two things in one file, the second found by the review of this pull
request's first head.

## The claims

`.yamllint.yaml` and `.taplo.toml` are shared byte-for-byte across the
organization's repositories, deliberately — and this repository's copies
were the last two still written as though each lived in one tree.
`.yamllint.yaml` recorded a survey's answers as settled fact ("80 reports
**62 lines against 8** at 100"), measured somewhere else; `.taplo.toml`
argued its two settings from "the ruff rule sets" and "a module to the
mutation session". Both now state the rule and the command that
re-derives the numbers in whichever tree is asking, and say outright that
nothing written in them may be true of one tree only. That is
btclib-org/.github#40.

## The defect the shared copy carried

**`extends: default` was missing.** yamllint enables no rule a
configuration does not name, so a file that lists `line-length` and
`document-start` and extends nothing runs *those two alone* —
indentation, trailing whitespace, duplicate keys and the rest of the
default set silently off, while the file's own prose said only `comments`
and `truthy` were:

```shell
printf -- '---\nfoo:   bar   \nfoo: baz\n' > t.yaml
uvx yamllint -f parsable t.yaml            # with the shared file: nothing
uvx yamllint -f parsable t.yaml            # + "extends: default":
# t.yaml:2:7:  too many spaces after colon (colons)
# t.yaml:2:11: trailing spaces (trailing-spaces)
# t.yaml:3:1:  duplication of key "foo" (key-duplicates)
```

A lint gate passes either way — a check nobody runs cannot fail — which
is how the copy travelled. `git log -- .yamllint.yaml` says it is not a
regression: `extends: default` has been absent from the three siblings'
copies since each was written, and **this repository is the only one that
still had it**. Adopting the shared file unchanged would have turned the
default set off in the one tree where it was on.

So the fix goes into the shared file: `extends: default` is back, and
`comments` and `truthy` are named under `rules:` as explicit `disable`s,
where a reader sees them instead of inferring them from what is missing.

## What it costs, measured in each tree

```shell
git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -f parsable \
  -d '{extends: default, rules: {line-length: {max: 100},
       comments: disable, truthy: disable}}'
```

| repository | findings |
| --- | --- |
| `btclib-secp256k1` | none |
| `bitcoin-core-rpc` | none |
| `btclib` | 1 — `comments-indentation` |
| `btclib-benchmarks` | 1 — `comments-indentation` |

This tree is clean, so the corrected file lands here first. The other
three take the same file in their own pull requests, with that one
finding fixed where there is one.

**No setting otherwise moves**: `max: 100`, `document-start`, the
four-space `indent_string`, `array_auto_collapse = false`.

btclib-org/.github#40 **stays open** until every copy is identical again
— which, until those three land, this pull request deliberately makes
false rather than claiming otherwise.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job and the
documentation build run beside this review on this same sha.

## Summary by Sourcery

Align the shared linting configuration with organization-wide usage while preserving yamllint's default checks and repository-independent documentation.

Bug Fixes:
- Restore yamllint's default rule set while explicitly disabling only the organization-approved `comments` and `truthy` rules.

Enhancements:
- Make the shared YAML and TOML configuration rationale repository-independent and provide commands to remeasure repository-specific findings.
- Update pre-commit documentation and changelog entries to reflect the broader YAML validation coverage and shared configuration policy.

Documentation:
- Document the shared configuration assumptions, rule trade-offs, and validation commands in the changelog and configuration comments.