### PR TITLE
The review prompt names the file that holds the gates

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -140,13 +140,13 @@ jobs:
             must contain and how it labels its severity, what becomes of
             everything you notice that the diff is not about, and the two
             forms the verdict takes. Follow it rather than the review
-            habits you would otherwise bring. CLAUDE.md has the facts
-            about this tree a review has to know, and CONTRIBUTING.md the
-            rules a finding cites.
+            habits you would otherwise bring. CONTRIBUTING.md's last
+            section has the gates and the rules a finding cites, and
+            CLAUDE.md the facts about this tree a review has to know.
 
             Do not run the gates. They are running beside you on this
             same sha, which is the reliance REVIEWING.md provides for and
-            CLAUDE.md makes sound. Review everything else the standard
+            CONTRIBUTING.md's last section makes sound. Review everything else the standard
             asks for, and say in the summary that no gates were run by
             this job and that those runs are what stands.
 


### PR DESCRIPTION
The alignment moved the gates and the required checks from `CLAUDE.md` to
`CONTRIBUTING.md`'s last section. The prompt this workflow hands a
reviewer still named `CLAUDE.md` for them, so a review was sent to a file
that no longer answers.

`btclib-org/.github` already carries the corrected wording; this takes
it.

**Why this is a pull request of its own**: the action validates its own
workflow against the default branch and refuses to run when the two
differ, failing with *"the action produced no execution file"*. A change
to this file inside another pull request therefore costs that pull
request its ack of record — which is why the alignment left it alone and
this follows it.

## Summary by Sourcery

Bug Fixes:
- Update the review prompt to identify CONTRIBUTING.md's final section as the source of review gates and finding rules.