### PR TITLE
Three hyphenated tokens stop being split across a line break (issue #318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ release-notes length in the first place, and are still in
   sibling repository shims is that repository's business, and a
   paragraph here that tracks it is a paragraph that goes stale when
   something happens somewhere else.
+- **Three hyphenated tokens stop being split across a line break**
+  (issue #318). Markdown joins two source lines with a space, so a word
+  wrapped at its own hyphen renders with the hyphen and then a space
+  inside it: `README.md`'s "read-any-number-of-times" came out as
+  "read-any- number-of-times", and `CHANGELOG.md`'s "33-" and
+  `RELEASING.md`'s "fast-forwarding" the same way. The source looks
+  right, which is why reading a diff does not find them -- the one that
+  opened the issue was found by scanning rendered `<code>` spans in
+  built HTML across the organization's documentation.
+
+  Nothing gates it. markdownlint has no rule for it, and `sphinx-build
+  -W` is not asked whether a token means anything. `git grep -n -E
+  '[A-Za-z0-9]-$' -- '*.md'` is what finds them, and it now answers
+  nothing here; it answers nothing in the sibling repositories either,
+  so this was the tree that had them. Whether that command becomes a
+  hook is btclib-org/.github#71, since a rule about markdown wrapping
+  belongs to every repository or to none.
 
 - **`CONTRIBUTING.md` sends a contributor to the organization standard**
   (btclib-org/.github#52). `README.md` in `btclib-org/.github` states
@@ -2036,9 +2053,10 @@ release-notes length in the first place, and are still in
   concerned — `lift_x` is the even-y point whatever form the x arrived
   in, and a signer whose point has odd y signs with `n - d` for exactly
   that reason — so the parity is a property of the serialization and not
-  of the key. `ssa.verify` and `xonly.tweak_add` used to refuse the 33-
-  and 65-byte forms, on the reasoning that a key with odd y "verifies as
-  the point that is not the one passed": it is not another point, it is
+  of the key. `ssa.verify` and `xonly.tweak_add` used to refuse the
+  33- and 65-byte forms, on the reasoning that a key with odd y
+  "verifies as the point that is not the one passed": it is not another
+  point, it is
   the same key, and what the refusal cost was a lift. Which form to hand
   in is now a question of cost alone — the uncompressed one is read
   rather than lifted, so `tweak_add` on it is **4.11 us against the 5.92**

--- a/README.md
+++ b/README.md
@@ -1120,11 +1120,11 @@ calls writing to it.
 
 `musig.SecretNonce` is neither of the two shapes above, being narrower
 than both: it is meant to be read exactly once, from whichever thread
-gets there first, and refused everywhere else — a keypair's read-any-
-number-of-times constness does not apply, and neither does a chain's
-one-object-one-thread convention, since a shared secret nonce is
-exactly the case this class has to make safe rather than ask a caller
-to avoid. Reading `self._secnonce` and then clearing it are two
+gets there first, and refused everywhere else — a keypair's
+read-any-number-of-times constness does not apply, and neither does a
+chain's one-object-one-thread convention, since a shared secret nonce
+is exactly the case this class has to make safe rather than ask a
+caller to avoid. Reading `self._secnonce` and then clearing it are two
 statements, and without ordering them two threads calling
 `partial_sign` on the same object could each pass the read before
 either reaches the clear, and both go on to drive

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -245,8 +245,8 @@ Then:
    the plain `gh pr merge` refused it locally.
 
    The button used to be the wrong landing on this pull request in
-   particular: it is the release commit that gets tagged, and fast-
-   forwarding from the command line kept that commit's signature the
+   particular: it is the release commit that gets tagged, and
+   fast-forwarding from the command line kept that commit's signature the
    maintainer's own where a squash composed by GitHub would have left it
    under the web-flow key instead. That distinction stopped mattering
    once `required_signatures` was read as asking for a valid signature


### PR DESCRIPTION
Markdown joins two source lines with a space, so a word wrapped at its
own hyphen renders with the hyphen **and then a space** inside it:

| file | source | rendered |
| --- | --- | --- |
| `README.md` | `read-any-`⏎`number-of-times` | `read-any- number-of-times` |
| `CHANGELOG.md` | `the 33-`⏎`and 65-byte forms` | `the 33- and 65-byte forms` |
| `RELEASING.md` | `fast-`⏎`forwarding` | `fast- forwarding` |

The source looks right, which is why reading a diff does not find them.
The one that opened the issue was found by scanning rendered `<code>`
spans in built HTML across four repositories — reading the *output*,
which is the one thing none of this organization's gates do.

```shell
git grep -n -E '[A-Za-z0-9]-$' -- '*.md'
```

is what finds them. It answers nothing here now, and answered nothing in
`btclib`, `bitcoin-core-rpc`, `btclib-benchmarks` or `.github`, so this
was the tree that had them.

Nothing gates it: markdownlint has no rule for it, and `sphinx-build -W`
is not asked whether a token means anything. **Whether that command
becomes a hook is btclib-org/.github#71** — a rule about markdown
wrapping belongs to every repository or to none, and that issue carries
the measurement and the two things to settle first.

`CHANGELOG.md`'s instance is inside a released section and is rewrapped
rather than reworded: no claim in that entry changes, only where the line
breaks.

Closes #318

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job and the
documentation build run beside this review on this same sha.

## Summary by Sourcery

Prevent Markdown line wrapping from splitting hyphenated tokens in rendered documentation.

Bug Fixes:
- Fix three Markdown line wraps so hyphenated tokens render without an unintended space after the hyphen.

Documentation:
- Document the hyphenated-token rendering issue and the command that detects trailing hyphens in Markdown source.