### PR TITLE
conf.py's toctree comment stops enumerating what a glob derives (issue #313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`docs/source/conf.py`'s toctree comment stops enumerating the pages
+  a glob already derives** (issue #313). It said "Four pages of the
+  toctree are this repository's README, CONTRIBUTING, SECURITY and
+  RELEASE_NOTES", and `docs/source/index.rst` lists six of them: the
+  comment missed `REVIEWING` and `CHANGELOG`, both of which have a
+  `*_link.md` shim and are globbed into `INCLUDED` twenty lines below it
+  exactly as the four it named are. Its "no CHANGELOG at all" clause was
+  flatly false by the time it was read.
+
+  The count and the list were the same defect twice. `ls
+  docs/source/*_link.md` is the set, and `INCLUDED`'s own
+  `glob("*_link.md")` is what the code reads, so the comment now points
+  at the derivation instead of restating its result -- which is what
+  keeps it right the next time a shim is added or dropped. The
+  comparison against `btclib`'s root files went with it: which files a
+  sibling repository shims is that repository's business, and a
+  paragraph here that tracks it is a paragraph that goes stale when
+  something happens somewhere else.
+
 - **`CONTRIBUTING.md` sends a contributor to the organization standard**
   (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
   the toolchain, the lint gate, the workflow set and the branch rules

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,12 +94,13 @@ html_theme = "sphinx_rtd_theme"
 
 # -- Links out of the included root markdown files ----------------------------
 
-# Four pages of the toctree are this repository's README, CONTRIBUTING,
-# SECURITY and RELEASE_NOTES, each pulled into a *_link.md shim by a myst
-# {include} -- three fewer than btclib, which also has CODE_OF_CONDUCT,
-# REPOSITORY and RELEASING among its root files but not among its shims,
-# and no CHANGELOG at all, RELEASE_NOTES being the only release notes
-# file here.
+# Some of the toctree's pages are this repository's own root markdown,
+# each pulled into a *_link.md shim by a myst {include}. Which ones is
+# `ls docs/source/*_link.md`, and that glob is also what INCLUDED reads
+# below, so the set is derived in one place and this comment does not
+# become a second copy of it the next time a shim is added or dropped.
+# What is not shimmed is a root file no page renders, which is a fact
+# about this repository rather than a rule.
 # Those root files are written for the three places that read them
 # unrendered -- the GitHub file view, the PyPI long description, and (for
 # this repository) nothing else, there being no website served from it --


### PR DESCRIPTION
`docs/source/conf.py` said:

> **Four pages** of the toctree are this repository's README,
> CONTRIBUTING, SECURITY and RELEASE_NOTES … and **no CHANGELOG at all**

`docs/source/index.rst` lists six of them. `REVIEWING` and `CHANGELOG`
both have a `*_link.md` shim, and both are globbed into `INCLUDED`
twenty lines below that comment — the same way the four it named are:

```python
INCLUDED = dict(map(included, sorted(Path(__file__).parent.glob("*_link.md"))))
```

```shell
ls docs/source/*_link.md
# changelog_link.md  contributing_link.md  readme_link.md
# release_notes_link.md  reviewing_link.md  security_link.md
```

So the count was wrong, the list was wrong, and the "no CHANGELOG at all"
clause was flatly false — one defect written twice, in a comment sitting
directly above the code that derives the answer.

The comment now points at that derivation instead of restating its
result, which is what keeps it right the next time a shim is added or
dropped.

**The comparison against `btclib`'s root files goes with it.** Which
files a sibling repository shims is that repository's business, and a
paragraph here that tracks it is a paragraph that goes stale when
something happens somewhere else — the same argument
btclib-org/.github#40 just finished making about two shared config
files.

Closes #313

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job and the
documentation build run beside this review on this same sha.

## Summary by Sourcery

Keep the toctree documentation aligned with the glob that determines which root markdown files are rendered.

Bug Fixes:
- Correct the documentation configuration comment so it no longer contains an inaccurate count, file list, or claim about CHANGELOG inclusion.

Enhancements:
- Make the toctree shim documentation refer to the existing glob-derived set instead of duplicating it.
- Remove the comparison with btclib root files so the comment describes only this repository’s documentation behavior.

Documentation:
- Update the changelog to document the correction to the toctree comment and its rationale.