### PR TITLE
.gitattributes is the organization's file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,28 +1,16 @@
-# RELEASE_NOTES.md is an append-only list that every release adds to at
-# the same place: the newest section goes on top, so two branches that
-# each add one conflict on the insertion point with nothing to decide.
-# `union` keeps both sides' added lines, on rebases included, which is
-# what a merge of two appends should be.
+# The changelog and the release notes are append-only lists, and every
+# branch appends to the same few groups: two branches each adding a bullet
+# conflict on the insertion point, which is a conflict with nothing to
+# decide. `union` resolves it by keeping both sides' added lines, in the
+# order base-then-ours, and it is built into git — nobody has to configure
+# anything for it to apply.
 #
-# Its price is that this file never conflicts at all any more, so two
-# branches editing *the same* line merge in silence. That is the trade: a
-# conflict with nothing to decide costs every branch, and a silent merge
-# costs only the branches that edited one line two ways.
-RELEASE_NOTES.md merge=union
-
-# CHANGELOG.md is the same list one level down. A branch appends its
-# bullet to the group the change belongs to, so two branches meet at that
-# group's last line rather than at the top of the file -- and they meet
-# there whenever both changes are the same kind of change, which is when
-# they are most likely to be open together. Without the driver that is a
-# conflict; with it both bullets survive, in the order the merge finds
-# them.
-#
-# The price is the one above and it bites harder here, because nothing
-# reads this file: RELEASE_NOTES.md at least states a version the release
-# path checks, while two branches rewriting one bullet two ways merge in
-# silence with nothing to notice it. What buys that off is what the file
-# holds -- prose about what changed, where the accident is a sentence and
-# not a behaviour -- and that the alternative is every branch resolving a
-# conflict with nothing to decide.
+# It applies to rebases too, which is where it earns its keep, and it has
+# a price worth knowing: these two files then never conflict at all, so
+# the same existing entry edited on two branches merges in silence rather
+# than being flagged. That is why neither states how many entries it has —
+# a count is exactly such an edit, and union would have kept both numbers.
+# Section 9 of the organization standard, btclib-org/.github's README.md,
+# is where this rule is recorded.
 CHANGELOG.md merge=union
+RELEASE_NOTES.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ release-notes length in the first place, and are still in
   `git grep -n -i 'code_of_conduct\|code of conduct'` answered with
   that pattern, the entry just named, and two lines of the file itself.
 
+- **`.gitattributes` is the organization's file** (btclib-org/.github#102).
+  Section 14 of the standard names it as the same file in every
+  repository, and `tests/verbatim_test.py` there compares the copies it
+  finds; this one was its own prose, two comments in its own words with
+  `RELEASE_NOTES.md` first and `CHANGELOG.md` under a second paragraph
+  about what nothing reads. It is now byte for byte the copy in
+  `btclib-org/.github`: one comment, both lines under it, and section 9
+  of the standard named as where the rule is recorded. This tree has no
+  attribute of its own to keep under `## This repository in particular`,
+  so it carries no such heading. `git check-attr merge` still answers
+  `union` for both files.
+
 - **`RELEASING.md` says what to do rather than what happened**. Two
   paragraphs were an account of the 0.7.1 rehearsal that failed before it
   worked and of the setup the rename made necessary a second time. What a


### PR DESCRIPTION
Under btclib-org/.github#34's regime: local gates the gate (pre-commit 0, and the suite where the tree has one), one local review round (`CLEARED 900e3d3821bc137c2f3081439b78354fc9678bfd`), landed by admin bypass pinned to that sha. Prose goes to the ex-post audit.

`.gitattributes` becomes the section 14 copy: the shared half is byte for byte btclib-org/.github's at a989db9, as `tests/verbatim_test.py` there compares it; what is this repository's own goes under `## This repository in particular`. Part of btclib-org/.github#102, which stays open until every copy agrees and the `EXPECTED_DRIFT` entry is deleted.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Align this repository’s `.gitattributes` with the organization-wide canonical copy.

Enhancements:
- Synchronize `.gitattributes` with the organization-wide canonical file while preserving the repository’s existing attribute behavior.

Documentation:
- Document the `.gitattributes` standardization in the changelog.