### PR TITLE
claude-review.yml stops counting the required checks

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,8 @@ name: claude-review
 # comment, which is an opinion for the author to weigh -- REPOSITORY.md's
 # rule is that `main`'s required contexts are named outside the repository,
 # and a review that gates a merge would make a model's judgement a branch
-# rule. The four required checks stay what they are.
+# rule. The required checks stay what they are, and which ones those
+# are is REPOSITORY.md's to record and the endpoint's to answer.
 #
 # It is one more job on every pull request, which is not free: GitHub Free
 # gives this organization twenty concurrent jobs and REPOSITORY.md measures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,30 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`claude-review.yml` stops counting the required checks, and here
+  the count was wrong** (btclib-org/.github#22). "The four required
+  checks stay what they are": `main` requires three in this repository.
+  The sentence is `btclib`'s, where four is right, and it travelled with
+  the workflow -- being true in the tree it was written in is exactly
+  what let it be wrong in the two it was copied to, this one and
+  `btclib-benchmarks`.
+
+  Nothing checks a workflow comment: `actionlint` reads the workflow,
+  `zizmor` reads it for injection, and prose beside them reads as
+  authoritative for sitting there. What the paragraph is for survives
+  without the number -- this job is not a required check and must not
+  become one, a model's judgement not being a branch rule -- so it now
+  says the required checks stay what they are and sends the reader to
+  `REPOSITORY.md` and the endpoint.
+
+  Found by the sweep that issue asks for, run here over the claims a
+  command can settle: every workflow named in a comment exists, every
+  cron matches the day its comment claims, and the trigger claims match
+  each `on:` block, `codeql.yml`'s "no `pull_request` trigger" included.
+  The prose half of the sweep -- reading every comment end to end, which
+  is how a stale claim that reads like a true one is found -- is not
+  done, and is what keeps that issue open.
+
 - **`.yamllint.yaml` keeps the default rule set on, and stops carrying
   one tree's claims** (btclib-org/.github#40, and the shared file's own
   defect found reviewing that change). Two things, one file.


### PR DESCRIPTION
`claude-review.yml`'s header says:

> a review that gates a merge would make a model's judgement a branch
> rule. **The four required checks stay what they are.**

`main` requires **three** here:

```shell
for r in btclib bitcoin-core-rpc btclib-secp256k1 btclib-benchmarks; do
  gh api repos/btclib-org/$r/branches/main/protection \
    --jq '.required_status_checks.checks|length'
done
# 4  4  3  3
```

It is `btclib`'s sentence, and it travelled with the workflow. Being
right in the tree it was written in is exactly what let it be wrong in
the two it was copied to — this repository and `btclib-benchmarks`.

Nothing checks a workflow comment: `actionlint` reads the workflow,
`zizmor` reads it for injection, and prose beside them reads as
authoritative for sitting there. **What the paragraph is for survives
without the number** — this job is not a required check and must not
become one — so it now says the required checks stay what they are and
sends the reader to `REPOSITORY.md` and the endpoint.

Found by btclib-org/.github#22's sweep, run here over the claims a
command can settle, and this was the only one that failed:

- every workflow named in a comment exists;
- every cron matches the day its comment claims — `links` Monday,
  `codeql` Tuesday, `macos` and `latest` Wednesday, `windows` Saturday,
  `mutation` Sunday, `published` and `vendored-vectors` the 1st;
- `codeql.yml`'s "no `pull_request` trigger" and `links.yml`'s "no push
  trigger" both match their `on:` blocks.

**The prose half is not done** — reading every comment end to end, which
is the only way a stale claim that reads exactly like a true one is
found — and is what keeps that issue open.

**This edits `claude-review.yml`, so it gets no review**: the action
refuses to run under a workflow file differing from the default branch's
copy, and the guard step fails the job rather than reporting a review
that never ran (btclib-org/.github#58). The red `Claude review` is that.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0, run
after the rebase onto current `main`. The suite, the lint job and the
documentation build run on this same sha.

## Summary by Sourcery

Stop the Claude review workflow from asserting a repository-specific number of required checks while preserving its non-gating policy.

Bug Fixes:
- Remove the incorrect hard-coded count of required checks from the Claude review workflow documentation.

Enhancements:
- Direct readers to the repository documentation and GitHub endpoint for the authoritative list of required checks.
- Document the workflow-comment claim correction and its validation in the changelog.