### PR TITLE
Declare which of section 7's conventions this suite tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,38 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **Which of section 7's conventions this suite tests is declared, and a
+  test says the declaration is true** (btclib-org/.github#32).
+  `tests/README.md` gains a table naming each convention the organization
+  standard lists that this repository tests and the module that tests it,
+  followed by a line naming the ones it does not.
+
+  **Some of the eight and not the rest**, which is the point of declaring
+  it rather than leaving it to be inferred: section 7 says a repository
+  needs the conventions its own prose states, so an absent convention
+  test reads exactly like a convention this repository does not have.
+  The reasons differ and are given one by one. The public surface is not
+  a convention this package has -- nothing here declares `__all__` --
+  and input validation and the calling convention are the two bullets
+  that rest on walking one, so `test_core.py` refusing plenty by hand is
+  not what section 7 asks for. The changelog is the near miss:
+  `test_vendored_data.py` forbids exactly the count that bullet forbids,
+  of `tests/README.md` rather than of the two history files it names.
+  The import graph and the build system have nothing standing in for
+  them.
+
+  `tests/test_conventions.py` is what keeps the declaration from being
+  prose -- section 7's own rule applied to section 7 itself -- and its
+  four assertions were each checked by making the declaration wrong in
+  that way and watching the suite go red.
+
+- **`test_vendored_data.py` stops assuming the Summary is the last
+  section**. `_summary()` sliced from its heading to the end of the file,
+  which was true while it was last and stops being true the moment a
+  section is added after it -- silently, its patterns then reading prose
+  it has no claim about. The change above is what would have made it
+  false, so it is what fixes it: the slice now ends at the next `##`.
+
 - **A Dependabot pull request can be reviewed**
   (btclib-org/.github#77). `claude-review.yml`'s review job fails on one,
   twice over. The credential is the first half and is fixed off the tree:

--- a/tests/README.md
+++ b/tests/README.md
@@ -281,3 +281,54 @@ also self-checks the RFC6979 `(k, r, s)` triples in its own docstring
 against `r == x(k*G)`, which is not a citation to a vendored file, and
 constructs the recovery id 2 and 3 signature published nowhere, holding
 it to arithmetic it does itself.
+
+## Convention tests
+
+Section 7 of the [organization standard][std] lists eight conventions a
+suite can turn into a red test, and says a repository needs the ones its
+own prose states rather than all of them. That escape clause is right and
+it costs something: an absent convention test reads exactly like a
+convention this repository does not have, and a `grep` over `tests/`
+cannot tell the two apart — the suites of the organization name the same
+idea three different ways.
+
+So which of the eight this repository tests is **declared here**, and
+`test_conventions.py` asserts the declaration is true: every convention
+named below is one of section 7's, every module named exists and holds at
+least one test, and the two halves together account for all eight.
+
+| convention | tested in |
+| --- | --- |
+| the copyright header | `test_copyright.py` |
+| the documentation | `test_docs.py` |
+
+Not tested here: the public surface; the import graph; the changelog;
+the build system; the calling convention; input validation.
+
+The reasons the rest are absent differ, and are given one by one because
+a reader needs which and not how many. **The public surface** is not a
+convention this package has: nothing here declares `__all__`, and no
+prose asks for one, so there is no census to walk and none of the three
+bullets that rest on such a walk applies. **Input validation** is one of
+those three — section 7 asks for it "driven by a walk over the public
+surface rather than by a hand-written list", and `test_core.py` refuses
+plenty by hand. **The calling convention** is the other: two tests read a
+signature, but each about one function rather than as a rule over the
+package.
+
+**The changelog** is the near miss. `test_vendored_data.py` forbids
+exactly the count section 7 forbids — a number nothing derives — but of
+this file rather than of `CHANGELOG.md` and `RELEASE_NOTES.md`, which is
+what that bullet names. The rule is here; the bullet's subject is not.
+
+**The import graph** and **the build system** have nothing standing in
+for them: `test_extension.py` reads `sys.modules` to hold an import cost
+rather than to establish that every module imports first, and
+`test_wheel_contents.py` tests the script that inspects a built wheel
+rather than what runs while one is built.
+
+What must not be aligned across the organization is where these live or
+what they are called; only which conventions are tested, and that each
+tree says which.
+
+[std]: https://github.com/btclib-org/.github/blob/main/README.md

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -1,0 +1,188 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The convention-test declaration in tests/README.md is true.
+
+Section 7 of the organization standard lists eight conventions a suite
+can turn into a red test, and closes with the clause that makes the list
+usable: a repository needs the ones its own prose states rather than all
+of them. That clause is right, and its price is that an *absent*
+convention test is indistinguishable from a convention this repository
+does not have. Nothing anywhere recorded which of the two it was.
+
+A filename cannot answer it either. The suites of the organization name
+the same idea three ways -- a `test_` prefix here, a module per bullet in
+the second, and in the third several of these checks folded into the one
+file that is about its single module, which is the honest shape for a
+package that is one module. So the audit reads a declaration rather than
+a directory, and this module is what keeps the declaration from being
+prose: section 7's own rule, that a convention worth stating is worth a
+test, applied to section 7 itself.
+
+Some of the eight are tested here and some are not, which the
+declaration says out loud rather than leaving to be inferred from an
+absence. tests/README.md is where it says which, and why for each; no
+count of either half is written anywhere, this module asserting the two
+halves cover the eight rather than how many fall on each side.
+
+What it does not check is whether a named module tests the convention it
+is named against. Nothing short of reading it can, and the four
+assertions below are the ones that fail on the ways a declaration
+actually rots: a convention invented here rather than taken from section
+7, a module renamed or deleted with the row left behind, a module emptied
+of its tests, and a bullet that quietly stops being accounted for by
+either half.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_TESTS = Path(__file__).parent
+_README = _TESTS / "README.md"
+
+# section 7's eight, in its order and its words: the lead of each bullet,
+# which is what the first column of the table repeats. This tuple is the
+# standard's rather than this repository's, so a bullet added there is a
+# failure here until both this and the table have caught up -- which is
+# the point of naming them rather than accepting whatever the table says.
+_CONVENTIONS = (
+    "the public surface",
+    "the copyright header",
+    "the documentation",
+    "the import graph",
+    "the changelog",
+    "the build system",
+    "the calling convention",
+    "input validation",
+)
+
+_HEADING = "## Convention tests"
+# the sentinel for the other half of the declaration. DOTALL as well as
+# MULTILINE because eighty columns wrap the list of names across lines
+# and the non-greedy match then stops at the first full stop that ends
+# one -- which is why no name in that list may carry a full stop of its
+# own. The two halves are checked against each other below rather than
+# each against nothing
+_NOT_TESTED = re.compile(r"^Not tested here: (.+?)\.$", re.MULTILINE | re.DOTALL)
+# a table row, and the separator row is what the second group's leading
+# backtick excludes: `| --- | --- |` has no backtick to match
+_ROW = re.compile(
+    r"^\| (?P<convention>[^|]+?) \| `(?P<module>[^`]+)` \|$", re.MULTILINE
+)
+
+
+def _section() -> str:
+    """Return the declaration section, heading to the next one or the end.
+
+    Read rather than the whole file: a `##` heading elsewhere in
+    tests/README.md must not contribute rows. The slice ends at the next
+    `## ` rather than at the end of the file, so that a section added
+    after this one is not read as part of it -- the fragility this
+    module's own arrival removed from test_vendored_data.py, and there is
+    no reason to reintroduce it here.
+    """
+    text = _README.read_text(encoding="utf-8")
+    assert text.count(_HEADING) == 1, f"{_README.name} has no one {_HEADING}"
+    section = text[text.index(_HEADING) + len(_HEADING) :]
+    return _HEADING + section.split("\n## ", 1)[0]
+
+
+_SECTION = _section()
+_ROWS = tuple((m["convention"], m["module"]) for m in _ROW.finditer(_SECTION))
+
+
+def test_the_table_is_not_empty() -> None:
+    """A declaration that parsed to nothing is the failure that hides.
+
+    Every assertion below quantifies over the rows, so a table this
+    module's regex stopped matching -- a column added, the backticks
+    dropped, the heading retitled -- would satisfy all of them silently.
+    """
+    assert _ROWS, f"{_README.name}'s {_HEADING} section parsed to no rows"
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_convention_named_is_one_of_section_sevens(
+    convention: str, module: str
+) -> None:
+    """A convention invented here is not a convention the standard has."""
+    assert convention in _CONVENTIONS, (
+        f"{module} is declared against {convention!r}, which is not one of"
+        f" section 7's: {', '.join(_CONVENTIONS)}"
+    )
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_module_named_exists(convention: str, module: str) -> None:
+    """A row outliving the file it names is the ordinary way this rots."""
+    assert (_TESTS / module).is_file(), (
+        f"{_README.name} declares {convention!r} tested in {module},"
+        " which is not a file in this directory"
+    )
+
+
+@pytest.mark.parametrize("convention, module", _ROWS, ids=lambda v: v)
+def test_every_module_named_holds_a_test(convention: str, module: str) -> None:
+    """A file emptied of its tests still satisfies the check above.
+
+    The source is parsed rather than the suite queried: an import would
+    make this module's result depend on every other module's import
+    side effects, and pytest's own collection is not available to a test
+    it has already collected.
+    """
+    # no guard for a missing file: the test above is what reports that,
+    # and a guard here would be a branch nothing can reach while it passes
+    path = _TESTS / module
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found = any(
+        isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.name.startswith("test_")
+        for node in ast.walk(tree)
+    )
+    assert found, (
+        f"{module} is declared to test {convention!r} and defines no"
+        " function whose name begins with test_"
+    )
+
+
+def test_the_two_halves_account_for_every_convention() -> None:
+    """The table and the "Not tested here" line partition section 7's eight.
+
+    This is the assertion the declaration exists for. Either half alone
+    is satisfiable by saying less: a table naming three conventions is
+    true about those three and silent about the other five, and silence
+    is exactly what section 7's escape clause makes unreadable. Together
+    they have to name each of the eight once.
+    """
+    match = _NOT_TESTED.search(_SECTION)
+    assert match, (
+        f'{_README.name} has no "Not tested here: ...." line;'
+        " the declaration is half of one"
+    )
+    listed = match[1].strip()
+    absent = () if listed == "none" else tuple(s.strip() for s in listed.split(";"))
+    tested = {convention for convention, _ in _ROWS}
+
+    overlap = tested.intersection(absent)
+    assert not overlap, (
+        f"{', '.join(sorted(overlap))} is both declared tested and listed as not tested"
+    )
+
+    unknown = [name for name in absent if name not in _CONVENTIONS]
+    assert not unknown, (
+        f"{', '.join(unknown)} is listed as not tested and is not one of"
+        f" section 7's: {', '.join(_CONVENTIONS)}"
+    )
+
+    unaccounted = [
+        name for name in _CONVENTIONS if name not in tested and name not in absent
+    ]
+    assert not unaccounted, (
+        f"{', '.join(unaccounted)} is neither declared tested nor listed as"
+        " not tested; section 7's eight are what the two halves must cover"
+    )

--- a/tests/test_vendored_data.py
+++ b/tests/test_vendored_data.py
@@ -27,9 +27,15 @@ _FORBIDDEN_IN_SUMMARY = r"(?m)^- \d+ [a-z]"
 
 
 def _summary() -> str:
-    """Return the Summary section, which ends at the end of the file."""
+    """Return the Summary section, heading to the next one or the end.
+
+    The slice stops at the next `## ` rather than at the end of the file:
+    the patterns below are claims about this section, and a section after
+    it would otherwise be read as part of it, silently.
+    """
     text = _README.read_text(encoding="utf-8")
-    return text[text.index("\n## Summary\n") :]
+    section = text[text.index("\n## Summary\n") + 1 :]
+    return section.split("\n## ", 1)[0]
 
 
 def test_the_readme_states_no_total() -> None:


### PR DESCRIPTION
btclib-org/.github#32's second repository. btclib-org/btclib#1241 is the
first and the reference; this one is where the exercise pays for itself,
because reading the suite gives a different answer from reading its
filenames.

## Two of the eight, and six not

| convention | tested in |
| --- | --- |
| the copyright header | `test_copyright.py` |
| the documentation | `test_docs.py` |

`Not tested here: the public surface; the import graph; the changelog;
the build system; the calling convention; input validation.`

#32's own table lists six modules for this repository and reads as broad
coverage. It is a filename table, and #32 says so in as many words: *"a
filename grep cannot answer it"*. Read against section 7's eight bullets,
the answer is two.

The reasons differ, which is why they are given one by one rather than
as a count:

- **The public surface** is not a convention this package has.
  `git grep __all__` over the whole repository returns nothing, and no
  prose here asks for one. Section 7's escape clause covers this exactly:
  a repository needs the conventions its own prose states.
- **Input validation** and **the calling convention** are the two bullets
  that rest on walking that surface — section 7 asks for validation
  "driven by a walk over the public surface rather than by a hand-written
  list", and `test_core.py` refuses plenty by hand. Two tests read a
  signature (`test_secret.py`, `test_verified_signing.py`), each about
  one function rather than as a rule over the package.
- **The changelog** is the near miss and the one worth arguing about.
  `test_vendored_data.py` forbids exactly the count section 7 forbids —
  a number nothing derives — but of `tests/README.md`, where that bullet
  names `CHANGELOG.md` and `RELEASE_NOTES.md`. The rule is here; the
  bullet's subject is not. Declared not tested, with the reason in the
  file, because the alternative is a table that reads as coverage the
  history files do not have.
- **The import graph** and **the build system** have nothing standing in
  for them. `test_extension.py` reads `sys.modules`, but to hold an
  import cost — that importing the package does not pull
  `importlib.metadata` — rather than to establish that every module
  imports first with nothing else there. `test_wheel_contents.py` tests
  the script that inspects a built wheel, not what runs while one is
  built.

None of this is a request to change the suite. It is the record #32 asks
for, and the value of it is that "not tested" and "not a convention here"
are now different sentences.

## The test, and one thing it found immediately

`tests/test_conventions.py`, ported from btclib-org/btclib#1241 with the
docstring corrected for this tree. It failed on first run here, and
correctly: this repository's "Not tested here" line names six
conventions, wraps at eighty columns, and the sentinel regex matched a
single line only. `re.DOTALL` is the fix, with the consequence written
beside it — no name in that list may carry a full stop of its own.

The four assertions were each checked by making the declaration wrong in
that way:

| what was broken | what failed |
| --- | --- |
| `test_docs.py` renamed in the table | `test_every_module_named_exists` |
| "the changelog" dropped from the not-tested line | `test_the_two_halves_account_for_every_convention` |
| "the changelog" claimed by both halves | the same |

## And a section added to `tests/README.md` would have broken a test in silence

`test_vendored_data.py`'s `_summary()` sliced from `## Summary` **to the
end of the file**, its docstring saying so. That was true while Summary
was the last section, and this pull request is what would have made it
false — its patterns would then have read the convention-test prose as
though it were the vendored-vector Summary, with nothing to say so.

So this pull request fixes it: the slice ends at the next `## `. Same
principle as the `codeql-passed` comment in btclib-org/btclib-secp256k1#331 —
the diff that falsifies a claim is the diff that owes the repair.

## What I ran

```
798 passed in 4.50s
```

The whole suite on this tree, plus `test_vendored_data.py` on its own
against the new file to confirm the Summary slice still ends where it
did.

## Summary by Sourcery

Declare the repository's section 7 convention coverage and make the associated README parsing robust to subsequent sections.

New Features:
- Declare which organization-standard conventions are tested by this repository and which are intentionally not tested.
- Add automated checks that validate the convention declaration and its referenced test modules.

Bug Fixes:
- Limit vendored-data README parsing to the Summary section so later sections are not interpreted as Summary content.

Documentation:
- Document the repository's convention-test coverage and the rationale for conventions not covered.

Tests:
- Add tests ensuring the convention declaration names valid conventions, existing test modules, and complete coverage of all standard conventions.