### PR TITLE
btclib-secp256k1 carries what the standard names

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,5 +1,5 @@
 ---
-description: Review a pull request against REVIEWING.md, this repository's standard
+description: Review a pull request against REVIEWING.md, the organization's standard
 argument-hint: <pull request number>
 ---
 
@@ -12,17 +12,20 @@ diff of the current branch against `origin/main`.
 is the first step rather than a reference to consult afterwards: it states
 what is under review, what to look for and in what order, what a finding
 must contain and how it labels its severity, what becomes of everything
-noticed that the diff is not about, and the two forms the verdict takes.
-Follow it in preference to the review habits you would otherwise bring.
+noticed that the diff is not about, and what a verdict is for. Follow it
+in preference to the review habits you would otherwise bring.
 
 Two files it leans on, worth loading with it:
 
-- `CLAUDE.md` for the gates and for what a review of *this* tree has to
-  know, the two branches of `_load_lib` above all — only one of them
-  exists in any given wheel, so the other is reachable in a test only
-  through a stand-in;
-- `CONTRIBUTING.md` for the rules a finding cites, so that a finding
-  names the line that states one.
+- `CONTRIBUTING.md` for the rules a finding cites and, in its last
+  section, for the gates of this tree;
+- `CLAUDE.md` for what a session has to know before it touches the
+  tree.
 
-Run the gates on the sha under review before writing the verdict, and
-read exit codes rather than filtered output.
+Run the gates on the sha under review before writing the verdict, unless
+they have already been run on it and that run is on the record — which is
+the case `REVIEWING.md` sets out, and it says what relying on one costs.
+Read exit codes rather than filtered output. Write nothing to the branch:
+no edit, no push, no amend, no merge, and `git status --porcelain` empty
+at the end. Where a gate was not run, the summary says so in those words
+rather than leaving it to be assumed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,9 @@ this closes, if there is one: "Closes #123".
 <!--
 The command you ran and what it answered, the test that covers the change,
 the vector it reproduces. This repository asks for a measurement rather than
-a claim -- see the "Verifying, rather than reasoning about, a change"
-section of CLAUDE.md -- and for a wrapper the vector has to come from
-somewhere other than these bindings: their own output agreeing with itself
-proves nothing.
+a claim -- see the "Verifying" section of CLAUDE.md -- and for a wrapper
+the vector has to come from somewhere other than these bindings: their
+own output agreeing with itself proves nothing.
 
 A claim about the build matrix is measurable too: `gh run view <id>
 --log-failed` reads better than a prediction of what CI will say.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@
 # that is not there is not an error anywhere, it is a repository where
 # nothing is ever proposed.
 #
-# Weekly, matching btclib: latest.yml upgrades everything and runs that
+# Weekly, matching btclib: deps-latest.yml upgrades everything and runs that
 # same matrix against it every Wednesday, off the critical path, so a
 # Thursday pull request is a diff whose result is already known, and a
 # smaller one is easier to read and to revert than a month of drift

--- a/.github/scripts/check_submodule_pin.py
+++ b/.github/scripts/check_submodule_pin.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/.github/scripts/verify_wheel_contents.py
+++ b/.github/scripts/verify_wheel_contents.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,7 @@ permissions:
 # cancel superseded runs on the same branch/PR, named literally rather than
 # through github.workflow for the reason lint.yml gives at length. No
 # concurrency-suffix input here, unlike every workflow release.yml calls
-# but published.yml, which takes a version instead: nothing calls this
+# but pypi-published.yml, which takes a version instead: nothing calls this
 # workflow, so github.ref is this run's own ref
 concurrency:
   group: codeql-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,7 @@ permissions:
 # cancel superseded runs on the same branch/PR, named literally rather than
 # through github.workflow for the reason lint.yml gives at length. No
 # concurrency-suffix input here, unlike every workflow release.yml calls
-# but pypi-published.yml, which takes a version instead: nothing calls this
+# but pypi-install.yml, which takes a version instead: nothing calls this
 # workflow, so github.ref is this run's own ref
 concurrency:
   group: codeql-${{ github.ref }}

--- a/.github/workflows/deps-latest.yml
+++ b/.github/workflows/deps-latest.yml
@@ -1,5 +1,5 @@
 ---
-name: latest
+name: deps-latest
 
 # the dependency sentinel: everything uv resolves, upgraded to the newest
 # release that satisfies pyproject.toml, and then put through the suite,
@@ -30,7 +30,7 @@ name: latest
 # ways an upstream release turns this tree red without anybody touching it
 # are not hypothetical. Determinism is what makes the gate legible; the
 # early warning belongs on a schedule, off the critical path -- the same
-# division published.yml makes for what PyPI serves.
+# division pypi-published.yml makes for what PyPI serves.
 #
 # Scope: what uv resolves. Not the pre-commit hook revisions, which are
 # pinned by rev in .pre-commit-config.yaml and moved by pre-commit.ci's
@@ -55,7 +55,7 @@ on:
   schedule:
     # Wednesday, the day before Dependabot's, which is the whole of the
     # placement: this reports on the upgrade before the pull request
-    # carrying it opens. published.yml follows an hour later, the pair
+    # carrying it opens. pypi-published.yml follows an hour later, the pair
     # asking what moved underneath -- the dependencies here, and what the
     # index serves there.
     # The time is the organization grid -- section 10 of
@@ -75,11 +75,11 @@ permissions:
 # workflow today, but that expression is the caller's name when something
 # does, and the convention is what keeps the groups distinct
 concurrency:
-  group: latest-${{ github.ref }}
+  group: deps-latest-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # far narrower than test.yml's matrix, and the reasoning is published.yml's:
+  # far narrower than test.yml's matrix, and the reasoning is pypi-published.yml's:
   # there, every (os, arch, interpreter) triple is a distinct C toolchain and
   # a distinct wheel; here what varies is which release of each dependency
   # the interpreter selects, and the two ends of the supported range are
@@ -128,7 +128,7 @@ jobs:
       # and worth knowing before running the same command in a working tree
       - name: Upgrade every dependency to its latest release
         # this matrix includes windows-latest, whose default shell is
-        # PowerShell rather than bash -- see windows.yml's suite-windows
+        # PowerShell rather than bash -- see os-windows.yml's suite-windows
         # job for the failure mode a POSIX-only step hits there unnoticed
         # (issue btclib-org/btclib#1148). Both steps below are one plain
         # command each and run identically under either shell today,

--- a/.github/workflows/deps-latest.yml
+++ b/.github/workflows/deps-latest.yml
@@ -30,7 +30,7 @@ name: deps-latest
 # ways an upstream release turns this tree red without anybody touching it
 # are not hypothetical. Determinism is what makes the gate legible; the
 # early warning belongs on a schedule, off the critical path -- the same
-# division pypi-published.yml makes for what PyPI serves.
+# division pypi-install.yml makes for what PyPI serves.
 #
 # Scope: what uv resolves. Not the pre-commit hook revisions, which are
 # pinned by rev in .pre-commit-config.yaml and moved by pre-commit.ci's
@@ -55,7 +55,7 @@ on:
   schedule:
     # Wednesday, the day before Dependabot's, which is the whole of the
     # placement: this reports on the upgrade before the pull request
-    # carrying it opens. pypi-published.yml follows an hour later, the pair
+    # carrying it opens. pypi-install.yml follows an hour later, the pair
     # asking what moved underneath -- the dependencies here, and what the
     # index serves there.
     # The time is the organization grid -- section 10 of
@@ -79,7 +79,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # far narrower than test.yml's matrix, and the reasoning is pypi-published.yml's:
+  # far narrower than test.yml's matrix, and the reasoning is pypi-install.yml's:
   # there, every (os, arch, interpreter) triple is a distinct C toolchain and
   # a distinct wheel; here what varies is which release of each dependency
   # the interpreter selects, and the two ends of the supported range are

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ permissions:
 # cancel superseded runs on the same branch/PR, named literally and
 # discriminated by an input rather than left to github.ref alone, for the
 # three reasons lint.yml gives at length: release.yml calls this workflow
-# beside lint.yml, test.yml, os-macos.yml, os-windows.yml and pypi-published.yml, and
+# beside lint.yml, test.yml, os-macos.yml, os-windows.yml and pypi-install.yml, and
 # a group computed from github.workflow would have every one of them
 # cancel the others, that expression being the caller's name in each
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ permissions:
 # cancel superseded runs on the same branch/PR, named literally and
 # discriminated by an input rather than left to github.ref alone, for the
 # three reasons lint.yml gives at length: release.yml calls this workflow
-# beside lint.yml, test.yml, macos.yml, windows.yml and published.yml, and
+# beside lint.yml, test.yml, os-macos.yml, os-windows.yml and pypi-published.yml, and
 # a group computed from github.workflow would have every one of them
 # cancel the others, that expression being the caller's name in each
 concurrency:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ name: links
 # third party answering 502 or throttling a runner would turn a red merge
 # into something to re-run rather than something to fix. Weekly, on demand,
 # and red in the Actions tab is where this belongs -- the same division
-# published.yml already makes for what PyPI serves.
+# pypi-published.yml already makes for what PyPI serves.
 # It therefore does not appear in main's required checks, and must not:
 # that rule lives outside the repository and names its checks as literal
 # strings. See REPOSITORY.md.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ name: links
 # third party answering 502 or throttling a runner would turn a red merge
 # into something to re-run rather than something to fix. Weekly, on demand,
 # and red in the Actions tab is where this belongs -- the same division
-# pypi-published.yml already makes for what PyPI serves.
+# pypi-install.yml already makes for what PyPI serves.
 # It therefore does not appear in main's required checks, and must not:
 # that rule lives outside the repository and names its checks as literal
 # strings. See REPOSITORY.md.

--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -1,55 +1,41 @@
 ---
-name: windows
+name: os-macos
 
-# the Windows third of the platform sweep, and ubuntu.yml's header is the
+# the macOS third of the platform sweep, and os-ubuntu.yml's header is the
 # argument for all three: what the merge gate keeps, what a sentinel then
 # owes, and why a cell here builds from the tree rather than installing a
 # wheel.
 #
-# The constraint is a ceiling rather than a wall clock, which is what makes
-# it worth re-deciding a split that was already made once: GitHub Free gives
-# an organization twenty concurrent jobs, shared across every repository in
-# it, and this workflow set asked for seventy-three of them on every commit
-# while btclib asked for thirty-nine and bitcoin-core-rpc for forty-four. On
-# one pull request run the twenty-one Windows suite cells were 27.3 of the
-# 112.9 runner-minutes and the largest single family of jobs in it, ahead of
-# every wheel build; the run's critical path was 1713 seconds, of which the
-# median cell spent 694 queueing. The command that re-derives it:
+# macOS is where the queue is longest, and that is why the split is a
+# measurement rather than a preference: the numbers, and the command that
+# re-derives them, are in test.yml's own header, next to the wheel builds
+# it keeps.
 #
-#     id=$(gh run list --workflow=test.yml --limit 1 \
-#         --json databaseId --jq '.[0].databaseId')
-#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
-#
-# **The Windows wheel builds stay in test.yml**, and that is the same line
-# macos.yml's header draws: the release publishes the artifacts of that run,
-# so a win_amd64 or win_arm64 wheel not built there is a wheel not on PyPI.
-# Those two jobs are not what stretched the run either -- what did was
-# twenty-one cells contending for slots behind them.
-#
-# What is given up is therefore narrower than twenty-one jobs suggests, and
-# cibuildwheel is why: `test-command` in pyproject.toml runs the whole suite
-# against every wheel it builds, on the runner that built it, so the Windows
-# wheels this package ships are still tested before a merge by the job that
-# produces them.
-#
-# This builds from the tree, twice per cell -- the static extension a
-# CPython wheel carries, then the dynamic one, which is the choice
+# This builds from the tree, twice per cell: the static extension a
+# CPython wheel carries, then the dynamic one, which is the same choice
 # `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
 # of `_load_lib`. Two steps of one job rather than two jobs, because the
-# queue is the cost being managed and a second job pays it again.
+# queue is the cost being managed here and a second job pays it again.
 #
-# It gates no commit and no merge -- a Windows regression sits on main for
-# at most a week -- but release.yml calls it, so one cannot be published
+# So this is the platform against the lock, on every interpreter, and
+# deps-latest.yml is the dependencies against the platforms. A red macOS column
+# in deps-latest.yml with this workflow green is an upgrade; red in both is
+# macOS. One variable each, and the pair reads as a difference.
+#
+# It gates no commit and no merge -- a macOS regression sits on main for at
+# most a week -- but release.yml calls it, so one cannot be published
 
 on:
   schedule:
-    # Saturday, the hour after macos.yml: see that file for why the two
-    # platforms share a day and not an hour.
+    # Saturday, with os-windows.yml an hour later: the two platforms a
+    # reviewer would wait longest for, sharing the day the grid gives to
+    # platforms and not the hour. Red in both is the tree; red in one is
+    # that platform, which is the whole of what running them apart buys.
     # The time is the organization grid -- section 10 of
     # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "8 5 * * 6"
+    - cron: "8 4 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -77,29 +63,37 @@ permissions:
 # and cancel each other. The suffix is the second half of the same problem,
 # github.ref inside a called workflow being the caller's ref: see lint.yml
 concurrency:
