### PR TITLE
The gate runs one image and one interpreter, and the sweeps run on the grid

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,23 +64,18 @@ on:
     # to be scanned itself, and a merge creates a commit nothing else tested
     branches: [main]
   schedule:
-    # Tuesday 04:33 UTC. Weekly, which is what default setup ran, and it
-    # earns the slot: a CodeQL release can find in unchanged code what the
-    # queries of the week before did not look for, so a repository that
-    # sits still is not a repository that stays clean.
-    # Not on the hour: GitHub queues scheduled workflows across every
-    # repository that asked for the same minute, and a run can be dropped
-    # outright when that queue is long. Tuesday is the day btclib and
-    # bitcoin-core-rpc analyse on too, and that is the convention rather
-    # than a collision: one workflow, one weekday, across the
-    # organization. What is not shared is the minute -- 33 here, against
-    # their 23 and 27 -- and `grep -rn 'cron:' .github/workflows/*.yml` in
-    # each is what re-derives both. The other days here are Monday
-    # (links), Wednesday (macos, latest), Saturday (windows), Sunday
-    # (mutation) and the 1st (published, vendored vectors).
+    # Tuesday, which the grid gives to this and to nothing else. Weekly,
+    # which is what default setup ran, and it earns the slot: a CodeQL
+    # release can find in unchanged code what the queries of the week
+    # before did not look for, so a repository that sits still is not a
+    # repository that stays clean.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
+    # A sibling repository analyses on the same day and not at the same
+    # minute, which is the whole of what the grid's minute is for.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "33 4 * * 2"
+    - cron: "8 4 * * 2"
   # the escape hatch, and with no pull_request trigger above it is the only
   # way to scan a branch before it is merged: worth reaching for on one that
   # touches a workflow, which is what the actions queries read

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -53,16 +53,16 @@ name: latest
 
 on:
   schedule:
-    # Wednesday 04:37 UTC, and not on the hour, for the reason links.yml
-    # gives. Wednesday, matching btclib's own latest.yml, and thirty minutes
-    # after macos.yml, which shares the morning on purpose: this one moves
-    # the dependencies over every platform, that one moves the platform at
-    # the lock, and the pair reads as a difference -- red in both is macOS,
-    # red here alone is the upgrade. Thursday is left for Dependabot,
-    # opening the day after this has already reported.
+    # Wednesday, the day before Dependabot's, which is the whole of the
+    # placement: this reports on the upgrade before the pull request
+    # carrying it opens. published.yml follows an hour later, the pair
+    # asking what moved underneath -- the dependencies here, and what the
+    # index serves there.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "37 4 * * 3"
+    - cron: "8 4 * * 3"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,19 +20,17 @@ name: links
 
 on:
   schedule:
-    # Monday 04:11 UTC. Not on the hour: GitHub queues scheduled workflows
-    # across every repository that asked for the same minute, and a run can
-    # be dropped outright when that queue is long.
-    # Monday, matching btclib's own links.yml, and first among the
-    # weekday sentinels: whether an external page still resolves is the
-    # least volatile of the questions this week asks -- codeql.yml
-    # (Tuesday), latest.yml (Wednesday) and Dependabot (Thursday) each
-    # asking something that changes more often than the last.
-    # published.yml asks the quietest of them all and asks it monthly,
-    # its subject being an artifact already released and therefore fixed.
+    # Monday, with vendored-vectors.yml an hour later: both ask whether
+    # what this tree points at is still where it was, one for a URL and
+    # one for a blob, and the week opens with its least volatile
+    # questions.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- which gives a workflow its day
+    # and its hour and this repository its minute, and is not this
+    # file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "11 4 * * 1"
+    - cron: "8 4 * * 1"
   # the escape hatch, and the way to check a branch before merging a
   # change that adds links
   workflow_dispatch:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,44 +1,41 @@
 ---
 name: macos
 
-# one of the two platforms the merge gate does not wait for -- windows.yml
-# is the other, and its header carries the number that moved it. test.yml
-# runs the suite on the two ubuntu images on every pull request and this one
-# runs the two macOS images, weekly and before a release, because macOS is
-# where the wait came from: the numbers, and the command that re-derives
-# them, are in test.yml's own header, next to the matrices these cells
-# left.
+# the macOS third of the platform sweep, and ubuntu.yml's header is the
+# argument for all three: what the merge gate keeps, what a sentinel then
+# owes, and why a cell here builds from the tree rather than installing a
+# wheel.
 #
-# What runs here is not what left, and the difference is the point. The
-# cells that moved installed a wheel built earlier in the same run, which
-# would mean rebuilding those wheels here -- ten minutes of cibuildwheel per
-# image, and artifact names the release must not confuse with test.yml's.
-# This builds from the tree instead, twice per cell: the static extension a
+# macOS is where the queue is longest, and that is why the split is a
+# measurement rather than a preference: the numbers, and the command that
+# re-derives them, are in test.yml's own header, next to the wheel builds
+# it keeps.
+#
+# This builds from the tree, twice per cell: the static extension a
 # CPython wheel carries, then the dynamic one, which is the same choice
 # `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
 # of `_load_lib`. Two steps of one job rather than two jobs, because the
 # queue is the cost being managed here and a second job pays it again.
 #
 # So this is the platform against the lock, on every interpreter, and
-# latest.yml is the dependencies against the platforms; the two are
-# scheduled on the same morning half an hour apart. A red macOS column in
-# latest.yml with this workflow green is an upgrade; red in both is macOS.
-# One variable each, and the pair reads as a difference.
+# latest.yml is the dependencies against the platforms. A red macOS column
+# in latest.yml with this workflow green is an upgrade; red in both is
+# macOS. One variable each, and the pair reads as a difference.
 #
 # It gates no commit and no merge -- a macOS regression sits on main for at
 # most a week -- but release.yml calls it, so one cannot be published
 
 on:
   schedule:
-    # Wednesday, the morning latest.yml also runs, and thirty minutes before
-    # it: the two answer halves of the same question and are worth reading
-    # together. A minute that is not the hour, as every cron here, for the
-    # reason links.yml gives, and minute 07 is shared with none of them,
-    # which `grep -h 'cron:' .github/workflows/*.yml` is what re-derives
-    # rather than a list here.
+    # Saturday, with windows.yml an hour later: the two platforms a
+    # reviewer would wait longest for, sharing the day the grid gives to
+    # platforms and not the hour. Red in both is the tree; red in one is
+    # that platform, which is the whole of what running them apart buys.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "07 4 * * 3"
+    - cron: "8 4 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -84,17 +81,19 @@ jobs:
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # the two images test.yml no longer runs the suite on. Both, and not
-        # the newest alone: one is Apple silicon and the other Intel, and
-        # what differs between them is the architecture the vendored library
-        # and the extension are compiled for
+        # both images, and not the newest alone: one is Apple silicon and
+        # the other Intel, and what differs between them is the
+        # architecture the vendored library and the extension are compiled
+        # for
         os:
           - macos-26-intel
           - macos-latest
-        # the union of the interpreters the two matrices of test.yml ran
-        # here, so that the platform is the only thing this workflow moved.
+        # every interpreter this package claims. ubuntu.yml and
+        # windows.yml carry the same list, so that the platform is the
+        # only thing that differs between the three and a red cell here is
+        # attributable to it.
         # Spelled as uv spells them, this being uv rather than
-        # setup-python: `pypy3.11`, not the `pypy-3.11` of test.yml
+        # setup-python: `pypy3.11`, not the `pypy-3.11` setup-python takes
         python-version:
           - "3.10"
           - "3.11"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -44,20 +44,17 @@ name: mutation
 
 on:
   schedule:
-    # Sunday 03:29 UTC, so a session measured in minutes has the weekend
-    # to itself. Not on the hour: GitHub queues scheduled workflows across
-    # every repository that asked for the same minute, and a run can be
-    # dropped outright when that queue is long.
-    # Sunday, matching btclib's own mutation.yml: the weekday sentinels
-    # run Monday through Thursday in the order the questions build on
-    # each other (links, codeql, latest, then Dependabot's pull
-    # request), and this one asks something on a different axis
-    # entirely -- the suite's own quality, not a dependency's -- which
-    # is what leaves it the weekend on its own rather than a weekday.
+    # Sunday, and the grid gives the hour to this alone: a session
+    # measured in minutes gets the day nothing else asks for. What it
+    # asks is on a different axis from every other sentinel here -- the
+    # suite's own quality, not a dependency's or a platform's -- which is
+    # why the answer waits for a morning of its own.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
     # Cron runs from the default branch only, so this file does nothing
     # until it reaches main -- on any other branch it is reachable through
     # the dispatch below and nowhere else
-    - cron: "29 3 * * 0"
+    - cron: "8 4 * * 0"
   # the escape hatch, and the way to re-measure after writing the tests a
   # survivor asked for
   workflow_dispatch:

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -50,7 +50,7 @@ on:
   # runs the default branch's copy of a workflow with the token of a push
   # nobody reviewed -- where a call runs inside the release that gated it, in
   # its graph and in its log. The caller passes the tag, and only the caller
-  # does: the monthly run and a dispatch have no particular version in mind,
+  # does: the weekly run and a dispatch have no particular version in mind,
   # which is the point of them
   workflow_call:
     inputs:
@@ -61,16 +61,16 @@ on:
         type: string
         default: ""
   schedule:
