### PR TITLE
pyroma reads the declared backend, show_error_codes goes, and .gitattributes is the standard's copy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,10 @@
 # a count is exactly such an edit, and union would have kept both numbers.
 # Section 9 of the organization standard, btclib-org/.github's README.md,
 # is where this rule is recorded.
+#
+# Both lines are in every repository's copy, a tree carrying no
+# RELEASE_NOTES.md included: section 2 of that README.md gives the
+# release notes to a repository that publishes, and an attribute on a
+# path the tree does not hold matches nothing.
 CHANGELOG.md merge=union
 RELEASE_NOTES.md merge=union

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,14 +23,8 @@ ci:
   # request with nowhere to land
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
-  # the two hooks pre-commit.ci cannot run, each for something that
-  # service does not give a hook rather than for anything either hook
-  # does. pyroma rates the metadata of the source tree, which means
-  # building that metadata, and pre-commit.ci runs hooks with no network
-  # at all -- so the isolated build cannot fetch hatchling to prepare it,
-  # and the fallback to a non-isolated one has no backend in the hook
-  # environment either.
-  #
+  # the one hook pre-commit.ci cannot run, for something that service
+  # does not give it rather than for anything the hook does.
   # submodule-pin resolves the release README.md names in the vendored
   # clone's refs, and there are no refs to resolve it against there.
   # `submodules: true` is the documented `ci:` key for that -- "whether to
@@ -41,13 +35,13 @@ ci:
   # key to ask that service for, so the key bought a clone nothing can use
   # and is not kept. REPOSITORY.md records the residual gap.
   #
-  # In both cases the lint workflow runs this same file with what the hook
-  # needs -- a network for the first, `submodules: true` and
-  # `fetch-depth: 0` for the second -- so what is skipped here is one of
-  # two runners rather than the hook: each still gates a commit on this
-  # machine and a pull request in that workflow, which is the required
-  # check. An entry may join them for a reason of that kind and no other
-  skip: [pyroma, submodule-pin]
+  # The lint workflow runs this same file with what the hook needs --
+  # `submodules: true` and `fetch-depth: 0` -- so what is skipped here is
+  # one of two runners rather than the hook: it still gates a commit on
+  # this machine and a pull request in that workflow, which is the
+  # required check. An entry may join it for a reason of that kind and no
+  # other
+  skip: [submodule-pin]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -639,14 +633,40 @@ repos:
   # what test.yml's own pyroma step rates the sdist for -- a missing
   # classifier or url, metadata that is valid but poor -- this rates the
   # source tree instead, for an answer before pushing rather than after
-  # the build. Matching btclib's own hook, unpinned to any args or
-  # additional_dependencies for the same reason every other hook here
-  # isn't: the rev below is the version pin.
-  #
-  # Named in the ci block's skip list at the top of this file, and it is
-  # the only hook there: building metadata needs an index to fetch the
-  # backend from, and pre-commit.ci has no network
+  # the build
   - repo: https://github.com/regebro/pyroma
     rev: "5.0.1"
     hooks:
       - id: pyroma
