### PR TITLE
Every step of release.yml carries a name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,8 @@ jobs:
       version-suffix: ${{ steps.suffix.outputs.version-suffix }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # the whole history, and every branch with it: the ancestry
@@ -99,7 +100,8 @@ jobs:
           # default shallow clone fetches
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # off, unlike everywhere else, and not by omission: a cache is
           # written by the jobs of a pull request and restored by this one,
@@ -334,13 +336,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*-wheels-*"
           merge-multiple: true
           path: dist
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist
@@ -349,7 +353,8 @@ jobs:
         run: ls -l dist
 
       # generates PEP 740 attestations by default
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -368,13 +373,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*-wheels-*"
           merge-multiple: true
           path: dist
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist
@@ -383,7 +390,8 @@ jobs:
         run: ls -l dist
 
       # generates PEP 740 attestations by default
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # the sdist reaches users by two routes and only one of them carried
   # provenance: the publish job above attaches a PEP 740 attestation to
@@ -425,7 +433,8 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist
@@ -456,7 +465,8 @@ jobs:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         run: cp "$BUNDLE_PATH" attestation.jsonl
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the attestation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: attestation
           path: attestation.jsonl
@@ -506,21 +516,24 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       # the sdist alone: the wheels are on PyPI, with their attestations,
       # and thirty assets mirroring an index nobody would install from by
       # hand are noise. What belongs here is the source of the tag
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist
 
       # into a directory of its own, so that the dist/* glob below stays
       # the distribution files and nothing else
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: attestation
           path: attestation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,42 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`release.yml` names its steps** (#300). The steps of this file that
+  carried no `name:` have one, where both siblings' `release.yml` names
+  all of theirs. GitHub renders an unnamed step as the command it runs,
+  so a failing job in a release run was read by expanding steps rather
+  than by scanning them, and the same step was harder to recognise across
+  the three repositories, which is the cost #300 names. Neither of the
+  divergences that issue cites was a missing name --
+  btclib-org/btclib#1141 is a step that has one and lacks `shell: bash`,
+  and btclib-org/btclib#1142 is a guard at job level -- so what a name
+  buys is that the next such comparison is made by scanning, not that it
+  would have caught either of those.
+
+  The names are the siblings' own wherever the step is theirs too:
+  `Checkout code`, `Setup uv`, `Publish to PyPI`, `Publish to TestPyPI`,
+  `Upload the attestation bundle`, `Download the attestation bundle`.
+  Where they disagree it is because this package publishes what the
+  siblings do not. Each publish job downloads twice where the siblings
+  download once, so its two steps are named apart -- `Download the
+  wheels` and `Download the source distribution` -- one wheel matrix
+  built by the jobs that compile the vendored library and an sdist built
+  by a job that does not, against a single `Download the distribution
+  files` that would name neither. `attest` and `github-release` take no
+  wheels at all, so the siblings' name would have fitted there; they read
+  `Download the source distribution` too, so that one artifact is fetched
+  under one name throughout the file.
+
+  #300 stays open, being about every workflow here rather than this one:
+  the other files keep their unnamed steps until a pull request that
+  touches each of them arrives, which is what that issue asks for instead
+  of a sweep. Nothing reports one -- `actionlint` has no rule for a step
+  without a name -- so the command is what answers:
+
+  ```shell
+  grep -nE '^ *- (uses|run):' .github/workflows/*.yml
+  ```
+
 - **The merge gate runs one cell of the suite, and the sweeps moved to
   the calendar** (btclib-org/.github#85). `test.yml`'s `suite-static` and
   `suite-dynamic` jobs are gone: two ubuntu images, each walking every


### PR DESCRIPTION
Every step of `release.yml` carries a `name:`, so the run page names
what each one does instead of showing the action it calls.

```shell
grep -nE '^ *- (uses|run):' .github/workflows/release.yml
```

prints nothing at this head, where on `origin/main` it prints a line per
unnamed step. The diff is mechanically name-only: the set of `uses:`
lines removed is identical to the set added, pins unchanged, each
re-indented by two, and no job name is touched — so no required check is
renamed out of existence.

This does **not** finish [ISS 300](https://github.com/btclib-org/btclib-secp256k1/issues/300),
which is about every workflow in this repository. It is the first slice
of it, and that issue's hold comment names an open pull request here as
the condition for releasing the rest of the sweep.

The branch is called `documented`, and the `documented` job of
[ISS 295](https://github.com/btclib-org/btclib-secp256k1/issues/295) is
not in it: Read the Docs answers zero tags active and built for this
project, which is what that issue's own comment names as the blocker.
That job stays where it is.

## Two names diverge from the siblings, deliberately

`Download the wheels` and `Download the source distribution` are this
package's own rather than the siblings' `Download the distribution
files`. Four jobs read the artifacts and two of them — `attest` and
`github-release` — take no wheels at all, so the siblings' name would
have fitted there and says less; the source distribution is fetched
under one name throughout the file. The cost is that the same step is
named differently across the three repositories, which is the subject of
[ISS 341](https://github.com/btclib-org/btclib-secp256k1/issues/341) and
whose re-deriving command still answers.

`Download the wheels` uses `pattern: "*-wheels-*"`, matched against the
artifact names actually uploaded: it selects every wheel artifact and
nothing else.

## Declined in review, so it is not raised again

The CHANGELOG entry originally argued that an unnamed step is how a fix
goes missing across the three repositories, citing btclib ISS 1141 and
ISS 1142. Measured, neither supports it: 1141's step has a name and
lacks `shell: bash`, and 1142 is a guard at job level. The entry now
says what the citations do support, with the negative result stated.

## Verified

Local review cleared this head. Gates on the worktree, exit codes:
`pre-commit run --all-files` 0; `pytest --cov` 0, coverage 100.00%;
`sphinx-build -W --keep-going` 0; `git status --porcelain` empty after
the last of them.

Collateral opened while reading, none of it caused by this diff:
[ISS 340](https://github.com/btclib-org/btclib-secp256k1/issues/340),
[ISS 342](https://github.com/btclib-org/btclib-secp256k1/issues/342),
[btclib ISS 1273](https://github.com/btclib-org/btclib/issues/1273).

## Summary by Sourcery

Name every step in the release workflow to improve visibility and consistency when reviewing release runs.

Enhancements:
- Add descriptive names to every step in the release workflow, making release runs easier to scan and troubleshoot without changing the actions, pins, or job names.

Documentation:
- Document the release workflow step-naming change and clarify its scope relative to the repository-wide workflow naming effort.