### PR TITLE
skip-checking-short-docstrings = false is kept, its reason restated as form (btclib-org/.github#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,20 @@ release-notes length in the first place, and are still in
   group and the lock are the single declaration, which was the argument
   for having no such file and had been left out.
 
+- **`[tool.pydoclint]`'s reason for `skip-checking-short-docstrings =
+  false` argued from what the check would find, not from what a
+  docstring here says** (btclib-org/.github#114). Section 4 of the
+  standard decides the key by the form a docstring's contract takes:
+  `false` where a section is how it is stated, the default where prose
+  states it. The comment instead argued that the default would let a
+  short docstring pass unread — the argument section 4 rejects when a
+  tree at the default makes it. This package's docstrings state their
+  contract in `Args` and `Returns` sections; the two that carry
+  neither, `Signer.wipe` and `SecretNonce.wipe`, take no argument and
+  return nothing, so they owe neither section under any setting of the
+  key. The comment now gives the form as the reason; the value is
+  unchanged.
+
 ### CI
 
 - **The rehearsal re-locks, and every build step passes `--locked`**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,9 +484,14 @@ style = "google"
 # the docstring is a second place to be wrong
 arg-type-hints-in-docstring = false
 check-return-types = false
-# the default skips a docstring that is only a summary line, which is
-# exactly the state this check exists to end: without it every function
-# documented in one line passes, and the gate holds nothing
+# false, and what decides it is the form a docstring's contract takes
+# here: an `Args` list naming each parameter and a `Returns` list
+# stating what comes back, the summary above them free to say only
+# what the call does. Left at the default, a docstring that already
+# carries those sections is held against the signature, and one with
+# neither -- `wipe`, taking and returning nothing -- is skipped along
+# with it; `false` asks the same question of both, and the two `wipe`
+# methods answer it by having nothing to state
 skip-checking-short-docstrings = false
 # and this one is off, deliberately. It compares the Raises section with
 # the `raise` statements of the body, and these wrappers raise mostly


### PR DESCRIPTION
`btclib-org/.github#114`'s second box, in the one tree nobody had
checked.

Section 4 of the standard decides `skip-checking-short-docstrings` by
**the form a docstring's contract takes**: `false` where a section is how
those docstrings say what the call takes and returns, the default where
they say it in prose. Three trees were brought into line earlier. This is
the fourth and the only one at `false`, and its comment argued from what
the check *buys* instead:

> the default skips a docstring that is only a summary line, which is
> exactly the state this check exists to end: without it every function
> documented in one line passes, and the gate holds nothing

That is an argument about coverage, not about form — which is #114's own
complaint reproduced here: the reasons do not sort along the axis the
setting sorts along. **The value is unchanged; only the reason is.**

## The value was checked before the reason was written

`false` is correct here, and that was measured rather than assumed:
`pydoclint==0.9.1 --config=pyproject.toml` over `btclib_secp256k1/` exits
0 with no violations, and a walk of every function and method docstring
in the package finds sections dominating.

The review re-derived that walk rather than sampling it: **159
docstrings, 157 carrying `Args:`/`Returns:`/`Raises:`, exactly two
without** — `Signer.wipe` at `ssa.py:436` and `SecretNonce.wipe` at
`musig.py:789`, both `(self) -> None`, so neither owes a section under
any setting of the key. It also checked for any function with real
parameters or a non-`None` return that lacked the matching section, and
found none. Had prose dominated, the finding would have been that the
*value* disagrees with section 4 rather than the comment, which is why
this was measured first.

The two `wipe` methods are named illustratively in the comment, not as an
exhaustive claim, so a third such method later does not falsify it.

The neighbouring `arg-type-hints-in-docstring = false` and
`check-return-types = false` keep their shared comment: it argues type
declarations being a second place to be wrong, which is a different axis
from the form-of-contract question, and it is worded near-identically in
the siblings. Verified rather than assumed, since if it were the same
defect it would have travelled with this.

## Gates

`uv run --locked --no-default-groups --group test pytest --cov` exit 0 at
**811 passed, coverage 100.00%**; `sphinx-build -W --keep-going` exit 0;
`uvx pre-commit validate-config` exit 0; tree clean after the last gate.
Each exit code read on its own rather than through a pipe.

`pre-commit run --all-files` exit 0 on the second run: the first failed
`submodule-pin` because the vendored clone was shallow and carried no
`v0.8.0` tag, fixed with `git -C secp256k1 fetch --unshallow --tags`. The
review confirmed against this repository's own `.pre-commit-config.yaml`
comment that this is that hook's documented failure mode, independent of
any edit — so it is environmental and not a pin problem.

`origin/main` is `5fa4035`, unmoved since the branch was cut, so no
rebase and the figures are this sha's.

Collateral the review filed, not a finding here:
`btclib-org/bitcoin-core-rpc#239` — that tree's own comment for the same
key describes *this* package as one where "a docstring is a summary
line", which the survey above falsifies outright, and this change removes
the reason it attributes here. It belongs to that repository's file.

`#114` lives in `btclib-org/.github`, where a closing keyword from
another repository is a link and not a close — so none is written.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_113391fa-bbf2-492d-92b5-389fd818a027

## Summary by Sourcery

Align the short-docstring configuration rationale with the documented contract format without changing its value.

Enhancements:
- Clarify that `skip-checking-short-docstrings = false` is selected because the package documents call contracts using `Args` and `Returns` sections, while retaining the existing setting.

Documentation:
- Document the corrected rationale for the pydoclint short-docstring setting in the changelog and configuration comments.