-    # monthly, on the first, where this was weekly: what it watches is
-    # external rot -- a new runner image, a new interpreter, a yanked
-    # dependency, a cffi ABI change -- and nothing in this repository moves
-    # it, so a week was a sample rate without a reason. After a release the
-    # trigger above answers immediately, which is what the weekly was
-    # standing in for.
-    # A minute that is not the hour: what everyone schedules on the hour
-    # queues together, and a run that waits is a failure noticed later. The
-    # minute and the hour are the ones this workflow always had, so a
-    # comparison with an older run compares like with like.
+    # Wednesday, the hour after latest.yml, and the pair is why this is
+    # weekly: latest.yml upgrades every dependency and runs the suite from
+    # the tree, this asks what the index actually serves, and read
+    # together they separate a break this repository caused from one that
+    # arrived. What it watches is external rot -- a new runner image, a
+    # new interpreter, a yanked dependency, a cffi ABI change -- which a
+    # week samples as well as anything longer, and after a release the
+    # trigger above answers immediately regardless.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone.
     # One caveat has no fix inside this file: GitHub suspends a schedule
@@ -78,7 +78,7 @@ on:
     # quiet period a sentinel exists to cover, and announces it only by
     # email. A silence from this workflow is worth a look at the Actions
     # tab before it is read as green
-    - cron: "23 6 1 * *"
+    - cron: "8 5 * * 3"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -88,7 +88,7 @@ permissions:
   contents: read
 
 # never cancel a sentinel, unlike every other workflow here: the run a
-# release calls, the monthly one and a dispatch share this group, each is a
+# release calls, the weekly one and a dispatch share this group, each is a
 # sample worth keeping, and none supersedes the others. A concurrent run
 # queues instead
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,17 @@ jobs:
       # see the lint job above
       concurrency-suffix: "-release"
 
-  # the platform test.yml does not run the suite on, for the reason its own
-  # header measures: a week is the right sample rate for a regression that
-  # can sit on main for a week, and the wrong one for a version that cannot
-  # be unpublished
+  # the suite on every platform and every interpreter, which test.yml runs
+  # one cell of, for the reason ubuntu.yml's header gives: a week is the
+  # right sample rate for a regression that can sit on main for a week,
+  # and the wrong one for a version that cannot be unpublished
+  ubuntu:
+    name: Run the ubuntu workflow
+    uses: ./.github/workflows/ubuntu.yml
+    with:
+      # see the lint job above
+      concurrency-suffix: "-release"
+
   macos:
     name: Run the macos workflow
     uses: ./.github/workflows/macos.yml
