### PR TITLE
enable_error_code is the organization's list (btclib-org/.github#165)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -518,6 +518,9 @@ repos:
           - types-cffi==2.0.0.20260518
           - hatchling==1.32.0
           - pytest==9.1.1
+          # hyphenated as uv.lock spells it, hook_pins_test.py keying
+          # the two on one name
+          - typing-extensions==4.16.0
   # the workflows are as much a part of this repository as the package,
   # and until now nothing checked them: an expression referring to a
   # context that does not exist, or a step reading an input a job never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,6 +927,24 @@ release-notes length in the first place, and are still in
 
 ### The gate
 
+- **`enable_error_code` is the organization's list**
+  (btclib-org/.github#165). Section 6's optional mypy error codes are one
+  list, the same in every repository that runs mypy; this tree's carried
+  `narrowed-type-not-subtype`, which the locked mypy reports under bare
+  `--strict` with no code enabled at all, and lacked `explicit-override`
+  and `unused-awaitable`. The comment beside the array now names the
+  standard instead of walking a survey of this tree and a comparison
+  against btclib's, a per-tree survey being the rule that let the lists
+  drift. `explicit-override` is the one code of the two with findings
+  here, every one a method of the build backend overriding
+  `FFIExtension` or hatchling's `BuildHookInterface`: those methods carry
+  `@override`, from `typing` at 3.12 and from `typing_extensions` below
+  it, so `[build-system] requires` gains `typing_extensions` under a
+  `python_version<"3.12"` marker -- resolved at build time and pinned by
+  no lock file, like everything else in that array. The mypy hook
+  declares the same package among its additional dependencies, what the
+  checked files import being declared there.
+
 - **The test modules are `*_test.py`, and `name-tests-test` runs at its
   default** (btclib-org/.github#131). Section 7 of the organization
   standard states one spelling and names the hook that enforces it at

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -448,8 +448,10 @@ class Signer:
 
     # PYI034 asks for `typing.Self` here, and that is 3.11 while this
     # package supports 3.10. The class itself says the same thing of a
-    # class nothing subclasses, and `typing_extensions` is a dependency
-    # this package does not have and would not add for one annotation
+    # class nothing subclasses, and `typing_extensions` is a runtime
+    # dependency this package does not have and would not add for one
+    # annotation ([build-system] requires carries it for scripts/, which
+    # never ships in the wheel)
     def __enter__(self) -> Signer:  # noqa: PYI034
         """Return this signer, for the `with` block that wipes it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ requires = [
     'cffi>=2.0; python_version>="3.14"',
     'setuptools; python_version>="3.12"',
     "cmake>=3.22",
+    # `typing.override` is 3.12: below it, scripts/ takes the decorator
+    # mypy's explicit-override asks for from here
+    'typing_extensions; python_version<"3.12"',
 ]
 build-backend = "hatchling.build"
 
@@ -277,31 +280,27 @@ required-version = ">=0.12.0"
 strict = true
 show_column_numbers = true
 show_error_codes = true
-# the optional error codes strict does not turn on, each measured with
-# its own --enable-error-code over btclib_secp256k1, tests and
-# scripts: every one of the eleven finds nothing today, so each is a
-# ratchet and none is a cleanup. Eleven rather than the nine btclib's
-# own pyproject.toml selects: redundant-expr and possibly-undefined are
-# the two more, both absent from btclib's list because of a runtime
-# isinstance guard on a field mypy already believes is typed from a
-# json Literal, an idiom this package has no occasion for, wrapping no
-# json of its own
+# the optional error codes strict does not turn on: section 6 of the
+# organization standard lists them, the same list in every repository
+# that runs mypy (btclib-org/.github#165). A code that finds nothing
+# here is a ratchet, and the line it would catch is the one written
+# after the survey
 enable_error_code = [
     "deprecated",
     "exhaustive-match",
+    "explicit-override",
     "ignore-without-code",
     "mutable-override",
-    "narrowed-type-not-subtype",
     "possibly-undefined",
     "redundant-expr",
     "redundant-self",
     "truthy-bool",
     "truthy-iterable",
     "unimported-reveal",
+    "unused-awaitable",
 ]
-# the third code btclib leaves out, and not part of the array above:
-# mypy exposes it as its own flag rather than through
-# --enable-error-code. Same absent idiom, same zero findings measured
+# a flag of its own rather than an error code, so not in the array
+# above; section 6 asks for it beside the list
 warn_unreachable = true
 # stubs/_btclib_secp256k1.pyi describes the cffi boundary; without it
 # ffi and lib are Any and every wrapper checks out vacuously

--- a/scripts/cffi_build.py
+++ b/scripts/cffi_build.py
@@ -28,11 +28,17 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from subprocess import PIPE, Popen
 from sysconfig import get_config_var, get_path, get_platform
 from typing import Any
 
 import cffi
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 cross_compile = os.environ.get("BTCLIB_LIBSECP256K1_CROSS_COMPILE", "false") == "true"
 static = os.environ.get("BTCLIB_LIBSECP256K1_DYNAMIC", "false") != "true"
@@ -325,6 +331,7 @@ class Secp256k1CFFIExtension(FFIExtension):
         self.libraries = ["secp256k1"]
         super().__init__()
 
+    @override
     def clean(self) -> None:
         """Remove the out-of-tree CMake build and the emitted extensions."""
         # a stale CMake cache remembers the previous configuration
@@ -386,6 +393,7 @@ class Secp256k1CFFIExtension(FFIExtension):
             return [f"-DCMAKE_OSX_ARCHITECTURES={arch}"]
         return []
 
+    @override
     def build_c(self) -> None:
         """Build the vendored library with CMake, on every platform."""
         self.cmake_dir.mkdir(parents=True, exist_ok=True)
@@ -494,6 +502,7 @@ class Secp256k1CFFIExtension(FFIExtension):
         if self.static and platform.system() == "Windows":
             self.libraries = ["libsecp256k1"]
 
+    @override
     def generate_def(self) -> tuple[str, str]:
         """Concatenate the public headers, and preprocess them for cffi.
 

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -19,11 +19,17 @@ the distinction reaches the installed package at all.
 import os
 import platform
 import shutil
+import sys
 import sysconfig
 from pathlib import Path
 from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 class CustomBuildHook(BuildHookInterface[Any]):
@@ -67,6 +73,7 @@ class CustomBuildHook(BuildHookInterface[Any]):
             raise RuntimeError(msg)
         return build_vars[ext_name]
 
+    @override
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         """Build the extensions and tell hatchling what it is packaging.
 


### PR DESCRIPTION
Section 6 of the organization standard lists the optional mypy error
codes, and this tree's `[tool.mypy]` now states exactly that list.
Prepares btclib-org/.github#165, which stays open until every tree that
runs mypy carries it.

`narrowed-type-not-subtype` leaves the array: under the locked mypy it
is enabled by default, so naming it bought nothing.
`explicit-override` reports the two build scripts' overriding methods,
each of which now carries `@override` — from `typing` at 3.12 and from
`typing_extensions` below it, which is why `typing_extensions` joins
`[build-system] requires` under a `python_version<"3.12"` marker rather
than a runtime dependency: the scripts run in the build frontend's
isolated environment, and no module of the package imports it.

Local review round, at fresh context, cleared this sha. The reviewer ran
the gates itself rather than relying on the author's run: suite twice at
two seeds and once at the 3.10 floor (0), `pre-commit run --all-files`
(0), the docs build with `-W` (0), and a floor wheel (0). It measured
the `@override` set by stripping the decorators and re-running mypy, and
confirmed the built wheel's metadata carries no new runtime dependency.

## Summary by Sourcery

Align static type-checking policy with the organization standard and enforce override annotations in build scripts.

Enhancements:
- Align the mypy enabled error-code configuration with the organization-wide standard, including explicit override and unused awaitable checks.
- Annotate build backend overrides and support the override decorator across supported Python versions without adding a runtime package dependency.

Build:
- Add typing_extensions as a Python-version-specific build requirement and pin it for pre-commit hook environments.