### PR TITLE
The rehearsal re-locks, and every build step passes --locked (issue btclib-org/.github#128)

### DIFF
--- a/.github/actions/dev-version/action.yml
+++ b/.github/actions/dev-version/action.yml
@@ -1,10 +1,11 @@
 ---
 name: Append a dev suffix to the version
 description: >
-  Rewrites the version in pyproject.toml, appending the given suffix, so
-  that a rehearsal builds a version no index has seen. Every build job of
-  the test workflow runs this, and they must all produce the same
-  version: the suffix is decided once, by the caller.
+  Rewrites the version in pyproject.toml, appending the given suffix, and
+  re-locks so that uv.lock agrees: what a rehearsal needs before it
+  builds a version no index has seen. Every build job of the test
+  workflow runs this, and they must all produce the same version: the
+  suffix is decided once, by the caller.
 
 inputs:
   suffix:
@@ -43,3 +44,16 @@ runs:
         path.write_text(text[: match.start()] + line + text[match.end() :], encoding="utf-8")
         PY
         grep -m1 '^version' pyproject.toml
+        # uv.lock carries the project version, so the rewrite above
+        # leaves the two disagreeing, and every uv command that passes
+        # --locked -- all of them, section 1 of the organization standard
+        # allowing no other flag -- then fails with "the lockfile needs
+        # to be updated". Re-locking here, rather than relaxing the
+        # build steps to --frozen, is btclib-org/.github#128's decision:
+        # the only entry this moves is the project's own, measured
+        # against the tree as `git diff --stat uv.lock` answering one
+        # line. It is also what makes the sdist coherent: that archive
+        # ships uv.lock, which otherwise declared the unsuffixed version
+        # inside a distribution named for the suffixed one. Every caller
+        # sets up uv before reaching this, as it does python
+        uv lock

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -47,7 +47,7 @@ name: os-ubuntu
 # `_load_lib`'s second branch, and not the artifact pip resolves to
 # wherever no static wheel matches. That set is wider than one cell:
 #
-#     uv run --frozen --only-group build cibuildwheel \
+#     uv run --locked --only-group build cibuildwheel \
 #         --platform windows --print-build-identifiers | grep pp
 #
 # answers nothing at all, and neither does musllinux on any PyPy, so

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -352,12 +352,11 @@ jobs:
       # push that did not touch it. --only-group omits the project, so
       # this installs no extension of its own; the build frontend
       # cibuildwheel then runs per interpreter comes from the same group.
-      # --frozen, not the --locked of the check-dist job: the step above
-      # rewrites the version in pyproject.toml on the rehearsal path,
-      # which is exactly the disagreement --locked refuses. That the lock
-      # is in step with pyproject.toml is asserted where it can be, by the
-      # uv-lock hook on every commit and by `uv lock --check` in the
-      # release workflow
+      # --locked, here as in the check-dist job: the dev-version step
+      # above rewrites the version in pyproject.toml on the rehearsal
+      # path and re-locks in the same step, so the lock agrees with the
+      # tree this builds whichever path the run took, and the flag asserts
+      # that agreement instead of skipping it (btclib-org/.github#128)
       # what a pull request has to answer about any of these images is
       # whether this tree still builds there, and that is answered by the
       # first wheel: the toolchain, the CMake build of the vendored
@@ -400,7 +399,7 @@ jobs:
       # (issue btclib-org/btclib#1148)
       - name: Build wheels
         shell: bash
-        run: uv run --frozen --only-group build cibuildwheel
+        run: uv run --locked --only-group build cibuildwheel
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -467,20 +466,20 @@ jobs:
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=$TARGET" >> "$GITHUB_ENV"
 
-      # the build group and --frozen: see build-cibuildwheel
+      # the build group and --locked: see build-cibuildwheel
       - name: Build wheel
-        run: BTCLIB_LIBSECP256K1_DYNAMIC=true uv run --frozen --only-group build python -m build -w
+        run: BTCLIB_LIBSECP256K1_DYNAMIC=true uv run --locked --only-group build python -m build -w
 
       # auditwheel and delocate decide the platform tag this wheel ends up
       # carrying, which is what pip matches against, so they are pinned
       # with the rest of the build group rather than installed with -U
       - name: Repair wheel (Linux)
         if: runner.os == 'Linux'
-        run: uv run --frozen --only-group build auditwheel repair dist/*
+        run: uv run --locked --only-group build auditwheel repair dist/*
 
       - name: Repair wheel (macOS)
         if: runner.os == 'macOS'
-        run: uv run --frozen --only-group build delocate-wheel -w wheelhouse dist/*
+        run: uv run --locked --only-group build delocate-wheel -w wheelhouse dist/*
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -519,9 +518,9 @@ jobs:
         with:
           suffix: ${{ inputs.version-suffix }}
 
-      # the build group and --frozen: see build-cibuildwheel
+      # the build group and --locked: see build-cibuildwheel
       - name: Build source
-        run: uv run --frozen --only-group build python -m build -s
+        run: uv run --locked --only-group build python -m build -s
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -657,14 +656,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt install -y mingw-w64
 
-      # the build group and --frozen: see build-cibuildwheel. The `wheel`
+      # the build group and --locked: see build-cibuildwheel. The `wheel`
       # this used to install with it is a setuptools-era requirement:
       # hatchling writes the wheel itself, and nothing here invokes that
       # package
       - name: Build Windows wheel
         run: |
           BTCLIB_LIBSECP256K1_CROSS_COMPILE=true CFFI_PLATFORM=Windows \
-            uv run --frozen --only-group build python -m build -w
+            uv run --locked --only-group build python -m build -w
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,35 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **The rehearsal re-locks, and every build step passes `--locked`**
+  (btclib-org/.github#128). The `dev-version` action rewrites the version
+  in `pyproject.toml` on the rehearsal path, and the build steps after it
+  passed `--frozen`, the organization standard's one exception to
+  `--locked`, never `--frozen`, documented in `CLAUDE.md`,
+  `CONTRIBUTING.md` and `RELEASING.md` here and nowhere in the standard.
+  The standard's decision is that a rehearsal re-locks rather than
+  relaxing the flag, which is what `btclib`'s action already did: this
+  one now runs `uv lock` after the rewrite, and the six `run:` commands
+  of `test.yml` that passed `--frozen` -- `build-cibuildwheel`'s
+  `Build wheels`, `build-dynamic`'s `Build wheel` and its two repair
+  steps, `build-sdist`'s `Build source`, and `build-windows`'s
+  `Build Windows wheel`, one more than the issue counted because that
+  one's flag sits on the second line of a `run: |` block its `sed` did
+  not reach -- pass `--locked`. Measured on a copy of `main` with the
+  action's own script appending `.dev421`: `uv run --locked --only-group
+  build python -m build -s` exits 2 with "The lockfile at `uv.lock`
+  needs to be updated, but `--locked` was provided"; `uv lock` then
+  moves one line, the project's own `version`, and the same command
+  exits 0. It also changes what a rehearsal's sdist ships: `uv.lock` is
+  in that archive, and the one built with `--frozen` declared `0.8.0.5`
+  inside `btclib_secp256k1-0.8.0.5.dev421.tar.gz`, where the re-locked
+  one declares `0.8.0.5.dev421`. The exception is gone from the three
+  files that stated it, and `os-ubuntu.yml`'s example command passes
+  `--locked` too, answering nothing with either flag. The lock in the
+  tree does not move: the re-lock happens in CI, on the rehearsal
+  alone, and `uv lock --check` in `release.yml` keeps asking that the
+  committed one agree.
+
 - **`links.yml` accepts every code lychee would accept unasked, and
   passes no cache flag** (btclib-org/.github#110, btclib-org/.github#111).
   `--accept 200,206,429` replaced lychee's default rather than adding to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,13 +230,10 @@ precisely so these stay true, and both must report zero findings.
   a `concurrency-suffix` input and `release.yml` passes one: without it a
   rehearsal dispatched on a branch shares a group with a push to that
   branch, and one cancels the other
-- uv commands pass `--locked`, never `--frozen` — except the wheel-build
-  steps of `test.yml` (`build-cibuildwheel`, `build-dynamic`,
-  `build-sdist`, the Windows cross-build), which run after the
-  `dev-version` action has rewritten `pyproject.toml` on the rehearsal
-  path; `--locked` refuses exactly that disagreement, so those steps use
-  `--frozen`, and the comment above `build-cibuildwheel`'s `Build wheels`
-  step has the reasoning in full
+- the rehearsal path rewrites the version in `pyproject.toml`, and the
+  `dev-version` action that does it re-locks in the same step, so every
+  uv command here passes `--locked` with no exception, the build steps
+  after that action included; the action's own comment has the reasoning
 - the packaging tools come from the pinned `check` group, not from `uvx`,
   which would fetch whatever the index holds when the job runs
 - a hook that needs a tool carries it in `additional_dependencies`, with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,13 +452,11 @@ command at all, for the reason above, and no longer gates.
 - `Build wheels on <os>`, for this platform only
 
   ```shell
-  uv run --frozen --only-group build cibuildwheel
+  uv run --locked --only-group build cibuildwheel
   ```
 
-  `--frozen`, not `--locked`: `test.yml` has the reason, next to the step
-  itself. The Linux wheels of that job are built in a manylinux
-  container, so reproducing them needs a container runtime (`colima` on
-  macOS)
+  The Linux wheels of that job are built in a manylinux container, so
+  reproducing them needs a container runtime (`colima` on macOS)
 
 - `Build dynamic wheel on <os>`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -618,20 +618,12 @@ shasum -a 256 dist/btclib_secp256k1-0.8.0.4.tar.gz
 ```
 
 is the whole of it — against a worktree rather than the primary
-checkout, for the reason CLAUDE.md gives, and `--locked` rather than
-the `--frozen` that `build-sdist` in `test.yml` runs. That is
-deliberate, not the two files drifting apart: `test.yml`'s own comment
-on `--frozen` names its reason, the rehearsal path patching a
-`.dev<run><attempt>` suffix into `pyproject.toml` before that step,
-which is exactly the lock-and-tree disagreement `--locked` refuses. A
-rebuild from a released tag carries no such patch — nothing rewrote the
-version, so the lock and `pyproject.toml` already agree — and
-`--locked` asserts that agreement rather than skipping it, checking
-that the lock is the one the tag committed instead of taking
-`uv.lock` as `--frozen` finds it. Both flags build the same sdist:
-`v0.8.0.4` rebuilt with `--locked` matches the published digest exactly
-as it did with `--frozen`, so this changes what the rebuild checks on
-the way, not what it produces. Compare the digest against
+checkout, for the reason CLAUDE.md gives, and with the command
+`build-sdist` in `test.yml` runs, `--locked` included: a rebuild from a
+released tag has nothing rewriting the version, so the lock and
+`pyproject.toml` already agree, and the flag asserts that the lock is
+the one the tag committed rather than taking `uv.lock` as it finds it.
+Compare the digest against
 `pypi.org/pypi/btclib-secp256k1/<version>/json`'s own, or against the
 `sdist` artifact `gh run download` pulls from the release's run; both
 name the file this reproduces.


### PR DESCRIPTION
Under btclib-org/.github#34's regime: local gates the gate (pre-commit 0, pytest 0 — 810 passed, 100% — `sphinx -W` 0), one local review round (`CLEARED 414c3f4296d2757ea629890aea82d4fe03fefc77`), landed by admin bypass pinned to that sha. Prose goes to the ex-post audit.

The decision on btclib-org/.github#128: `dev-version` re-locks after rewriting the version, so every build step passes `--locked` and section 1's rule holds here with no exception. Measured on an export: before the re-lock `uv run --locked --only-group build python -m build -s` refuses; `uv lock` moves one line of `uv.lock`, the project's own version; after it the same command builds. The re-lock runs only on a rehearsal (`version-suffix` set), never on the tag path. The issue stays open for section 1's sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFB7QST7JN4J8RToymde1k

## Summary by Sourcery

Ensure rehearsal version changes are re-locked so every CI build step can enforce a consistent lockfile with `--locked`.

Bug Fixes:
- Re-lock rehearsal builds after applying development version suffixes so generated distributions contain a lockfile consistent with their version.

Enhancements:
- Use `uv run --locked` for all build, wheel-repair, and packaging steps, removing the previous rehearsal-only `--frozen` exception.
- Update project guidance and release documentation to reflect the uniform locked-build policy.

CI:
- Align CI examples and build workflow commands with the locked dependency policy.

Documentation:
- Document the rehearsal re-lock behavior and the removal of the `--frozen` exception across contributor, release, and development guidance.