@@ -316,7 +323,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, macos, windows]
+    needs: [test, lint, docs, ubuntu, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -350,7 +357,7 @@ jobs:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, macos, windows]
+    needs: [test, lint, docs, ubuntu, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,31 @@
 ---
 name: test
 
-# the merge gate: everything this package ships, built and then tested on
-# the platforms it claims, minus the two platforms a reviewer would wait
-# for. Their suite cells are macos.yml's and windows.yml's, and each file
-# carries the measurement that moved it; the wheel builds for all six stay
-# here, because the release publishes the artifacts of this run.
+# the merge gate: everything this package ships, built, inspected and
+# installed, and the suite run on the one cell a reviewer should wait for.
+# That cell is the `coverage` job below -- ubuntu-latest on the
+# interpreter .python-version pins -- and every other cell of the suite is
+# ubuntu.yml's, macos.yml's or windows.yml's, run weekly and before a
+# release. ubuntu.yml's header is the argument for the split; the numbers
+# behind it are here, next to the jobs they were measured on.
 #
-# macOS was the first of the two, and the split is a measurement rather than
-# a preference. Over six pull request runs of this workflow, ninety-eight jobs
-# each, thirty-five of them on the two macOS images: a macOS job waited 20.8
-# and 19.0 minutes on average for a runner, against 2.1 to 2.6 elsewhere,
-# and the wait grows with the number of cells asking at once -- in the
-# slowest of the six the macOS suite cells took the last thirty places
-# before the aggregate, their queue rising from 16.7 to 70.2 minutes, and
-# the run took 95 minutes for 105 minutes of work spread over 98 jobs. The
-# command that re-derives it, for whoever doubts the split later:
+# **The wheel builds for all six images stay here**, and that is the line
+# this file draws against the sentinels: the release publishes the
+# artifacts of this run, so a wheel not built here is a wheel not on PyPI.
+# They are not what stretched a run either -- the four macOS wheel jobs
+# finished at 24.6 minutes against the 23.5 of the ubuntu-latest build
+# beside them. Four macOS jobs queue; thirty-one contended.
+#
+# macOS was where the wait first showed, and the split is a measurement
+# rather than a preference. Over six pull request runs of this workflow,
+# ninety-eight jobs each, thirty-five of them on the two macOS images: a
+# macOS job waited 20.8 and 19.0 minutes on average for a runner, against
+# 2.1 to 2.6 elsewhere, and the wait grows with the number of cells asking
+# at once -- in the slowest of the six the macOS suite cells took the last
+# thirty places before the aggregate, their queue rising from 16.7 to 70.2
+# minutes, and the run took 95 minutes for 105 minutes of work spread over
+# 98 jobs. The command that re-derives it, for whoever doubts the split
+# later:
 #
 #     id=$(gh run list --workflow=test.yml --limit 1 \
 #         --json databaseId --jq '.[0].databaseId')
@@ -28,13 +38,11 @@ name: test
 # runner-minutes, the largest family of jobs in the run and ahead of every
 # wheel build. windows.yml has the rest of that measurement.
 #
-# So the macOS *suite* cells moved to macos.yml, which runs them weekly and
-# before a release. The macOS *wheel builds* stay here, and the same
-# measurement is why: the release publishes the artifacts of this run, so a
-# macOS wheel not built here is a macOS wheel not on PyPI -- and those four
-# jobs are not what stretched the run, finishing at 24.6 minutes against the
-# 23.5 of the ubuntu-latest build beside them. Four macOS jobs queue;
-# thirty-one contend.
+# The ubuntu suite cells are the third, against the same ceiling: two
+# images times every interpreter, on the platform whose cells are the
+# cheapest to wait for and therefore the last a gate gives up. What
+# decides them is that the gate asks one question of the suite and the
+# calendar asks the rest, which is what ubuntu.yml's header argues.
 
 on:
   push:
@@ -350,21 +358,23 @@ jobs:
       # is in step with pyproject.toml is asserted where it can be, by the
       # uv-lock hook on every commit and by `uv lock --check` in the
       # release workflow
-      # what a pull request has to answer about macOS and Windows is
+      # what a pull request has to answer about any of these images is
       # whether this tree still builds there, and that is answered by the
       # first wheel: the toolchain, the CMake build of the vendored
       # library and the cffi extension are what differ per platform, and
-      # they do not differ per interpreter. The other six wheels of those
-      # images are that build again for another ABI tag, and the four jobs
-      # they happen in were 39.0 of the 59.5 runner-minutes the six wheel
-      # jobs cost. Measured on the run of the change itself, those four
-      # came to 7.2: 14.4 and 5.7 on the two macOS images became 1.5 and
-      # 1.2, and 8.7 and 10.2 on the two Windows ones became 1.8 and 2.7.
+      # they do not differ per interpreter. The rest of an image's wheels
+      # are that build again for another ABI tag. Measured on the macOS
+      # and Windows images, the four jobs were 39.0 of the 59.5
+      # runner-minutes the six wheel jobs cost and came to 7.2 with it:
+      # 14.4 and 5.7 on the two macOS images became 1.5 and 1.2, and 8.7
+      # and 10.2 on the two Windows ones became 1.8 and 2.7.
       #
-      # The two ubuntu images keep the whole set, because suite-static
-      # consumes it: what that job exists to check is pip's selection
-      # among a directory of wheels tagged for seven interpreters, and a
-      # directory holding one is not that question.
+      # Every image, ubuntu included: nothing on a pull request reads past
+      # the first build of an image. check-dist installs one wheel by
+      # path and takes it from build-dynamic, which builds whole, and
+      # pip's selection among a directory of wheels tagged for several
+      # interpreters is asked nowhere -- ubuntu.yml's header carries that
+      # trade and what answers the rest of the question instead.
       #
       # A push to main, a release and a rehearsal all build everything --
       # in a called workflow github.event_name is the caller's, which is
@@ -372,9 +382,7 @@ jobs:
       # branch is reached by the run that follows the merge, and the
       # release publishes nothing this shortcut has touched
       - name: Build one interpreter where a pull request only asks whether it builds
-        if: >-
-          github.event_name == 'pull_request'
-          && !startsWith(matrix.os, 'ubuntu')
+        if: github.event_name == 'pull_request'
         # bash, and the two Windows images are the whole of the reason:
         # the default shell there is PowerShell, where "$GITHUB_ENV" is
         # not the variable but a literal, so this wrote a file of that
@@ -591,14 +599,14 @@ jobs:
       # pattern verbatim.
       #
       # pip and pytest unpinned, unlike every tool that comes from a group
-      # of pyproject.toml, and deliberately: this job and the two wheel
-      # test jobs hold no uv and no lock, because their subject is pip
-      # resolving and building a published artifact the way a user does,
-      # and pinning pytest would reintroduce the resolution they exist to
-      # exclude. The price is that filterwarnings = error makes a pytest
-      # release able to fail these jobs on a day nothing here changed;
-      # that is the same signal the published workflow carries, a fact
-      # about what a user hits, and it surfaces in a pull request
+      # of pyproject.toml, and deliberately: this job holds no uv and no
+      # lock, because its subject is pip resolving and building a
+      # published artifact the way a user does, and pinning pytest would
+      # reintroduce the resolution it exists to exclude. The price is that
+      # filterwarnings = error makes a pytest release able to fail this
+      # job on a day nothing here changed; that is the same signal the
+      # published workflow carries, a fact about what a user hits, and it
+      # surfaces in a pull request
       - name: Install from sdist
         shell: bash
         run: |
@@ -723,15 +731,15 @@ jobs:
           uv run --no-project --python 3.14 \
             .github/scripts/verify_wheel_contents.py dist/*.whl
 
-      # the wheel test jobs install cffi by hand and then the wheel with
-      # --no-index, which resolves nothing: what the metadata declares is
-      # only ever checked against a cffi that is already installed, so a
-      # requirement dropped from it would go unnoticed by all of them.
-      # Here one wheel is installed by path into an environment holding
-      # nothing, its dependencies resolved from PyPI, and imported from an
-      # empty directory, where nothing can resolve to the source tree. The
-      # dynamic wheel is the subject because it is the one that needs cffi
-      # at run time, a static extension carrying its own
+      # one wheel installed by path into an environment holding nothing,
+      # its dependencies resolved from PyPI, and imported from an empty
+      # directory where nothing can resolve to the source tree: what this
+      # asks is whether the metadata a user's pip reads is enough to make
+      # the wheel importable, which a requirement dropped from it would
+      # fail. The dynamic wheel is the subject because it is the one that
+      # needs cffi at run time, a static extension carrying its own.
+      # Importing it is the whole of what runs here -- the suite against
+      # this artifact is a cost ubuntu.yml's header records
       - name: Install a wheel with its dependencies resolved from PyPI
         run: |
           # the glob itself, not ls parsed by a pipeline: nullglob is what
@@ -757,211 +765,19 @@ jobs:
       - name: Rate the packaging metadata
         run: uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
 
-  suite-dynamic:
-    # the linkage is in the name, and it has to be: this job and the one
-    # below run the same interpreters on the same images against two
-    # different wheels, so one name for both produced two check runs
-    # called the same thing -- and a branch rule matches a context by name
-    # alone, which is what makes an ambiguous one worth avoiding even where
-    # no rule names it today
-    name: >-
-      Run the suite on the dynamic wheel,
-      every interpreter, ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
-    runs-on: ${{ matrix.os }}
-    # one job now walks what eight did, so the cap is the sum of theirs
-    # rather than one of them: eight installs and eight suites in
-    # sequence, where each cell was under two minutes
-    timeout-minutes: 30
-    env:
-      # one statement of which interpreters are tested, read twice in this
-      # job: setup-python installs the list, and the loop below walks it.
-      # A version added to one and not the other is either an interpreter
-      # installed and never run or a run that fails on a missing
-      # executable, and both say so immediately.
-      # 3.14t, the free-threaded interpreter, matters here in particular:
-      # the dynamic wheel is tagged py3-none, so it is what a
-      # free-threaded interpreter installs, and unlike the static wheels
-      # nothing else exercises it (cibuildwheel tests every wheel it
-      # builds, including cp314t; this job has no such counterpart)
-      PYTHONS: |
-        3.10
-        3.11
-        3.12
-        3.13
-        3.14
-        3.14t
-        pypy-3.10
-        pypy-3.11
-    strategy:
-      fail-fast: false
-      matrix:
-        # the macOS images are macos.yml's and the Windows ones are
-        # windows.yml's; see the header
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-    needs: [build-windows, build-dynamic]
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # every interpreter of PYTHONS at once: setup-python takes a list and
-      # puts each on the PATH under its own name, which is what lets one
-      # job do what one cell per version did
-      - name: Set up every interpreter
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ env.PYTHONS }}
-
-      # only the wheel built for this platform: downloading all of them
-      # meant every job in the matrix listing and fetching four
-      # artifacts to install one, and the artifact service answers a
-      # fan-out that wide with the occasional 403. The x86_64 Windows
-      # wheel is the mingw cross-compiled one, hence its artifact name
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dynamic-wheels-${{ matrix.os == 'windows-latest' && 'windows' || matrix.os }}
-          path: dist
-
-      # pip and pytest unpinned, and for the reason spelled out in
-      # suite-sdist: a user's environment rather than the locked one.
-      #
-      # What a red check says is what this trades away, and the loop is
-      # written to give it back: a matrix cell named the interpreter in the
-      # check itself, where this job names the image and leaves the
-      # interpreter to the log. So every version runs even after one has
-      # failed -- `fail-fast: false` between cells, kept between iterations
-      # -- each inside a fold of its own, and the failures are named
-      # together at the end rather than being the first one to abort
-      - name: Install the wheel and run the suite under each interpreter
-        run: |
-          failed=""
-          for version in $PYTHONS; do
-            case $version in
-              pypy-*) python=pypy${version#pypy-} ;;
-              *) python=python$version ;;
-            esac
-            echo "::group::$version ($python)"
-            if "$python" --version \
-              && "$python" -m pip install -U pip pytest cffi \
-              && "$python" -m pip install --verbose --no-index \
-                --find-links dist/ btclib_secp256k1 \
-              && "$python" -m pytest; then
-              echo "$version passed"
-            else
-              failed="$failed $version"
-            fi
-            echo "::endgroup::"
-          done
-          if [ -n "$failed" ]; then
-            echo "::error::the suite failed under:$failed"
-            exit 1
-          fi
-
-  suite-static:
-    # the linkage is in the name: see suite-dynamic
-    name: >-
-      Run the suite on the static wheel,
-      every interpreter, ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
-    runs-on: ${{ matrix.os }}
-    # see suite-dynamic, one interpreter fewer
-    timeout-minutes: 30
-    env:
-      # one statement of the interpreters, as in suite-dynamic, and one
-      # shorter by pypy-3.10: no static wheel is built for it.
-      # cibuildwheel already runs the suite against every wheel it builds,
-      # cp314t included: what this job adds is that pip, given a directory
-      # holding all of them, selects the right one, which for the
-      # free-threaded interpreter nothing checked
-      PYTHONS: |
-        3.10
-        3.11
-        3.12
-        3.13
-        3.14
-        3.14t
-        pypy-3.11
-    strategy:
-      fail-fast: false
-      matrix:
-        # the macOS images are macos.yml's and the Windows ones are
-        # windows.yml's; see the header. What is given up there is narrower
-        # than elsewhere, and cibuildwheel is why: it runs the suite against
-        # every wheel it builds, on the runner that built it, so the macOS
-        # and Windows wheels this workflow ships are still tested by the job
-        # that produces them. What moves is pip's selection among them.
-        # With both Windows rows gone so are the three exclusions they
-        # carried, each of them a wheel that is not built rather than a
-        # platform not worth running: no PyPy wheel on Windows on either
-        # architecture, and no CPython before 3.11 on windows arm64
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-    needs: build-cibuildwheel
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # see suite-dynamic
-      - name: Set up every interpreter
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ env.PYTHONS }}
-
-      # only the wheels built for this platform, as above
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: static-wheels-${{ matrix.os }}
-          path: dist
-
-      # the loop, the folds and the failures named together: see
-      # suite-dynamic. The install is the point of this job rather than a
-      # step before it -- pip choosing among a directory of wheels tagged
-      # for seven interpreters -- so it stays inside the loop with the run
-      - name: Install the wheel and run the suite under each interpreter
-        run: |
-          failed=""
-          for version in $PYTHONS; do
-            case $version in
-              pypy-*) python=pypy${version#pypy-} ;;
-              *) python=python$version ;;
-            esac
-            echo "::group::$version ($python)"
-            if "$python" --version \
-              && "$python" -m pip install -U pip pytest cffi \
-              && "$python" -m pip install --verbose --no-index \
-                --find-links dist/ btclib_secp256k1 \
-              && "$python" -m pytest; then
-              echo "$version passed"
-            else
-              failed="$failed $version"
-            fi
-            echo "::endgroup::"
-          done
-          if [ -n "$failed" ]; then
-            echo "::error::the suite failed under:$failed"
-            exit 1
-          fi
-
-  # one context for the branch rule, instead of the matrix's own. A rule
-  # naming `Run the suite on the static wheel, 3.10, ubuntu-latest` names a
-  # context that stops being produced the moment the matrix changes, and a
-  # required check that produces no run blocks every merge with nothing in
-  # the tree to explain why -- the rule living outside the repository. So
-  # the rule names this job, and a job added to this workflow belongs in
-  # the `needs` below or it gates nothing. REPOSITORY.md carries the branch
+  # one context for the branch rule, instead of the matrices' own. A rule
+  # naming `Build wheels on ubuntu-24.04-arm` names a context that stops
+  # being produced the moment the matrix changes, and a required check
+  # that produces no run blocks every merge with nothing in the tree to
+  # explain why -- the rule living outside the repository. So the rule
+  # names this job, and a job added to this workflow belongs in the
+  # `needs` below or it gates nothing. REPOSITORY.md carries the branch
   # rule itself.
   #
   # The name carries the workflow because a context is keyed by name alone:
   # two workflows with a job named the same thing produce one ambiguous
-  # check, and macos.yml and windows.yml are two more workflows over the
-  # same matrix shape.
+  # check, and ubuntu.yml, macos.yml and windows.yml are three more
+  # workflows whose jobs run the suite.
   #
   # `if: !cancelled()` because a job with unmet `needs` is skipped, and a
   # skipped check is not a failed one: without it a failing matrix cell
@@ -989,8 +805,6 @@ jobs:
       - suite-sdist
       - build-windows
       - check-dist
-      - suite-dynamic
-      - suite-static
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,192 @@
+---
+name: ubuntu
+
+# the ubuntu third of the platform sweep, and the header the other two
+# point at: what the merge gate keeps, what a sentinel then owes, and why
+# a cell of any of the three builds from the tree rather than installing a
+# wheel.
+#
+# **The gate is one cell**: ubuntu-latest on the interpreter
+# .python-version pins, which is the `coverage` job of test.yml, beside
+# the lint, docs and packaging jobs. Everything exhaustive is here or in
+# macos.yml or windows.yml. What that gives up is the point of the
+# arrangement rather than a cost it hides: a regression on 3.10, on arm or
+# on PyPy is no longer refused before a merge, and sits on main until the
+# weekly sentinel for it runs. What it buys is every pull request --
+# GitHub Free gives an organization twenty concurrent jobs, shared across
+# every repository in it, and a matrix on each commit is what a reviewer
+# waits behind. test.yml's header has the measurement.
+#
+# **The matrix is whole**, the cell the gate already covers included. A
+# sweep that subtracted it would be a matrix with a hole in it, and
+# whoever asked what ran would have to re-derive the hole from another
+# file.
+#
+# **A cell builds from the tree, twice.** Installing a wheel instead would
+# mean building one here -- cibuildwheel per image, and artifact names the
+# release must not confuse with test.yml's. So each cell compiles the static
+# extension a CPython wheel carries, runs the suite, then compiles the
+# dynamic one and runs it again: the choice
+# `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer, and both branches of
+# `_load_lib`. Two steps of one job rather than two jobs, because the
+# queue is the cost being managed and a second job pays it again.
+#
+# What that trades away, stated here rather than discovered later: pip's
+# *selection* among a directory of wheels tagged for several interpreters
+# is now asked nowhere. Each wheel is still tested by the job that builds
+# it -- `test-command` in pyproject.toml runs the whole suite against
+# every wheel cibuildwheel produces, on the runner that produced it --
+# and check-dist installs one by path into an empty environment. What no
+# longer runs is pip choosing between them.
+#
+# The other half of that same trade: no suite runs against the dynamic
+# wheel as a package. `test-command` in pyproject.toml reaches
+# cibuildwheel's static wheels alone, and test.yml's build-dynamic and
+# build-windows jobs run `python -m build -w` and no tests. The cells
+# below cover the dynamic *extension* compiled from this tree, which is
+# `_load_lib`'s second branch, and not the artifact pip resolves to
+# wherever no static wheel matches. That set is wider than one cell:
+#
+#     uv run --frozen --only-group build cibuildwheel \
+#         --platform windows --print-build-identifiers | grep pp
+#
+# answers nothing at all, and neither does musllinux on any PyPy, so
+# pypy3.10 everywhere and any PyPy on musl take the py3-none wheel too.
+#
+# What that artifact's packaging is asserted by, so the gap is the size
+# it is and no larger: check-dist installs the dynamic manylinux wheel
+# by path into an empty environment and imports it, which is the .so
+# beside the module, hatch_build.py's tag and the cffi requirement;
+# published.yml's `kind: dynamic` cell asks the same of what the index
+# actually serves. What no run asks is the suite through the packaged
+# artifact, against an extension the cells below have already compiled
+# and tested byte for byte.
+#
+# **Both images**, and not the newest alone: what differs between them is
+# the architecture the vendored library, the extension and the interpreter
+# are compiled for, and ubuntu-24.04-arm is the only Linux aarch64 this
+# package is asked about from source. macos.yml and windows.yml carry the
+# arm image of their own platform for the same reason.
+#
+# It gates no commit and no merge, but release.yml calls it, so one cannot
+# be published over a platform this never answered for
+
+on:
+  schedule:
+    # Friday, alone: a platform sentinel is two images times every
+    # interpreter, compiling libsecp256k1 twice a cell, and three of them
+    # in one morning is the queue this arrangement exists to avoid.
+    # macos.yml and windows.yml share Saturday between them; this one
+    # takes the day before.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "8 4 * * 5"
+  # lets release.yml gate a publication on this platform too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+    inputs:
+      concurrency-suffix:
+        description: >
+          Appended to the concurrency group, and the release workflow is
+          the only caller that passes one. See the group below.
+        type: string
+        default: ""
+  # the escape hatch: the platform on demand, for a branch that touches the
+  # build, the loader or anything a toolchain decides
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies, build scripts) can read the token, so it must not
+# be able to write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than through github.workflow, which in
+# a called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other. The suffix is the second half of the same problem,
+# github.ref inside a called workflow being the caller's ref: see lint.yml
+concurrency:
+  group: ubuntu-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  cancel-in-progress: true
+
+jobs:
+  suite-ubuntu:
+    name: Run the suite on ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # libsecp256k1 is compiled twice per cell, from a cache that is cold
+    # whenever the lock moved: far above what the suite itself needs, and
+    # what it bounds is a hung job rather than a slow one. The queueing this
+    # workflow exists to move happens before a job starts and is not counted
+    # here
+    timeout-minutes: 40
+    strategy:
+      # every cell to the end: which interpreter fails on which image is the
+      # whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # both images, for the reason the header gives
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+        # every interpreter this package claims, as macos.yml and
+        # windows.yml carry it, so that the platform is the only thing
+        # that differs between the three. What "claims" means is checked
+        # rather than asserted: tests/test_interpreters.py reads this
+        # list against `requires-python`, the classifiers, and the lists
+        # the other two sentinels declare, which it requires to be equal
+        # to this one rather than merely to overlap it.
+        # 3.14t is the free-threaded build, and it is here for what this
+        # package is: a cffi extension holding no interpreter lock of its
+        # own, whose thread safety is a claim tests/test_concurrency.py
+        # makes and only a build without the GIL can put under load.
+        # Spelled as uv spells them, this being uv rather than
+        # setup-python: `pypy3.11`, not the `pypy-3.11` setup-python takes
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.10"
+          - "pypy3.11"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the vendored library is what gets compiled here
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # the wheels of the test group, not the extension, which is built
+          # from the tree twice below whatever the cache holds
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      # the command CONTRIBUTING.md gives a developer, and the one the
+      # coverage job of test.yml runs: a static build, where `_load_lib`
+      # returns the extension's own `lib`. No --cov here, against the
+      # --cov that job passes: what a cell asks is whether an (image,
+      # interpreter) pair passes, and coverage is measured and gated once,
+      # there, on lines no interpreter here walks differently
+      - name: Run pytest against a static build
+        run: uv run --locked --no-default-groups --group test pytest
+
+      # the other branch of `_load_lib`: cffi in ABI mode, dlopening the
+      # shared object beside the module.
+      # --reinstall-package with --no-cache because the extension already
+      # installed by the step above is the other linkage, and neither the
+      # environment nor the build cache is keyed on the variable that
+      # chooses between them
+      - name: Run pytest against a dynamic build
+        env:
+          BTCLIB_LIBSECP256K1_DYNAMIC: "true"
+        run: >
+          uv run --locked --no-default-groups --group test
+          --reinstall-package btclib_secp256k1 --no-cache pytest

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -3,30 +3,35 @@ name: vendored vectors
 
 # tests/README.md pins every vendored test vector to a commit and a git
 # blob SHA-1, with a documented manual procedure to re-check one. How
-# many there are is that file's to say and not this one's. This runs that procedure
-# once a month instead, over every pin the script can check, and opens or
-# updates an issue on drift rather than fixing anything: refreshing a
-# vector file is a decision the script does not get to make. Matches
-# btclib's own workflow of the same name, script included (issue #397).
+# many there are is that file's to say and not this one's. This runs
+# that procedure weekly instead, over every pin the script can check,
+# and opens or updates an issue on drift rather than fixing anything:
+# refreshing a vector file is a decision the script does not get to
+# make. Matches btclib's own workflow of the same name, script included
+# (issue #397).
 #
 # issues: write is new to this repository -- links.yml's own comment
 # explains why every other scheduled workflow here stops at contents:
 # read, an automatic issue being the usual next step it deliberately
 # does not take. This one does take it, on purpose: a link is noticed
 # the next time somebody follows it, where a vendored vector is trusted
-# without anybody looking at it again, and that is exactly what a
-# monthly issue is for
+# without anybody looking at it again, and that is exactly what an
+# opened issue is for
 
 on:
   schedule:
-    # the 1st of the month, 04:49 UTC. Not on the hour, for the reason
-    # links.yml's own cron comment gives -- GitHub queues same-minute
-    # scheduled workflows across every repository that asked for it, and
-    # a long queue can drop the run outright. Minute 49 is not shared
-    # with any other cron in this repository, which
-    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives, nor
-    # with btclib's own copy of this workflow, at minute 53
-    - cron: "49 4 1 * *"
+    # Monday, the hour after links.yml: the two ask the same question of
+    # different things, whether what this tree points at is still what it
+    # pointed at, and reading them together separates an upstream edit
+    # from a network having a bad morning. Weekly rather than monthly,
+    # which is what the grid has to give: a vector file drifts when
+    # upstream edits it in place, and the sample rate for that was never
+    # derived from the subject.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "8 5 * * 1"
   workflow_dispatch:
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
@@ -42,7 +47,7 @@ on:
     # a branch nobody is going to look at again. "This pull request's
     # own group" is the part github.ref alone gets wrong: for a closed,
     # merged pull request it resolves to the base branch's ref, which
-    # this workflow has no push trigger to collide with, but the monthly
+    # this workflow has no push trigger to collide with, but the weekly
     # schedule and a workflow_dispatch both also run on the default
     # branch and would resolve to that same ref. The concurrency block
     # below groups by the pull request's own number instead, immune to
@@ -134,9 +139,9 @@ jobs:
   # It opens no issue where the job above does, and the asymmetry is in
   # the subject rather than in the effort. A vendored vector file drifts
   # because upstream edits it in place, with nothing here changing and
-  # nobody looking, which is exactly what a monthly issue is for. A pin
+  # nobody looking, which is exactly what an opened issue is for. A pin
   # cannot drift: it moves only in a commit of this repository. So the
-  # monthly run here is a backstop against upstream retagging, or a
+  # scheduled run here is a backstop against upstream retagging, or a
   # signature that stops verifying, and a red run says all of that.
   pin:
     name: Check the pinned libsecp256k1 release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,10 @@
 ---
 name: windows
 
-# the second platform the merge gate does not wait for, and the whole of
-# this file is macos.yml's argument applied to the rows beside those.
+# the Windows third of the platform sweep, and ubuntu.yml's header is the
+# argument for all three: what the merge gate keeps, what a sentinel then
+# owes, and why a cell here builds from the tree rather than installing a
+# wheel.
 #
 # The constraint is a ceiling rather than a wall clock, which is what makes
 # it worth re-deciding a split that was already made once: GitHub Free gives
@@ -28,15 +30,10 @@ name: windows
 # cibuildwheel is why: `test-command` in pyproject.toml runs the whole suite
 # against every wheel it builds, on the runner that built it, so the Windows
 # wheels this package ships are still tested before a merge by the job that
-# produces them. What moves to Saturday is pip's *selection* among them --
-# the question suite-static exists to ask, and the one nothing else covers.
+# produces them.
 #
-# What runs here is not what left, for the reason macos.yml gives at the
-# same point: the cells that moved installed a wheel built earlier in the
-# same run, and rebuilding those here would mean cibuildwheel per image and
-# artifact names the release must not confuse with test.yml's. This builds
-# from the tree instead, twice per cell -- the static extension a CPython
-# wheel carries, then the dynamic one, which is the choice
+# This builds from the tree, twice per cell -- the static extension a
+# CPython wheel carries, then the dynamic one, which is the choice
 # `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
 # of `_load_lib`. Two steps of one job rather than two jobs, because the
 # queue is the cost being managed and a second job pays it again.
@@ -46,17 +43,13 @@ name: windows
 
 on:
   schedule:
-    # Saturday, the day nothing else here asks for -- the mutation session
-    # Sunday, links Monday, codeql Tuesday, macos and latest Wednesday,
-    # Dependabot Thursday -- so a failure notification still names the
-    # workflow by the day it arrived. A minute that is not the hour, as
-    # every cron here, for the reason links.yml gives, and minute 17 is
-    # shared with none of them, which
-    # `grep -h 'cron:' .github/workflows/*.yml` is what re-derives rather
-    # than a list here.
+    # Saturday, the hour after macos.yml: see that file for why the two
+    # platforms share a day and not an hour.
+    # The time is the organization grid -- section 10 of
+    # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "17 4 * * 6"
+    - cron: "8 5 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -97,18 +90,16 @@ jobs:
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # the two images test.yml's suite matrices no longer carry. Both,
-        # because what differs between them is the architecture the
-        # interpreter and the compiled extension target
+        # both images, because what differs between them is the
+        # architecture the interpreter and the compiled extension target
         os:
           - windows-latest
           - windows-11-arm
-        # the interpreter set the matrices ran, and the exclusions those
-        # carried are gone with the wheels that caused them: nothing here
-        # installs a published wheel, so there is no PyPy-on-Windows wheel
-        # to be missing. What remains is what an interpreter cannot do --
-        # CPython has no Windows arm64 build before 3.11, so 3.10 has no
-        # interpreter to run on that image
+        # every interpreter this package claims, as ubuntu.yml and
+        # macos.yml carry it: nothing here installs a published wheel, so
+        # no exclusion is a wheel that is missing. The one below is what an
+        # interpreter cannot do -- CPython has no Windows arm64 build
+        # before 3.11, so 3.10 has none to run on that image
         python-version:
           - "3.10"
           - "3.11"
@@ -116,8 +107,8 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
-          - "pypy-3.10"
-          - "pypy-3.11"
+          - "pypy3.10"
+          - "pypy3.11"
         exclude:
           - os: windows-11-arm
             python-version: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,71 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **The merge gate runs one cell of the suite, and the sweeps moved to
+  the calendar** (btclib-org/.github#85). `test.yml`'s `suite-static` and
+  `suite-dynamic` jobs are gone: two ubuntu images, each walking every
+  interpreter against a wheel built earlier in the same run, asked before
+  every review on an organization whose plan gives it twenty concurrent
+  jobs across every repository. What waits for a review now is the
+  `coverage` job -- `ubuntu-latest` on the version `.python-version`
+  names -- beside the lint, docs and packaging jobs, and the wheel builds
+  that a release publishes the artifacts of.
+
+  `ubuntu.yml` is where those cells went, and it is the third of a set
+  `macos.yml` and `windows.yml` already had: both images of a platform,
+  every interpreter, compiling the vendored library twice a cell so that
+  `BTCLIB_LIBSECP256K1_DYNAMIC` and both branches of `_load_lib` are
+  covered. It runs weekly and `release.yml` calls it, so a version cannot
+  be published over a platform nothing answered for. Its header carries
+  the argument for all three, and the other two now point at it.
+
+  Each matrix runs whole, the cell the gate already covers included. A
+  sweep that subtracted the gate would be a matrix with a hole in it, and
+  whoever asked what ran would have to re-derive the hole from another
+  file.
+
+  What it costs, said here rather than found later. A regression on an
+  interpreter or an architecture the gate no longer reaches sits on
+  `main` until the weekly sentinel for it runs. Pip's *selection* among a
+  directory of wheels tagged for several interpreters is now asked
+  nowhere -- each wheel is still tested by the cibuildwheel job that
+  builds it, and `check-dist` still installs one by path into an empty
+  environment, but nothing chooses between them. And no suite runs
+  against the dynamic wheel as a package any more: `test-command` in
+  `pyproject.toml` reaches cibuildwheel's static wheels alone,
+  `build-dynamic` and `build-windows` build without testing, and
+  `check-dist` imports the dynamic wheel rather than running the suite
+  through it. What the sentinels cover is the dynamic extension compiled
+  from the tree, which is `_load_lib`'s second branch and not the
+  artifact pip resolves to where no static wheel matches. `ubuntu.yml`'s
+  header records both, beside each other.
+
+  With no consumer of a whole image's set left on a branch, the wheel
+  shortcut widens to ubuntu too, as it already applied on macOS and
+  Windows: a pull request builds one interpreter's wheels per image,
+  which is what answers whether this tree still builds there, and
+  `check-dist` takes its wheel from `build-dynamic`, which builds whole.
+
+  Every schedule here is on the organization's grid, which gives a
+  workflow its day and its hour and this repository its minute. Eight
+  crons moved and a ninth is new; `published.yml` and
+  `vendored-vectors.yml` go from monthly to weekly with the rest, a month
+  having been a sample rate nothing derived from their subjects. The grid
+  is section 10 of `btclib-org/.github`, which is why the cadence table in
+  `CONTRIBUTING.md` no longer names a day and `CLAUDE.md`'s copy of it is
+  gone: one calendar covering the organization is one thing to remember,
+  and a copy of it per repository is one more thing to keep true in each.
+
+  `tests/test_interpreters.py` reads the three sentinels' matrices where
+  it read `test.yml`'s two `PYTHONS` blocks, the declaration it compares
+  against `requires-python` and the classifiers having moved with the
+  cells. It reads each file separately and requires the three to be
+  equal, rather than comparing their union: each sentinel's matrix
+  comment already says the other two carry the same list, and a union is
+  a reading in which a list that drifted in one file is covered by the
+  other two. `windows.yml` spelled PyPy `pypy-3.11` where the others
+  spell it `pypy3.11`, which is what the new check found first.
+
 - **The interpreters this package claims are the ones it runs on**
   (btclib-org/.github#83). `requires-python`, the per-version
   `Programming Language :: Python ::` classifiers and `test.yml`'s own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,30 +236,24 @@ is deliberate in every case — each is expected to go red for a reason no
 pull request introduced, and a red check nobody can act on from a branch
 is noise. Their crons are spread out, because sentinels landing in one inbox
 on one morning are one sentinel, and `codeql` keeps a morning of its own
-for the same reason. Two pairs share a morning even so. `macos` and
-`latest` do it deliberately, and both cron comments say why: half an hour
-apart on Wednesday, they answer halves of one question and are worth
-reading together. `published` and `vendored-vectors` are the other pair,
-both monthly on the 1st.
+for the same reason. Which day and which minute each takes is section 10
+of the organization standard in `btclib-org/.github` and not this file's to
+restate; where two deliberately share a morning an hour apart, their cron
+comments say what reading the pair together buys. What each
+sentinel asks is the first thing its own header says, and the `on:` block
+under that header is when.
 
-| workflow | asks | when |
-| --- | --- | --- |
-| `links` | do the URLs in the prose still resolve | Mon |
-| `macos` | does the suite pass on macOS | Wed, and a release |
-| `latest` | does the tree survive every dependency at its newest | Wed |
-| `windows` | does the suite pass on Windows | Sat, and a release |
-| `mutation` | would the suite notice a wrong line | Sun |
-| `published` | can the world install what PyPI serves | 1st, a release |
-| `vendored-vectors` | do the vendored vectors still match upstream | 1st |
-
-`macos` and `windows` are the two sentinels a pull request would otherwise
-have waited for, and each left the gate on a measurement rather than a
-preference — the macOS runners queue for tens of minutes where every other
-platform queues for two, and the Windows cells were the largest family of
-jobs in a run asking for more of them at once than an organization on GitHub
-Free is given. `test.yml`'s header carries the first measurement and
-`windows.yml`'s the second. A release calls both, so what a merge no longer
-waits for a publication still does.
+`ubuntu`, `macos` and `windows` are the three platform sentinels: the suite
+on both images of a platform and on every interpreter, which is the whole
+of what the gate's single cell does not ask. Keeping them off the gate is a
+measurement rather than a preference — macOS runners queue for tens of
+minutes where every other platform queues for two, and GitHub Free gives an
+organization twenty concurrent jobs shared across every repository in it,
+which a matrix on every commit spends before a reviewer is reached.
+`test.yml`'s header carries the numbers and the command that re-derives
+them, `windows.yml`'s the rest of the second, and `ubuntu.yml`'s header is
+the argument the other two point at. `release` calls all three, so what a
+merge does not wait for a publication still does.
 
 `latest` is the one that covers a gap nothing else does. Every uv command
 elsewhere passes `--locked`, the dependency groups declare no version, and
@@ -267,11 +261,11 @@ the one runtime dependency is cffi — which this package does not merely
 import but *compiles against*, so a cffi, setuptools or cmake release can
 break the build rather than a test — and none of those three is something
 Dependabot moves, `[build-system] requires` being resolved at build time
-and pinned by no lock file. Dependabot is weekly, on the Thursday after
-this runs, which is the other half of the arrangement: the sentinel
-answers on Wednesday, so the pull requests that arrive the next morning
-are a diff whose result is already known. `.github/dependabot.yml` carries
-that reasoning where the day is set.
+and pinned by no lock file. Dependabot is weekly and lands the morning
+after this runs, which is the other half of the arrangement: the sentinel
+answers first, so the pull requests that arrive next are a diff whose
+result is already known. `.github/dependabot.yml` carries that reasoning
+where the day is set, and `latest.yml`'s cron comment where this one is.
 
 `mutation` is scoped by `.github/mutation/bindings.toml`, which is also
 what a local run reads, so there is one statement of what is mutated and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,43 +189,68 @@ read by every checkout of this repository.
 
 | workflow | when | what it varies |
 | --- | --- | --- |
-| `test` | pull request, push | the wheels, and ubuntu × every interpreter |
+| `test` | pull request, push | the wheels, the sdist, one suite cell |
 | `lint`, `docs` | pull request, push | — |
 | `claude-review` | pull request, and `@claude` in a comment | — |
-| `vendored-vectors` | monthly, a change to itself | — |
-| `codeql` | push to main, Tuesday | the two scanned languages |
-| `macos` | Wednesday, a release | both macOS images, both linkages |
-| `windows` | Saturday, a release | both Windows images, both linkages |
-| `latest` | Wednesday | the dependencies, at their newest |
+| `vendored-vectors` | weekly, a change to itself | — |
+| `codeql` | push to main, and weekly | the two scanned languages |
+| `ubuntu` | weekly, a release | both ubuntu images × every interpreter |
+| `macos` | weekly, a release | both macOS images × every interpreter |
+| `windows` | weekly, a release | both Windows images × every interpreter |
+| `latest` | weekly | the dependencies, at their newest |
 | `links`, `mutation` | weekly | — |
-| `published` | monthly, a release | what PyPI serves |
-| `release` | a tag | calls the gates, `macos`, `windows`, `published` |
+| `published` | weekly, a release | what PyPI serves |
+| `release` | a tag | calls the gates and the rows marked *a release* |
 
-The first two rows are what a merge waits for.
+The first two rows are what a merge waits for, and the suite cell among them
+is one: `ubuntu-latest` on the interpreter `.python-version` pins, measured
+for coverage. Which day each of the rest runs, and at which minute, is
+section 10 of the organization standard in `btclib-org/.github` and not this
+file's to restate — one calendar covering the organization is one thing to
+remember, and a copy of it per repository is one more thing to keep true in
+each.
 
-What the rows below them have in common is one number: GitHub Free gives an
-organization twenty concurrent jobs (as of 2026-08-21), shared across every
-repository in it. A commit here, in btclib and in bitcoin-core-rpc each ask
-for more jobs than that ceiling alone allows, so a pull request in any of
-the three spent its wall clock waiting for a slot. A platform therefore
-earns a place
-before a review only if it is cheap to wait for, and neither of these is:
-macOS runners queue for tens of minutes rather than for two, and the
-twenty-one Windows suite cells were 27.3 of a run's 112.9 runner-minutes,
-the largest family of jobs in it and ahead of every wheel build. The numbers
-are in `test.yml`'s header and in each of the two files.
+Why so little gates is one number: GitHub Free gives an organization twenty
+concurrent jobs (as of 2026-08-21), shared across every repository in it. A
+commit here, in btclib and in bitcoin-core-rpc each ask for more jobs than
+that ceiling alone allows, so a pull request in any of the three spent its
+wall clock waiting for a slot. At that ceiling a cell before a review buys a
+rarer answer at the price of every review: macOS runners queue for tens of
+minutes rather than for two, and the twenty-one Windows suite cells were
+27.3 of a run's 112.9 runner-minutes, the largest family of jobs in it and
+ahead of every wheel build. The numbers are in `test.yml`'s header.
 
-**The wheels for both are still built on every pull request**, which is the
-half that does not move: `cibuildwheel` runs the suite against each wheel as
-it builds it, and the release publishes the artifacts of that run. What
-waits a week is pip's *selection* among them, and the dynamic build.
+**What the sentinels vary, they vary whole.** `ubuntu` runs both images on
+every interpreter, the cell the gate already covers included. A matrix with
+the gate's cell cut out of it is one nobody can read the shape of, and
+whoever asked what ran would have to re-derive the hole from the gate.
+
+**Every image still builds wheels on every pull request**: `cibuildwheel`
+runs the suite against each wheel as it builds it, and the release publishes
+the artifacts of a run that built every one. What narrows on a branch is how
+many per image — one interpreter's rather than every interpreter's, ubuntu
+included — because what a pull request asks of an image is whether this tree
+still builds there, and the toolchain, the CMake build of the vendored
+library and the cffi extension are what differ per image rather than per
+interpreter. Nothing on a branch reads past that first build: `check-dist`
+installs one wheel by path and takes it from `build-dynamic`, which builds
+whole. `test.yml` carries the measurement beside the step.
+
+What a pull request no longer asks is pip's *selection* among a directory of
+wheels tagged for several interpreters, which now runs nowhere; the wheel
+each interpreter would get is still tested by the job that builds it, and
+`ubuntu`, `macos` and `windows` still compile both linkages from the tree on
+every interpreter. What no run asks at all is the suite against the dynamic
+wheel as a package — the sentinels compile that linkage from the tree
+instead. `ubuntu.yml`'s header records both costs beside each other.
+
 Everything but the first two rows also takes `workflow_dispatch`, which for
-`codeql` and the two platform workflows is the only way to ask about a
+`codeql` and the three platform workflows is the only way to ask about a
 branch at all. `claude-review` is the exception that takes none: both its
 jobs read the pull request or the comment that triggered them, so a manual
 run would start with nothing to read.
 
-`codeql` runs on `main` and on its Tuesday schedule and not on a pull
+`codeql` runs on `main` and on its weekly schedule and not on a pull
 request, which is the same arithmetic as the rows above: three slots held
 while a review waits. What still reads a branch before it merges is
 `zizmor`, a `pre-commit` hook and therefore part of `lint`, which audits
@@ -282,23 +307,6 @@ command at all, for the reason above, and no longer gates.
   ```shell
   uv run --locked --no-default-groups --group test pytest --cov
   ```
-
-- `Run the suite on the static wheel, <version>, <os>`, and its dynamic
-  counterpart, one row of either matrix. In `test.yml` those two jobs read
-  `every interpreter` where the version would be, one job per image
-  walking the whole list, so the version a failure names is in the log
-  rather than in the name of the check; `macos.yml` and `windows.yml`
-  still have a cell per version
-
-  ```shell
-  uv run --python 3.10 --no-cache pytest
-  BTCLIB_LIBSECP256K1_DYNAMIC=true uv run --python 3.10 --no-cache \
-      --reinstall-package btclib_secp256k1 pytest
-  ```
-
-  the two steps of `macos.yml`'s and `windows.yml`'s own cells are these
-  two, in this order and for the same reason: neither the environment nor
-  the build cache is keyed on the variable that chooses the linkage
 
 - `Build wheels on <os>`, for this platform only
 
@@ -375,9 +383,24 @@ The sentinels beside it gate nothing, so a red one is read in the Actions
 tab rather than fixed on a branch. Each is dispatchable, and all but `links`
 run locally.
 
-- `macos` and `windows`, which are the suite on those images and reproducible only
-  on a Mac. Both linkages, the commands being the pair given above under
-  the suite job
+- `ubuntu`, `macos` and `windows`, which are the suite on both images of
+  a platform and on every interpreter, so only the row matching the
+  machine at hand reproduces. A cell is these two commands in this order —
+  the coverage job's own command without `--cov`, run once against each
+  linkage, with `--python` standing for the interpreter the row names:
+
+  ```shell
+  uv run --locked --no-default-groups --group test --python 3.10 pytest
+  BTCLIB_LIBSECP256K1_DYNAMIC=true uv run --locked --no-default-groups \
+      --group test --python 3.10 --reinstall-package btclib_secp256k1 \
+      --no-cache pytest
+  ```
+
+  the second re-installs rather than reusing what the first built,
+  because neither the environment nor the build cache is keyed on the
+  variable that chooses the linkage. `--cov` is not in either: what a cell
+  asks is whether an (image, interpreter) pair passes, and coverage is
+  measured and gated once, on the gate's cell
 
 - `latest`, which resolves every dependency at its newest before running
   the suite. The upgrade rewrites `uv.lock`, so restore it afterwards with

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -382,10 +382,10 @@ Then:
    finishes it has already installed from PyPI what was just uploaded, on
    every platform and at both ends of the supported interpreter range, and
    verified BIP340 vector 0 with it. Read its result in the run rather
-   than dispatching a second one. It still runs monthly on its own too, on
-   the first, and a failure there means the outside world moved, not this
-   repository — which is why it stayed a workflow of its own rather than
-   folding into `release.yml` outright.
+   than dispatching a second one. It still runs weekly on its own too, and
+   a failure there means the outside world moved, not this repository —
+   which is why it stayed a workflow of its own rather than folding into
+   `release.yml` outright.
 
    A cell of that matrix can still lose the race with the index even
    though `version-check` already confirmed PyPI serves the version: 0.8.0

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -14,12 +14,12 @@ and the command that reads it is beside it.
 
 **Never name matrix contexts in a branch rule.** The rule lives outside
 the repository, so a context that stops being produced blocks every merge
-with nothing in the tree to explain why — and the matrix here is
-`Run the suite on the static wheel, ${{ matrix.python-version }},
-${{ matrix.os }}`, whose contexts change with every interpreter added or
-dropped. `test: every job passed` is the aggregate job at the end of
-`test.yml` that `needs` every other job in it; a job added to that
-workflow belongs in its `needs` list, or it gates nothing. The name
+with nothing in the tree to explain why — and the matrices here are
+`Build wheels on ${{ matrix.os }}` and its siblings, whose contexts
+change with every image added or dropped. `test: every job passed` is the
+aggregate job at the end of `test.yml` that `needs` every other job in it;
+a job added to that workflow belongs in its `needs` list, or it gates
+nothing. The name
 carries the workflow because a context is keyed by name alone: two
 workflows with a job named the same thing produce one ambiguous check.
 
@@ -32,7 +32,7 @@ gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
 
 | Check | Produced by |
 | --- | --- |
-| `test: every job passed` | `test.yml`, aggregate over the matrix |
+| `test: every job passed` | `test.yml`, aggregate over its jobs |
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
 
@@ -42,7 +42,7 @@ twenty concurrent jobs (as of 2026-08-21), shared across every repository
 in it: this one, btclib and bitcoin-core-rpc each ask for more jobs than
 that on every commit, so a pull request in any of the three waited for a
 slot rather than for the work. `codeql.yml` now runs on `main`
-and on its Tuesday schedule, the analysis landing on the merge commit rather
+and on its weekly schedule, the analysis landing on the merge commit rather
 than ahead of it, and it still produces that aggregate — the name is
 available, so requiring it again is a patch to the rule and nothing in the
 tree.
@@ -76,15 +76,14 @@ rule names, `Lint and type-check`, checks the submodule out with
 developer's own commit. Re-read that skip list before adding to it: an
 entry may join for a reason of that kind and no other.
 
-Neither `macos.yml`, `windows.yml`, `latest.yml`, `links.yml`,
-`mutation.yml`, `published.yml` nor `vendored-vectors.yml` appears in the
-rule, and none of them must: each is expected to go red for a reason no pull
-request introduced. `macos.yml` and `windows.yml` are the two worth naming
+Neither `ubuntu.yml`, `macos.yml`, `windows.yml`, `latest.yml`,
+`links.yml`, `mutation.yml`, `published.yml` nor `vendored-vectors.yml`
+appears in the rule, and none of them must: each is expected to go red for a
+reason no pull request introduced. The first three are the ones worth naming
 twice, because they do run the suite: what a merge no longer waits for is
-the platform whose runners queue for tens of minutes and the one whose cells
-were the largest family of jobs in a run, both measured in `test.yml`'s
-header and theirs, and `release.yml` calls both so that a publication still
-does.
+every cell of it but one, the reasoning being in `ubuntu.yml`'s header and
+the numbers in `test.yml`'s, and `release.yml` calls all three so that a
+publication still does.
 
 A check can be bound to the app that produces it — `checks` with an
 `app_id` rather than the bare `contexts` list — so that nothing else can
@@ -649,13 +648,13 @@ GitHub free to move the numbers without notice):
 
 **Read the second column before spending anything on the first.** The
 twenty is what `windows.yml`'s header measured against, and paying for
-Team would triple it; the five is what `macos.yml`'s header measured
-against, and Team does not move it at all. A macOS column that queued for
-tens of minutes was far more jobs than five slots could clear at once,
-and only Enterprise changes that arithmetic. So the split that took those
-cells out of the merge gate is not a workaround for a plan — on this
-repository it is the answer, and the plan below Enterprise that would
-undo it does not exist.
+Team would triple it; the five is the ceiling behind the macOS queue
+`test.yml`'s header measures, and Team does not move it at all. A macOS
+column that queued for tens of minutes was far more jobs than five slots
+could clear at once, and only Enterprise changes that arithmetic. So the
+split that took those cells out of the merge gate is not a workaround
+for a plan — on this repository it is the answer, and the plan below
+Enterprise that would undo it does not exist.
 
 What Team would buy is the rest: the Linux and Windows crowding, and the
 contention with the other repositories of the organization, `btclib` and

--- a/tests/README.md
+++ b/tests/README.md
@@ -203,10 +203,11 @@ Verdict: **identical**. Every case, both directions of each. It is also
 the blob libsecp256k1 vendors, at
 `src/modules/silentpayments/bip352_send_and_receive_test_vectors.json`
 in the submodule: byte for byte the same file, which is worth saying
-because it makes the copy here look redundant and it is not. The wheel
-test jobs check out without `submodules: recursive` -- what they exercise
-is the module inside an installed wheel, not a build -- so a test reading
-the submodule would silently not run there.
+because it makes the copy here look redundant and it is not. The sdist
+suite job checks out without `submodules: recursive` -- what it exercises
+is an install of the published sdist, which carries the vendored sources
+of its own -- so a test reading the submodule would silently not run
+there.
 
 Read in part, and the part is a decision rather than a limit. Each case
 carries its transaction as scriptSig, witness and prevout scriptPubKey

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -7,11 +7,20 @@
 
 One fact, declared three times: `requires-python` is the floor,
 `Programming Language :: Python :: X.Y` is what PyPI shows whoever is
-choosing the package, and `test.yml`'s own list is what actually runs.
-Nothing compared them, and the three drift in the direction that is
-hardest to notice -- a classifier left behind when a floor moves is a
-package advertising an interpreter its suite never touches, and the
-person it misleads is not reading this repository.
+choosing the package, and the platform sentinels' own lists are what
+actually runs. Nothing compared them, and the three drift in the
+direction that is hardest to notice -- a classifier left behind when a
+floor moves is a package advertising an interpreter its suite never
+touches, and the person it misleads is not reading this repository.
+
+The sentinels are where the interpreter set lives because that is where
+the suite meets every interpreter: the merge gate runs one cell, on the
+version `.python-version` pins, and `ubuntu.yml`'s header says why. Each
+of the three carries the list in full, and each of their comments says
+the other two carry the same one, so the list is read per file and the
+three are required to agree: a version added to one and forgotten in
+another is a difference between platforms, which is the one thing a
+platform sweep is arranged so as not to have.
 
 The organization standard's rule is that a library covers every Python
 that is not out of support, so all three move together twice around each
@@ -23,7 +32,7 @@ say the same thing.
 
 Read with a regex rather than parsed. `tomllib` arrives in 3.11 and the
 floor here is 3.10, which is the reason `test_copyright.py` reads
-pyproject.toml the same way; the workflow is yaml and no group here
+pyproject.toml the same way; a workflow is yaml and no group here
 carries a parser for it.
 """
 
@@ -32,7 +41,11 @@ from pathlib import Path
 
 _ROOT = Path(__file__).parents[1]
 _PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-_TEST_WORKFLOW = (_ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+_SENTINELS = ("ubuntu.yml", "macos.yml", "windows.yml")
+_WORKFLOWS = {
+    name: (_ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
+    for name in _SENTINELS
+}
 
 # "3.10" out of `requires-python = ">=3.10"`, the floor and nothing else:
 # an upper bound is not declared here and would be a different claim
@@ -43,9 +56,13 @@ _CLASSIFIER = re.compile(
     r'^    "Programming Language :: Python :: (?P<version>3\.\d+)",$', re.MULTILINE
 )
 _PYPY_CLASSIFIER = "Programming Language :: Python :: Implementation :: PyPy"
-# the block `test.yml` reads twice, once to install and once to walk
+# the `python-version` list of a sentinel's suite matrix. The key has to
+# be alone on its line, which is what leaves out the `exclude:` entries
+# below it: those spell the same key with a value beside it, and an
+# excluded cell is an interpreter that cannot run on one image rather
+# than one this package does not claim
 _PYTHONS = re.compile(
-    r"^      PYTHONS: \|\n(?P<block>(?:^        \S+\n)+)", re.MULTILINE
+    r'^        python-version:\n(?P<block>(?:^          - "\S+"\n)+)', re.MULTILINE
 )
 
 
@@ -54,16 +71,22 @@ def _versions(pattern: re.Pattern[str], text: str) -> tuple[str, ...]:
     return tuple(m["version"] for m in pattern.finditer(text))
 
 
-def _matrix() -> tuple[str, ...]:
-    """Return the interpreters `test.yml`'s suite matrices name."""
-    found: set[str] = set()
-    for match in _PYTHONS.finditer(_TEST_WORKFLOW):
-        found.update(line.strip() for line in match["block"].splitlines())
-    return tuple(sorted(found))
+def _matrix(text: str) -> tuple[str, ...]:
+    """Return the interpreters one sentinel's suite matrix names, in order."""
+    return tuple(
+        line.strip().lstrip("- ").strip('"')
+        for match in _PYTHONS.finditer(text)
+        for line in match["block"].splitlines()
+    )
 
 
 _CLASSIFIED = _versions(_CLASSIFIER, _PYPROJECT)
-_MATRIX = _matrix()
+_DECLARED = {name: _matrix(text) for name, text in _WORKFLOWS.items()}
+# the list the classifier checks below quantify over: one file's, which
+# the equality test makes all three. Any other way of combining them
+# reports a version some sentinel carries, and the question those checks
+# ask is about a version every sentinel runs
+_MATRIX = _DECLARED[_SENTINELS[0]]
 # the free-threaded build and PyPy are the same interpreter version as
 # far as a classifier is concerned: "3.14t" is CPython 3.14, and
 # "pypy-3.11" is what the PyPy classifier covers rather than a version
@@ -74,13 +97,34 @@ _CPYTHON = tuple(sorted({v.rstrip("t") for v in _MATRIX if not v.startswith("pyp
 def test_the_three_declarations_were_read() -> None:
     """Each pattern found something, so the checks below quantify over it.
 
-    A key renamed, a classifier reindented, the workflow's block moved:
-    each would leave one of these empty and every comparison below
-    trivially true.
+    A key renamed, a classifier reindented, a sentinel's matrix
+    reindented: each would leave one of these empty and every comparison
+    below trivially true.
     """
     assert _FLOOR.search(_PYPROJECT), "pyproject.toml declares no requires-python"
     assert _CLASSIFIED, "pyproject.toml declares no per-version Python classifier"
-    assert _MATRIX, "test.yml declares no PYTHONS block"
+    unread = [name for name, declared in _DECLARED.items() if not declared]
+    assert not unread, (
+        f"declares no python-version list: {', '.join(unread)}."
+        " A key renamed or a matrix reindented reads as an empty list"
+    )
+
+
+def test_the_three_sentinels_carry_the_same_interpreters() -> None:
+    """The platform is the only thing that differs between the three.
+
+    Each sentinel's matrix comment says the other two carry the same
+    list; this is that sentence checked. Order included: the three are
+    read side by side when one of them goes red, and a list in a
+    different order is one a reader has to diff rather than compare.
+    """
+    reference, *others = _SENTINELS
+    for name in others:
+        assert _DECLARED[name] == _DECLARED[reference], (
+            f"{name} runs {', '.join(_DECLARED[name])} where {reference} runs"
+            f" {', '.join(_DECLARED[reference])}: an interpreter covered on"
+            " one platform and not another is a gap no red cell reports"
+        )
 
 
 def test_the_floor_is_the_lowest_classifier() -> None:
@@ -98,7 +142,7 @@ def test_every_classified_interpreter_is_in_the_matrix() -> None:
     """A version PyPI advertises is a version the suite runs."""
     unrun = [v for v in _CLASSIFIED if v not in _CPYTHON]
     assert not unrun, (
-        f"classified and not in test.yml's matrix: {', '.join(unrun)}."
+        f"classified and run by no platform sentinel: {', '.join(unrun)}."
         " PyPI shows a classifier to whoever is choosing this package"
     )
 
@@ -107,7 +151,7 @@ def test_every_matrix_interpreter_is_classified() -> None:
     """A version the suite runs is a version PyPI advertises."""
     unclassified = [v for v in _CPYTHON if v not in _CLASSIFIED]
     assert not unclassified, (
-        f"in test.yml's matrix and not classified: {', '.join(unclassified)}"
+        f"run by a platform sentinel and not classified: {', '.join(unclassified)}"
     )
 
 


### PR DESCRIPTION
The merge gate becomes one image and one interpreter. Everything
exhaustive moves to a weekly sentinel on the organization grid, at this
repository's minute `:08`.

`suite-static` and `suite-dynamic` are deleted — two jobs, each looping
every interpreter against a wheel built earlier in the same run, across
`ubuntu-latest` and `ubuntu-24.04-arm`. `ubuntu.yml` takes their place:
both images against every interpreter, run **whole** including the cell
the gate spends, each cell building from the tree twice — static, then
`BTCLIB_LIBSECP256K1_DYNAMIC`, which is both branches of `_load_lib`.

Nine crons at `:08`, on the days section 10 gives. `published` and
`vendored-vectors` become weekly with them.

## What this gives up, recorded rather than discovered later

**pip's selection among a directory of wheels is now asked nowhere.**
Each wheel is still tested by the job that builds it, and `check-dist`
installs one by path into an empty environment; what no longer runs is
pip choosing between them.

**No suite runs against the dynamic wheel as a package.** The sentinel
cells cover the dynamic *extension* compiled from this tree, not the
artifact pip resolves to wherever no static wheel matches — and that set
is wider than one cell:

```shell
uv run --frozen --only-group build cibuildwheel \
    --platform windows --print-build-identifiers | grep pp
```

answers nothing at all, and no PyPy is built on musllinux, so `pypy3.10`
everywhere and any PyPy on musl take the `py3-none` wheel too.

The gap is the size it is and no larger: `check-dist` asserts that
artifact's packaging — the `.so` beside the module, `hatch_build.py`'s
tag, the `cffi` requirement — and `published.yml`'s `kind: dynamic` cell
asks the same of what the index actually serves. What no run asks is the
suite through the packaged artifact, against an extension the sentinel
cells have already compiled and tested byte for byte.

## The test that keeps the three lists one fact

`tests/test_interpreters.py` read `test.yml`'s `PYTHONS:` blocks, which
this change deletes. It now reads the three sentinels and asserts their
interpreter lists are **equal**, order included, rather than unioning
them — a union hides a list drifting in one file behind the other two.
That assertion found a real divergence on its first run: `windows.yml`
spelled `pypy-3.10` where the other two spell `pypy3.10`.

`release.yml` calls `ubuntu.yml` beside `macos.yml` and `windows.yml`,
and both publish jobs take it as a `needs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao774JtUq6tF3SnK359Krm

## Summary by Sourcery

Streamline the merge gate to one fast suite cell while moving exhaustive platform and interpreter validation to weekly organization-grid sentinels and release checks.

New Features:
- Add a weekly Ubuntu platform sentinel covering both Ubuntu images, all supported interpreters, and both static and dynamic extension linkages.

Bug Fixes:
- Detect and prevent interpreter matrix drift across the Ubuntu, macOS, and Windows platform workflows, including inconsistent PyPy naming.

Enhancements:
- Reduce the merge gate to a single Ubuntu suite cell while retaining wheel builds, packaging checks, linting, documentation, and coverage.
- Run exhaustive platform and interpreter sweeps weekly and require all platform sentinels during releases.
- Align scheduled workflows with the organization-wide calendar and increase published-artifact and vendored-vector checks to weekly cadence.

CI:
- Replace the static and dynamic wheel suite jobs with scheduled platform workflows that build and test directly from the source tree.
- Update release publishing dependencies to include the Ubuntu platform sweep.

Documentation:
- Update CI, contribution, release, repository, and changelog documentation to describe the streamlined merge gate, weekly sweeps, and associated coverage trade-offs.

Tests:
- Update interpreter consistency tests to compare the ordered interpreter lists declared by all three platform sentinels.