### PR TITLE
COPYRIGHT, AUTHORS.md and CODE_OF_CONDUCT.md are the same file everywhere

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,9 +1,5 @@
 # Authors
 
-To see the list of btclib_secp256k1 authors for copyright purposes,
-see the revision history in source control:
-<https://github.com/btclib-org/btclib-secp256k1/graphs/contributors>
-
-The vendored [libsecp256k1](https://github.com/bitcoin-core/secp256k1) is
-not this project's work: it is distributed under its own licence, by its
-own authors, and the `secp256k1` submodule is only ever read from.
+To see the list of btclib authors for copyright purposes, see the revision
+history in source control:
+<https://github.com/btclib-org/btclib/graphs/contributors>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 # Authors
 
-To see the list of btclib authors for copyright purposes, see the revision
-history in source control:
-<https://github.com/btclib-org/btclib/graphs/contributors>
+To see the list of btclib-secp256k1 authors for copyright purposes, see the
+revision history in source control:
+<https://github.com/btclib-org/btclib-secp256k1/graphs/contributors>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 -->
 
 Every change of a release, in full: what changed, why, and what it cost.
-[RELEASE_NOTES.md](./RELEASE_NOTES.md) has the release notes, which say
-what a user has to act on; this file is the record behind them, and is
-where a claim in those notes can be checked.
+The release notes, which say what a user has to *act* on, are in
+[RELEASE_NOTES.md](./RELEASE_NOTES.md); this file is the record behind
+them.
 
 This file starts at v0.7.1.2. The releases before it were documented at
 release-notes length in the first place, and are still in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,10 @@
 # Code of Conduct
 
-Everyone interacting in the btclib project's codebases, issue trackers,
-chat rooms, and mailing lists is expected to follow the
-[PSF Code of Conduct](https://www.python.org/psf/conduct/).
+Everyone interacting in a btclib-org project — its codebase, its issue
+tracker, its pull requests and its discussions — is expected to follow
+the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
+
+The copy in [btclib-org/.github](https://github.com/btclib-org/.github)
+is what GitHub shows for a repository of the organization carrying none
+of its own. A repository that does carry one carries this same file, so
+that no repository of the organization advertises a second policy.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,3 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,13 @@ Python objects for as long as the interpreter keeps them: see
 
 ## The vendored library is not optional
 
+The vendored [libsecp256k1](https://github.com/bitcoin-core/secp256k1) is
+not this project's work: it is distributed under its own licence, by its
+own authors, and the `secp256k1` submodule is only ever read from. That
+sentence used to be in `AUTHORS.md`, which section 14 makes the same file
+in every repository — an attribution true of one tree cannot live in a
+file every tree carries, and this is the section it is about.
+
 Linking against a libsecp256k1 already installed on the system, instead
 of the vendored one, is what a distribution packager needs: Debian,
 Fedora, conda-forge, Nix and Alpine have policies against vendored copies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 # Release notes
 
-Notable changes to the codebase are documented here. Every entry of a
-release is in [CHANGELOG.md](./CHANGELOG.md); what follows is what a user
-has to act on and what a user gains, and it is what the GitHub release of
-a tag is generated from.
+What a user has to *act* on, and nothing else: a breaking change, a
+migration, a default that moved under them. Everything a reader would
+merely notice is in [CHANGELOG.md](./CHANGELOG.md), which is the record
+behind this file.
 
 ## v0.8.0.5 (work in progress, not released yet)
 


### PR DESCRIPTION
## What this changes

Section 14 calls the three verbatim; the alignment suite reports all
three drifted. This tree held a variant of each:

- `COPYRIGHT` — a blank comment line after the holder that no other copy
  has;
- `AUTHORS.md` — pointing at this repository's own contributor graph,
  where section 14 says the file is *"kept for the organization rather
  than per package, a contributor to one being a contributor"*;
- `CODE_OF_CONDUCT.md` — scoped to the btclib project, where the copy
  GitHub falls back to for a repository carrying none is
  `btclib-org/.github`'s. Two policies is what section 14's own reason
  for the file is against.

**One fact could not survive the move**, and it is the reason this pull
request touches `README.md` too. `AUTHORS.md` here carried the
attribution for the vendored libsecp256k1 — its own licence, its own
authors, the submodule only ever read from. An attribution true of one
tree cannot live in a file every tree carries, so it moves to *The
vendored library is not optional*, which is the section it is about.

`CHANGELOG.md` and `RELEASE_NOTES.md` take the shared opening and keep
their bodies and their own paragraphs.

## How it was verified

```shell
git submodule update --init
git -C secp256k1 fetch --unshallow --tags
uv run --locked --only-group lint pre-commit run --all-files   # exit 0
```

The first two are not incidental: in a fresh worktree the `submodule-pin`
hook fails twice before it can answer — once because the submodule is not
checked out, once because a `--depth 1` clone carries no tag for it to
resolve. Both messages say exactly what to run, which is why this is a
note and not a finding.

`COPYRIGHT` and `AUTHORS.md` are byte-identical to the copies going into
the other repositories.

## Checks

- [x] the lint gate is clean
- [ ] the suite is not run: no module changes
- [ ] no `CHANGELOG.md` entry — the change *is* that file's own opening
- [x] every commit carries a verified signature

## Anything the reviewer should know

One pull request per repository, across the seven projects and
`btclib-org/.github`. btclib-org/btclib#1264 is the first.

## Summary by Sourcery

Align shared repository documentation across the organization and relocate repository-specific attribution to the appropriate README section.

Enhancements:
- Standardize the organization-wide COPYRIGHT, AUTHORS, and CODE_OF_CONDUCT files while preserving a single shared conduct policy.
- Move vendored libsecp256k1 attribution into the README section describing the vendored library.
- Clarify the distinct roles and relationship between CHANGELOG.md and RELEASE_NOTES.md.

Documentation:
- Update repository documentation to reflect organization-wide authorship, conduct-policy scope, and vendored-library attribution.