### PR TITLE
README.md ends with section 2's support line (issue btclib-org/.github#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,12 @@ release-notes length in the first place, and are still in
   fast-forward that brings a clean checkout forward without working in
   it.
 
+- **`README.md` ends with the line naming who supports the work.** The
+  organization standard states the line as tier 1's, for the reason
+  `SECURITY.md` is: the archive leaves github.com, and a reader who has
+  it and not the repository meets the project with no organization
+  beside it (btclib-org/.github#98).
+
 ### CI
 
 - **The rehearsal re-locks, and every build step passes `--locked`**

--- a/README.md
+++ b/README.md
@@ -1263,3 +1263,8 @@ for, and
 is where this project's own boundary is timed against the others', one
 run kept whole rather than reduced to a single figure — an order of
 magnitude to read there, never a number to quote here.
+
+---
+
+The btclib organization and its projects are actively supported by
+[DGI](https://dgi.io) and [CheckSig](https://checksig.com).


### PR DESCRIPTION
Part of [btclib-org/.github#98](https://github.com/btclib-org/.github/issues/98).

Section 2 of the standard says `README.md` ends with the line naming
who supports the work, and gives the text verbatim. This adds it.

The line is tier 1's, for the reason `SECURITY.md` is: the archive
leaves github.com, and a reader who has only the sdist has only what
the repository shipped. That is three repositories — section 2's tier
table and its "every repository that publishes" are what scope it —
and this is the last of the three.

No closing keyword: section 11 says a keyword naming another
repository's issue is a link and not a close, so #98 is closed by hand
once this lands.

Local review CLEARED at this head.

## Summary by Sourcery

Add the required support attribution to README.md and record the documentation change.

New Features:
- Add the organization support attribution line to the end of README.md.

Documentation:
- Document that the btclib organization and its projects are supported by DGI and CheckSig.

Chores:
- Record the README support-attribution update in the changelog.