+        # the backend, in pyroma's own environment, because pyroma builds
+        # this project to read its metadata and its command line has no
+        # way to say how. It asks `build` for the metadata without
+        # isolation and falls back to an isolated build when that raises,
+        # and an isolated build is a virtual environment pre-commit.ci
+        # cannot populate, that service running hooks with no network.
+        # The non-isolated path imports the backend out of the hook
+        # environment and checks nothing else, so the backend alone is
+        # what it takes: the cffi and cmake requirements beside hatchling
+        # in [build-system] are the compiled extension's, and preparing
+        # the metadata asks for neither. Measured, rather than read off
+        # the fallback's shape:
+        #
+        #   PIP_NO_INDEX=1 uv run --locked --only-group lint \
+        #     pre-commit run pyroma --all-files
+        #
+        # passes with this line and dies in pip with it removed, the
+        # traceback ending in the isolated fallback installing what
+        # [build-system] requires. That run is why pyroma is not in the
+        # ci block's skip list at the top of this file. Section 12 words
+        # the non-isolated path as taken where the environment satisfies
+        # `requires`, which is not what decides it --
+        # btclib-org/.github#251 has the measurement.
+        #
+        # The specifier is [build-system]'s, and has to stay it: section
+        # 12 of the organization standard asks that a hook building this
+        # project build it with a backend that declaration admits
+        # (btclib-org/.github#197). Not pinned, unlike the additional
+        # dependencies above: what this has to match is a range rather
+        # than a release, and the isolated build it replaces would have
+        # resolved the same range itself
+        additional_dependencies: ["hatchling>=1.27"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`.gitattributes` is the organization's file byte for byte**
+  (btclib-org/.github#192). Section 14 of the standard makes the two
+  `merge=union` entries and the reasoning beside them the standard's
+  text rather than each tree's, and the paragraph missing from this copy
+  is the one saying both lines belong in every repository's copy, a tree
+  carrying no `RELEASE_NOTES.md` included: an attribute on a path the
+  tree does not hold matches nothing. This tree has no attribute of its
+  own, so it carries no `## This repository in particular` heading and
+  the whole file is the shared half. `shasum -a256` agrees with the raw
+  file the API serves for `btclib-org/.github`, and
+  `git check-attr merge` still answers `union` for `CHANGELOG.md` and
+  `RELEASE_NOTES.md`.
+
 - **`REVIEWING.md`'s *The gates are the evidence* excepts no gate from
   the run a reviewer may rely on, the test suite included.** The
   organization's copy, shared half byte for byte (section 14): a run is
@@ -933,6 +946,41 @@ release-notes length in the first place, and are still in
   command that re-reads both keys together.
 
 ### The gate
+
+- **`show_error_codes` leaves `[tool.mypy]`** (btclib-org/.github#191).
+  mypy has error codes on: `Options` carries `hide_error_codes`, `False`
+  before any configuration file is read, and no `show_error_codes`
+  attribute at all -- `config_parser.py` accepts that key only through
+  its generic `show_`/`hide_` inversion, and `mypy --help` writes the
+  spelling that changes the default, `--hide-error-codes`. Section 6 of
+  the organization standard drops the line from its sample for that
+  reason and keeps `show_column_numbers`, whose default is `False`.
+  Measured on the mypy `uv.lock` pins, against a file with one
+  incompatible return: the diagnostic and its `[return-value]` code are
+  byte for byte the same with the key and without it.
+
+- **`pyroma` builds this project with a backend `[build-system]` admits,
+  and runs on pre-commit.ci** (btclib-org/.github#197). Section 12 asks
+  that a hook building the project build it with the backend that
+  declaration admits. pyroma reads the metadata through `build`, whose
+  non-isolated path imports the backend out of the hook's own
+  environment, so the hook carries `additional_dependencies:
+  ["hatchling>=1.27"]`, which is `[build-system]`'s own specifier. That
+  path checks nothing beyond the backend it imports: the hook
+  environment holds hatchling and pyroma's own dependencies and neither
+  the cffi nor the cmake requirement declared beside it, and
+
+  ```shell
+  PIP_NO_INDEX=1 uv run --locked --only-group lint \
+      pre-commit run pyroma --all-files
+  ```
+
+  passes. With the line removed the same command dies in pip, the
+  traceback ending in the isolated fallback installing what
+  `[build-system]` requires -- the network pre-commit.ci does not give.
+  So `pyroma` leaves the `ci:` block's `skip:` list, where
+  `submodule-pin` stays for the reason its own comment gives, and
+  `REPOSITORY.md`'s paragraph on that list names the hook it holds.
 
 - **`enable_error_code` is the organization's list**
   (btclib-org/.github#165). Section 6's optional mypy error codes are one

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -68,13 +68,13 @@ more than that checkout gives: `submodule-pin` resolves the release
 `ci:` is the documented key for the clone, and it was tried on #132 rather
 than reasoned about — with it the submodule arrives and the hook still
 fails, `the vendored clone is shallow and carries no v0.8.0 tag`. There is
-no `fetch-depth` key to ask that service for, so the hook is in the `ci:`
-`skip` list beside `pyroma`, which needs a network that service also does
-not give. What that costs is one of the hook's two runners: the one the
-rule names, `Lint and type-check`, checks the submodule out with
-`fetch-depth: 0` precisely so it has what the hook needs, and so does a
-developer's own commit. Re-read that skip list before adding to it: an
-entry may join for a reason of that kind and no other.
+no `fetch-depth` key to ask that service for, so the hook is the one
+entry in the `ci:` `skip` list. What that costs is one of the hook's two
+runners: the one the rule names, `Lint and type-check`, checks the
+submodule out with `fetch-depth: 0` precisely so it has what the hook
+needs, and so does a developer's own commit. Re-read that skip list
+before adding to it: an entry may join for a reason of that kind and no
+other.
 
 Neither `os-ubuntu.yml`, `os-macos.yml`, `os-windows.yml`, `deps-latest.yml`,
 `links.yml`, `mutation.yml`, `pypi-install.yml` nor `vendored-vectors.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ required-version = ">=0.12.0"
 # type-checks against, so a wrong one propagates
 strict = true
 show_column_numbers = true
-show_error_codes = true
 # the optional error codes strict does not turn on: section 6 of the
 # organization standard lists them, the same list in every repository
 # that runs mypy (btclib-org/.github#165). A code that finds nothing


### PR DESCRIPTION
Three of the standard's recent findings reach this tree, and one of them
turned out to be a defect in the standard rather than in the tree.

**`show_error_codes` is on already** — btclib-org/.github#191. There is no
such option: `mypy/options.py` carries `hide_error_codes`, `False` before
any config file is read, and `config_parser.py:543`'s generic
`show_`/`hide_` inversion is the whole of why the key parses at all.
Measured on the mypy this tree pins: an erroring probe gives byte-identical
output with the line and without it. `show_column_numbers` stays — a real
option, defaulting to `False`, and section 6's sample carries it.

**The `.gitattributes` reasoning** — btclib-org/.github#192. Section 14
makes that file verbatim, and the standard's copy gained a paragraph this
tree did not have: both `merge=union` lines are in every copy, a tree
carrying no `RELEASE_NOTES.md` included, because an attribute on a path
the tree does not hold matches nothing. Written whole rather than by
stripping from a marker line, and checked by digest three ways — the
committed file, `git show origin/main:` in the standard, and the API's own
content all give
`1708d2c8a38eb70bd26a37e51f25c85ae37dbc48cf58366ee59e2d90e66a1d79`.

**`pyroma` was passing on a path pre-commit.ci cannot take** —
btclib-org/.github#197. The hook carried no `additional_dependencies`, so
in its own environment `build.util.project_wheel_metadata(isolated=False)`
raised `Backend 'uv_build' is not available` and pyroma fell back to the
isolated path, which builds an environment from the network. It passed
that way. With `additional_dependencies: ["hatchling>=1.27"]` — this
tree's own `[build-system]` specifier — the non-isolated path succeeds and
`pyroma` leaves the `ci:` block's `skip:` list, now `[submodule-pin]`
alone. `REPOSITORY.md`'s paragraph named `pyroma` beside `submodule-pin`;
this diff falsified it, so it is rewritten here rather than filed.

**`check-sdist` does not exist in this tree**, so btclib-org/.github#197's
other half does not reach it. That gap is this repository's own #344 and
nothing new was opened for it.

**btclib-org/.github#178 does not reach this tree either.** Its
`[tool.ruff.lint] ignore` holds `magic-value-comparison` and
`raise-vanilla-args`, each commented, and no D203/D213 anywhere — so there
was nothing to delete, and the "run the lint with and without the entries"
comparison had no entries to remove. It was **not** synthesized to produce
a demonstration; the finding is that the issue does not reach here, and it
is recorded in the commit body so the next pass does not re-derive it.

**Filed against the standard**: btclib-org/.github#251. Section 12 says
`build` takes its non-isolated path *"exactly where the environment
satisfies `requires`"*. On the path `pyroma` reaches — `build/util.py`'s
`project_wheel_metadata(isolated=False)` — it does not read `requires` at
all: there is no `check_dependencies` on that branch, and two unimportable
`requires` entries still resolve metadata successfully. The review
confirmed the scope is right: `build/__main__.py`'s `--no-isolation` path,
which `check-sdist --installer=pip` drives, **does** check them, and
section 12's adjacent bullet already says so correctly. Two functions, one
of the two bullets wrong. The hook comment here states the mechanism
measured rather than repeating the standard's wording.

Gates, this repository's own three, after the two prerequisites a linked
worktree needs — `git submodule update --init secp256k1`, which a worktree
does not inherit, and `uv sync --locked`, which compiles libsecp256k1 and
the cffi extension: lint exit 0, `pytest --cov` exit 0 at 811 passed with
coverage 100.00%, and the `sphinx-build -W --keep-going` docs build exit 0.
Three rounds, the loaded one green. Tree clean.

Local review: CLEARED a943f9b, no blocking findings, with `build` 1.5.0's
two entry points read as source and both raises reproduced, and the
standard's own `EXPECTED_DRIFT` row checked against all eight trees to
confirm this landing does not turn that strict xfail red.

All the issues above live in `btclib-org/.github`, where a closing keyword
is a link and not a close, so none is written.

## Summary by Sourcery

Align repository configuration and documentation with the organization standard and make pyroma usable in network-restricted pre-commit environments.

Bug Fixes:
- Configure pyroma with the declared Hatchling build backend so it can run without network access in pre-commit.ci.

Enhancements:
- Remove the ineffective show_error_codes mypy setting while retaining column numbers.
- Align .gitattributes with the organization's standard copy.
- Update repository guidance to reflect that only submodule-pin remains skipped by pre-commit.ci.

Documentation:
- Document the mypy, pyroma, and .gitattributes standard-alignment changes in the changelog.