### PR TITLE
A markdown line does not end inside a word

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,11 +332,11 @@ repos:
         entry: |-
           (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
-      # a word wrapped at its own hyphen, which markdown renders with a
-      # space inside it. Section 4 of the organization standard is the
-      # rule: why a line ending inside a word is the shape to refuse,
-      # what the pattern cannot see, and what the measurement was before
-      # it was proposed
+      # a line that ends inside a word, at that word's own hyphen.
+      # Section 4 of the organization standard is the rule: what such a
+      # line renders as, why nothing else here catches it, what this
+      # pattern cannot see, and what the measurement was before it was
+      # proposed
       - id: no-hyphen-at-end-of-line
         name: a word is not wrapped at its own hyphen
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,6 +332,16 @@ repos:
         entry: |-
           (?<![`!\[])(?:!?\[(?:[^]]|\]\([^)]*\))*\]\(|^\x20{0,3}\[[^]]+\]:\s*)(?!\./|#|[A-Za-z][A-Za-z0-9+.-]*:)[^)\s]
         types: [markdown]
+      # a word wrapped at its own hyphen, which markdown renders with a
+      # space inside it. Section 4 of the organization standard is the
+      # rule: why a line ending inside a word is the shape to refuse,
+      # what the pattern cannot see, and what the measurement was before
+      # it was proposed
+      - id: no-hyphen-at-end-of-line
+        name: a word is not wrapped at its own hyphen
+        language: pygrep
+        entry: "[A-Za-z0-9]-$"
+        types: [markdown]
   # what ruff-format is for Python, on the structured files ruff does not
   # read: yaml, and the jsonc that carries a comment. Before yamllint above
   # in effect and not in order -- pre-commit runs this file top to bottom, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,24 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **A markdown line does not end inside a word**
+  (btclib-org/.github#71). Markdown joins two source lines with a space,
+  so a word wrapped at its own hyphen renders with the hyphen and then a
+  space inside it. This is the repository the rule came from: #318 fixed
+  three of them here, in `README.md`, `CHANGELOG.md` and `RELEASING.md`,
+  and the one that started it was found by scanning rendered `<code>`
+  spans in built html rather than by reading markdown -- the source
+  looks correct, which is why reading a diff does not find one.
+
+  Nothing here read the output: markdownlint has no rule for it, the
+  width rules read a line rather than what two lines become, and
+  `sphinx-build -W` is not asked whether a token means anything. A
+  `pygrep` hook now does, for the reason `local-link-prefix` beside it
+  is one. The rule and what the hook cannot see -- a code span whose
+  content breaks at a `/` or a `.` renders the same way and has no
+  hyphen to match -- are in section 4 of the organization standard,
+  which the comment points at rather than restates.
+
 - **`claude-review.yml` stops counting the required checks, and here
   the count was wrong** (btclib-org/.github#22). "The four required
   checks stay what they are": `main` requires three in this repository.


### PR DESCRIPTION
Markdown joins two source lines with a space, so a word wrapped at its
own hyphen renders with the hyphen **and then a space** inside it:

```markdown
a keypair's read-any-
number-of-times constness
```

renders `read-any- number-of-times`. **The source looks correct**, which
is why reading a diff does not find one.

Nothing here read the output: markdownlint has no rule for it, the width
rules read a line rather than what two lines become, and `sphinx-build
-W` is not asked whether a token means anything. A `pygrep` hook now
does, for the reason `local-link-prefix` beside it is one — nothing off
the shelf does it and the pattern is one line:

```yaml
      - id: no-hyphen-at-end-of-line
        name: a word is not wrapped at its own hyphen
        language: pygrep
        entry: "[A-Za-z0-9]-$"
        types: [markdown]
```

The rule, and **what the hook cannot see** — a code span whose content
breaks at a `/` or a `.` renders with the same intruding space and has no
hyphen to match — are in section 4 of the organization standard, which
the comment points at rather than restates.

**This tree was already clean under it**, so the hook costs nothing today
and exists to keep the next one from being written. `git grep -n -E
'[A-Za-z0-9]-$' -- '*.md'` is what says so.

Part of btclib-org/.github#71, which carries the measurement for every
repository and the two things settled before proposing it. The standard's
own copy is btclib-org/.github#73. No parenthetical in the title: this
closes no issue in this repository.

---

**Gate on the pushed sha:** `pre-commit run --all-files` exit 0,
including the new hook over this repository's own markdown, run after the
rebase onto current `main`.

## Summary by Sourcery

Prevent Markdown word wraps at hyphens from producing unintended spaces in rendered text.

New Features:
- Add a pre-commit check that prevents Markdown lines from ending at a word's own hyphen, avoiding unintended spaces when Markdown joins wrapped lines.

Documentation:
- Document the new Markdown validation in the changelog, including its scope and limitations.