### PR TITLE
CLAUDE.md names the worktree wt-<tracker>-<issue>-<repo>-<role> (issue btclib-org/.github#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,15 @@ release-notes length in the first place, and are still in
   `SECURITY.md` is: the archive leaves github.com, and a reader who has
   it and not the repository meets the project with no organization
   beside it (btclib-org/.github#98).
+- **`CLAUDE.md`'s worktree recipe named the worktree after the issue
+  alone, `wt<issue>`** (btclib-org/.github#292). A worktree's
+  administrative directory lives in the one shared `.git`, keyed on its
+  path's basename, and one issue is routinely owed by several
+  repositories of the organization, so a session working this repository
+  against such an issue computed the same name a sibling repository's
+  session was computing too, with no error and a silent collision. The
+  recipe now names the worktree `wt-<tracker>-<issue>-<repo>-<role>`,
+  most general part first.
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,13 +423,19 @@ release-notes length in the first place, and are still in
   beside it (btclib-org/.github#98).
 - **`CLAUDE.md`'s worktree recipe named the worktree after the issue
   alone, `wt<issue>`** (btclib-org/.github#292). A worktree's
-  administrative directory lives in the one shared `.git`, keyed on its
-  path's basename, and one issue is routinely owed by several
-  repositories of the organization, so a session working this repository
-  against such an issue computed the same name a sibling repository's
-  session was computing too, with no error and a silent collision. The
-  recipe now names the worktree `wt-<tracker>-<issue>-<repo>-<role>`,
-  most general part first.
+  administrative directory lives in the `.git` of the repository
+  `git worktree add` was run from, one per repository, so two
+  repositories cannot collide there; what the recipe left uncovered was
+  a same-repository collision, between two worktrees of different work
+  sharing a generic basename, and a *path* collision across
+  repositories, since the workers of one session share one scratchpad
+  directory and a session carrying one issue into several repositories
+  computed the same target path for each. The recipe now names the
+  worktree `wt-<tracker>-<issue>-<repo>-<role>`, most general part
+  first: `tracker` because an issue number is unique only within one
+  tracker, `issue` against the same-repository collision, `repo` against
+  the cross-repository path collision, and `role` against a coder and
+  its reviewer holding a worktree at once.
 
 ### CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,18 @@ the permitted side of *never work in it*, not an exception to it. Stop if
 the checkout is not on `main` or is not clean: that is no longer bringing
 it forward.
 
-**Every session works in a worktree**, its own, from the first edit:
+**Every session works in a worktree**, its own, from the first edit,
+named `wt-<tracker>-<issue>-<repo>-<role>` rather than after the issue
+alone: a worktree's administrative directory lives in the one shared
+`.git`, keyed on its path's basename, and one issue is routinely owed by
+several repositories of the organization, so a name that dropped the
+repository collided silently between them. `issue` is what prevents a
+collision between two different issues sharing a generic name; `role`
+covers a coder and its reviewer holding a worktree at once, which the
+ordinary sequence avoids by each removing its own.
 
 ```shell
-WT=<scratchpad>/wt<issue>
+WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>  # wt-github-255-btclib-coder
 git worktree add -b <branch> "$WT" origin/main
 cd "$WT"
 git submodule update --init secp256k1  # a worktree isolates files, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,22 @@ it forward.
 
 **Every session works in a worktree**, its own, from the first edit,
 named `wt-<tracker>-<issue>-<repo>-<role>` rather than after the issue
-alone: a worktree's administrative directory lives in the one shared
-`.git`, keyed on its path's basename, and one issue is routinely owed by
-several repositories of the organization, so a name that dropped the
-repository collided silently between them. `issue` is what prevents a
-collision between two different issues sharing a generic name; `role`
-covers a coder and its reviewer holding a worktree at once, which the
-ordinary sequence avoids by each removing its own.
+alone. `tracker` is the repository whose issue tracker holds the issue:
+an issue number is unique only within one tracker, so
+`btclib-org/.github#45` and `btclib-org/btclib#45` are different issues
+that would otherwise name the same worktree. `issue` is what prevents
+the collision that has actually happened — two worktrees of different
+work sharing a generic basename in one repository's own `.git`, keyed on
+its path's basename. `repo` prevents a different collision, a *path*
+one rather than a `.git` one: two repositories each keep their own
+`.git/worktrees/<basename>` and cannot collide there, but the workers of
+one session share one scratchpad directory, so a session carrying one
+issue into several repositories computes the same target path for each
+of them, and `git worktree add` refuses a directory that already
+exists — or worse, a second worker reads the first one's tree; naming it
+this way also sorts every worktree of one issue together. `role` covers
+the narrower case of a coder and its reviewer holding a worktree at
+once, which the ordinary sequence avoids by each removing its own.
 
 ```shell
 WT=<scratchpad>/wt-<tracker>-<issue>-<repo>-<role>  # wt-github-255-btclib-coder


### PR DESCRIPTION
Part of [btclib-org/.github#292](https://github.com/btclib-org/.github/issues/292).

`CLAUDE.md`'s recipe named the worktree after the issue alone, `wt<issue>`,
in every repository of the organization. One issue is routinely owed by
several trees, so a session working one of them computed the same name
for every tree it touched — with no error, and a worktree has been found
sitting on another session's commit with an empty reflog.

The recipe now names it `wt-<tracker>-<issue>-<repo>-<role>`, and each of
the four parts earns its place against a different collision:

- `tracker` — an issue number is unique only within one tracker, so
  `btclib-org/.github#45` and `btclib-org/btclib#45` would otherwise name
  the same worktree.
- `issue` — the collision that has actually happened: two worktrees of
  different work sharing a generic basename in one repository's own
  `.git`, keyed on the path's basename.
- `repo` — a *path* collision, not a `.git` one. Two repositories each
  keep their own `.git/worktrees/<basename>` and cannot collide there;
  what they share is the one scratchpad directory the workers of a
  session write into.
- `role` — the narrower case of a coder and its reviewer holding a
  worktree at once.

The order is most general part first, which also sorts every worktree of
one issue together — which is what a port leaves behind.

No closing keyword: section 11 says a keyword naming another
repository's issue is a link and not a close. #292 is closed by hand
once the last tree lands.

Local review CLEARED, and both defects the round found — the mechanism
`repo` was said to prevent, and `tracker` going unexplained — are fixed
in every tree, checked across all eight.

## Summary by Sourcery

Use tracker-, issue-, repository-, and role-qualified worktree names to prevent collisions across sessions and repositories.

Bug Fixes:
- Prevent worktree name collisions across trackers, repositories, issues, and concurrent coder/reviewer roles by using a uniquely qualified naming scheme.

Enhancements:
- Update the CLAUDE.md worktree workflow to use tracker, issue, repository, and role components in names and document the rationale for each component.

Documentation:
- Document the revised worktree naming convention and its collision-avoidance rules in CLAUDE.md.

Chores:
- Record the worktree naming correction in the changelog.