### PR TITLE
The shipped package and its published docs stop naming btclib (issue btclib-org/.github#81)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -474,6 +474,24 @@ repos:
         language: pygrep
         entry: '\b(text|universal_newlines)=True'
         files: \.py$
+  # Scoped to btclib_secp256k1, which is what actually ships in the
+  # wheel: a comment here is read by someone who installed only this
+  # package, upstream of btclib rather than the other way round. The
+  # organization that publishes the package is allowed -- "btclib-org"
+  # in a URL, "The btclib developers" in the copyright line -- because a
+  # consumer does care who publishes it; naming the downstream package
+  # that depends on this one is not. -i because a downstream name can
+  # open a sentence or sit in a class-name-style compound, and this
+  # package's own name never needs the capitalized spelling to appear
+  # inside btclib_secp256k1/.
+  - repo: local
+    hooks:
+      - id: no-downstream-name-in-package
+        name: the shipped package does not name btclib, org spelling excepted
+        language: pygrep
+        args: ["-i"]
+        entry: 'btclib(?!-secp256k1|_secp256k1|-org|\.org|-node|_node|-benchmarks| developers)'
+        files: ^btclib_secp256k1/.*\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,43 @@ release-notes length in the first place, and are still in
   tracker, `issue` against the same-repository collision, `repo` against
   the cross-repository path collision, and `role` against a coder and
   its reviewer holding a worktree at once.
+- **The shipped package and this repository's published docs stop
+  naming `btclib`** (btclib-org/.github#81). This package is upstream of
+  `btclib` -- `cffi` only, and `btclib`'s `secp256k1` extra depends on
+  it -- so a reader of `btclib_secp256k1/` or of the built documentation
+  is not guaranteed to have `btclib` at all. `__init__.py`'s lazy
+  `__version__` docstring named `btclib` as an example of a caller that
+  never asks for the version, and loses only the example by dropping the
+  name. `README.md`'s ergonomics aside deferred a design tradeoff to
+  `btclib` by name; it now defers to the caller generally, the same
+  reasoning intact. `docs/source/package-content-policy.md` explained
+  why this package's sdist policy carries no include-list check by
+  contrasting it with `btclib`'s own script; the same argument now
+  stands on the shape of an include list rather than on that comparison.
+  `README.md`'s MuSig2 section named `btclib`'s own PSBT machinery and
+  API to argue that wrapping libsecp256k1's own session is worth
+  something to `btclib`'s test suite -- an argument about the dependent
+  rather than about this package, correctly cut whole. What that
+  paragraph also carried, and what stays, is the boundary a reader of
+  `musig.KeyAggCache`/`musig.Session` needs regardless of `btclib`: a
+  PSBT's multi-party signing state is not what `Session` is, that object
+  being scoped to one process and one two-round exchange, so whoever
+  needs PSBT-level coordination holds that state elsewhere. What stays
+  everywhere is the organization that publishes this package and the one
+  sentence in `README.md` saying who else uses it, both of which section
+  9 of the standard names as the exception. A
+  `no-downstream-name-in-package` pygrep hook holds `btclib_secp256k1/`
+  to it, case-insensitively -- a downstream name can as easily open a
+  sentence or sit in a class-name-style compound as sit mid-sentence, the
+  shape every occurrence found here took -- the organization spelling
+  and the copyright line's "The btclib developers" excepted.
+
+- **`README.md`'s GitHub badge label names this repository, not the one
+  it was renamed from.** The alt text and the link target were both
+  updated when the repository moved to `btclib-secp256k1` (#133), but
+  the shields.io image label itself still read `btclib--libsecp256k1`,
+  the pre-rename spelling baked into the badge's own URL rather than
+  into any text a diff of the rendered page would show.
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bitcoin-core-rpc carry the same three lines. -->
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-secp256k1/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-secp256k1/main)
 [![documentation build](https://readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
 
-[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--libsecp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
+[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--secp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
 
 ---
 
@@ -468,7 +468,7 @@ this package is [stateless by construction](#design), and
 object with an owner and an invalidation and, [Thread safety](#thread-safety)
 says, its own answer to sharing one across threads. What the rule above
 does not weigh is ergonomics — the line a caller does not have to write
-is real, and belongs in btclib along with the lifetimes.
+is real, and belongs with the caller along with the lifetimes.
 
 So the numbers **confirm** the rule rather than establish it, and it is
 worth being clear which of them would survive a different machine. Not
@@ -1040,16 +1040,11 @@ calls it on the way out. `ssa.Signer` is the model this follows, and
 SECURITY.md records both as the buffers in this package whose zeroing is
 asked for rather than done.
 
-[btclib](https://github.com/btclib-org/btclib) still carries its own
-MuSig2 signing state, independent of the C library's: its PSBT is the
-multi-party signing machinery MuSig2 plugs into, and the specifications
-say so too (BIP327 the protocol, BIP373 its PSBT fields, BIP328 its
-descriptors). `btclib.ecc.musig2.sign` zeroes the secret nonce it
-consumes and `btclib.psbt.musig2.partial_sign` carries the same
-guarantee into a PSBT round, in a pure-python implementation of BIP327
-that is a different thing from wrapping libsecp256k1's own session --
-`musig` is what btclib can now check that implementation against,
-rather than only against published vectors.
+A PSBT's multi-party signing state is not what `musig.Session` is:
+that object is scoped to one process and one two-round exchange -- it
+has no serialization, the module docstring above giving the reason
+that is taken as an exception here -- so whoever needs PSBT-level
+coordination holds that state elsewhere, outside this package.
 
 The aggregate signature `Session.partial_sig_agg` answers is a plain
 BIP340 signature, over the aggregate key `KeyAggCache.pubkey_get` or

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -91,8 +91,7 @@ else:
         of the table and what the 14 milliseconds are made of, so that
         the decomposition is written down once. So the caller that wants
         the version pays for it and the one that never asks pays
-        nothing; btclib, which depends on this package, is one of
-        those.
+        nothing.
 
         The value is stored into the module's own namespace on the way
         out, which is the usual shape of PEP 562 and is what keeps the

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -102,10 +102,10 @@ check here or in `check-wheel-contents` reads a member's size at all.
 
 ## The sdist is not this policy's subject
 
-`btclib`'s sibling script checks the sdist because `MANIFEST.in` there
-is an *include* list: a file the tree gains and `MANIFEST.in` does not
-name is a file the sdist silently drops, which is the failure this whole
-class of check exists for. `[tool.hatch.build.targets.sdist] exclude` in
+A `MANIFEST.in`-based sdist is an *include* list: a file the tree gains
+and `MANIFEST.in` does not name is a file the sdist silently drops,
+which is the class of check an include list needs and this repository
+does not. `[tool.hatch.build.targets.sdist] exclude` in
 this repository's `pyproject.toml` is the opposite shape — a file the
 tree gains ships by default, and has to be named to be left out — so the
 failure mode here is an sdist too wide rather than one silently narrow,


### PR DESCRIPTION
Part of [btclib-org/.github#81](https://github.com/btclib-org/.github/issues/81).

Section 9 says a package upstream of another does not name the one
downstream, with two carve-outs: positioning in the family, and the
organization. This triages this tree's prose against that rule and adds
a `pygrep` hook to hold it.

Three sites in prose a stranger reads:

- The shipped module's lazy-`__version__` docstring loses only its
  example; the sentence needs none to make its point.
- `README.md`'s ergonomics aside deferred a design tradeoff to a
  project the reader may not have, and now defers it to the caller
  generally, the same reasoning intact.
- `docs/source/package-content-policy.md`, a published page, explained
  this package's sdist policy by contrast with a sibling's script. It
  now stands on the shape of an include list rather than on that
  comparison.

The MuSig2 paragraph is the one that is not a rewording. Its argument
about what the dependent gains is cut whole; the fact it carried about
*this* package's own scope — that a PSBT's multi-party signing state is
not what `musig.Session` is, that object having no serialization and
being scoped to one two-round exchange — is restored in its place,
written from `musig.py`'s own docstrings.

Kept, as the rule's own carve-outs: `README.md`'s "As used by the
`btclib` library", and the organization spellings in `SECURITY.md` and
`pyproject.toml`'s `authors`.

The hook is case-insensitive, so a sentence-initial or compound spelling
cannot slip through. Its divergence from `bitcoin-core-rpc`'s copy is
[#299](https://github.com/btclib-org/.github/issues/299).

Collateral, one token in a file already touched: the GitHub badge still
carried the pre-rename label baked into its image URL.

**This does not close #81.** `bitcoin-core-rpc` still owes its prose —
`REPOSITORY.md` and `RELEASING.md` both name btclib outside the two
carve-outs — and section 11 says a keyword naming another repository's
issue is a link, not a close.

Local review CLEARED; rebased since, with the content proved identical.

## Summary by Sourcery

Stop the shipped package and published documentation from naming its downstream package while enforcing the policy in pre-commit checks.

Bug Fixes:
- Update the repository badge URL so its rendered label reflects the current repository name.

Enhancements:
- Remove downstream package references from shipped package prose and published documentation while retaining permitted organization and usage references.
- Preserve the MuSig2 documentation’s explanation of session scope without tying it to a downstream package.

CI:
- Add a case-insensitive pre-commit check preventing prohibited downstream package names in shipped Python modules.

Documentation:
- Revise README and package policy documentation to describe behavior and packaging independently of the downstream package.

Chores:
- Record the documentation and naming cleanup in the changelog.