### PR TITLE
Read every workflow comment end to end (issue btclib-org/.github#22)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,11 @@
 ---
 name: codeql
 
-# the fourth gate, and the one that used to have no file: code scanning ran
-# from GitHub's default setup, a repository setting, so the only required
-# check on main whose definition a diff could not review was the one looking
-# for vulnerabilities. Every other check here is a file with pinned SHAs, and
-# this makes CodeQL one too -- the languages, the query suite, the schedule
-# and the permissions all readable, reviewable and moved by dependabot.
+# code scanning as a file rather than as a repository setting: the
+# languages, the query suite, the schedule and the permissions are
+# readable, reviewable and moved by dependabot, as every other check here
+# is. It gates nothing -- the `on:` block below is where that is decided
+# and why.
 #
 # It reproduces what the setting held rather than inventing a configuration,
 # which is what keeps the alert history continuous. Read from the API before
@@ -71,12 +70,14 @@ on:
     # sits still is not a repository that stays clean.
     # Not on the hour: GitHub queues scheduled workflows across every
     # repository that asked for the same minute, and a run can be dropped
-    # outright when that queue is long. Tuesday and minute 33 are shared
-    # with no other cron here, nor with btclib's or bitcoin-core-rpc's --
-    # `grep -rn 'cron:' .github/workflows/*.yml` in each is what re-derives
-    # that, and the other days are Monday (links), Wednesday (macos,
-    # latest), Saturday (windows), Sunday (mutation) and the 1st
-    # (published, vendored vectors).
+    # outright when that queue is long. Tuesday is the day btclib and
+    # bitcoin-core-rpc analyse on too, and that is the convention rather
+    # than a collision: one workflow, one weekday, across the
+    # organization. What is not shared is the minute -- 33 here, against
+    # their 23 and 27 -- and `grep -rn 'cron:' .github/workflows/*.yml` in
+    # each is what re-derives both. The other days here are Monday
+    # (links), Wednesday (macos, latest), Saturday (windows), Sunday
+    # (mutation) and the 1st (published, vendored vectors).
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "33 4 * * 2"
@@ -92,8 +93,9 @@ permissions:
 
 # cancel superseded runs on the same branch/PR, named literally rather than
 # through github.workflow for the reason lint.yml gives at length. No
-# concurrency-suffix input here, unlike the three gates release.yml calls:
-# nothing calls this workflow, so github.ref is this run's own ref
+# concurrency-suffix input here, unlike every workflow release.yml calls
+# but published.yml, which takes a version instead: nothing calls this
+# workflow, so github.ref is this run's own ref
 concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
@@ -103,13 +105,16 @@ jobs:
     # one job per language, so a failure says which analysis failed instead
     # of leaving two to be told apart in a log. Default setup's own two jobs
     # were `Analyze (actions)` and `Analyze (python)`; these are named for
-    # the question they answer, as every job here is, and neither name is a
-    # required check -- the aggregate below is
+    # the question they answer, as every job here is. Neither name is a
+    # required check, and neither is the aggregate below: the three this
+    # repository requires are `Lint and type-check`, `Build the
+    # documentation` and `test: every job passed`, which REPOSITORY.md
+    # records and the branches/main/protection endpoint answers
     name: Analyze ${{ matrix.language }} with CodeQL
-    # a draft pull request is work in progress and spends no runner here
-    # either: the same condition lint.yml, docs.yml and test.yml carry, and
-    # ready_for_review is a trigger type above for the same reason
-    if: ${{ !github.event.pull_request.draft }}
+    # no draft condition, where every job of test.yml carries one: this
+    # workflow no longer runs on a pull request at all, so there is no
+    # draft to skip and `github.event.pull_request.draft` is an expression
+    # that could only read empty here
     runs-on: ubuntu-latest
     # the two analyses of default setup took 41 to 48 seconds each, measured
     # on the last pull request it ran on, so this is tolerance for a cold
@@ -197,9 +202,7 @@ jobs:
     needs: [analyze]
     # not success(): a job whose dependencies failed is skipped, and a
     # skipped check reports `skipped`, which branch protection counts as
-    # satisfied. The gate has to run to be able to fail -- and it carries
-    # the draft condition every job above carries, so a draft skips
-    # uniformly rather than tripping the skip check below
+    # satisfied. The gate has to run to be able to fail
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,8 +71,9 @@ permissions:
 # cancel superseded runs on the same branch/PR, named literally and
 # discriminated by an input rather than left to github.ref alone, for the
 # three reasons lint.yml gives at length: release.yml calls this workflow
-# beside lint.yml and test.yml, and a group computed from github.workflow
-# would have the three cancel each other
+# beside lint.yml, test.yml, macos.yml, windows.yml and published.yml, and
+# a group computed from github.workflow would have every one of them
+# cancel the others, that expression being the caller's name in each
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -16,10 +16,11 @@ name: latest
 # library is built, breaks the build itself and not a test. That has
 # happened, and it was found by other means.
 #
-# uv.lock moves on a monthly dependabot pull request here, with a seven day
-# cooldown in front of it, so without this workflow an upstream break can
-# sit unseen for five weeks and then arrive inside a diff of many entries,
-# where its cause is one line among them.
+# uv.lock moves on a weekly dependabot pull request here -- Thursdays, the
+# day the cron below runs one ahead of -- with a seven day cooldown in
+# front of it, so without this workflow an upstream break can sit unseen
+# for a fortnight and then arrive inside a diff of many entries, where its
+# cause is one line among them.
 #
 # The obvious alternative -- dropping --locked from test.yml and resolving
 # afresh every run -- is what this exists instead of: a pull request would
@@ -33,9 +34,14 @@ name: latest
 #
 # Scope: what uv resolves. Not the pre-commit hook revisions, which are
 # pinned by rev in .pre-commit-config.yaml and moved by pre-commit.ci's
-# weekly pull request, which runs the whole matrix. mypy is the exception
-# and the reason the lint job below exists at all: its hook is a local one
-# shelling out to uv, so it is the lock that pins it.
+# weekly pull request, which runs the whole matrix. mypy is one of those
+# and not an exception to it: its hook is `mirrors-mypy` at a pinned rev,
+# and the stub packages it type-checks against are pinned by hand in
+# `additional_dependencies`, so nothing `uv lock --upgrade` writes reaches
+# it. That is the second of the two answers section 4 of the organization
+# standard gives, and the right one for a package whose types rest on a
+# handful of stubs rather than on itself. It is also why the lint job
+# below reaches less here than the job of the same name in btclib.
 #
 # Nothing here gates anything, by construction: a workflow of its own, no
 # aggregate job, named by no branch protection rule (see REPOSITORY.md).
@@ -140,13 +146,14 @@ jobs:
         shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
-  # mypy is the whole reason this job exists, and it is worth being explicit
-  # about how little else differs from the lint gate: the hooks pinned by
-  # rev are the same ones a commit runs, pre-commit.ci moving those and this
-  # not being able to. What the upgrade reaches is pre-commit itself and,
-  # through the local hook that shells out to uv, mypy and types-cffi -- a
-  # new release of either adding a check this tree fails, on a schedule
-  # rather than on somebody's branch
+  # what this adds over the lint gate is one release, and it is worth
+  # being explicit about which: the hooks are pinned by rev in
+  # .pre-commit-config.yaml and are the same ones a commit runs,
+  # pre-commit.ci moving those and this not being able to, and mypy is
+  # among them rather than among what uv resolves -- the header has why.
+  # What the upgrade does reach is pre-commit itself, which comes from the
+  # lint group, so a release of it that changes how a hook is invoked
+  # fails here on a schedule rather than on somebody's branch
   lint-latest:
     name: Lint and type-check, dependencies at latest
     runs-on: ubuntu-latest

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -3,8 +3,9 @@ name: links
 
 # the documentation of this package is mostly links: the BIPs a wrapper
 # implements, the upstream functions it calls, the packaging specifications
-# the release follows. Eighty-six distinct external URLs across the
-# markdown, and until this workflow nothing looked at one of them.
+# the release follows. The globs below are which markdown that is, and
+# lychee's own summary is how many URLs it holds; nothing here looked at
+# one of them before this workflow.
 #
 # Not a pull request gate, and that is the design rather than a caution. A
 # link rots without anybody touching the repository, so checking it per
@@ -24,9 +25,11 @@ on:
     # be dropped outright when that queue is long.
     # Monday, matching btclib's own links.yml, and first among the
     # weekday sentinels: whether an external page still resolves is the
-    # least volatile of the four questions this week asks, published.yml
+    # least volatile of the questions this week asks -- codeql.yml
     # (Tuesday), latest.yml (Wednesday) and Dependabot (Thursday) each
     # asking something that changes more often than the last.
+    # published.yml asks the quietest of them all and asks it monthly,
+    # its subject being an artifact already released and therefore fixed.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "11 4 * * 1"
@@ -116,7 +119,12 @@ jobs:
         with:
           # the prose, and named by path rather than as `**/*.md`, so that
           # adding `submodules: true` above could not silently widen the
-          # sweep to upstream's documentation.
+          # sweep to upstream's documentation. Narrower than btclib's and
+          # bitcoin-core-rpc's own globs, which reach docs/ and tests/,
+          # and not by omission: what those two would add carries no
+          # external URL, which `grep -rl http --include='*.md' docs
+          # tests` is what says rather than a claim here about what
+          # those pages are.
           # The retries, the timeout and the cache are what keep a slow or
           # throttling host from being reported as a dead one, and the
           # measurement behind them is this repository's own: of the

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,8 +5,9 @@ name: macos
 # is the other, and its header carries the number that moved it. test.yml
 # runs the suite on the two ubuntu images on every pull request and this one
 # runs the two macOS images, weekly and before a release, because macOS is
-# where the wait came from: the numbers, and the command that re-derives them, are in
-# test.yml's own header, next to the matrices these cells left.
+# where the wait came from: the numbers, and the command that re-derives
+# them, are in test.yml's own header, next to the matrices these cells
+# left.
 #
 # What runs here is not what left, and the difference is the point. The
 # cells that moved installed a wheel built earlier in the same run, which
@@ -32,8 +33,9 @@ on:
     # Wednesday, the morning latest.yml also runs, and thirty minutes before
     # it: the two answer halves of the same question and are worth reading
     # together. A minute that is not the hour, as every cron here, for the
-    # reason links.yml gives, and minute 07 is shared with none of them
-    # (11, 23, 29, 37, 49).
+    # reason links.yml gives, and minute 07 is shared with none of them,
+    # which `grep -h 'cron:' .github/workflows/*.yml` is what re-derives
+    # rather than a list here.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "07 4 * * 3"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -50,7 +50,7 @@ on:
     # dropped outright when that queue is long.
     # Sunday, matching btclib's own mutation.yml: the weekday sentinels
     # run Monday through Thursday in the order the questions build on
-    # each other (links, published, latest, then Dependabot's pull
+    # each other (links, codeql, latest, then Dependabot's pull
     # request), and this one asks something on a different axis
     # entirely -- the suite's own quality, not a dependency's -- which
     # is what leaves it the weekend on its own rather than a weekday.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,9 +161,14 @@ jobs:
           cat files.txt
           # the allowlist is what nothing built reads: the prose files of
           # the root and of .github, and neither README.md nor a file
-          # under docs/, which the sdist carries. An empty list is not a
-          # documentation change, it is a question this could not answer,
-          # so the count is checked before the pattern.
+          # under docs/, which the sdist carries. AUTHORS.md is off it for
+          # the same reason as README.md rather than by oversight: the
+          # wheel carries it as a license file, `WHEEL_LICENSE_FILES` in
+          # .github/scripts/verify_wheel_contents.py names it and
+          # tests/test_wheel_contents.py asserts it is there, so adding it
+          # would skip the matrix on a change check-dist reads. An empty
+          # list is not a documentation change, it is a question this
+          # could not answer, so the count is checked before the pattern.
           #
           # The mutation configuration and the detect-secrets baselines are
           # on it for the same reason as the prose and were measured off it:
@@ -178,12 +183,13 @@ jobs:
           # Anchored on the *file* and not on the directory, which is the
           # same staleness this comment declines below in the direction that
           # looks cheap: `^\.github/mutation/` would exempt in advance any
-          # file a later change drops there, and two tests already load a
+          # file a later change drops there, and tests already load a
           # script by path one directory over (`.github/scripts/`), so such
           # a script would skip the matrix and take its own test with it.
           # `.toml` rather than `bindings\.toml` so a second configuration
           # needs no edit here; a script belongs in .github/scripts/, which
-          # is where the three of them are.
+          # is where all of them are, and `git ls-files .github/scripts` is
+          # what counts them rather than a number here.
           #
           # A workflow is *not* on it, deliberately, and that is the answer
           # to the other half of #239 rather than an omission. Which
@@ -195,7 +201,7 @@ jobs:
           # run, which is the expensive direction; leaving every workflow
           # change to run everything is the cheap one, at the cost this
           # comment now records
-          prose='^(CHANGELOG|CLAUDE|CONTRIBUTING|RELEASE_NOTES|RELEASING|REPOSITORY|SECURITY)\.md$|^\.github/[^/]*\.md$|^\.github/mutation/[^/]*\.toml$|^\.secrets\..*baseline$'
+          prose='^(CHANGELOG|CLAUDE|CODE_OF_CONDUCT|CONTRIBUTING|RELEASE_NOTES|RELEASING|REPOSITORY|REVIEWING|SECURITY)\.md$|^\.github/[^/]*\.md$|^\.github/mutation/[^/]*\.toml$|^\.secrets\..*baseline$'
           if [ ! -s files.txt ] || grep -qvE "$prose" files.txt; then
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "something the matrix reads changed: everything runs"

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -1,13 +1,13 @@
 ---
 name: vendored vectors
 
-# tests/README.md pins each of the three vendored test vectors to a
-# commit and a git blob SHA-1, with a documented manual procedure to
-# re-check one. This runs that procedure once a month instead, over
-# every pin the script can check, and opens or updates an issue on drift
-# rather than fixing anything: refreshing a vector file is a decision
-# the script does not get to make. Matches btclib's own workflow of the
-# same name, script included (issue #397).
+# tests/README.md pins every vendored test vector to a commit and a git
+# blob SHA-1, with a documented manual procedure to re-check one. How
+# many there are is that file's to say and not this one's. This runs that procedure
+# once a month instead, over every pin the script can check, and opens or
+# updates an issue on drift rather than fixing anything: refreshing a
+# vector file is a decision the script does not get to make. Matches
+# btclib's own workflow of the same name, script included (issue #397).
 #
 # issues: write is new to this repository -- links.yml's own comment
 # explains why every other scheduled workflow here stops at contents:
@@ -23,8 +23,9 @@ on:
     # links.yml's own cron comment gives -- GitHub queues same-minute
     # scheduled workflows across every repository that asked for it, and
     # a long queue can drop the run outright. Minute 49 is not shared
-    # with any other cron in this repository (11, 23, 29, 37), nor with
-    # btclib's own copy of this workflow, at minute 53
+    # with any other cron in this repository, which
+    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives, nor
+    # with btclib's own copy of this workflow, at minute 53
     - cron: "49 4 1 * *"
   workflow_dispatch:
   pull_request:
@@ -41,7 +42,7 @@ on:
     # a branch nobody is going to look at again. "This pull request's
     # own group" is the part github.ref alone gets wrong: for a closed,
     # merged pull request it resolves to the base branch's ref, which
-    # this workflow has no push trigger to collide with, but the weekly
+    # this workflow has no push trigger to collide with, but the monthly
     # schedule and a workflow_dispatch both also run on the default
     # branch and would resolve to that same ref. The concurrency block
     # below groups by the pull request's own number instead, immune to

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,9 @@ on:
     # Dependabot Thursday -- so a failure notification still names the
     # workflow by the day it arrived. A minute that is not the hour, as
     # every cron here, for the reason links.yml gives, and minute 17 is
-    # shared with none of them (07, 11, 23, 29, 37, 49).
+    # shared with none of them, which
+    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives rather
+    # than a list here.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "17 4 * * 6"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,17 +21,15 @@
 # this file against a release tag's tree and succeeds, so the missing
 # thing is the URL and not an untested build.
 #
-# The slug is the other half. The project is served under
-# `btclib-libsecp256k1`, which the rename never followed, while
-# README.md's badge and link name `btclib-secp256k1`; the read the docs
-# project's own *name* has been renamed and its slug has not.
+# The slug is `btclib-secp256k1`, which is what README.md's badge, the
+# link behind it and pyproject.toml's `documentation` url name.
 #
-# Both halves are dashboard actions rather than anything a pull request
-# reaches: issue #302 for the slug, btclib-org/.github#26 for the rule
-# and for the commands that re-derive all of this, and issue #295 for
-# the release check that reads the rendered tag URL, which stays blocked
-# while there is no such URL to read. That check would be reachable only
-# on a tag, the shape btclib-org/.github#49 is about, which is a reason
+# The rule is a dashboard action rather than anything a pull request
+# reaches: btclib-org/.github#26 carries it, and the commands that
+# re-derive all of this. Issue #295, the release check that reads the
+# rendered tag URL, stays blocked while there is no such URL to read.
+# That check would be reachable only on a tag, the shape
+# btclib-org/.github#49 is about, which is a reason
 # to order it after the URL exists rather than before; nothing here
 # settles btclib-org/.github#49.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,50 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`RELEASING.md` says what to do rather than what happened**. Two
+  paragraphs were an account of the 0.7.1 rehearsal that failed before it
+  worked and of the setup the rename made necessary a second time. What a
+  reader needs from them is neither: that a trusted publisher can only be
+  registered by an owner of the project, so a name an unrelated project
+  holds on an index cannot be registered from here and the run stops at
+  the token exchange with `invalid-publisher` having built the whole
+  matrix; and that a registration is per project name, so a name this has
+  not been done for needs it done on both indexes before anything is
+  published under it. Both now say that, in the present tense, and
+  `gh run rerun <run id> --failed` is named where the recovery is
+  described, the artifacts being already built.
+
+- **Read the Docs serves `btclib-secp256k1`, and `.readthedocs.yaml`
+  says so** (issue #302). The project was published under the old slug
+  and `README.md`'s badge, the link behind it and `pyproject.toml`'s
+  `documentation` url all named the new one, so the URL this package
+  advertises everywhere -- including in the metadata of every version
+  already on PyPI, and in the bodies of the v0.8.0 and v0.7.1.1 GitHub
+  releases, neither of which a pull request can edit -- answered 404.
+  The slug has been renamed on the dashboard and all of them resolve.
+
+  What the file's comment still records is the half that has not moved:
+  no version named for a release has been built, so `/en/v<version>/` is
+  a 404 where both siblings serve it. `stable` and `latest` both answer
+  200, and the twenty-one tags moved with the project, so what is
+  missing is the automation rule and not a build --
+  btclib-org/.github#26 carries it, with the command that re-derives all
+  of this.
+
+- **The benchmarks link in `README.md` names the file that exists**
+  (btclib-org/.github#22). The Comparison section pointed at
+  `btclib-benchmarks/blob/main/results/libsecp256k1-wrappers.md`, which
+  `#152` wrote on 2026-08-14 and `btclib-org/btclib-benchmarks#11` renamed
+  on 2026-08-15, one day later, when that repository named every result
+  file for what it answers. The table is `results/01-libsecp256k1.md`,
+  titled "The libsecp256k1 wrappers", which is what the link text already
+  said.
+
+  `links.yml` is what found it, on its Monday run of 2026-08-17, and that
+  run has been red ever since with nobody acting on the notification. It
+  is the sentinel working: a link rots because somebody edits a different
+  repository, which is the one case reading a diff here cannot catch.
+
 - **`docs/source/conf.py`'s toctree comment stops enumerating the pages
   a glob already derives** (issue #313). It said "Four pages of the
   toctree are this repository's README, CONTRIBUTING, SECURITY and
@@ -272,13 +316,9 @@ release-notes length in the first place, and are still in
   nowhere in this tree to learn it — `REPOSITORY.md` has no Read the
   Docs section, where btclib's does.
 
-  The slug is the other half and is #302's. The documentation is served
-  under `btclib-libsecp256k1`, which the rename never followed, while
-  `README.md`'s badge and the link behind it name `btclib-secp256k1`;
-  the read the docs project's *name* has been renamed and only its slug
-  has not, which is a finer reading than #302 records. Both halves are
-  dashboard actions rather than anything a pull request reaches, so what
-  lands here is the record beside the file: #302 for the slug, #295 for
+  The slug is the other half and is #302's. Both halves are dashboard
+  actions rather than anything a pull request reaches, so what lands
+  here is the record beside the file: #302 for the slug, #295 for
   the release check that reads the rendered tag URL and stays blocked
   while there is none, and btclib-org/.github#26 for the commands that
   re-derive all of it. That check would be reachable only on a tag, the
@@ -296,6 +336,96 @@ release-notes length in the first place, and are still in
   for having no such file and had been left out.
 
 ### CI
+
+- **Every workflow comment read end to end, and `codeql.yml` stopped
+  calling itself a gate** (btclib-org/.github#22). #142 moved this
+  analysis off `main`'s required checks and removed its `pull_request`
+  trigger, correctly, and updated the `on:` block to say so. Three
+  statements #114 had written survived it, in the same file: the header
+  called this "the fourth gate"; the `analyze` job said "neither name is
+  a required check -- the aggregate below is", which the `on:` block
+  twelve lines up already contradicted with "no longer a required check
+  on main"; and the job carried `if: ${{ !github.event.pull_request.draft
+  }}` under a comment saying "ready_for_review is a trigger type above",
+  in a workflow that has no `pull_request` trigger at all, so the
+  expression could only ever read empty. `main` requires three checks
+  here -- `Lint and type-check`, `Build the documentation` and `test:
+  every job passed` -- and the file now says so once, where it used to
+  say two different things and imply a third. The dead condition is gone,
+  taking btclib's own wording for why there is none.
+
+- **`latest.yml`'s lint job says what it actually reaches** here, which
+  is not mypy (btclib-org/.github#22). The header and the job both
+  claimed mypy moves with `uv lock --upgrade` "through the local hook
+  that shells out to uv", and that this is "the reason the lint job
+  below exists at all". No hook in `.pre-commit-config.yaml` shells out
+  to uv: mypy is `mirrors-mypy` at a pinned `rev`, and the packages it
+  type-checks against are pinned by hand in `additional_dependencies`,
+  as that file's own comment says. The sentence is btclib's, where it is
+  true -- its mypy hook is `repo: local` running `uv run --locked ...
+  mypy`. Section 4 of the organization standard calls this "a trade-off
+  with two right answers rather than a rule", and by its own criterion a
+  package whose types rest on a handful of stubs takes the second: the
+  configuration is right and the comment was wrong. What the job does
+  reach is `pre-commit` itself, from the lint group, which is worth a
+  weekly run and is now what it claims.
+
+- **`published.yml` is on no weekday, and two files put it on Tuesday**
+  (btclib-org/.github#22). `links.yml` and `mutation.yml` both enumerate
+  the weekday sentinels as links, published, latest, Dependabot; its cron
+  is `23 6 1 * *`, monthly, and has been since the run stopped being
+  weekly. The same sentence was fixed in btclib by btclib-org/btclib#1236
+  and in bitcoin-core-rpc before that: three copies of one calendar, and
+  this is the shape btclib-org/.github#76 is about.
+
+- **Three cron-minute lists and three counts replaced by the commands
+  that re-derive them** (btclib-org/.github#22). `macos.yml` named five
+  of this repository's minutes where there are eight, `windows.yml` six,
+  `vendored-vectors.yml` four; each list was complete when it was
+  written. `vendored-vectors.yml` also said `tests/README.md` pins "the
+  three vendored test vectors", where it pins ten, and called a
+  `49 4 1 * *` cron "the weekly schedule". `test.yml` said
+  `.github/scripts/` holds "the three of them", where it holds four, and
+  that "two tests" load a script by path, where three do. Every one of
+  them now points at `grep -h 'cron:' .github/workflows/*.yml`, at
+  `git ls-files .github/scripts`, or at nothing at all -- a count written
+  out is complete on the day it is written.
+
+- **`codeql.yml` and `docs.yml` stop saying `release.yml` calls three
+  workflows** (btclib-org/.github#22). It calls six: `lint`, `docs`,
+  `test`, `macos`, `windows` and `published`, five of which declare the
+  `concurrency-suffix` input the two comments are about. `codeql.yml`'s
+  was true when #114 wrote it and drifted; `docs.yml`'s was written by
+  `35c6931`, the very commit that added two of the calls it does not
+  name.
+
+- **`test.yml`'s prose allowlist gains `CODE_OF_CONDUCT.md` and
+  `REVIEWING.md`, and records why `AUTHORS.md` is not on it**
+  (btclib-org/.github#22). The comment describes the list as "the prose
+  files of the root and of .github"; three of the eleven root markdown
+  files were missing from it, so editing one spent the whole matrix to
+  prove it changes nothing built. `AUTHORS.md` is the one that must stay
+  off: the wheel carries it as a license file, named by
+  `WHEEL_LICENSE_FILES` in `.github/scripts/verify_wheel_contents.py` and
+  asserted by `tests/test_wheel_contents.py`, so adding it would skip the
+  matrix on a change `check-dist` reads. That reason is now in the
+  comment, because the sentence as it stood invited exactly that edit.
+
+- **Prose repairs with nothing behind them but the reading**
+  (btclib-org/.github#22). `latest.yml` said `uv.lock` moves on "a
+  monthly dependabot pull request" and could sit unseen "five weeks",
+  where `.github/dependabot.yml` has said `interval: weekly, day:
+  thursday` since #111 -- and where line 55 of the same file already said
+  "Thursday is left for Dependabot". `codeql.yml` said Tuesday is "shared
+  with no other cron here, nor with btclib's or bitcoin-core-rpc's", where
+  both siblings analyse on Tuesday deliberately and it is the minute that
+  is unique. `links.yml`'s "Eighty-six distinct external URLs" is
+  eighty-seven seventeen days later, and its narrower glob is now
+  explained rather than left to look like an omission: the nine markdown
+  files btclib's and bitcoin-core-rpc's globs would add carry no external
+  URL at all. `macos.yml` carried the one comment line in these thirteen
+  files past eighty columns, at eighty-five, which is how the paragraph
+  came to be reread.
 
 - **A markdown line does not end inside a word**
   (btclib-org/.github#71). Markdown joins two source lines with a space,

--- a/README.md
+++ b/README.md
@@ -1259,7 +1259,7 @@ calls — how much a caller pays to cross it. Measuring that honestly, and
 publishing the run rather than a claim, is what
 [btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks) is
 for, and
-[the libsecp256k1 wrappers table](https://github.com/btclib-org/btclib-benchmarks/blob/main/results/libsecp256k1-wrappers.md)
+[the libsecp256k1 wrappers table](https://github.com/btclib-org/btclib-benchmarks/blob/main/results/01-libsecp256k1.md)
 is where this project's own boundary is timed against the others', one
 run kept whole rather than reduced to a single figure — an order of
 magnitude to read there, never a number to quote here.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -505,15 +505,14 @@ The rehearsal is what the release machinery itself is tested with, when
 the workflow, the packaging metadata or the build matrix changed. A
 release that only bumps versions and notes does not need one.
 
-The rehearsal of 0.7.1 is what taught this section most of what it says,
-having failed once before it worked. The first attempt built the whole
-matrix, collected every artifact, waited for its approval, and then
-stopped at the token exchange with `invalid-publisher`: on TestPyPI the
-name `btclib-libsecp256k1` was an unrelated `0.0.1`, and a trusted
-publisher can only be registered by an owner of the project. Owner
-rights on that project, and a registration matching the claims the
-failure had printed, were all it needed; the second attempt published,
-without rebuilding anything.
+A trusted publisher can only be registered by an owner of the project,
+so a name an unrelated project already holds on an index cannot be
+registered from here: the run builds the whole matrix, collects every
+artifact, waits for its approval and then stops at the token exchange
+with `invalid-publisher`. Owner rights on that project, and a
+registration matching the claims the failure prints, are the whole of
+what it takes; `gh run rerun <run id> --failed` then publishes from the
+artifacts already built.
 
 1. run the `release` workflow from the Actions tab, on the branch holding
    it: a manual run builds the full matrix and stops at the `testpypi`
@@ -689,20 +688,14 @@ worth keeping, as what a yanked file was built from.
 
 ## One-time setup, per index
 
-The PyPI side was done for `btclib-libsecp256k1`, and a registration is
-per project name, so **the rename needed it done again** — on PyPI and on
-TestPyPI both — before 0.8.0 could be published at all. For a name no
-project holds yet the form to use is a *pending* publisher, which is the
-same registration made against a name rather than a project and which
-creates the project on the first upload it accepts. Without it the run
-gets as far as the token exchange and stops there with
-`invalid-publisher`, having built the whole matrix first: the failure
-this file already describes twice, and a third time would have been
-expected rather than mysterious. It was not needed a third time: the
-0.8.0 TestPyPI rehearsal published `0.8.0.dev701` cleanly, proving both
-pending publishers were already registered against `btclib-secp256k1`
-before the tag needed them, and the tag itself published just as cleanly
-after. The next rename, if there is one, still needs this done again.
+A registration is per project name, so **a name this has not been done
+for needs it done** — on PyPI and on TestPyPI both — before anything can
+be published under it. For a name no project holds yet the form to use
+is a *pending* publisher, which is the same registration made against a
+name rather than a project and which creates the project on the first
+upload it accepts. Without it the run gets as far as the token exchange
+and stops there with `invalid-publisher`, having built the whole matrix
+first.
 
 The rest of this section is here for the next index, or the next fork.
 


### PR DESCRIPTION
The `btclib-secp256k1` half of btclib-org/.github#22. Thirteen workflow
files, 4,262 lines, read end to end — not grepped, because a stale
comment reads exactly like a true one. Every checkable claim was checked
against the tree rather than against another comment, every command a
comment tells the reader to run was run, and `git log -S` separated "was
true, drifted" from "never matched".

Twelve findings across nine files. None of them is a thing the mechanical
pass could have reached.

## One change's prose remainder, three sites in one file

`#142` moved CodeQL off `main`'s required checks and removed its
`pull_request` trigger — correctly — and rewrote the `on:` block to say
so. Three sentences `#114` had written stayed behind in the same file:

- the header called this **"the fourth gate"**;
- the `analyze` job said *"neither name is a required check — **the
  aggregate below is**"*, twelve lines below an `on:` block that already
  said *"the aggregate below is no longer a required check on main"*. The
  endpoint agrees with the `on:` block:
  `["Lint and type-check","Build the documentation","test: every job passed"]`;
- the job carried `if: ${{ !github.event.pull_request.draft }}` under
  *"ready_for_review is a trigger type above for the same reason"* — in a
  workflow with **no `pull_request` trigger at all**, so the expression
  could only ever read empty and the trigger type it names does not
  exist. `btclib`'s own `codeql.yml` already carries the wording for why
  there is no draft condition; it is taken verbatim.

## A comment that describes the other repository

`latest.yml` justifies `lint-latest` twice — in the header's *Scope*
paragraph and above the job — by *"the local hook that shells out to uv"*,
which is what makes `uv lock --upgrade` reach mypy and `types-cffi`.

**No hook here shells out to uv.** No `entry:` in
`.pre-commit-config.yaml` names it. mypy is `pre-commit/mirrors-mypy` at
`rev: v2.3.1`, and the packages it type-checks against are pinned by hand
in `additional_dependencies` — as that file's own comment says: *"Nothing
moves an additional dependency, so these are moved by hand"*. So the job's
stated whole reason for existing is not something it does.

The sentence is `btclib`'s, where it is true: its mypy hook is
`repo: local`, `entry: uv run --locked --no-default-groups --group lint
--group test mypy btclib tests .github/scripts`.

**The configuration is right and the prose was wrong**, and the standard
says which: §4 calls this *"a trade-off with two right answers rather
than a rule"*, with the criterion *"a project whose types rest on its own
package wants the first, one whose types rest on a handful of stub
packages can afford the second"*. This package's types rest on `cffi` and
`types-cffi`. So the fix is the comment, not the hook — and it now also
records that `lint-latest` adds less here than the job of the same name in
`btclib`, which is the honest consequence.

## Counts and lists, each complete on the day it was written

| where | said | is |
| --- | --- | --- |
| `macos.yml` | minutes `(11, 23, 29, 37, 49)` | eight, missing 17 and 33 |
| `windows.yml` | minutes `(07, 11, 23, 29, 37, 49)` | eight, missing 33 |
| `vendored-vectors.yml` | minutes `(11, 23, 29, 37)` | eight, missing 07, 17, 33 |
| `vendored-vectors.yml` | "the **three** vendored test vectors" | `tests/README.md` pins **ten** |
| `test.yml` | `.github/scripts/` holds "**the three** of them" | four |
| `test.yml` | "**two tests** already load a script by path" | three |
| `codeql.yml` | "the **three** gates release.yml calls" | six calls, five carry the input |
| `docs.yml` | "beside lint.yml and test.yml … the **three**" | six calls |
| `links.yml` | "**Eighty-six** distinct external URLs" | eighty-seven |

Each now points at the command that re-derives it — `grep -h 'cron:'
.github/workflows/*.yml`, `git ls-files .github/scripts` — or says
nothing at all, which is the other correct answer.

The two "three workflows" claims have different histories, and `git log
-S` is what separates them. `codeql.yml`'s entered in `4f7b710` (#114)
when three was right, and `35c6931` and `d4d29df` broke it. `docs.yml`'s
entered **in `35c6931` itself** — the very commit that added two of the
calls it does not name.

## The calendar, again

`links.yml` and `mutation.yml` both list the weekday sentinels as *links,
published, latest, Dependabot*. `published.yml` is `23 6 1 * *` —
monthly, on no weekday. The same sentence was fixed in `btclib` by
btclib-org/btclib#1236 and in `bitcoin-core-rpc` before that; this is the
third copy, and the shape btclib-org/.github#76 is about.

`codeql.yml` also claimed *"Tuesday and minute 33 are shared with no
other cron here, nor with btclib's or bitcoin-core-rpc's"*. The minute is
unique; **Tuesday is shared with both, deliberately** — one workflow, one
weekday, across the organization. The comment asserted the opposite of the
convention.

And `latest.yml` said `uv.lock` moves on *"a monthly dependabot pull
request"* and can sit unseen *"five weeks"*, where `.github/dependabot.yml`
has said `interval: weekly, day: thursday` since `47450ce` (#111) — and
where line 55 of the same file already said *"Thursday is left for
Dependabot"*.

## One behaviour change, and one non-change worth recording

`test.yml`'s `changes` job describes its allowlist as *"the prose files of
the root and of .github"*. Three of the eleven root markdown files were
missing from it, so editing one spent the whole matrix to prove it changes
nothing built. `CODE_OF_CONDUCT.md` and `REVIEWING.md` are added.

`AUTHORS.md` **stays off it**, and the comment now says why: the wheel
carries it as a license file — `WHEEL_LICENSE_FILES` in
`.github/scripts/verify_wheel_contents.py` names it and
`tests/test_wheel_contents.py` asserts it is there — so adding it would
skip the matrix on a change `check-dist` reads. The sentence as it stood
invited exactly that edit.

The same applies to `links.yml`'s lychee glob, and there the answer went
the other way. It is narrower than `btclib`'s and `bitcoin-core-rpc`'s,
which reach `docs/` and `tests/`, and comparing the three is what made me
look. **The glob is right**: the nine markdown files it does not reach —
seven `{include}` shims under `docs/source/`, `tests/README.md`,
`.claude/commands/review.md` — contain **zero** external URLs between
them, against eighty-seven in the files it does name. That is now in the
comment, so the next reader making the same comparison stops where I did.

## What passed

`macos.yml:8` was the only comment line in these thirteen files past
eighty columns, at eighty-five, from `d4d29df` — the anomaly that made me
reread the paragraph. `awk 'length>80 && /^ *#/'` over all thirteen now
returns nothing.

Verified and left alone: `release.yml`'s `project.urls` claim (`download`
does point at the releases page); its "the wheels are attached to no
release" (v0.8.0.4 carries the sdist and the attestation bundle, nothing
else); `latest.yml`'s cache-key claim (`git grep -n 'pre-commit-\${{' --
.github/workflows/` returns `latest.yml` and `lint.yml`, identical);
`test.yml`'s `test-passed` `needs` list (all ten non-aggregate jobs);
`vendored-vectors.yml`'s maintainer fingerprints and the `git tag -v`
argument.

---

Closes nothing: btclib-org/.github#22's `btclib-secp256k1` box. The
`bitcoin-core-rpc` half is what remains.

## Summary by Sourcery

Bring workflow and release documentation in line with the repository’s current configuration and repair the outdated benchmark reference.

Bug Fixes:
- Correct inaccurate workflow documentation, schedules, dependency-scope descriptions, repository counts, required-check statements, and release instructions.
- Fix the README benchmark link and align Read the Docs slug documentation with the current project URL.

Enhancements:
- Remove a dead draft-pull-request condition from the CodeQL workflow and clarify which checks and workflows participate in release orchestration.
- Improve test change detection by including CODE_OF_CONDUCT.md and REVIEWING.md while documenting why AUTHORS.md remains excluded.
- Replace stale hard-coded workflow counts and lists with descriptions or commands that derive current values.
- Clarify the scope of link checking and the behavior of scheduled dependency and lint validation workflows.

CI:
- Update workflow comments and behavior across CodeQL, documentation, dependency, link-checking, platform, mutation, testing, and vendored-vector workflows to reflect their current triggers, schedules, relationships, and responsibilities.

Documentation:
- Refresh release guidance to describe trusted-publisher registration and rerun recovery in general terms rather than historical incidents.
- Record the workflow and documentation-audit findings in the changelog.