### PR TITLE
The mypy hook's pins are checked against uv.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,28 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **The mypy hook's pins are checked against `uv.lock`**. The type gate
+  runs in an environment of its own, built from the mirror's `rev` and
+  its `additional_dependencies`; the editor cannot use that environment,
+  this package being a compiled extension whose import does not resolve
+  where nothing built one, so it reads the project's instead. The two
+  are the same mypy only while the two declarations say so, and what
+  said so was a procedure -- `.pre-commit-config.yaml`'s own "moved by
+  hand, with the lint and test groups of uv.lock".
+
+  `tests/test_hook_pins.py` makes it a red test instead. It is the
+  second declaration section 4 of the organization standard names as the
+  price of this branch, and the part that was unchecked is now the part
+  that fails: a `uv lock` moving mypy, `cffi`, `types-cffi`, `hatchling`
+  or `pytest` without the hook following is silent otherwise -- both
+  environments still build, and mypy still passes in each, against
+  different versions.
+
+  Parsed rather than loaded, for the reason `test_copyright.py` gives:
+  `tomllib` arrives in 3.11 and the floor here is 3.10, and no group
+  carries a yaml parser. Each of the three ways the pins can drift was
+  made to happen and watched to fail.
+
 - **Which of section 7's conventions this suite tests is declared, and a
   test says the declaration is true** (btclib-org/.github#32).
   `tests/README.md` gains a table naming each convention the organization

--- a/tests/test_hook_pins.py
+++ b/tests/test_hook_pins.py
@@ -1,0 +1,111 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The mypy hook's pins are the versions `uv.lock` resolves.
+
+The type gate runs in an environment of its own: `.pre-commit-config.yaml`
+gives the mirror a `rev` and a list of `additional_dependencies`, and
+pre-commit builds that environment once and keeps it. The editor cannot
+use it -- this package is a compiled extension and the import does not
+resolve where nothing built one -- so what the editor reads is the
+project environment instead, and the two are the same mypy only while the
+two declarations say the same thing.
+
+Nothing made them say it. `.pre-commit-config.yaml` records that they are
+"moved by hand, with the lint and test groups of uv.lock", which is a
+procedure rather than a check, and section 4 of the organization standard
+names that second declaration as the price of this branch. This module is
+what turns the procedure into a red test: a `uv lock` that moves one of
+these and a hand that does not follow is the whole of what it catches,
+and it is silent -- both environments still build, and mypy still passes
+in each, against different versions.
+
+Parsed rather than loaded. `uv.lock` is toml and the floor here is 3.10,
+where `tomllib` is not yet in the standard library, which is the reason
+`test_copyright.py` beside this one reads pyproject.toml the same way;
+`.pre-commit-config.yaml` is yaml and no group here carries a parser for
+it. Both shapes are narrow enough to match: a `[[package]]` table with a
+name and a version, and a two-space-indented `- name==version` under the
+key that lists them.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parents[1]
+_CONFIG = _ROOT / ".pre-commit-config.yaml"
+_LOCK = _ROOT / "uv.lock"
+
+# the mypy hook's block, from its repo line to the next hook's: the pins
+# read below are that hook's and not another's, `shellcheck-py` being
+# pinned the same way one hook over and deliberately absent from the lock
+_MYPY_BLOCK = re.compile(
+    r"^  - repo: https://github\.com/pre-commit/mirrors-mypy\n(.*?)(?=^  - repo: )",
+    re.MULTILINE | re.DOTALL,
+)
+_REV = re.compile(r"^    rev: v?(?P<version>[0-9][0-9a-z.]*)\s*$", re.MULTILINE)
+_PIN = re.compile(
+    r"^          - (?P<name>[a-z0-9_.-]+)==(?P<version>\S+)\s*$", re.MULTILINE
+)
+
+
+def _block() -> str:
+    """Return the mypy hook's block of `.pre-commit-config.yaml`."""
+    match = _MYPY_BLOCK.search(_CONFIG.read_text(encoding="utf-8"))
+    assert match, "no mirrors-mypy hook in .pre-commit-config.yaml"
+    return match[1]
+
+
+def _locked(name: str) -> str | None:
+    """Return the version `uv.lock` resolves for `name`, or None."""
+    pattern = re.compile(
+        rf'^name = "{re.escape(name)}"\nversion = "(?P<version>[^"]+)"$',
+        re.MULTILINE,
+    )
+    match = pattern.search(_LOCK.read_text(encoding="utf-8"))
+    return match["version"] if match else None
+
+
+_BLOCK = _block()
+_PINS = tuple((m["name"], m["version"]) for m in _PIN.finditer(_BLOCK))
+
+
+def test_the_hook_block_was_read() -> None:
+    """A block that parsed to nothing satisfies every check below.
+
+    The two patterns are anchored on an indentation `.pre-commit-config
+    .yaml` happens to use, so a reformat that changed it would leave the
+    pins unread and the assertions quantifying over nothing.
+    """
+    assert _PINS, "the mirrors-mypy hook lists no pinned additional_dependencies"
+
+
+def test_the_rev_is_the_locked_mypy() -> None:
+    """The isolated environment's mypy and the project's are one version.
+
+    They have to be: the editor reads the project's, the gate reads the
+    hook's, and a developer told the two disagree learns it from a
+    finding one reports and the other does not.
+    """
+    rev = _REV.search(_BLOCK)
+    assert rev, "the mirrors-mypy hook declares no rev"
+    assert rev["version"] == _locked("mypy"), (
+        f"the hook pins mypy {rev['version']} where uv.lock resolves {_locked('mypy')}"
+    )
+
+
+@pytest.mark.parametrize("name, version", _PINS, ids=lambda v: v)
+def test_every_pin_is_the_locked_version(name: str, version: str) -> None:
+    """Each package the hook installs is the one the project installs."""
+    locked = _locked(name)
+    assert locked is not None, (
+        f"the mypy hook pins {name}=={version} and uv.lock resolves no"
+        f" {name}: it is not one of the packages the lock keeps level"
+    )
+    assert version == locked, (
+        f"the mypy hook pins {name}=={version} where uv.lock resolves {locked}"
+    )


### PR DESCRIPTION
btclib-org/.github#82 asked whether this repository is aligned with the
others on mypy. It is — and the alignment rests on two declarations kept
equal by hand, which nothing checked.

## What is aligned, measured

| | | |
| --- | --- | --- |
| `uv.lock` | mypy | `2.3.1` |
| `.pre-commit-config.yaml` | `rev:` | `v2.3.1` |
| `uv.lock` | cffi, types-cffi, hatchling, pytest | `2.1.1`, `2.0.0.20260518`, `1.32.0`, `9.1.1` |
| `.pre-commit-config.yaml` | `additional_dependencies` | the same four |

All five agree today. So the editor and the gate read the same mypy, with
the same packages, and this repository's `.vscode/settings.json` is right
where it says so.

## Why the two declarations exist at all

This is section 4's second branch, and it is the right one here — the
types rest on `cffi` and `types-cffi` rather than on the package itself.
The editor half is the exception that makes the pairing load-bearing:
**this package is a compiled extension**, so the mirror's isolated
environment has no built one and `import btclib_secp256k1` does not
resolve there. The editor cannot use the gate's environment whatever the
hook does; it reads the project's. They are the same mypy only while the
two declarations say the same thing.

`.pre-commit-config.yaml` already says how that is maintained:

> Nothing moves an additional dependency, so these are moved by hand,
> with the lint and test groups of uv.lock

A procedure, and section 4 names that second declaration as the price of
this branch. What it did not have was a check.

## What drifting looks like without one

Nothing. A `uv lock` that moves `pytest` and a hand that does not follow
leaves both environments building and mypy passing in each — against
different versions. The editor then reports a finding the gate does not,
or the other way round, and the first person to notice is whoever spends
an afternoon on a red check that is green locally.

## The check

`tests/test_hook_pins.py`. Three assertions, plus the guard that the
block parsed at all — the two patterns are anchored on the file's
indentation, so a reformat that changed it would leave the pins unread
and everything quantifying over nothing.

Parsed rather than loaded, and the reason is the one `test_copyright.py`
beside it gives: `tomllib` arrives in 3.11 and the floor here is 3.10, so
`uv.lock` is read with a regex the way that module reads `pyproject.toml`.
No group here carries a yaml parser either.

Each way the pins can drift was made to happen and watched to fail:

| what was broken | what failed |
| --- | --- |
| `rev: v2.3.1` → `v2.3.0` | `test_the_rev_is_the_locked_mypy` |
| `pytest==9.1.1` → `9.1.0` | `test_every_pin_is_the_locked_version[pytest-9.1.0]` |
| a pin the lock does not carry (`shellcheck-py`) | the same, with the message that it is not one of the packages the lock keeps level |

The third case is worth the assertion of its own it gets: `shellcheck-py`
is pinned exactly this way one hook over and is deliberately **not** in
the lock, so "every pin must be in `uv.lock`" is a claim about this hook
and not about the file.

## What I ran

```
804 passed in 4.81s
```

The whole suite on this tree, six of them new.

## Summary by Sourcery

Keep the mypy pre-commit environment aligned with uv.lock through automated tests.

Enhancements:
- Add automated checks ensuring the mypy pre-commit hook revision and dependency pins match the versions resolved in uv.lock.

Documentation:
- Document the new mypy hook pin consistency check in the changelog.

Tests:
- Add tests covering missing, mismatched, and correctly aligned mypy hook pins.