-  group: windows-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: os-macos-${{ github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:
-  suite-windows:
+  suite-macos:
     name: Run the suite on ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # libsecp256k1 is compiled twice per cell, from a cache that is cold
+    # whenever the lock moved: far above what the suite itself needs, and
+    # what it bounds is a hung job rather than a slow one. The queueing this
+    # workflow exists to move happens before a job starts and is not counted
+    # here
+    timeout-minutes: 40
     strategy:
       # every cell to the end: which interpreter fails on which image is the
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # both images, because what differs between them is the
-        # architecture the interpreter and the compiled extension target
+        # both images, and not the newest alone: one is Apple silicon and
+        # the other Intel, and what differs between them is the
+        # architecture the vendored library and the extension are compiled
+        # for
         os:
-          - windows-latest
-          - windows-11-arm
-        # every interpreter this package claims, as ubuntu.yml and
-        # macos.yml carry it: nothing here installs a published wheel, so
-        # no exclusion is a wheel that is missing. The one below is what an
-        # interpreter cannot do -- CPython has no Windows arm64 build
-        # before 3.11, so 3.10 has none to run on that image
+          - macos-26-intel
+          - macos-latest
+        # every interpreter this package claims. os-ubuntu.yml and
+        # os-windows.yml carry the same list, so that the platform is the
+        # only thing that differs between the three and a red cell here is
+        # attributable to it.
+        # Spelled as uv spells them, this being uv rather than
+        # setup-python: `pypy3.11`, not the `pypy-3.11` setup-python takes
         python-version:
           - "3.10"
           - "3.11"
@@ -109,9 +103,6 @@ jobs:
           - "3.14t"
           - "pypy3.10"
           - "pypy3.11"
-        exclude:
-          - os: windows-11-arm
-            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -129,22 +120,13 @@ jobs:
 
       # the command CONTRIBUTING.md gives a developer, and the one the
       # coverage job of test.yml runs on ubuntu: a static build, where
-      # `_load_lib` returns the extension's own `lib`.
-      #
-      # both steps below run on windows-latest or windows-11-arm, where
-      # the default shell is PowerShell rather than bash -- see
-      # published.yml's own fix, issue btclib-org/btclib#1141, for the
-      # failure mode a POSIX-only step hits there unnoticed. Each is one
-      # plain command and runs identically under either shell today,
-      # which is exactly the hazard: a future edit adding POSIX-only
-      # syntax would go green on this cell having run nothing (issue
-      # btclib-org/btclib#1148)
+      # `_load_lib` returns the extension's own `lib`
       - name: Run pytest against a static build
-        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
-      # the other branch of `_load_lib`: cffi in ABI mode, dlopening the
-      # shared object beside the module.
+      # the other branch of `_load_lib`, and the only thing that exercises
+      # the dynamic macOS wheel now that test.yml does not: cffi in ABI
+      # mode, dlopening the shared object beside the module.
       # --reinstall-package with --no-cache because the extension already
       # installed by the step above is the other linkage, and neither the
       # environment nor the build cache is keyed on the variable that
@@ -152,7 +134,6 @@ jobs:
       - name: Run pytest against a dynamic build
         env:
           BTCLIB_LIBSECP256K1_DYNAMIC: "true"
-        shell: bash
         run: >
           uv run --locked --no-default-groups --group test
           --reinstall-package btclib_secp256k1 --no-cache pytest

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-name: ubuntu
+name: os-ubuntu
 
 # the ubuntu third of the platform sweep, and the header the other two
 # point at: what the merge gate keeps, what a sentinel then owes, and why
@@ -9,7 +9,7 @@ name: ubuntu
 # **The gate is one cell**: ubuntu-latest on the interpreter
 # .python-version pins, which is the `coverage` job of test.yml, beside
 # the lint, docs and packaging jobs. Everything exhaustive is here or in
-# macos.yml or windows.yml. What that gives up is the point of the
+# os-macos.yml or os-windows.yml. What that gives up is the point of the
 # arrangement rather than a cost it hides: a regression on 3.10, on arm or
 # on PyPy is no longer refused before a merge, and sits on main until the
 # weekly sentinel for it runs. What it buys is every pull request --
@@ -57,7 +57,7 @@ name: ubuntu
 # it is and no larger: check-dist installs the dynamic manylinux wheel
 # by path into an empty environment and imports it, which is the .so
 # beside the module, hatch_build.py's tag and the cffi requirement;
-# published.yml's `kind: dynamic` cell asks the same of what the index
+# pypi-published.yml's `kind: dynamic` cell asks the same of what the index
 # actually serves. What no run asks is the suite through the packaged
 # artifact, against an extension the cells below have already compiled
 # and tested byte for byte.
@@ -65,7 +65,7 @@ name: ubuntu
 # **Both images**, and not the newest alone: what differs between them is
 # the architecture the vendored library, the extension and the interpreter
 # are compiled for, and ubuntu-24.04-arm is the only Linux aarch64 this
-# package is asked about from source. macos.yml and windows.yml carry the
+# package is asked about from source. os-macos.yml and os-windows.yml carry the
 # arm image of their own platform for the same reason.
 #
 # It gates no commit and no merge, but release.yml calls it, so one cannot
@@ -76,7 +76,7 @@ on:
     # Friday, alone: a platform sentinel is two images times every
     # interpreter, compiling libsecp256k1 twice a cell, and three of them
     # in one morning is the queue this arrangement exists to avoid.
-    # macos.yml and windows.yml share Saturday between them; this one
+    # os-macos.yml and os-windows.yml share Saturday between them; this one
     # takes the day before.
     # The time is the organization grid -- section 10 of
     # btclib-org/.github's README.md -- and not this file's to restate.
@@ -110,7 +110,7 @@ permissions:
 # and cancel each other. The suffix is the second half of the same problem,
 # github.ref inside a called workflow being the caller's ref: see lint.yml
 concurrency:
-  group: ubuntu-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: os-ubuntu-${{ github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:
@@ -132,8 +132,8 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-        # every interpreter this package claims, as macos.yml and
-        # windows.yml carry it, so that the platform is the only thing
+        # every interpreter this package claims, as os-macos.yml and
+        # os-windows.yml carry it, so that the platform is the only thing
         # that differs between the three. What "claims" means is checked
         # rather than asserted: tests/test_interpreters.py reads this
         # list against `requires-python`, the classifiers, and the lists

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -57,7 +57,7 @@ name: os-ubuntu
 # it is and no larger: check-dist installs the dynamic manylinux wheel
 # by path into an empty environment and imports it, which is the .so
 # beside the module, hatch_build.py's tag and the cffi requirement;
-# pypi-published.yml's `kind: dynamic` cell asks the same of what the index
+# pypi-install.yml's `kind: dynamic` cell asks the same of what the index
 # actually serves. What no run asks is the suite through the packaged
 # artifact, against an extension the cells below have already compiled
 # and tested byte for byte.

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -133,7 +133,7 @@ jobs:
       #
       # both steps below run on windows-latest or windows-11-arm, where
       # the default shell is PowerShell rather than bash -- see
-      # pypi-published.yml's own fix, issue btclib-org/btclib#1141, for the
+      # pypi-install.yml's own fix, issue btclib-org/btclib#1141, for the
       # failure mode a POSIX-only step hits there unnoticed. Each is one
       # plain command and runs identically under either shell today,
       # which is exactly the hazard: a future edit adding POSIX-only

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -1,41 +1,55 @@
 ---
-name: macos
+name: os-windows
 
-# the macOS third of the platform sweep, and ubuntu.yml's header is the
+# the Windows third of the platform sweep, and os-ubuntu.yml's header is the
 # argument for all three: what the merge gate keeps, what a sentinel then
 # owes, and why a cell here builds from the tree rather than installing a
 # wheel.
 #
-# macOS is where the queue is longest, and that is why the split is a
-# measurement rather than a preference: the numbers, and the command that
-# re-derives them, are in test.yml's own header, next to the wheel builds
-# it keeps.
+# The constraint is a ceiling rather than a wall clock, which is what makes
+# it worth re-deciding a split that was already made once: GitHub Free gives
+# an organization twenty concurrent jobs, shared across every repository in
+# it, and this workflow set asked for seventy-three of them on every commit
+# while btclib asked for thirty-nine and bitcoin-core-rpc for forty-four. On
+# one pull request run the twenty-one Windows suite cells were 27.3 of the
+# 112.9 runner-minutes and the largest single family of jobs in it, ahead of
+# every wheel build; the run's critical path was 1713 seconds, of which the
+# median cell spent 694 queueing. The command that re-derives it:
 #
-# This builds from the tree, twice per cell: the static extension a
-# CPython wheel carries, then the dynamic one, which is the same choice
+#     id=$(gh run list --workflow=test.yml --limit 1 \
+#         --json databaseId --jq '.[0].databaseId')
+#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# **The Windows wheel builds stay in test.yml**, and that is the same line
+# os-macos.yml's header draws: the release publishes the artifacts of that run,
+# so a win_amd64 or win_arm64 wheel not built there is a wheel not on PyPI.
+# Those two jobs are not what stretched the run either -- what did was
+# twenty-one cells contending for slots behind them.
+#
+# What is given up is therefore narrower than twenty-one jobs suggests, and
+# cibuildwheel is why: `test-command` in pyproject.toml runs the whole suite
+# against every wheel it builds, on the runner that built it, so the Windows
+# wheels this package ships are still tested before a merge by the job that
+# produces them.
+#
+# This builds from the tree, twice per cell -- the static extension a
+# CPython wheel carries, then the dynamic one, which is the choice
 # `BTCLIB_LIBSECP256K1_DYNAMIC` gives a developer and covers both branches
 # of `_load_lib`. Two steps of one job rather than two jobs, because the
-# queue is the cost being managed here and a second job pays it again.
+# queue is the cost being managed and a second job pays it again.
 #
-# So this is the platform against the lock, on every interpreter, and
-# latest.yml is the dependencies against the platforms. A red macOS column
-# in latest.yml with this workflow green is an upgrade; red in both is
-# macOS. One variable each, and the pair reads as a difference.
-#
-# It gates no commit and no merge -- a macOS regression sits on main for at
-# most a week -- but release.yml calls it, so one cannot be published
+# It gates no commit and no merge -- a Windows regression sits on main for
+# at most a week -- but release.yml calls it, so one cannot be published
 
 on:
   schedule:
-    # Saturday, with windows.yml an hour later: the two platforms a
-    # reviewer would wait longest for, sharing the day the grid gives to
-    # platforms and not the hour. Red in both is the tree; red in one is
-    # that platform, which is the whole of what running them apart buys.
+    # Saturday, the hour after os-macos.yml: see that file for why the two
+    # platforms share a day and not an hour.
     # The time is the organization grid -- section 10 of
     # btclib-org/.github's README.md -- and not this file's to restate.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "8 4 * * 6"
+    - cron: "8 5 * * 6"
   # lets release.yml gate a publication on this platform too, which is what
   # keeps a weekly sentinel from being the only thing that ever asks
   workflow_call:
@@ -63,37 +77,29 @@ permissions:
 # and cancel each other. The suffix is the second half of the same problem,
 # github.ref inside a called workflow being the caller's ref: see lint.yml
 concurrency:
-  group: macos-${{ github.ref }}${{ inputs.concurrency-suffix }}
+  group: os-windows-${{ github.ref }}${{ inputs.concurrency-suffix }}
   cancel-in-progress: true
 
 jobs:
-  suite-macos:
+  suite-windows:
     name: Run the suite on ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # libsecp256k1 is compiled twice per cell, from a cache that is cold
-    # whenever the lock moved: far above what the suite itself needs, and
-    # what it bounds is a hung job rather than a slow one. The queueing this
-    # workflow exists to move happens before a job starts and is not counted
-    # here
-    timeout-minutes: 40
+    timeout-minutes: 30
     strategy:
       # every cell to the end: which interpreter fails on which image is the
       # whole answer, and stopping at the first one hides the rest
       fail-fast: false
       matrix:
-        # both images, and not the newest alone: one is Apple silicon and
-        # the other Intel, and what differs between them is the
-        # architecture the vendored library and the extension are compiled
-        # for
+        # both images, because what differs between them is the
+        # architecture the interpreter and the compiled extension target
         os:
-          - macos-26-intel
-          - macos-latest
-        # every interpreter this package claims. ubuntu.yml and
-        # windows.yml carry the same list, so that the platform is the
-        # only thing that differs between the three and a red cell here is
-        # attributable to it.
-        # Spelled as uv spells them, this being uv rather than
-        # setup-python: `pypy3.11`, not the `pypy-3.11` setup-python takes
+          - windows-latest
+          - windows-11-arm
+        # every interpreter this package claims, as os-ubuntu.yml and
+        # os-macos.yml carry it: nothing here installs a published wheel, so
+        # no exclusion is a wheel that is missing. The one below is what an
+        # interpreter cannot do -- CPython has no Windows arm64 build
+        # before 3.11, so 3.10 has none to run on that image
         python-version:
           - "3.10"
           - "3.11"
@@ -103,6 +109,9 @@ jobs:
           - "3.14t"
           - "pypy3.10"
           - "pypy3.11"
+        exclude:
+          - os: windows-11-arm
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -120,13 +129,22 @@ jobs:
 
       # the command CONTRIBUTING.md gives a developer, and the one the
       # coverage job of test.yml runs on ubuntu: a static build, where
-      # `_load_lib` returns the extension's own `lib`
+      # `_load_lib` returns the extension's own `lib`.
+      #
+      # both steps below run on windows-latest or windows-11-arm, where
+      # the default shell is PowerShell rather than bash -- see
+      # pypi-published.yml's own fix, issue btclib-org/btclib#1141, for the
+      # failure mode a POSIX-only step hits there unnoticed. Each is one
+      # plain command and runs identically under either shell today,
+      # which is exactly the hazard: a future edit adding POSIX-only
+      # syntax would go green on this cell having run nothing (issue
+      # btclib-org/btclib#1148)
       - name: Run pytest against a static build
+        shell: bash
         run: uv run --locked --no-default-groups --group test pytest
 
-      # the other branch of `_load_lib`, and the only thing that exercises
-      # the dynamic macOS wheel now that test.yml does not: cffi in ABI
-      # mode, dlopening the shared object beside the module.
+      # the other branch of `_load_lib`: cffi in ABI mode, dlopening the
+      # shared object beside the module.
       # --reinstall-package with --no-cache because the extension already
       # installed by the step above is the other linkage, and neither the
       # environment nor the build cache is keyed on the variable that
@@ -134,6 +152,7 @@ jobs:
       - name: Run pytest against a dynamic build
         env:
           BTCLIB_LIBSECP256K1_DYNAMIC: "true"
+        shell: bash
         run: >
           uv run --locked --no-default-groups --group test
           --reinstall-package btclib_secp256k1 --no-cache pytest

--- a/.github/workflows/pypi-install.yml
+++ b/.github/workflows/pypi-install.yml
@@ -1,5 +1,5 @@
 ---
-name: pypi-published
+name: pypi-install
 
 # the sentinel on what users actually install. Every other workflow here
 # tests artifacts built in the same run, from the tree that triggered it:
@@ -92,7 +92,7 @@ permissions:
 # sample worth keeping, and none supersedes the others. A concurrent run
 # queues instead
 concurrency:
-  group: pypi-published-${{ github.ref }}
+  group: pypi-install-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pypi-published.yml
+++ b/.github/workflows/pypi-published.yml
@@ -1,5 +1,5 @@
 ---
-name: published
+name: pypi-published
 
 # the sentinel on what users actually install. Every other workflow here
 # tests artifacts built in the same run, from the tree that triggered it:
@@ -61,8 +61,8 @@ on:
         type: string
         default: ""
   schedule:
-    # Wednesday, the hour after latest.yml, and the pair is why this is
-    # weekly: latest.yml upgrades every dependency and runs the suite from
+    # Wednesday, the hour after deps-latest.yml, and the pair is why this is
+    # weekly: deps-latest.yml upgrades every dependency and runs the suite from
     # the tree, this asks what the index actually serves, and read
     # together they separate a break this repository caused from one that
     # arrived. What it watches is external rot -- a new runner image, a
@@ -92,7 +92,7 @@ permissions:
 # sample worth keeping, and none supersedes the others. A concurrent run
 # queues instead
 concurrency:
-  group: published-${{ github.ref }}
+  group: pypi-published-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,26 +53,26 @@ jobs:
       concurrency-suffix: "-release"
 
   # the suite on every platform and every interpreter, which test.yml runs
-  # one cell of, for the reason ubuntu.yml's header gives: a week is the
+  # one cell of, for the reason os-ubuntu.yml's header gives: a week is the
   # right sample rate for a regression that can sit on main for a week,
   # and the wrong one for a version that cannot be unpublished
   ubuntu:
     name: Run the ubuntu workflow
-    uses: ./.github/workflows/ubuntu.yml
+    uses: ./.github/workflows/os-ubuntu.yml
     with:
       # see the lint job above
       concurrency-suffix: "-release"
 
   macos:
     name: Run the macos workflow
-    uses: ./.github/workflows/macos.yml
+    uses: ./.github/workflows/os-macos.yml
     with:
       # see the lint job above
       concurrency-suffix: "-release"
 
   windows:
     name: Run the windows workflow
-    uses: ./.github/workflows/windows.yml
+    uses: ./.github/workflows/os-windows.yml
     with:
       # see the lint job above
       concurrency-suffix: "-release"
@@ -566,6 +566,6 @@ jobs:
   published:
     name: Install the published version from PyPI
     needs: publish-pypi
-    uses: ./.github/workflows/published.yml
+    uses: ./.github/workflows/pypi-published.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,8 @@ jobs:
             exit 1
           fi
 
-      # CONTRIBUTING.md and RELEASING.md both say a release is a tag on
-      # a commit on main; nothing enforced it. The deployment tag policy
+      # RELEASING.md says a release is a tag on a commit on main, every
+      # invariant a release rests on resting on that; nothing enforced it. The deployment tag policy
       # of the pypi environment constrains the *name* of the ref and
       # nothing else, so a v* tag on a branch head, on a stale state or
       # on a fork-synced commit reaches the environment exactly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -566,6 +566,6 @@ jobs:
   published:
     name: Install the published version from PyPI
     needs: publish-pypi
-    uses: ./.github/workflows/pypi-published.yml
+    uses: ./.github/workflows/pypi-install.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ name: test
 # installed, and the suite run on the one cell a reviewer should wait for.
 # That cell is the `coverage` job below -- ubuntu-latest on the
 # interpreter .python-version pins -- and every other cell of the suite is
-# ubuntu.yml's, macos.yml's or windows.yml's, run weekly and before a
-# release. ubuntu.yml's header is the argument for the split; the numbers
+# os-ubuntu.yml's, os-macos.yml's or os-windows.yml's, run weekly and before a
+# release. os-ubuntu.yml's header is the argument for the split; the numbers
 # behind it are here, next to the jobs they were measured on.
 #
 # **The wheel builds for all six images stay here**, and that is the line
@@ -36,13 +36,13 @@ name: test
 # every repository in it, and this workflow set asked for seventy-three on
 # every commit. The twenty-one Windows suite cells were 27.3 of the 112.9
 # runner-minutes, the largest family of jobs in the run and ahead of every
-# wheel build. windows.yml has the rest of that measurement.
+# wheel build. os-windows.yml has the rest of that measurement.
 #
 # The ubuntu suite cells are the third, against the same ceiling: two
 # images times every interpreter, on the platform whose cells are the
 # cheapest to wait for and therefore the last a gate gives up. What
 # decides them is that the gate asks one question of the suite and the
-# calendar asks the rest, which is what ubuntu.yml's header argues.
+# calendar asks the rest, which is what os-ubuntu.yml's header argues.
 
 on:
   push:
@@ -373,7 +373,7 @@ jobs:
       # the first build of an image. check-dist installs one wheel by
       # path and takes it from build-dynamic, which builds whole, and
       # pip's selection among a directory of wheels tagged for several
-      # interpreters is asked nowhere -- ubuntu.yml's header carries that
+      # interpreters is asked nowhere -- os-ubuntu.yml's header carries that
       # trade and what answers the rest of the question instead.
       #
       # A push to main, a release and a rehearsal all build everything --
@@ -558,7 +558,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS is macos.yml's, for the reason the header gives; what that
+        # macOS is os-macos.yml's, for the reason the header gives; what that
         # workflow runs there is a source build of the same tree, which is
         # what an install from the sdist is
         os: [ubuntu-latest, windows-latest]
@@ -739,7 +739,7 @@ jobs:
       # fail. The dynamic wheel is the subject because it is the one that
       # needs cffi at run time, a static extension carrying its own.
       # Importing it is the whole of what runs here -- the suite against
-      # this artifact is a cost ubuntu.yml's header records
+      # this artifact is a cost os-ubuntu.yml's header records
       - name: Install a wheel with its dependencies resolved from PyPI
         run: |
           # the glob itself, not ls parsed by a pipeline: nullglob is what
@@ -776,7 +776,7 @@ jobs:
   #
   # The name carries the workflow because a context is keyed by name alone:
   # two workflows with a job named the same thing produce one ambiguous
-  # check, and ubuntu.yml, macos.yml and windows.yml are three more
+  # check, and os-ubuntu.yml, os-macos.yml and os-windows.yml are three more
   # workflows whose jobs run the suite.
   #
   # `if: !cancelled()` because a job with unmet `needs` is skipped, and a

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -38,8 +38,8 @@ version: 2
 
 # every automodule directive imports this package, and this package
 # compiles the vendored libsecp256k1 to do that -- read the docs has to
-# check out the git submodule, matching what CONTRIBUTING.md's Build
-# section already asks a developer to do, or every directive gets a bare
+# check out the git submodule, matching what CONTRIBUTING.md's
+# environment section already asks a developer to do, or every directive gets a bare
 # heading and nothing beneath it, silently, the same failure mode
 # .readthedocs.yaml's -W exists to turn into a build error instead
 submodules:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -55,10 +55,22 @@ rules:
     # allow-non-breakable-words stays at its default, true: a line that
     # is one long token has nowhere to break, which is the exemption
     # MD013 already makes for a bare URL
-  # the "---" every yaml file here opens with, which is yamllint's
-  # default and one line each. What it buys is that the files answer the
-  # question the same way instead of each beginning however its author
-  # left it, and that the default set carries one exemption fewer to
-  # justify. On line 1, above the header comment rather than below it, so
-  # there is no second place to look for it
-  document-start: enable
+  # the "---" every yaml file here opens with, one line each. What it buys
+  # is that the files answer the question the same way instead of each
+  # beginning however its author left it. On line 1, above the header
+  # comment rather than below it, so there is no second place to look for
+  # it.
+  #
+  # The level is what this entry is for: the default set already carries
+  # this rule, at warning, and the pre-commit hook runs plain `yamllint`
+  # with no --strict, where a warning exits 0. At the inherited level the
+  # rule therefore reports the convention and gates nothing -- which is
+  # what the entry said it bought and did not. Raising it to error costs
+  # nothing today:
+  #
+  #   git ls-files '*.yml' '*.yaml' \
+  #     | xargs -I{} sh -c 'head -1 {} | grep -q "^---" || echo {}'
+  #
+  # answers with nothing in every repository of the organization.
+  document-start:
+    level: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,7 @@
-# Working on btclib_secp256k1
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working
+with code in this repository.
 
 Python bindings to a vendored [libsecp256k1](./secp256k1/), built from
 source. The package is thin: the cryptography is upstream, and what lives
@@ -9,26 +12,27 @@ that asks it, and `gh run view <id> --json artifacts` answers it; a number
 here would be a line every matrix change has to edit, and nothing would
 fail when it was not edited.
 
-Repository configuration — branch protection, required checks, token
-permissions, publishing environments, Dependabot, secret scanning — is in
-[REPOSITORY.md](./REPOSITORY.md). Read that file before changing a workflow,
-a branch rule or a repository setting. Writing code does not need it.
+How to work here — what the issue tracker takes, the prose style, how a
+pull request is opened and landed — is
+[CONTRIBUTING.md](./CONTRIBUTING.md), which is the same file in every
+repository of the organization up to its last section, that one holding
+this tree's environment, its gate commands and which of its workflows
+decide a merge. Reviewing is [REVIEWING.md](./REVIEWING.md), the same way
+and with the same last section, and `/review` is that file as a command;
+read it before reviewing a pull request and before opening one, since it
+is what the pull request will be answered against. Repository
+configuration — branch protection, required checks, token permissions,
+publishing environments, Dependabot, secret scanning — is
+[REPOSITORY.md](./REPOSITORY.md): read it before changing a workflow, a
+branch rule or a setting.
 
-Reviewing a pull request — what a review establishes before it gives
-an ack, what a finding must contain, and why everything it notices
-that the diff is not about becomes an issue rather than a comment — is
-[REVIEWING.md](./REVIEWING.md), and `/review` is that file as a command.
-
-This file is for what is not written down elsewhere. The documentation is,
-and stays, in:
+The rest of the documentation, and none of it repeated here:
 
 - [README.md](./README.md) — design, wrapped modules, build, and the
   static/dynamic/sdist distinction
-- [CONTRIBUTING.md](./CONTRIBUTING.md) — how to build and test
-  locally, how to reproduce each CI job, and what a change has to satisfy
 - [RELEASING.md](./RELEASING.md) — the release, and the rehearsal
-- [scripts/README.md](./scripts/README.md) — the build backend, one file at
-  a time
+- [scripts/README.md](./scripts/README.md) — the build backend, one file
+  at a time
 - the comments in `.github/workflows/*.yml` and `pyproject.toml`, which
   carry the reasoning behind their choices
 
@@ -51,10 +55,12 @@ Above it, one module per libsecp256k1 module wrapped: `dsa`, `ssa`,
 the boundary. No module is one call of another: `mult` had become that
 -- `pubkey_from_prvkey` with a flag fixed -- and was folded into `keys`.
 
-MuSig2 is deliberately *not* wrapped: its two-round protocol needs a
-session whose secret nonce cannot be reused, which belongs where the
-signing state lives, in btclib; it is reachable through the raw `ffi`
-and `lib` this package exposes. See the Design section of the README
+MuSig2 is deliberately *not* wrapped as a protocol: its two-round session
+holds a secret nonce that cannot be reused, which belongs where the
+signing state lives, in btclib. `musig.KeyAggCache` and `musig.Session`
+are the one place this package holds a libsecp256k1 object with no
+serialization to be one, and `musig.py`'s module docstring carries the
+reasoning for taking that exception. See the Design section of the README
 before adding a module.
 
 Below it, `scripts/cffi_build.py` builds the vendored library with CMake
@@ -64,23 +70,6 @@ compiled at all — chosen by `BTCLIB_LIBSECP256K1_DYNAMIC`,
 `BTCLIB_LIBSECP256K1_CROSS_COMPILE` and `CFFI_PLATFORM`.
 `stubs/_btclib_secp256k1.pyi` is what lets strict mypy typecheck a
 module that only exists after a build.
-
-## The gate is one file
-
-`.pre-commit-config.yaml` is the single definition of what "clean" means.
-The `lint` workflow runs that very file, so what CI enforces is what a
-commit enforces:
-
-```shell
-uvx pre-commit run --all-files
-```
-
-Never add a check that exists only in a workflow, and never leave a hook
-weaker locally than on a runner: a hook that needs a tool the developer
-may not have carries it in `additional_dependencies` (this is why
-`actionlint` ships `shellcheck-py` and `zizmor` is a `local` hook pinned
-to a version). A check discovered by CI after a push is a check in the
-wrong place.
 
 ## The primary checkout is the maintainer's
 
@@ -180,186 +169,8 @@ cause. Use `/model opus` for the session, then switch back to Sonnet.
 
 Do not use Fable unless explicitly instructed.
 
-## Commands whose flags are load-bearing
+## Non-obvious facts that will otherwise waste a session
 
-```shell
-# the suite, as the coverage job runs it: uv run syncs by itself, and
-# without these flags it installs the whole dev set
-uv run --locked --no-default-groups --group test pytest --cov
-
-# another interpreter; --no-cache because the cached extension
-# belongs to one ABI
-uv run --python 3.10 --no-cache pytest
-
-# the packaging gates, pinned by uv.lock rather than fetched by uvx
-uv build --sdist
-uv run --locked --only-group check twine check --strict dist/*
-uv run --locked --only-group check pyroma --min 10 dist/*.tar.gz
-
-# after touching pyproject.toml; the uv-lock hook does it too
-uv lock
-
-# after adding a hex constant to a test module; the vendored vector
-# data has a baseline of its own, whose command is in CONTRIBUTING.md.
-# Neither file is excluded from the scan, only recorded as reviewed.
-# --slim and a redirect, not --baseline: the flag is what keeps a moved
-# line from rewriting the file, and --baseline writes the full form
-# whatever it read -- it also merges, so a redirect drops what an audit
-# marked; CONTRIBUTING.md carries both halves
-uvx --from detect-secrets detect-secrets scan --slim \
-    --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
-    > .secrets.baseline
-```
-
-## The workflows that gate, and the ones that do not
-
-The suite's aggregate, the lint job and the documentation build are the
-required checks on a pull request, and `REPOSITORY.md` reads the rule
-back from the endpoint rather than asserting it. So code does not reach a
-review without having passed them or passing them beside it on the same
-sha, and a reviewer may rely on that rather than establishing it again;
-`REVIEWING.md` has what the reliance takes.
-
-`lint`, `docs` and `test` are the gate, and `release` reuses all three.
-`codeql` is not one of them and holds nothing: no branch rule names its
-aggregate, and it has no `pull_request` trigger at all, so a merge never
-waits on it. It runs on the push to `main` that a merge creates — its
-own `on:` block says what that trade bought and what it defers — and
-weekly besides, which is what covers the code nobody touched. `release`
-does not reuse it and does not have to: a tag is an ancestor of `main`
-before the matrix builds anything (`version-check` in `release.yml`), so
-the tree it publishes is one that push-triggered analysis has already
-read. The rest are sentinels: each is a workflow of its own, has no
-aggregate job, is named by no branch rule, and opens no issue on failure
-(`vendored-vectors` excepted, for the reason its own header gives). That
-is deliberate in every case — each is expected to go red for a reason no
-pull request introduced, and a red check nobody can act on from a branch
-is noise. Their crons are spread out, because sentinels landing in one inbox
-on one morning are one sentinel, and `codeql` keeps a morning of its own
-for the same reason. Which day and which minute each takes is section 10
-of the organization standard in `btclib-org/.github` and not this file's to
-restate; where two deliberately share a morning an hour apart, their cron
-comments say what reading the pair together buys. What each
-sentinel asks is the first thing its own header says, and the `on:` block
-under that header is when.
-
-`os-ubuntu`, `os-macos` and `os-windows` are the three platform sentinels: the suite
-on both images of a platform and on every interpreter, which is the whole
-of what the gate's single cell does not ask. Keeping them off the gate is a
-measurement rather than a preference — macOS runners queue for tens of
-minutes where every other platform queues for two, and GitHub Free gives an
-organization twenty concurrent jobs shared across every repository in it,
-which a matrix on every commit spends before a reviewer is reached.
-`test.yml`'s header carries the numbers and the command that re-derives
-them, `os-windows.yml`'s the rest of the second, and `os-ubuntu.yml`'s header is
-the argument the other two point at. `release` calls all three, so what a
-merge does not wait for a publication still does.
-
-`deps-latest` is the one that covers a gap nothing else does. Every uv command
-elsewhere passes `--locked`, the dependency groups declare no version, and
-the one runtime dependency is cffi — which this package does not merely
-import but *compiles against*, so a cffi, setuptools or cmake release can
-break the build rather than a test — and none of those three is something
-Dependabot moves, `[build-system] requires` being resolved at build time
-and pinned by no lock file. Dependabot is weekly and lands the morning
-after this runs, which is the other half of the arrangement: the sentinel
-answers first, so the pull requests that arrive next are a diff whose
-result is already known. `.github/dependabot.yml` carries that reasoning
-where the day is set, and `deps-latest.yml`'s cron comment where this one is.
-
-`mutation` is scoped by `.github/mutation/bindings.toml`, which is also
-what a local run reads, so there is one statement of what is mutated and
-what judges it. Two things to know before starting one: it mutates the
-source in place and restores it, so nothing else may read the tree while it
-runs, and `cosmic-ray baseline` comes first — without it a stale test
-command fails every mutant identically and the session reports a perfect
-kill rate, which is the one failure mode that looks like good news.
-
-## What this repository expects
-
-- **the prose style is CONTRIBUTING.md's "Documentation and comments"
-  section**, stated once there because contributors read that file and not
-  this one. Its shortest form: comments say why, the what being in the
-  diff; a change that makes a comment untrue updates the comment, in the
-  workflows and the build scripts as much as in the package; and never
-  state a count that nothing checks
-- **tests validate against external vectors.** A test that compares these
-  bindings with themselves proves nothing. `tests/test_vectors.py`
-  documents where each vendored file comes from
-- **coverage is a ratchet at 100%,** with `raise RuntimeError` excluded:
-  see the reasoning in `pyproject.toml`
-- **warnings are errors** (`filterwarnings`), because the 3.10 to 3.14
-  spread turns a deprecation into a breakage
-- **the version is declared once,** in `pyproject.toml`; `__version__`
-  reads the installed metadata. Never bump it in an ordinary change:
-  releases are cut by a maintainer, and the release workflow checks the
-  tag against it. The one bump that is not a release is the fourth number
-  opened straight after one, so that the tree stops claiming the version
-  it shipped: RELEASING.md's step that opens the next version, and the
-  reason that step exists
-- **the `secp256k1` submodule moves in a change of its own,** with the
-  version named in `README.md` and `RELEASE_NOTES.md` moved with it
-- **`main` is the only long-lived branch**, so a pull request targets it
-  and a tag on it is a release; it is protected, and every change gets
-  there through a pull request, and through nothing else — a direct push
-  is refused for everyone. Squash is the only merge button enabled, and
-  auto-merge is what presses it once review and checks are in: one
-  commit regardless of how many the branch carried, composed and signed
-  by GitHub, whose signature is what the rule asks for, a valid one
-  rather than a particular signer's. GitHub therefore reconciles every
-  landing — Merged, `Closes #N` in the description fires, and the head
-  branch goes — with no case left where a commit arrives that no pull
-  request names. REPOSITORY.md has the settings that make that true. A
-  pull request stacked on another is rebased once its parent lands, and
-  pays a fresh run of the matrix for it. The `dev` this repository used
-  to develop on, and the
-  release merge into `master` that went with it, are gone; RELEASING.md
-  is the file that describes what replaced them
-
-## Conventions the workflows hold to
-
-Each of these was arrived at by something going wrong, and `actionlint`
-and `zizmor` are hooks precisely so they stay true. Both must report zero
-findings.
-
-- every action pinned to a commit SHA, with the tag in a trailing comment
-- every workflow declares `permissions: contents: read`, and a job that
-  needs more declares it itself
-- every job declares `timeout-minutes`
-- `concurrency` groups are named literally (`test-${{ github.ref }}`),
-  never through `github.workflow`: in a called workflow what that resolves
-  to is undocumented, and if it is the caller's name the two workflows a
-  release calls would cancel each other. `github.ref` in a called workflow
-  is the *caller's* ref, so a reusable workflow also takes a
-  `concurrency-suffix` input, and `release.yml` passes one: without it a
-  rehearsal dispatched on a branch shares a group with a push to that
-  branch, and one cancels the other
-- `actions/checkout` passes `persist-credentials: false`, so the token
-  does not stay in `.git/config` where an artifact upload could carry it
-- uv commands pass `--locked`, never `--frozen` — except the wheel-build
-  steps of `test.yml` (`build-cibuildwheel`, `build-dynamic`,
-  `build-sdist`, the Windows cross-build), which run after the
-  `dev-version` action has rewritten `pyproject.toml` on the rehearsal
-  path; `--locked` refuses exactly that disagreement, so those steps use
-  `--frozen`, and the comment above `build-cibuildwheel`'s `Build wheels`
-  step has the reasoning in full
-- the packaging tools come from the pinned `check` group, not from `uvx`,
-  which would fetch whatever the index holds when the job runs
-- a hook that needs a tool carries it in `additional_dependencies`, with
-  a version: unpinned it is whatever existed when each environment was
-  built, and nothing ever moves it
-
-## Facts that would otherwise cost a session
-
-- **`uv run --python 3.10 …` replaces `.venv`** with an environment built
-  on that interpreter, and leaves it there. Going back is another
-  `uv sync`, plus `--reinstall-package btclib_secp256k1 --no-cache` if
-  the extension in the cache belongs to the ABI just left. The README
-  says so, at the end of a long section
-- **`uv run` syncs the environment itself.** Without
-  `--no-default-groups --group test` it installs the whole dev set, which
-  is how the coverage job came to install twenty-nine packages after
-  deliberately installing ten
 - **the settings that cannot be enabled are in REPOSITORY.md**, with the
   API call that shows each still off: the two secret-scanning extensions
   are the ones that answer a PATCH with 200 and change nothing. Do not
@@ -387,19 +198,52 @@ findings.
   used where its size and truncated mtime match — which is the same
   window as above, and the reason the hand recipe wants the control run
   and not only the variable
-- **`detect-secrets` runs twice, over two baselines**: the tree with the
-  entropy detectors on, and `tests/*.csv`/`tests/*.json` with them off,
-  those files being hex and nothing else. Adding to either side fails its
-  hook until that baseline is regenerated; both commands are in
-  CONTRIBUTING.md, and reading the diff is the point of a baseline
-- **the `pypi-published` workflow went green with 0.7.1**, on 4 August 2026,
-  nineteen cells out of nineteen, having been nineteen out of nineteen red
-  the day before: 0.4.0 had no arm64 wheel and its sdist no longer built,
-  so that red was a fact about what users could install rather than a
-  broken workflow. A red there still means the outside world moved, which
-  is why it is a workflow of its own and not a job of `release`
+- **a mutation session mutates the source in place and restores it**, so
+  nothing else may read the tree while one runs: no second session, no
+  `pytest` in another shell, and a `git status` in the middle is a
+  working tree with a mutant in it. `cosmic-ray baseline` comes first,
+  always — without it a stale test command fails every mutant
+  identically and the session reports a perfect kill rate, which is the
+  one failure mode of a mutation run that looks like good news
+- **the `pypi-published` workflow went green with 0.7.1**, on 4 August
+  2026, nineteen cells out of nineteen, having been nineteen out of
+  nineteen red the day before: 0.4.0 had no arm64 wheel and its sdist no
+  longer built, so that red was a fact about what users could install
+  rather than a broken workflow. A red there still means the outside
+  world moved, which is why it is a workflow of its own and not a job of
+  `release`
 
-## Verifying, rather than reasoning about, a change
+## Conventions to match
+
+Section 9 of the organization standard is the prose style and section 10
+is what every workflow of the organization does; neither is re-listed
+here, that standard's own *One fact in one place* being the reason.
+`CONTRIBUTING.md`'s last section has the gates and the commands, and what
+a change to these bindings has to satisfy.
+
+What is left to this file is where this tree departs from section 10, or
+holds something it does not reach. `actionlint` and `zizmor` are hooks
+precisely so these stay true, and both must report zero findings.
+
+- `concurrency` groups are named literally, and `github.ref` in a called
+  workflow is the *caller's* ref, so a reusable workflow here also takes
+  a `concurrency-suffix` input and `release.yml` passes one: without it a
+  rehearsal dispatched on a branch shares a group with a push to that
+  branch, and one cancels the other
+- uv commands pass `--locked`, never `--frozen` — except the wheel-build
+  steps of `test.yml` (`build-cibuildwheel`, `build-dynamic`,
+  `build-sdist`, the Windows cross-build), which run after the
+  `dev-version` action has rewritten `pyproject.toml` on the rehearsal
+  path; `--locked` refuses exactly that disagreement, so those steps use
+  `--frozen`, and the comment above `build-cibuildwheel`'s `Build wheels`
+  step has the reasoning in full
+- the packaging tools come from the pinned `check` group, not from `uvx`,
+  which would fetch whatever the index holds when the job runs
+- a hook that needs a tool carries it in `additional_dependencies`, with
+  a version: unpinned it is whatever existed when each environment was
+  built, and nothing ever moves it
+
+## Verifying
 
 The build matrix is expensive — tens of jobs compiling C — and this
 package exists to behave identically everywhere, so a claim about it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Do not use Fable unless explicitly instructed.
   always — without it a stale test command fails every mutant
   identically and the session reports a perfect kill rate, which is the
   one failure mode of a mutation run that looks like good news
-- **the `pypi-published` workflow went green with 0.7.1**, on 4 August
+- **the `pypi-install` workflow went green with 0.7.1**, on 4 August
   2026, nineteen cells out of nineteen, having been nineteen out of
   nineteen red the day before: 0.4.0 had no arm64 wheel and its sdist no
   longer built, so that red was a fact about what users could install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ comments say what reading the pair together buys. What each
 sentinel asks is the first thing its own header says, and the `on:` block
 under that header is when.
 
-`ubuntu`, `macos` and `windows` are the three platform sentinels: the suite
+`os-ubuntu`, `os-macos` and `os-windows` are the three platform sentinels: the suite
 on both images of a platform and on every interpreter, which is the whole
 of what the gate's single cell does not ask. Keeping them off the gate is a
 measurement rather than a preference — macOS runners queue for tens of
@@ -251,11 +251,11 @@ minutes where every other platform queues for two, and GitHub Free gives an
 organization twenty concurrent jobs shared across every repository in it,
 which a matrix on every commit spends before a reviewer is reached.
 `test.yml`'s header carries the numbers and the command that re-derives
-them, `windows.yml`'s the rest of the second, and `ubuntu.yml`'s header is
+them, `os-windows.yml`'s the rest of the second, and `os-ubuntu.yml`'s header is
 the argument the other two point at. `release` calls all three, so what a
 merge does not wait for a publication still does.
 
-`latest` is the one that covers a gap nothing else does. Every uv command
+`deps-latest` is the one that covers a gap nothing else does. Every uv command
 elsewhere passes `--locked`, the dependency groups declare no version, and
 the one runtime dependency is cffi — which this package does not merely
 import but *compiles against*, so a cffi, setuptools or cmake release can
@@ -265,7 +265,7 @@ and pinned by no lock file. Dependabot is weekly and lands the morning
 after this runs, which is the other half of the arrangement: the sentinel
 answers first, so the pull requests that arrive next are a diff whose
 result is already known. `.github/dependabot.yml` carries that reasoning
-where the day is set, and `latest.yml`'s cron comment where this one is.
+where the day is set, and `deps-latest.yml`'s cron comment where this one is.
 
 `mutation` is scoped by `.github/mutation/bindings.toml`, which is also
 what a local run reads, so there is one statement of what is mutated and
@@ -366,8 +366,9 @@ findings.
   spend a session rediscovering them
 - **every `schedule` and `workflow_dispatch` here is inert off `main`**:
   both only run from the default branch, so a rehearsal of `release.yml`
-  cannot be dispatched from a branch, and `macos.yml`, `latest.yml` and the
-  other sentinels are reachable there through nothing at all until merged
+  cannot be dispatched from a branch, and `os-macos.yml`,
+  `deps-latest.yml` and the other sentinels are reachable there through
+  nothing at all until merged
 - **a hand-applied mutation can outlive its restore.** `(0, 1, 2, 3)` and
   `(0, 1, 1, 3)` are the same length, so restoring the file with `cp` in the
   same second leaves mtime *and* size matching what the `.pyc` recorded, and
@@ -391,7 +392,7 @@ findings.
   those files being hex and nothing else. Adding to either side fails its
   hook until that baseline is regenerated; both commands are in
   CONTRIBUTING.md, and reading the diff is the point of a baseline
-- **the `published` workflow went green with 0.7.1**, on 4 August 2026,
+- **the `pypi-published` workflow went green with 0.7.1**, on 4 August 2026,
   nineteen cells out of nineteen, having been nineteen out of nineteen red
   the day before: 0.4.0 had no arm64 wheel and its sdist no longer built,
   so that red was a fact about what users could install rather than a

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,10 @@
 # Code of Conduct
 
-Everyone interacting in the btclib project's codebases, issue trackers,
-chat rooms, and mailing lists is expected to follow the
-[PSF Code of Conduct](https://www.python.org/psf/conduct/).
+Everyone interacting in a btclib-org project — its codebase, its issue
+tracker, its pull requests and its discussions — is expected to follow
+the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
+
+The copy in [btclib-org/.github](https://github.com/btclib-org/.github)
+is what GitHub shows for a repository of the organization carrying none
+of its own. A repository that does carry one carries this same file, so
+that no repository of the organization advertises a second policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,12 +194,12 @@ read by every checkout of this repository.
 | `claude-review` | pull request, and `@claude` in a comment | — |
 | `vendored-vectors` | weekly, a change to itself | — |
 | `codeql` | push to main, and weekly | the two scanned languages |
-| `ubuntu` | weekly, a release | both ubuntu images × every interpreter |
-| `macos` | weekly, a release | both macOS images × every interpreter |
-| `windows` | weekly, a release | both Windows images × every interpreter |
-| `latest` | weekly | the dependencies, at their newest |
+| `os-ubuntu` | weekly, a release | both ubuntu images × every interpreter |
+| `os-macos` | weekly, a release | both macOS images × every interpreter |
+| `os-windows` | weekly, a release | both Windows images × every interpreter |
+| `deps-latest` | weekly | the dependencies, at their newest |
 | `links`, `mutation` | weekly | — |
-| `published` | weekly, a release | what PyPI serves |
+| `pypi-published` | weekly, a release | what PyPI serves |
 | `release` | a tag | calls the gates and the rows marked *a release* |
 
 The first two rows are what a merge waits for, and the suite cell among them
@@ -220,8 +220,8 @@ minutes rather than for two, and the twenty-one Windows suite cells were
 27.3 of a run's 112.9 runner-minutes, the largest family of jobs in it and
 ahead of every wheel build. The numbers are in `test.yml`'s header.
 
-**What the sentinels vary, they vary whole.** `ubuntu` runs both images on
-every interpreter, the cell the gate already covers included. A matrix with
+**What the sentinels vary, they vary whole.** `os-ubuntu` runs both images
+on every interpreter, the cell the gate already covers included. A matrix with
 the gate's cell cut out of it is one nobody can read the shape of, and
 whoever asked what ran would have to re-derive the hole from the gate.
 
@@ -239,10 +239,11 @@ whole. `test.yml` carries the measurement beside the step.
 What a pull request no longer asks is pip's *selection* among a directory of
 wheels tagged for several interpreters, which now runs nowhere; the wheel
 each interpreter would get is still tested by the job that builds it, and
-`ubuntu`, `macos` and `windows` still compile both linkages from the tree on
-every interpreter. What no run asks at all is the suite against the dynamic
-wheel as a package — the sentinels compile that linkage from the tree
-instead. `ubuntu.yml`'s header records both costs beside each other.
+`os-ubuntu`, `os-macos` and `os-windows` still compile both linkages from
+the tree on every interpreter. What no run asks at all is the suite
+against the dynamic wheel as a package — the sentinels compile that
+linkage from the tree instead. `os-ubuntu.yml`'s header records both
+costs beside each other.
 
 Everything but the first two rows also takes `workflow_dispatch`, which for
 `codeql` and the three platform workflows is the only way to ask about a
@@ -376,14 +377,14 @@ command at all, for the reason above, and no longer gates.
       sphinx-build -W --keep-going -b html docs/source docs/build/html
   ```
 
-The `published` workflow has no local equivalent by design: what it
+The `pypi-published` workflow has no local equivalent by design: what it
 installs is what PyPI serves.
 
 The sentinels beside it gate nothing, so a red one is read in the Actions
 tab rather than fixed on a branch. Each is dispatchable, and all but `links`
 run locally.
 
-- `ubuntu`, `macos` and `windows`, which are the suite on both images of
+- `os-ubuntu`, `os-macos` and `os-windows`, the suite on both images of
   a platform and on every interpreter, so only the row matching the
   machine at hand reproduces. A cell is these two commands in this order —
   the coverage job's own command without `--cov`, run once against each
@@ -402,9 +403,9 @@ run locally.
   asks is whether an (image, interpreter) pair passes, and coverage is
   measured and gated once, on the gate's cell
 
-- `latest`, which resolves every dependency at its newest before running
-  the suite. The upgrade rewrites `uv.lock`, so restore it afterwards with
-  `git checkout uv.lock`:
+- `deps-latest`, which resolves every dependency at its newest before
+  running the suite. The upgrade rewrites `uv.lock`, so restore it
+  afterwards with `git checkout uv.lock`:
 
   ```shell
   uv lock --upgrade

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,6 +255,13 @@ own equivalent: every `automodule` directive imports this package, which
 means compiling libsecp256k1 first. Coverage is measured in branch mode
 and gated by the `fail_under` ratchet in `pyproject.toml`.
 
+The group flags are not decoration. `uv run` syncs the environment
+itself, and without `--no-default-groups --group test` it installs the
+whole dev set, which is how the coverage job came to install twenty-nine
+packages after deliberately installing ten. After touching
+`pyproject.toml`, `uv lock` — the `uv-lock` hook does it too, and then the
+gate is a second run.
+
 **Check exit codes, not filtered output.** `pre-commit run ... | grep -v
 Passed` hides a failure, and `grep` finding nothing exits 1, which is not
 the gate's answer to anything.
@@ -635,6 +642,23 @@ tree's prose:
   branch, so a release always needs the tagged commit
 
 ### What gates a merge, and what only reports
+
+`.pre-commit-config.yaml` is the single definition of what "clean" means,
+and the `lint` workflow runs that very file, so what CI enforces is what
+the local gate enforces. Never add a check that exists only in a
+workflow, and never leave a hook weaker locally than on a runner: a hook
+that needs a tool the developer may not have carries it in
+`additional_dependencies`, which is why `actionlint` ships `shellcheck-py`
+and `zizmor` is a `local` hook pinned to a version. A check discovered by
+CI after a push is a check in the wrong place.
+
+The aggregate of `test`, the `lint` job and the documentation build are
+the required checks, and `REPOSITORY.md` reads that rule back from the
+endpoint rather than restating it. `release` reuses all three. Everything
+else reports: a sentinel opens no issue when it fails, `vendored-vectors`
+excepted for the reason its own header gives, because each is expected to
+go red for something no pull request introduced and a red check nobody
+can act on from a branch is noise.
 
 | workflow | when | what it varies |
 | --- | --- | --- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,7 +517,7 @@ command at all, for the reason above, and no longer gates.
       sphinx-build -W --keep-going -b html docs/source docs/build/html
   ```
 
-The `pypi-published` workflow has no local equivalent by design: what it
+The `pypi-install` workflow has no local equivalent by design: what it
 installs is what PyPI serves.
 
 The sentinels beside it gate nothing, so a red one is read in the Actions
@@ -672,7 +672,7 @@ can act on from a branch is noise.
 | `os-windows` | weekly, a release | both Windows images × every interpreter |
 | `deps-latest` | weekly | the dependencies, at their newest |
 | `links`, `mutation` | weekly | — |
-| `pypi-published` | weekly, a release | what PyPI serves |
+| `pypi-install` | weekly, a release | what PyPI serves |
 | `release` | a tag | calls the gates and the rows marked *a release* |
 
 The first two rows are what a merge waits for, and the suite cell among them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,172 @@
-# How to contribute
+# Contributing
 
-<!-- The toolchain badges are here rather than in the README because they
-report no state: each names a choice, and this is the file that says how
-the choice is enforced and what the command for it is. The README keeps the
-badges that can turn red. btclib and bitcoin-core-rpc do the same, with a
-cal_ver badge this project has no use for: the version tracks the vendored
-libsecp256k1 release rather than the calendar. -->
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![format: ruff](https://img.shields.io/badge/format-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/formatter/)
-[![lint: ruff](https://img.shields.io/badge/lint-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/)
-[![docstrings: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d)
-[![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/)
-[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
-[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
-
-Thank you for investing your time in this project. What follows is how to
-build and test these bindings, and what this repository
-expects of a change. What the build itself does on each platform is in
-the [Build](./README.md#build) section of the README, which is not repeated
-here.
-
-Please read the [Code of Conduct](./CODE_OF_CONDUCT.md) too.
-
-What this repository holds in common with its siblings — the toolchain,
-the lint gate, the tool tables behind it, the workflow set and the branch
-rules — is stated once in the
-[btclib-org repository standard](https://github.com/btclib-org/.github/blob/main/README.md),
+What this repository holds in common with the others of the organization
+— the toolchain, the lint gate, the tool tables behind it, the workflow
+set and the branch rules — is stated once in the
+[btclib-org repository standard](https://github.com/btclib-org/.github),
 each rule with the alternative it was decided against. It binds this
 repository, so a change departing from it is a divergence, and one filed
 as an issue in that repository rather than here: a difference between two
 repositories belongs to neither of them.
 
-## Which project is this
+**This file is the same in every repository of the organization up to
+its last section.** What is true of one tree only — the commands that
+build its environment, the gates it runs, which of its workflows decide
+a merge — is under that heading, and the comparison stops there.
+
+## The issue tracker
+
+Where an issue is filed, and what an alignment finding has to name, is
+[the standard's *What this repository is*][s-what]: an issue spanning
+repositories, or whose subject is the standard, goes to
+[btclib-org/.github](https://github.com/btclib-org/.github/issues), and
+one about this tree alone stays here.
+
+A finding noticed while doing something else is filed, not carried.
+`REVIEWING.md`'s *Every collateral finding becomes an issue* is the whole
+of what to do with one, and it applies to an author as much as to a
+reviewer: a pull request answering two questions cannot be accepted for
+either.
+
+## Documentation and comments
+
+[Section 9 of the standard][s9] is the prose style, and it governs the
+prose this tree ships — comments, docstrings and markdown. It is not
+restated here: a second wording is the one that goes stale, which is
+that section's own *One fact in one place*.
+
+A commit message is prose this tree ships too, though section 9 does not
+say so: squash is the only merge method and the landing commit carries
+the messages, so what is written in one is read on `main` long after the
+branch is gone.
+
+## Pull requests
+
+What `main` accepts, and what it refuses to everyone, is [section 11 of
+the standard][s11]. Run the gates locally before opening anything —
+the last section of this file says which they are — because CI runs
+exactly them, so a red run there is a local run that was not done.
+
+What a pull request's title and description have to say about the issues
+it closes, and why a manual link in the Development panel is a trap
+neither of them shows, is [the standard's *What a pull request says it
+is*][s-title]. Read it before opening one; it is the rule most often
+found broken after the fact.
+
+`REVIEWING.md` is the standard a review is written against, and is this
+file's other half. Read before opening a pull request, it is what the
+pull request will be answered against.
+
+`CHANGELOG.md` gets an entry for anything a reader would notice, and the
+release notes move only for something a user has to *act* on, in the
+repositories that publish.
+
+### One subject, opened as soon as it is written
+
+A pull request answers one question. Issues that share a subject are one
+pull request, closing each of them; issues that do not are one pull
+request each, however small either of them is.
+
+It is opened the moment it is written and verified — not held for the
+previous one to be reviewed or to land, and not batched with the next. A
+batch arrives as one reviewing job with several subjects, which is the
+shape that costs the most to read; a finished pull request held back is
+review that could have started and did not.
+
+Working this way stacks branches, which is fine and costs one rule: a
+child whose base was amended is moved with the old base named,
+
+```shell
+git rebase --onto <new-base> <old-base-sha> <child>
+```
+
+because a plain rebase replays the base's old commit inside the child,
+and the forge then shows the base's old text as additions with nothing
+red anywhere. Read the child's diff afterwards rather than trusting the
+rebase, and retarget each child onto `main` as its parent lands.
+
+### The review
+
+A review is given promptly and on local evidence. It does not wait for
+CI, does not report a check as a finding, and does not discuss a run at
+all: whether CI is green is the author's business, once, at landing time.
+
+The exchange is anchored to a sha rather than to a branch, a branch being
+free to move under a review:
+
+- the author hands off by naming the sha pushed and the evidence run
+  against it, then leaves that head alone;
+- the reviewer answers with findings — where, what is wrong, how they
+  know it, and whether each is blocking;
+- the author accepts what is reasonable, declines the rest with a reason
+  in the thread, and pushes the answer without waiting for CI;
+- the reviewer resolves the threads they opened, that being what says a
+  finding is closed, and re-reviews the delta rather than the branch.
+
+**What ends the loop is the ack of record**, and the author does not
+supply their own. A reading that says what it found and delivers no
+verdict is a review too and ends nothing; [the standard's *Review*][s-rev]
+has which is which, and `REVIEWING.md` has how each is written. A
+disagreement that survives a second exchange goes to the maintainer
+instead of into a third round.
+
+### Landing it
+
+CI is read once, and this is where. Rebase onto `main`'s tip, push that
+head so the checks run on the tree that will land, and only then wait for
+them: checks read before a rebase describe a tree nobody is landing. A
+rebase that moved nothing but the base leaves the ack standing; one that
+resolved a conflict does not, that resolution being a change no reviewer
+has seen.
+
+Then squash, [the only method the rule accepts][s11].
+
+**The maintainer's bypass is not automatic — it has to be invoked, and
+`gh pr merge` cannot invoke it**, refusing client-side before it asks
+GitHub anything:
+
+```text
+Pull request is not mergeable: the base branch policy prohibits the merge
+```
+
+The merge endpoint applies it server-side, and it is the same endpoint
+the merge button asks:
+
+```shell
+gh api -X PUT repos/{owner}/{repo}/pulls/<n>/merge \
+  -f merge_method=squash
+```
+
+**Verify what landed rather than trusting the answer**, the signature
+[the standard asks for][s-sigs] being a valid one rather than a
+particular signer's:
+
+```shell
+gh api repos/{owner}/{repo}/commits/main \
+  --jq '.commit.verification | {verified, reason}'
+```
+
+The forge deletes the head branch itself, per the setting section 11
+names. What is still yours is bringing every checkout sitting on `main`
+up to date,
+that being where the next session starts from and a stale one being where
+a branch gets built on a base that has moved. `REPOSITORY.md` carries the
+settings and why they are what they are.
+
+[s-what]: https://github.com/btclib-org/.github#what-this-repository-is
+[s11]: https://github.com/btclib-org/.github#11-github-settings
+[s9]: https://github.com/btclib-org/.github#9-prose-comments-and-docstrings
+[s-title]: https://github.com/btclib-org/.github#what-a-pull-request-says-it-is
+[s-rev]: https://github.com/btclib-org/.github#review
+[s-sigs]: https://github.com/btclib-org/.github#signatures
+
+## This repository in particular
+
+Everything above is the same file in every repository of the
+organization; everything below is this one's, and the comparison stops at
+this heading.
+
+### Which of three repositories this is
 
 These are thin python bindings to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1). Three
@@ -52,33 +186,38 @@ to route:
   the argument validation at the cffi boundary, the packaging, and the
   wheels
 
-A vulnerability is never an issue: see the
-[security policy](./SECURITY.md).
-
-## Opening an issue
-
-Search the [issues](https://github.com/btclib-org/btclib-secp256k1/issues)
-and [pull requests](https://github.com/btclib-org/btclib-secp256k1/pulls)
-first, then use one of the
-[forms](https://github.com/btclib-org/btclib-secp256k1/issues/new/choose).
 The bug form asks which of the three artifacts is installed — a static
 wheel, a dynamic one, or a build from the sdist — because they differ in
-how libsecp256k1 is linked and a bug is rarely in all three.
+how libsecp256k1 is linked and a bug is rarely in all three. A
+vulnerability is never an issue: see the
+[security policy](./SECURITY.md).
 
-Issues are not assigned to anyone: if one interests you, you are welcome
-to open a pull request for it.
+### The environment and the gates
 
-## Building and testing
+<!-- The toolchain badges are here rather than in README.md because they
+report no state: each names a choice, and this is the section that says
+how the choice is enforced and what the command for it is. They are under
+this heading rather than at the top of the file because everything above
+it is the same file in every repository of the organization, so nothing
+at the top of it can be one repository's. The README keeps the badges
+that can turn red. -->
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![format: ruff](https://img.shields.io/badge/format-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/formatter/)
+[![lint: ruff](https://img.shields.io/badge/lint-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/)
+[![docstrings: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d)
+[![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/)
+[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
+[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
-The btclib_secp256k1 project includes
-[libsecp256k1](https://github.com/bitcoin-core/secp256k1)
-as submodule in the secp256k1 folder.
-By default, when cloning a project you get the directories that contain
-submodules, but none of the files within them.
-You must run `git submodule init` to initialize
-your local configuration file,
-and `git submodule update` to fetch the submodule data
-and check out the appropriate commit.
+uv is the only thing that has to be installed; it fetches interpreters
+and tools itself. A C toolchain is the second prerequisite, this package
+compiling the vendored library and an extension against it, and the
+[Build](./README.md#build) section of the README says what each platform
+needs.
+
+The vendored library is a submodule, and a clone gets the directory
+without the files in it, so a checkout is two commands before it is
+anything:
 
 <!-- markdownlint-disable MD013 -->
 ```console
@@ -89,47 +228,110 @@ Cloning into 'secp256k1'...
 ```
 <!-- markdownlint-enable MD013 -->
 
-The project uses [uv](https://docs.astral.sh/uv/) to manage the
-development environment. The interpreter it is built on is pinned in
-`.python-version`, and uv installs it if missing: neither pyenv nor a
-hand-made virtualenv is needed. The development dependencies are the
-PEP 735 groups declared in `pyproject.toml`.
+Then the environment. `.python-version` pins the interpreter and uv
+installs it if it is missing, so neither pyenv nor a hand-made virtualenv
+is needed; the development dependencies are the PEP 735 groups declared
+in `pyproject.toml`.
 
 ```shell
-uv sync
+uv sync --locked
 ```
 
-This also builds and installs the extension in editable mode, so the
-C toolchain the README describes must be available.
+That also builds and installs the extension in editable mode, which is
+the minutes rather than seconds part of it.
 
-To build:
+Three gates decide a merge, and each command below is the one its
+workflow runs:
 
 ```shell
-uv build --sdist
-uv build --wheel
+uv run --locked --only-group lint pre-commit run --all-files
+uv run --locked --no-default-groups --group test pytest --cov
+uv run --locked --no-default-groups --group docs \
+    sphinx-build -W --keep-going -b html docs/source docs/build/html
 ```
 
-To test:
+The documentation build needs the submodule checked out, unlike btclib's
+own equivalent: every `automodule` directive imports this package, which
+means compiling libsecp256k1 first. Coverage is measured in branch mode
+and gated by the `fail_under` ratchet in `pyproject.toml`.
+
+**Check exit codes, not filtered output.** `pre-commit run ... | grep -v
+Passed` hides a failure, and `grep` finding nothing exits 1, which is not
+the gate's answer to anything.
+
+**The lint gate is not installed as a git hook.** `pre-commit install`
+writes into the common git directory, which every worktree of this
+repository shares:
 
 ```shell
-uv run pytest
+git -C <worktree> rev-parse --git-path hooks
 ```
 
-To measure the code coverage provided by tests:
+answers with the primary checkout's `.git/hooks`, so one session
+installing it installs it for every other. Run the gate by hand before
+committing.
+
+Two hooks are regenerated rather than fixed when they fail. The test data
+is private keys, so `detect-secrets` would report all of it; the known
+findings are recorded as reviewed rather than excluded, in two baselines
+that differ only in whether the entropy detectors run. Adding a hex
+constant to a test module, or a vector to a file under `tests/` matching
+`*.csv` or `*.json`, fails the corresponding hook until its baseline is
+regenerated:
 
 ```shell
-uv run pytest --cov
+# the tree, entropy detectors on. --slim omits `line_number` and
+# `generated_at`, so the file stops changing when a flagged line
+# moves; a fresh scan rather than `--baseline`, which writes the full
+# form whatever it read -- `--slim` reaches `format_for_output` only on
+# the branch that prints to stdout -- and therefore the exclusion
+# spelled out rather than read back from the baseline's own filter
+uvx --from detect-secrets detect-secrets scan --slim \
+    --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
+    > .secrets.baseline
+
+# the vendored vector data, entropy detectors off: these files are
+# 64-character hex and nothing else, so a new vector would read as a
+# new secret. The paths are the hook's `files` pattern spelled out
+uvx --from detect-secrets detect-secrets scan --slim \
+    --disable-plugin HexHighEntropyString \
+    --disable-plugin Base64HighEntropyString \
+    tests/*.csv tests/*.json \
+    > .secrets.vectors.baseline
 ```
 
-Coverage is measured in branch mode and gated by the `fail_under`
-ratchet in `pyproject.toml`; the same check runs in CI.
+Both are slim, and what that costs is one field of the diff: a new secret
+still arrives as a new `hashed_secret` under its filename, and finding
+*where* it is takes a grep instead of a line number. `detect-secrets
+audit` needs the full form and says so, which is a reason to regenerate
+without `--slim` for an audit rather than to keep the churn in the
+committed file.
 
-To run everything CI checks before a PR, i.e. the formatter, the
-linters and the type checker:
+The redirect costs a second thing, which is the one to know before
+auditing: `--baseline` does not only save, it **merges**, and what it
+carries forward is exactly the audit's product — `is_secret` and
+`is_verified` per finding, "verification of secrets, both automated and
+manual" in its own words. A scan into a file has no old baseline to
+merge, so those marks go back to their defaults, and slim output prints
+no `is_secret` at all when it is unset: the loss shows up as a diff of
+nothing. `jq '[.results[][]] | length' .secrets.baseline` (and the same
+against `.secrets.vectors.baseline`) is how to check whether there is
+anything to lose — every finding in either file being unverified and none
+carrying `is_secret` means there isn't, today — but an audit's marks want
+saving elsewhere or re-applying after the next regeneration. Read the
+diff before committing it, which is the whole point of a baseline: what
+appears there is what nobody has looked at yet.
 
-```shell
-uv run pre-commit run --all-files
-```
+Two things the gates enforce about the prose, which section 9 of the
+standard states as a rule and does not say is checked here. `pydoclint`
+requires an `Args` entry per parameter and a `Returns` section, in the
+Google style napoleon renders, so a new argument nobody documented fails
+the lint gate; `Raises` is not enforced, and `pyproject.toml` says why
+beside the setting that turns it off. And anything written as a doctest,
+in a docstring or in `README.md`, is run by `tests/test_examples.py` on
+every interpreter and every kind of wheel — which constrains an example
+to be deterministic: fixed keys, and a verification rather than a
+signature wherever the value depends on randomness that is not pinned.
 
 To time these bindings against the other python wrappers of
 libsecp256k1, clone
@@ -172,7 +374,14 @@ UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --python 3.10 --no-cache pytest
 `.gitignore` matches that name with `.venv*/`, the comment beside the
 pattern saying what ships the environment when nothing matches it.
 
-### The editor
+To build the distributions:
+
+```shell
+uv build --sdist
+uv build --wheel
+```
+
+#### The editor
 
 `.vscode/settings.json` and `.vscode/extensions.json` are tracked, and they
 hold no preference: the recommended extensions are the tools
@@ -184,82 +393,6 @@ at the commit that trips over it.
 Anything machine-local — an interpreter path, a telemetry answer, a theme —
 belongs in the editor's own user settings instead, those two files being
 read by every checkout of this repository.
-
-### What runs when
-
-| workflow | when | what it varies |
-| --- | --- | --- |
-| `test` | pull request, push | the wheels, the sdist, one suite cell |
-| `lint`, `docs` | pull request, push | — |
-| `claude-review` | pull request, and `@claude` in a comment | — |
-| `vendored-vectors` | weekly, a change to itself | — |
-| `codeql` | push to main, and weekly | the two scanned languages |
-| `os-ubuntu` | weekly, a release | both ubuntu images × every interpreter |
-| `os-macos` | weekly, a release | both macOS images × every interpreter |
-| `os-windows` | weekly, a release | both Windows images × every interpreter |
-| `deps-latest` | weekly | the dependencies, at their newest |
-| `links`, `mutation` | weekly | — |
-| `pypi-published` | weekly, a release | what PyPI serves |
-| `release` | a tag | calls the gates and the rows marked *a release* |
-
-The first two rows are what a merge waits for, and the suite cell among them
-is one: `ubuntu-latest` on the interpreter `.python-version` pins, measured
-for coverage. Which day each of the rest runs, and at which minute, is
-section 10 of the organization standard in `btclib-org/.github` and not this
-file's to restate — one calendar covering the organization is one thing to
-remember, and a copy of it per repository is one more thing to keep true in
-each.
-
-Why so little gates is one number: GitHub Free gives an organization twenty
-concurrent jobs (as of 2026-08-21), shared across every repository in it. A
-commit here, in btclib and in bitcoin-core-rpc each ask for more jobs than
-that ceiling alone allows, so a pull request in any of the three spent its
-wall clock waiting for a slot. At that ceiling a cell before a review buys a
-rarer answer at the price of every review: macOS runners queue for tens of
-minutes rather than for two, and the twenty-one Windows suite cells were
-27.3 of a run's 112.9 runner-minutes, the largest family of jobs in it and
-ahead of every wheel build. The numbers are in `test.yml`'s header.
-
-**What the sentinels vary, they vary whole.** `os-ubuntu` runs both images
-on every interpreter, the cell the gate already covers included. A matrix with
-the gate's cell cut out of it is one nobody can read the shape of, and
-whoever asked what ran would have to re-derive the hole from the gate.
-
-**Every image still builds wheels on every pull request**: `cibuildwheel`
-runs the suite against each wheel as it builds it, and the release publishes
-the artifacts of a run that built every one. What narrows on a branch is how
-many per image — one interpreter's rather than every interpreter's, ubuntu
-included — because what a pull request asks of an image is whether this tree
-still builds there, and the toolchain, the CMake build of the vendored
-library and the cffi extension are what differ per image rather than per
-interpreter. Nothing on a branch reads past that first build: `check-dist`
-installs one wheel by path and takes it from `build-dynamic`, which builds
-whole. `test.yml` carries the measurement beside the step.
-
-What a pull request no longer asks is pip's *selection* among a directory of
-wheels tagged for several interpreters, which now runs nowhere; the wheel
-each interpreter would get is still tested by the job that builds it, and
-`os-ubuntu`, `os-macos` and `os-windows` still compile both linkages from
-the tree on every interpreter. What no run asks at all is the suite
-against the dynamic wheel as a package — the sentinels compile that
-linkage from the tree instead. `os-ubuntu.yml`'s header records both
-costs beside each other.
-
-Everything but the first two rows also takes `workflow_dispatch`, which for
-`codeql` and the three platform workflows is the only way to ask about a
-branch at all. `claude-review` is the exception that takes none: both its
-jobs read the pull request or the comment that triggered them, so a manual
-run would start with nothing to read.
-
-`codeql` runs on `main` and on its weekly schedule and not on a pull
-request, which is the same arithmetic as the rows above: three slots held
-while a review waits. What still reads a branch before it merges is
-`zizmor`, a `pre-commit` hook and therefore part of `lint`, which audits
-these workflows for an injected expression; REPOSITORY.md has the trade in
-full. It is also the one workflow with no local command: reproducing it
-means the CodeQL CLI, a bundle GitHub distributes rather than a dependency
-`uv.lock` can pin, so what answers a finding is the run itself and the
-Security tab beside it.
 
 ### Running what CI runs
 
@@ -469,252 +602,110 @@ run locally.
   that raised, which is Cosmic Ray not having measured rather than a test
   that is missing.
 
-## What a change has to satisfy
+### What a change here has to satisfy
 
-`main` is the only long-lived branch, so that is what a pull request
-targets and where every change lands; a tag on `main` is a release.
+Past the gates above, and past what section 9 of the standard asks of any
+tree's prose:
 
-- **the pre-commit hooks pass.** `uv run pre-commit run --all-files` runs
-  the formatter, the linters and the type checker; the `lint` workflow
-  runs that very configuration, so what CI enforces is what the hook
-  does. `uvx pre-commit install` makes it a commit hook
-- **the tests pass with full coverage.** `uv run pytest --cov`; the
-  `fail_under` ratchet in `pyproject.toml` is what makes the number mean
-  something, so new code arrives with the tests that cover its branches
-- **the secret-scanning baseline follows the vectors.** The test data is
-  private keys, so `detect-secrets` would report all of it; the known
-  findings are recorded as reviewed rather than excluded, in two baselines
-  that differ only in whether the entropy detectors run. Adding a hex
-  constant to a test module, or a vector to a file under `tests/` matching
-  `*.csv` or `*.json`, fails the corresponding hook until its baseline is
-  regenerated:
-
-  ```shell
-  # the tree, entropy detectors on. --slim omits `line_number` and
-  # `generated_at`, so the file stops changing when a flagged line
-  # moves; a fresh scan rather than `--baseline`, which writes the full
-  # form whatever it read -- `--slim` reaches `format_for_output` only on
-  # the branch that prints to stdout -- and therefore the exclusion
-  # spelled out rather than read back from the baseline's own filter
-  uvx --from detect-secrets detect-secrets scan --slim \
-      --exclude-files '^(\.secrets\..*baseline|tests/.*\.(csv|json))$' \
-      > .secrets.baseline
-
-  # the vendored vector data, entropy detectors off: these files are
-  # 64-character hex and nothing else, so a new vector would read as a
-  # new secret. The paths are the hook's `files` pattern spelled out
-  uvx --from detect-secrets detect-secrets scan --slim \
-      --disable-plugin HexHighEntropyString \
-      --disable-plugin Base64HighEntropyString \
-      tests/*.csv tests/*.json \
-      > .secrets.vectors.baseline
-  ```
-
-  Both are slim, and what that costs is one field of the diff: a new
-  secret still arrives as a new `hashed_secret` under its filename, and
-  finding *where* it is takes a grep instead of a line number.
-  `detect-secrets audit` needs the full form and says so, which is a
-  reason to regenerate without `--slim` for an audit rather than to keep
-  the churn in the committed file.
-
-  The redirect costs a second thing, which is the one to know before
-  auditing: `--baseline` does not only save, it **merges**, and what it
-  carries forward is exactly the audit's product — `is_secret` and
-  `is_verified` per finding, "verification of secrets, both automated and
-  manual" in its own words. A scan into a file has no old baseline to
-  merge, so those marks go back to their defaults, and slim output prints
-  no `is_secret` at all when it is unset: the loss shows up as a diff of
-  nothing. `jq '[.results[][]] | length' .secrets.baseline` (and the
-  same against `.secrets.vectors.baseline`) is how to check whether
-  there is anything to lose — every finding in either file being
-  unverified and none carrying `is_secret` means there isn't, today —
-  but an audit's marks want saving elsewhere or re-applying after the
-  next regeneration.
-
-  read the diff before committing it, which is the whole point of a
-  baseline: what appears there is what nobody has looked at yet
 - **new wrapped functionality is validated against external vectors.**
   A test that compares these bindings against themselves proves nothing.
   `tests/test_vectors.py` documents where each vendored vector file comes
   from — BIP340, RFC6979, trezor-firmware — and a new wrapper should
-  reach for something published elsewhere in the same way
+  reach for something published elsewhere in the same way. A test's
+  docstring says which side of the assertion is the independent one,
+  which is why a docstring is required of a test at all: the name says
+  which call is under test, and not what is being claimed about it
 - **a new wrapper checks sizes and delegates the rest.** What the
   boundary is for is stopping a short buffer from reaching a bare
   pointer; whether the bytes are a valid key, point or signature is
   libsecp256k1's answer to give, and an argument of the wrong size or
   form raises rather than being padded or reinterpreted into a valid one.
   The reasoning is in the README, under What the boundary checks
-- **the prose satisfies the section below.** The workflows, the build
-  scripts and the configuration files in this repository carry the
-  reasoning behind their choices, because that is the part a reader
-  cannot recover, and a hook can check that a docstring exists but not
-  what it says
+- **warnings are errors** (`filterwarnings`), because the spread of
+  interpreters this package claims turns a deprecation into a breakage
+- **the version is declared once,** in `pyproject.toml`, and
+  `__version__` reads the installed metadata. Never bump it in an
+  ordinary change: releases are cut by a maintainer following
+  [RELEASING.md](./RELEASING.md), and `release.yml` checks the tag
+  against it
 - **the vendored submodule moves on purpose.** Bumping `secp256k1` is a
   change of what this package wraps: it belongs in its own pull request,
   with the version named in the README and in `RELEASE_NOTES.md` moved
   with it. Dependabot signals upstream movement but tracks the default
   branch, so a release always needs the tagged commit
 
-### Documentation and comments
+### What gates a merge, and what only reports
 
-What "satisfies" means for the prose is written down here, because a hook
-can check that a docstring exists and not what it says. It governs the
-workflows, `pyproject.toml` and `.pre-commit-config.yaml` as much as the
-package: the reasoning with its negative results is what makes those
-files reviewable rather than merely readable.
+| workflow | when | what it varies |
+| --- | --- | --- |
+| `test` | pull request, push | the wheels, the sdist, one suite cell |
+| `lint`, `docs` | pull request, push | — |
+| `claude-review` | pull request, and `@claude` in a comment | — |
+| `vendored-vectors` | weekly, a change to itself | — |
+| `codeql` | push to main, and weekly | the two scanned languages |
+| `os-ubuntu` | weekly, a release | both ubuntu images × every interpreter |
+| `os-macos` | weekly, a release | both macOS images × every interpreter |
+| `os-windows` | weekly, a release | both Windows images × every interpreter |
+| `deps-latest` | weekly | the dependencies, at their newest |
+| `links`, `mutation` | weekly | — |
+| `pypi-published` | weekly, a release | what PyPI serves |
+| `release` | a tag | calls the gates and the rows marked *a release* |
 
-**Tone of voice: neutral, factual, dry.** The same register everywhere:
-no jokes, no salesmanship, no emphasis where the fact is enough.
-Explanatory detail is wanted; decoration is not.
+The first two rows are what a merge waits for, and the suite cell among them
+is one: `ubuntu-latest` on the interpreter `.python-version` pins, measured
+for coverage. Which day each of the rest runs, and at which minute, is
+section 10 of the organization standard in `btclib-org/.github` and not this
+file's to restate — one calendar covering the organization is one thing to
+remember, and a copy of it per repository is one more thing to keep true in
+each.
 
-**Length is a cost, and the reason is what buys it.** One sentence where
-one will carry it, and a paragraph only where a shorter one would leave
-the reader wrong. Three habits lengthen prose here without adding to it,
-and each is worth deleting on sight:
+Why so little gates is one number: GitHub Free gives an organization twenty
+concurrent jobs (as of 2026-08-21), shared across every repository in it. A
+commit here, in btclib and in bitcoin-core-rpc each ask for more jobs than
+that ceiling alone allows, so a pull request in any of the three spent its
+wall clock waiting for a slot. At that ceiling a cell before a review buys a
+rarer answer at the price of every review: macOS runners queue for tens of
+minutes rather than for two, and the twenty-one Windows suite cells were
+27.3 of a run's 112.9 runner-minutes, the largest family of jobs in it and
+ahead of every wheel build. The numbers are in `test.yml`'s header.
 
-- the same reason in a second wording — not emphasis, but a second copy
-  to keep true, and the one that drifts;
-- the sentence that only introduces the next one;
-- the tour of alternatives, where the rejected one and the thing that
-  rejects it are the whole of the negative result.
+**What the sentinels vary, they vary whole.** `os-ubuntu` runs both images
+on every interpreter, the cell the gate already covers included. A matrix with
+the gate's cell cut out of it is one nobody can read the shape of, and
+whoever asked what ran would have to re-derive the hole from the gate.
 
-Nothing checks prose the way the suite checks code, so every line of it
-is one a later change can falsify in silence. That is what its length is
-weighed against.
+**Every image still builds wheels on every pull request**: `cibuildwheel`
+runs the suite against each wheel as it builds it, and the release publishes
+the artifacts of a run that built every one. What narrows on a branch is how
+many per image — one interpreter's rather than every interpreter's, ubuntu
+included — because what a pull request asks of an image is whether this tree
+still builds there, and the toolchain, the CMake build of the vendored
+library and the cffi extension are what differ per image rather than per
+interpreter. Nothing on a branch reads past that first build: `check-dist`
+installs one wheel by path and takes it from `build-dynamic`, which builds
+whole. `test.yml` carries the measurement beside the step.
 
-**A docstring states the contract.** What the function takes, what it
-returns or raises, and the rule the behaviour comes from — not a
-restatement of the name. In the package the first two are enforced:
-`pydoclint` requires an `Args` entry per parameter and a `Returns`
-section, in the Google style napoleon renders, so a new argument that
-nobody documented fails the gate. `Raises` is not enforced and is still
-required — these wrappers raise mostly through what they call, so the
-check that compares a `Raises` section with the body's own `raise`
-statements would ask the docstrings to be wrong; `pyproject.toml` says
-so where it turns that check off.
+What a pull request no longer asks is pip's *selection* among a directory of
+wheels tagged for several interpreters, which now runs nowhere; the wheel
+each interpreter would get is still tested by the job that builds it, and
+`os-ubuntu`, `os-macos` and `os-windows` still compile both linkages from
+the tree on every interpreter. What no run asks at all is the suite
+against the dynamic wheel as a package — the sentinels compile that
+linkage from the tree instead. `os-ubuntu.yml`'s header records both
+costs beside each other.
 
-A test's docstring states what it verifies: the property, the published
-vector, the failure mode, and which side of the assertion is the
-independent one. That last part is why a docstring is required of a test
-at all — the name says which call is under test, which is not the same as
-what is being claimed about it.
+Everything but the first two rows also takes `workflow_dispatch`, which for
+`codeql` and the three platform workflows is the only way to ask about a
+branch at all. `claude-review` is the exception that takes none: both its
+jobs read the pull request or the comment that triggered them, so a manual
+run would start with nothing to read.
 
-**An example is executed.** Anything written as a doctest, in a docstring
-or in README.md, is run by `tests/test_examples.py` on every interpreter
-and every kind of wheel. That constrains an example to be deterministic —
-fixed keys, and a verification rather than a signature wherever the value
-depends on randomness that is not pinned — which is the price of the one
-form of documentation this repository can gate like a test.
-
-**A comment carries the reasoning, including the negative result.** Say
-why the code is as it is and why *not* the obvious alternative. The second
-half is what stops the next reader from "fixing" a deliberate choice, and
-it is why this repository's configuration files are as long as they are.
-
-**Cite the authority.** Where behaviour comes from a BIP, an RFC, or
-libsecp256k1 itself, name it rather than asserting the behaviour as if
-these bindings had decided it. Where they deviate, say so and say why.
-
-**Measure, don't assert.** A number in prose comes from a command, and the
-command belongs beside it, so the next reader can re-measure instead of
-trusting a figure whose date they cannot see. Never state a count that
-nothing checks — an unchecked number drifts into a false claim — and never
-state how many of anything a file or a matrix holds: a stated total is a
-line every open branch has to edit, and two branches moving it to the same
-wrong number merge without a conflict. A dated measurement is the
-exception, and it is dated for exactly that reason.
-
-**One fact in one place.** Two files stating the same thing become two
-files disagreeing about it; the second one points at the first. That is
-why [REPOSITORY.md](./REPOSITORY.md) holds the repository settings and
-CLAUDE.md points at it.
-
-**No history in the prose.** Comments and docstrings say why the code is
-as it is, in the present tense; they do not tell the story of what it used
-to be. "This is here rather than X because X breaks Y" stays, whatever
-prompted it; "this used to be X, until Z" goes — unless the old spelling
-is something a caller can still encounter, in which case it is not history
-but the present. History has a file of its own,
-[RELEASE_NOTES.md](./RELEASE_NOTES.md), and the commit messages.
-
-## Pull requests
-
-The whole build and test matrix — tens of jobs, each compiling
-libsecp256k1 from source — runs on every pull request and on every push
-to it, which is deliberate: this package exists to be identical
-everywhere. It does mean a draft pull request is the polite place for
-work in progress.
-
-Every change starts with an open issue; `Closes #N` in the pull
-request's description is what closes it, once a reviewed pull request
-merges. A pull request needs an approving review from somebody other
-than its author before it can merge — GitHub refuses a self-approval.
-[REVIEWING.md](./REVIEWING.md) is the standard that review is written
-against, and is this file's other half: what a review establishes before
-it gives an ack, how a finding states its severity, and why everything it
-notices that the pull request is not about becomes an issue rather than a
-comment. Read before opening a pull request, it is what the pull request
-will be answered against. Allow maintainer edits so the branch can be
-updated for a merge, and mark review conversations resolved as you
-address them.
-
-`main` enforces four things on every commit that reaches it, not only
-at review time: a verified signature, linear history, no force push, no
-branch deletion. These run as a GitHub ruleset with no bypass actor —
-not a rule trusted to hold on its own — so a commit that is unsigned, or
-a push that rewrites history, is rejected before it is something to
-review. A verified signature is GPG, SSH or S/MIME; GitHub's
-[documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
-has what counts and how to set one up.
-
-**A correction is a commit of its own, never an amend.** Once a branch is
-pushed and under review, `git commit --amend` and a force-push replace the
-commits the review is attached to: the reviewer loses the diff they read,
-"changes since your last review" has nothing to compare against, and every
-one of those matrix jobs starts again from a commit nobody has seen. Add
-the fix on top, with a message saying what it fixes, and reply to the
-comment with the sha. Two force-pushes carry no new work, and stay right
-for that reason. One is yours: a `git rebase origin/main` on a branch
-whose base has moved, which wants the gates re-run after it, not only
-before, and a note in the pull request saying the head moved. The other
-is the maintainer's and comes at the end, your branch's own commits
-collapsed into the one about to land — the paragraph after next is where
-that is, and it is worth expecting rather than reading as a rewrite of
-the review.
-
-Nothing is lost in `main`'s history by working that way, because a pull
-request lands as one commit: a branch of several is squashed into one
-whose subject is the pull request title with its number, so the review's
-commits are the record of the review and `main` keeps one commit per
-landed change. A merge commit would put the branch's steps into `main`
-and a rebase merge would replay them one by one — `main` is linear by
-branch rule, and one change is one commit there.
-
-**How that commit reaches `main` is the squash button**, pressed by
-auto-merge once the review and the checks are in. GitHub composes it and
-signs it with its web-flow key, which is a valid signature and therefore
-all the branch rule asks for. There is no other way in: `main` takes a
-pull request and nothing else, a direct push being refused for everyone.
-REPOSITORY.md has the settings that make that true, and what the other
-two merge methods would have cost.
-
-What a pull request set to merge itself once the checks go green is
-holding is `gh pr view <n> --json autoMergeRequest`.
-
-None of that changes the shape of a correction: it is decided at the
-landing and not on the branch, so a fix added on top of a reviewed branch
-is still the right shape — by the time it is squashed the review has its
-record.
-Enabling it is the way to not wait for a matrix that compiles C on every
-platform, and what it costs is the paragraph above: GitHub signs what it
-composes, so a pull request left to merge itself lands a commit signed
-by the web-flow key rather than by the maintainer, and one whose sha the
-branch never carried. GitHub only offers it while something is still
-pending, and it merges nothing the branch rule would not have let
-through by hand.
-
-Releases are cut by a maintainer, following [RELEASING.md](./RELEASING.md);
-nothing about a version needs to be touched in a pull request.
-
-Once merged, your contribution is visible on the
-[contributors page](https://github.com/btclib-org/btclib-secp256k1/graphs/contributors).
+`codeql` runs on `main` and on its weekly schedule and not on a pull
+request, which is the same arithmetic as the rows above: three slots held
+while a review waits. What still reads a branch before it merges is
+`zizmor`, a `pre-commit` hook and therefore part of `lint`, which audits
+these workflows for an injected expression; REPOSITORY.md has the trade in
+full. It is also the one workflow with no local command: reproducing it
+means the CodeQL CLI, a bundle GitHub distributes rather than a dependency
+`uv.lock` can pin, so what answers a finding is the run itself and the
+Security tab beside it.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,3 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2026 The btclib developers
+Copyright (c) The btclib developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,7 +93,7 @@ the release it rehearses.
 
 ## Cutting a release
 
-`latest` is worth dispatching before the tag rather than waiting for its
+`deps-latest` is worth dispatching before the tag rather than waiting for its
 cron, because what it answers is cheaper to know before a version is
 consumed than after. It gates nothing, so it will not stop you: reading
 it is the point. It resolves every dependency at its newest and then runs
@@ -120,13 +120,13 @@ Updating the pinned dependencies is a decision of the same shape, and
 belongs here for the same reason: whether to run `uv lock --upgrade` (or
 wait for Dependabot's own pull requests to catch up) is not itself a
 release-timing question, `uv.lock` pinning what ships regardless of what
-`latest` resolved against. Unlike `mutation`, though, it is worth
-deciding on purpose rather than defaulting by omission: `latest`'s run
+`deps-latest` resolved against. Unlike `mutation`, though, it is worth
+deciding on purpose rather than defaulting by omission: `deps-latest`'s run
 for 0.8.0.4 found ruff 0.16.3→0.16.4, stevedore 5.9.0→5.9.1 and pygments
 2.20.0→2.21.0 already past what `uv.lock` pinned, with nobody having
-chosen either way. State the choice — upgraded, or left as `latest`
+chosen either way. State the choice — upgraded, or left as `deps-latest`
 found it, and why — in the release pull request, the same line
-`latest`'s own result already gets.
+`deps-latest`'s own result already gets.
 
 Then:
 
@@ -205,14 +205,14 @@ Then:
    and against the open sections of `CHANGELOG.md` and
    `RELEASE_NOTES.md`, which closing the release notes above has just
    closed and which are where each change was described as it landed.
-   `latest`'s result and the breaking-changes check's griffe findings
+   `deps-latest`'s result and the breaking-changes check's griffe findings
    belong here too, a line rather than a screenshot: neither gates
    anything, and a pull request that never
    mentions them having run reads exactly like one that skipped them.
 
    A deliberate skip and an item nobody has gotten to yet are different
    facts and do not fit under one checkbox: 0.7.1.2's own checklist
-   folded "dispatch `latest`" and "`mutation` is owed" into a single
+   folded "dispatch `deps-latest`" and "`mutation` is owed" into a single
    line, which could not say "skipped this once, on purpose" and "done,
    by hand and out of band" at the same time without being rewritten
    first. Separate lines for independent questions cost nothing and stay
@@ -370,13 +370,13 @@ Then:
    "
    ```
 
-   BIP340 vector 0, the same check `published` makes below. Then check
+   BIP340 vector 0, the same check `pypi-published` makes below. Then check
    the attestations, the two checks the rehearsal makes and for the same
    reasons: a compiled extension can install and not work, and the
    attestations are under `/integrity/<project>/<version>/<filename>/provenance`
    rather than in the JSON API, which answers `null` for `provenance`
    even where they are
-1. `published` no longer needs a manual dispatch to answer this for the
+1. `pypi-published` no longer needs a manual dispatch to answer this for the
    release itself: `release.yml`'s own `published` job (`needs:
    publish-pypi`) calls the same workflow directly, so by the time the run
    finishes it has already installed from PyPI what was just uploaded, on
@@ -558,7 +558,7 @@ artifacts already built.
    and `--prerelease allow` for the `.dev<run><attempt>` suffix the
    version installed carries
 1. run something with it, installing being weaker than working where a
-   compiled extension is what was installed. The check the `published`
+   compiled extension is what was installed. The check the `pypi-published`
    workflow makes — BIP340 vector 0, and the round trip of a signature
    the build makes itself — is the one to reach for, and it is worth
    reaching for here rather than only after PyPI: this is the first

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -252,8 +252,8 @@ Then:
    once `required_signatures` was read as asking for a valid signature
    and not for a particular signer — a commit GitHub composes and signs
    on merge is exactly as good a base for the release tag as one signed
-   from the command line, and CLAUDE.md now says so for every pull
-   request here, this one included.
+   from the command line, which is what section 11 of the organization
+   standard asks of every pull request here, this one included.
 
    What no landing here can cost any more is the history of a cycle. It
    could once: 0.7.1 was *Squash and merge* on a release pull request

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -370,13 +370,13 @@ Then:
    "
    ```
 
-   BIP340 vector 0, the same check `pypi-published` makes below. Then check
+   BIP340 vector 0, the same check `pypi-install` makes below. Then check
    the attestations, the two checks the rehearsal makes and for the same
    reasons: a compiled extension can install and not work, and the
    attestations are under `/integrity/<project>/<version>/<filename>/provenance`
    rather than in the JSON API, which answers `null` for `provenance`
    even where they are
-1. `pypi-published` no longer needs a manual dispatch to answer this for the
+1. `pypi-install` no longer needs a manual dispatch to answer this for the
    release itself: `release.yml`'s own `published` job (`needs:
    publish-pypi`) calls the same workflow directly, so by the time the run
    finishes it has already installed from PyPI what was just uploaded, on
@@ -558,7 +558,7 @@ artifacts already built.
    and `--prerelease allow` for the `.dev<run><attempt>` suffix the
    version installed carries
 1. run something with it, installing being weaker than working where a
-   compiled extension is what was installed. The check the `pypi-published`
+   compiled extension is what was installed. The check the `pypi-install`
    workflow makes — BIP340 vector 0, and the round trip of a signature
    the build makes itself — is the one to reach for, and it is worth
    reaching for here rather than only after PyPI: this is the first

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -318,8 +318,10 @@ gh api repos/btclib-org/btclib-secp256k1/rulesets \
   --jq '.[] | "\(.name) \(.enforcement) bypass=\(.bypass_actors | length)"'
 ```
 
-`main-integrity` is the four CONTRIBUTING.md names — a verified
-signature, linear history, no force push, no branch deletion — with **no
+`main-integrity` is the four [section 11 of the organization
+standard](https://github.com/btclib-org/.github#11-github-settings)
+names — a verified signature, linear history, no force push, no branch
+deletion — with **no
 bypass actor at all**, which is what makes "on every commit, not at
 review time" true of an administrator too, `enforce_admins` above being
 off. `main-self-merge` is the pull request rule, and names the maintainer

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -77,7 +77,7 @@ developer's own commit. Re-read that skip list before adding to it: an
 entry may join for a reason of that kind and no other.
 
 Neither `os-ubuntu.yml`, `os-macos.yml`, `os-windows.yml`, `deps-latest.yml`,
-`links.yml`, `mutation.yml`, `pypi-published.yml` nor `vendored-vectors.yml`
+`links.yml`, `mutation.yml`, `pypi-install.yml` nor `vendored-vectors.yml`
 appears in the rule, and none of them must: each is expected to go red for a
 reason no pull request introduced. The first three are the ones worth naming
 twice, because they do run the suite: what a merge no longer waits for is

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -76,12 +76,12 @@ rule names, `Lint and type-check`, checks the submodule out with
 developer's own commit. Re-read that skip list before adding to it: an
 entry may join for a reason of that kind and no other.
 
-Neither `ubuntu.yml`, `macos.yml`, `windows.yml`, `latest.yml`,
-`links.yml`, `mutation.yml`, `published.yml` nor `vendored-vectors.yml`
+Neither `os-ubuntu.yml`, `os-macos.yml`, `os-windows.yml`, `deps-latest.yml`,
+`links.yml`, `mutation.yml`, `pypi-published.yml` nor `vendored-vectors.yml`
 appears in the rule, and none of them must: each is expected to go red for a
 reason no pull request introduced. The first three are the ones worth naming
 twice, because they do run the suite: what a merge no longer waits for is
-every cell of it but one, the reasoning being in `ubuntu.yml`'s header and
+every cell of it but one, the reasoning being in `os-ubuntu.yml`'s header and
 the numbers in `test.yml`'s, and `release.yml` calls all three so that a
 publication still does.
 
@@ -647,7 +647,7 @@ GitHub free to move the numbers without notice):
 | Enterprise | 500 | 50 |
 
 **Read the second column before spending anything on the first.** The
-twenty is what `windows.yml`'s header measured against, and paying for
+twenty is what `os-windows.yml`'s header measured against, and paying for
 Team would triple it; the five is the ceiling behind the macOS queue
 `test.yml`'s header measures, and Team does not move it at all. A macOS
 column that queued for tens of minutes was far more jobs than five slots

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,14 +1,22 @@
-# Reviewing a btclib_secp256k1 pull request
+# Reviewing a pull request
 
-The standard a review of this repository is written against: what a
+The standard a review of a btclib-org repository is written against: what a
 review has to establish before it can be given, how a finding is stated,
 and what becomes of everything a reviewer notices that the diff under
 review is not about.
 
 This is the reviewer's half of [CONTRIBUTING.md](./CONTRIBUTING.md),
 which is the author's. It does not restate the rules a review cites —
-those are in that file, in REPOSITORY.md and in CLAUDE.md, and a finding
-names the line that states them rather than a copy kept here.
+most are in the organization's standard, the rest in that file, in
+REPOSITORY.md and in CLAUDE.md — and a finding names the line that
+states them rather than a copy kept here.
+
+**This file is the same in every repository of the organization**, and
+deliberately so: a review that means one thing here and another there is
+not a standard. Section 14 of that standard is what says so, and
+`tests/verbatim_test.py` of that repository is what compares the copies.
+So nothing written here may be true of one tree only, down to the last
+section: that one is this tree's, and the comparison stops at it.
 
 It is for whoever reviews: a contributor reading somebody else's pull
 request, the maintainer, an agent session that starts with the pull
@@ -39,6 +47,20 @@ directions:
   as a nit, if it is worth saying at all.
 - **Work the diff never set out to do is not a finding either.** It is
   an issue; the section below is the whole of what to do with it.
+- **Prose that does not land is a finding only where it decides
+  something.** Squash carries the branch's commit messages into the
+  landing commit, so those are tree prose and answer for themselves like
+  any other. A pull request's body does not land: it is read once, by
+  whoever presses the button. A false claim there is worth a round when
+  it is the account the landing rests on — what the change costs, what
+  it leaves owed — and is not worth one when correcting it changes
+  neither `main` nor a decision.
+
+  The reason to draw the line is that a body describes a tip that keeps
+  moving: a measurement written into it is stale by the next commit, and
+  a round spent restating it buys nothing that the next round does not
+  undo. Where a figure is worth having, the command that re-derives it
+  belongs there instead of the figure.
 
 ## What is under review
 
@@ -52,9 +74,10 @@ directions:
    the parent branch where this one is stacked. A finding that belongs
    to the parent goes on the parent's pull request — repeated on the
    child, the author answers it twice and resolves it once.
-1. **The tree at that sha**, checked out and gated. `gh pr checkout <N>`
-   and `uv sync --locked`; `CLAUDE.md` has where a checkout may be made
-   and where it may not.
+1. **The tree at that sha**, checked out and gated. `gh pr checkout <N>`,
+   and whatever this repository's `CONTRIBUTING.md` says builds its
+   environment; `CLAUDE.md` has where a checkout may be made and where it
+   may not.
 
 Read the whole diff before writing the first comment. A comment on line
 5 that line 60 answers costs the author a reply and the reviewer their
@@ -75,6 +98,12 @@ In priority order, stopping at what this diff can be wrong about:
   state, cited by the line that states it. This is the class of finding
   a review exists for: the author has the diff in view and the document
   out of view.
+- **Does a pointer say what it promises?** Read the passage cited, not
+  the term cited. That a fact exists where a reference says it does is
+  not the same as the reference being honest about it, and a search for
+  the cited term cannot tell the two apart: the passage has to say what
+  the pointer promises, at the same generality. The diff's own prose
+  about the tree takes the same treatment.
 - **Is what it adds tested and documented the way this repository tests
   and documents things?** Its `CHANGELOG.md` entry included.
 - **Is it simpler than it needs to be?** As a non-blocking finding, and
@@ -167,15 +196,15 @@ in the browser — no checkout, no editor, one click:
 
 *Add suggestion to batch* takes several of them into one commit, which
 is what to use when a review leaves more than one.
-`CONTRIBUTING.md` states the same thing from the author's side, as
-something they may apply directly through the interface.
+The author may apply one directly through the interface, which is why a
+suggestion is offered where a description would do.
 
 Two properties make this the right shape here and not merely a
 convenience: the commit GitHub writes is signed with its web-flow key,
 and `main` requires a valid signature rather than one particular
 signer; and it lands as a commit of its own on top of the branch,
-which is the shape `CONTRIBUTING.md` asks a correction to take, so the
-shas the review is attached to survive it.
+which is the shape section 11 of the standard asks a correction to take,
+so the shas the review is attached to survive it.
 
 Two properties decide when not to:
 
@@ -241,17 +270,19 @@ What this is not:
 
 ## The gates are the evidence
 
-Run them on that sha, and read **exit codes, not filtered output** — a
-pipe into `grep -v Passed` hides the failure it was meant to find. What
-the gates are, and the two ways a run of them lies, is `CLAUDE.md`: a
-suite run over a subset is not the coverage gate, and `pre-commit`
-passing is not the lint gate, sphinx being a job of its own.
+Run them on that sha, and read exit codes rather than filtered output —
+a pipe into `grep -v Passed` hides the failure it was meant to find.
+**What the gates of this tree are is `CONTRIBUTING.md`'s last
+section**, and so is every way a run of them lies — a suite run over a
+subset that is not the coverage gate, a hook set that is not the whole
+of what CI runs. A reviewer who names a
+gate this repository does not have has reported nothing.
 
 **Unless they have already been run on this sha and that run is on the
 record.** Then rely on it, and say whose it is. Two runs qualify: the
 workflows of the required checks, running beside a review on the same
-commit — `CLAUDE.md` names which checks those are — and an author handing
-over a branch they gated themselves and said so. What is relied on is
+commit — `CONTRIBUTING.md` names which checks those are — and an author
+handing over a branch they gated themselves and said so. What is relied on is
 that those gates run and hold the merge, not the colour of a check, which
 stays none of a reviewer's business for the reason below.
 
@@ -280,45 +311,39 @@ be the concurrency group as the diff; whether CI is green is the
 author's problem at landing time, and the local run is the evidence
 either way.
 
-## What a review of this tree checks that a generic one would not
+## What every review here also checks
 
-Each of these is a question, and the document that answers it is named
-because that document, and not this one, is where the rule lives.
+Each of these is a question the organization asks of every tree, and the
+document that answers it is named because that document, and not this
+one, is where the rule lives.
 
-- A change to `btclib_secp256k1/__init__.py` or to the build: does it
-  keep **both branches of `_load_lib`** right? Only one of the two — the
-  extension with libsecp256k1 linked in, or the shared object
-  `ffi.dlopen`s beside it — exists in any given wheel, so the other is
-  reachable in a test only through a stand-in. `CLAUDE.md`'s
-  "Architecture" is where that lives, and it is the answer to every
-  question of the form "why does this differ between platforms".
-- A new binding: does it carry its entry in
-  `stubs/_btclib_secp256k1.pyi`? That file is what lets strict mypy
-  typecheck a module which exists only after a build.
-- A new module: is it more than one call of another? `mult` was exactly
-  that, and was folded into `keys`. And is it one the README's Design
-  section says belongs here at all — `musig.KeyAggCache` and
-  `musig.Session` are the one place this package holds a libsecp256k1
-  object with no serialization to be one, and the reasoning for taking
-  that exception is in `musig.py`'s own module docstring.
-- A check added to a workflow: is it in `.pre-commit-config.yaml`
-  instead? `CLAUDE.md` states that file as the single definition of
-  clean, and a check discovered by CI after a push is a check in the
-  wrong place.
-- Does the diff **state a count** of anything? `CONTRIBUTING.md` says why
-  it must not, and only some of those are caught by a test.
-- If the branch was rebased: do `CHANGELOG.md` and `RELEASE_NOTES.md`
-  say what the branch meant them to say? They are `merge=union`, so
-  they never conflict and a rebase can put back a line the branch had
-  removed.
-- A new or changed workflow: the conventions in `CLAUDE.md`, and
-  `REPOSITORY.md` before any rule or setting is touched. A renamed job is
-  a required check renamed out of existence.
+- Does the diff **state a count** of anything — of files, of entries, of
+  findings, of seconds? Section 9 of the standard says why it must not,
+  and only some of those are caught by a test.
+- If the branch was rebased: does `CHANGELOG.md` still say what the
+  branch meant it to say, and the release notes with it where the
+  repository has them? Section 9 marks them `merge=union`, so they never
+  conflict and a rebase can put back a line the branch had removed.
+- A new or changed workflow: section 10 of the standard, and
+  `REPOSITORY.md` before any rule or setting is touched. A renamed job
+  is a required check renamed out of existence.
+- Is a reference to another repository **qualified**? Section 9 of the
+  standard has the rule and its one exemption, and a bare number is the
+  shape that breaks it.
+- Does the pull request's **title** say what it closes, and does its
+  description close what the title says? Section 11 has the rule, and it
+  is the one most often found broken after the fact.
+
+**What this tree checks beyond these is the last section of this file**,
+which is that repository's own. A repository whose last section names
+nothing further has nothing further to check, which is an answer and not
+a gap.
 
 ## The verdict
 
 Inline comments for the line-anchored findings, then exactly one summary
-comment whose last line is one of two forms:
+comment. **A review that decides whether the pull request lands** ends
+that comment with one of two lines:
 
 ```text
 CHANGES REQUESTED <sha>
@@ -329,15 +354,31 @@ ACK <sha>
 ```
 
 Nothing else is an ack — not "looks good", and not a forge approval,
-which `CONTRIBUTING.md` records GitHub as refusing to the author of the
-pull request. That refusal is why the record of a review here is a
+which section 11 of the standard records GitHub as refusing to the author
+of the pull request. That refusal is why the record of a review here is a
 comment at all. It names the sha because an ack belongs to a tree and
 not to a branch.
 
+**A review that does not decide ends without one, and is not an
+unfinished review.** Somebody who reads a diff and says what they found
+is worth more than the same person saying nothing because a verdict on
+the whole change was the price of speaking, and the readings worth
+having are the ones nobody was assigned. What a pull request lands on is
+the ack of record; every other comment on it is evidence a person weighs
+before pressing.
+
 The summary says, in a few lines, what was reviewed — the sha, the gates
 and their exit codes —, lists the blocking findings, and names the
-issues filed. No blocking findings and no ack is a contradiction: either
-the finding is blocking or the ack is due.
+issues filed. **In a verdict**, no blocking findings and no ack is a
+contradiction: either the finding is blocking or the ack is due. In a
+reading it is neither, the reading having declined to say.
+
+And, in either, **what was not checked**: a command that could not be
+run, an issue that could not be read, a part of the tree left unopened.
+A review that answered "does it answer its issues" against the pull
+request's own account of them, having been unable to read the issues, is
+reasoning in a circle — and has to say so, because somebody reading the
+last line alone would never see it.
 
 Post it the moment it is written, and where several pull requests are
 waiting, finish and post one before opening the next: a batch of reviews
@@ -348,8 +389,9 @@ before its child, and otherwise the oldest.
 ## Re-review
 
 The delta is `git diff <old-sha>..<new-sha>`, and there is one to read
-because `CONTRIBUTING.md` has corrections added as commits rather than
-amended in: the shas the review was attached to are still there.
+because section 11 of the standard has corrections added as commits
+rather than amended in: the shas the review was attached to are still
+there.
 
 - **Resolve every thread the author addressed, and only those.** A
   thread they declined stays open only if it is still blocking; where
@@ -381,3 +423,42 @@ amended in: the shas the review was attached to are still there.
 Ack when every blocking finding is closed, the gates passed locally on
 that sha, and the diff answers its issues. Non-blocking findings and
 nits do not hold an ack — say that they are left to the author.
+
+## This repository in particular
+
+Everything above is the same file in every repository of the
+organization; everything below is this one's, and the comparison stops at
+this heading.
+
+Each of these is a question, and the document that answers it is named
+because that document, and not this one, is where the rule lives.
+
+- A change to `btclib_secp256k1/__init__.py` or to the build: does it
+  keep **both branches of `_load_lib`** right? Only one of the two — the
+  extension with libsecp256k1 linked in, or the shared object
+  `ffi.dlopen`s beside it — exists in any given wheel, so the other is
+  reachable in a test only through a stand-in. `CLAUDE.md`'s
+  *Architecture* is where that lives, and it is the answer to every
+  question of the form "why does this differ between platforms".
+- A new binding: does it carry its entry in
+  `stubs/_btclib_secp256k1.pyi`? That file is what lets strict mypy
+  typecheck a module which exists only after a build.
+- A new module: is it more than one call of another? `mult` was exactly
+  that, and was folded into `keys`. And is it one the README's Design
+  section says belongs here at all — `musig.KeyAggCache` and
+  `musig.Session` are the one place this package holds a libsecp256k1
+  object with no serialization to be one, and the reasoning for taking
+  that exception is in `musig.py`'s own module docstring.
+- A new wrapper: is it validated against a vector published somewhere
+  other than these bindings, and does the test's docstring say which
+  side of the assertion is the independent one? Their own output
+  agreeing with itself proves nothing, and `CONTRIBUTING.md`'s *What a
+  change here has to satisfy* is where that is asked.
+- A check added to a workflow: is it in `.pre-commit-config.yaml`
+  instead? `CONTRIBUTING.md`'s last section states that file as the
+  single definition of clean, and a check discovered by CI after a push
+  is a check in the wrong place.
+- A move of the `secp256k1` submodule: is it a pull request of its own,
+  with the version named in the README and in `RELEASE_NOTES.md` moved
+  with it? Bumping it changes what this package wraps, and Dependabot
+  tracks upstream's default branch rather than its tags.

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/_cdata.py
+++ b/btclib_secp256k1/_cdata.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/_scalar.py
+++ b/btclib_secp256k1/_scalar.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/_secret.py
+++ b/btclib_secp256k1/_secret.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/context.py
+++ b/btclib_secp256k1/context.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/hashes.py
+++ b/btclib_secp256k1/hashes.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,9 +32,10 @@ PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 project = "btclib_secp256k1"
 # no __copyright__ in this package to read back, unlike btclib's own
-# conf.py: LICENSE is the only place the holder and years are declared,
-# so this reads that file instead, minus the "Copyright (c) " sphinx
-# prepends itself
+# conf.py: LICENSE is the only place the holder is declared, so this reads
+# that file instead, minus the "Copyright (c) " sphinx prepends itself.
+# What comes out carries no year, section 14 of the organization standard
+# having LICENSE name the holder and no range, so the footer dates nothing
 project_copyright = re.search(
     r"^Copyright \(c\) (.+)$",
     (ROOT / "LICENSE").read_text(encoding="utf-8"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,8 +232,8 @@ mutation = ["cosmic-ray"]
 # matching btclib's own docs group exactly: myst-parser reads the four
 # root markdown files docs/source/*_link.md includes, sphinx_rtd_theme
 # is the html theme docs/source/conf.py names, and sphinx itself compiles
-# this package to autodoc it -- the reason CONTRIBUTING.md's Build
-# section and the git submodule matter here in a way they do not for
+# this package to autodoc it -- the reason the environment section of
+# CONTRIBUTING.md and the git submodule matter here in a way they do not for
 # btclib's own pure Python build
 docs = ["myst-parser", "sphinx", "sphinx_rtd_theme"]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -576,7 +576,7 @@ max-complexity = 10
 # the hook's pattern matched only \.py$ and not \.pyi$, and ruff lints
 # .pyi files by default, so there is no second extension to remember
 # this time
-notice-rgx = "^# Copyright \\(c\\) The btclib developers\\n#\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
+notice-rgx = "^# Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/cffi_build.py
+++ b/scripts/cffi_build.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/stubs/_btclib_secp256k1.pyi
+++ b/stubs/_btclib_secp256k1.pyi
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_bytes_like.py
+++ b/tests/test_bytes_like.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_conventions.py
+++ b/tests/test_conventions.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -20,18 +20,20 @@ import re
 from pathlib import Path
 
 _ROOT = Path(__file__).parents[1]
-_HOLDER_RE = r"Copyright \([Cc]\) (\d{4})(?:-(\d{4}))? (.+)"
+# the holder line, with no year group to make a range optional: section
+# 14 of the organization standard has LICENSE name the holder and no
+# range, so a year left in the file is read as part of the holder here
+# and disagrees with `authors`, which is the direction that reports it
+# rather than tolerating it
+_HOLDER_RE = r"Copyright \([Cc]\) (.+)"
 _AUTHOR_RE = r'authors\s*=\s*\[\{\s*name\s*=\s*"([^"]+)"'
 
 
-def _license_holder() -> tuple[str, str, str]:
+def _license_holder() -> str:
     text = (_ROOT / "LICENSE").read_text(encoding="utf-8")
     match = re.search(_HOLDER_RE, text)
-    assert match, (
-        f"LICENSE has no 'Copyright (c) YYYY[-YYYY] holder' line: {text[:80]!r}"
-    )
-    start, end, holder = match.group(1), match.group(2), match.group(3)
-    return start, end or start, holder
+    assert match, f"LICENSE has no 'Copyright (c) holder' line: {text[:80]!r}"
+    return match.group(1)
 
 
 def _pyproject_author() -> str:
@@ -43,7 +45,7 @@ def _pyproject_author() -> str:
 
 def test_license_holder_matches_the_declared_author() -> None:
     """The wheel's `Author` metadata is the same holder LICENSE names."""
-    _, _, license_holder = _license_holder()
+    license_holder = _license_holder()
     author = _pyproject_author()
     assert license_holder == author, (
         f"LICENSE names {license_holder!r}, pyproject.toml's author "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_hook_pins.py
+++ b/tests/test_hook_pins.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -14,7 +14,7 @@ touches, and the person it misleads is not reading this repository.
 
 The sentinels are where the interpreter set lives because that is where
 the suite meets every interpreter: the merge gate runs one cell, on the
-version `.python-version` pins, and `ubuntu.yml`'s header says why. Each
+version `.python-version` pins, and `os-ubuntu.yml`'s header says why. Each
 of the three carries the list in full, and each of their comments says
 the other two carry the same one, so the list is read per file and the
 three are required to agree: a version added to one and forgotten in
@@ -40,7 +40,7 @@ from pathlib import Path
 
 _ROOT = Path(__file__).parents[1]
 _PYPROJECT = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-_SENTINELS = ("ubuntu.yml", "macos.yml", "windows.yml")
+_SENTINELS = ("os-ubuntu.yml", "os-macos.yml", "os-windows.yml")
 _WORKFLOWS = {
     name: (_ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
     for name in _SENTINELS

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_musig.py
+++ b/tests/test_musig.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_mutation_counts.py
+++ b/tests/test_mutation_counts.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_nonces.py
+++ b/tests/test_nonces.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_parsed_keys.py
+++ b/tests/test_parsed_keys.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_submodule_pin.py
+++ b/tests/test_submodule_pin.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_vendored_data.py
+++ b/tests/test_vendored_data.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_verified_signing.py
+++ b/tests/test_verified_signing.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -1,5 +1,4 @@
 # Copyright (c) The btclib developers
-#
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 


### PR DESCRIPTION
Brings this tree to `btclib-org/.github`, which section 14 of that
repository's `README.md` governs and which `tests/verbatim_test.py` there
measures.

## What changed

- **`CONTRIBUTING.md` and `REVIEWING.md` are verbatim in part.**
  Everything before `## This repository in particular` is the
  organization's file, byte for byte; under that heading is what belongs
  to this tree alone. What the shared half already said was deleted
  rather than reworded — the issue tracker, the prose style, pull
  requests, the review, landing it — because one fact lives in one place
  and the shared half is that place.
- **The section 14 configuration and licence files are the
  organization's copies**, byte for byte. `AUTHORS.md` points at this
  repository's own contributor graph, which is the one thing section 14
  says that file must not share.
- **`CLAUDE.md` keeps only what no document written for a human can
  hold.** The commands and the gates went to `CONTRIBUTING.md`'s last
  section, where a contributor finds them without opening an agent's
  file.
- **The workflows say what they ask, and a prefix groups a family.** File
  names and `name:` keys only: a job name is a status check's context,
  and moving one is its own migration.

## Measured

Every section 14 path diffs empty against `btclib-org/.github` at
`origin/main`, and the shared halves match at the byte counts the
standard's own `shared()` reports.

## Gates

The lint gate, the suite and the documentation build all exit 0 on the
tip, and `git status --porcelain` is empty.

## Summary by Sourcery

Align repository standards, documentation, workflow naming, and metadata with the btclib organization-wide conventions.

Enhancements:
- Align repository documentation and governance files with the organization-wide standard while retaining repository-specific guidance.
- Centralize contributor, reviewer, environment, and gate instructions in the appropriate documents to reduce duplication.
- Rename workflows and update their references to use descriptive, consistently grouped status-check names.
- Strengthen repository conventions, including YAML document-start validation and license metadata consistency.

CI:
- Update CI workflow references and concurrency identifiers to reflect the renamed dependency, platform, and PyPI installation workflows.

Documentation:
- Adopt organization-managed copies and shared sections for contribution, review, conduct, licensing, and configuration documentation.

Tests:
- Update repository checks for renamed workflows and the organization’s license-holder format.

Chores:
- Normalize copyright headers and related references across source, scripts, tests, and documentation.