### PR TITLE
release.yml: rewrap a stray comment, drop an uncounted figure, name three release-only steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Check that uv.lock is up to date
         run: uv lock --check
 
-      - name: Check that the tag matches the declared version
+      - name: Check that the tag matches the declared version (release only)
         if: github.event_name == 'push'
         run: |
           version=$(uv version --short)
@@ -139,17 +139,17 @@ jobs:
           fi
 
       # RELEASING.md says a release is a tag on a commit on main, every
-      # invariant a release rests on resting on that; nothing enforced it. The deployment tag policy
-      # of the pypi environment constrains the *name* of the ref and
-      # nothing else, so a v* tag on a branch head, on a stale state or
-      # on a fork-synced commit reaches the environment exactly
-      # as the release tag does -- and the reviewer approving sees the
-      # tag name, not its ancestry. This is the ancestry, before the
-      # matrix builds anything.
+      # invariant a release rests on resting on that; nothing enforced
+      # it. The deployment tag policy of the pypi environment constrains
+      # the *name* of the ref and nothing else, so a v* tag on a branch
+      # head, on a stale state or on a fork-synced commit reaches the
+      # environment exactly as the release tag does -- and the reviewer
+      # approving sees the tag name, not its ancestry. This is the
+      # ancestry, before the matrix builds anything.
       # origin/main rather than a fetch of its own: the checkout above
       # takes the whole history, remote-tracking branches included, and a
       # missing origin/main fails the step, which is the safe way round
-      - name: Check that the tag is on main
+      - name: Check that the tag is on main (release only)
         if: github.event_name == 'push'
         run: |
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
@@ -192,7 +192,7 @@ jobs:
       # String comparison rather than a regex, so that the dots of the
       # version match dots and not any character, and awk rather than
       # grep, one pass answering all three questions
-      - name: Check that the release notes are retitled for the tag
+      - name: Check that the release notes are retitled for the tag (release only)
         if: github.event_name == 'push'
         run: |
           for file in RELEASE_NOTES.md CHANGELOG.md; do
@@ -522,8 +522,8 @@ jobs:
           persist-credentials: false
 
       # the sdist alone: the wheels are on PyPI, with their attestations,
-      # and thirty assets mirroring an index nobody would install from by
-      # hand are noise. What belongs here is the source of the tag
+      # and assets mirroring an index nobody would install from by hand
+      # are noise. What belongs here is the source of the tag
       - name: Download the source distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,6 +476,34 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`release.yml`'s prose stays inside the width its neighbours hold, and
+  states no count nothing derives** (#340, #342). The paragraph above
+  `Check that the tag is on main` left one line at exactly the
+  100-column limit `.yamllint.yaml` enforces, where every other line of
+  that block wraps between 63 and 73 -- a rewrap begun and not
+  finished, invisible to the hook because it sits at the limit rather
+  than past it; it wraps the same way as its neighbours now. The
+  comment above `github-release`'s sdist-only download named the
+  release matrix's asset count as `thirty`; nothing in the workflow
+  computes that figure, and it moves with cibuildwheel's own identifier
+  list, the skip list and the image matrix, so the sentence no longer
+  states one.
+
+- **Three `release.yml` steps that run only on a push now say so in
+  their name** (#341). `Check that the tag matches the declared
+  version`, `Check that the tag is on main` and `Check that the release
+  notes are retitled for the tag` each carry
+  `if: github.event_name == 'push'`, and none of the three said
+  `(release only)`, the suffix both `btclib` and `bitcoin-core-rpc`
+  already carry on the same condition; they do now. `Sign a build
+  provenance statement for the sdist` and `Create the release, with
+  RELEASE_NOTES.md as its notes` keep their own names: both jobs run on
+  `always()` rather than on that event check -- the attest job accepts
+  either publish job succeeding, and the release job runs off
+  `publish-pypi` succeeding rather than off the trigger directly -- so
+  the suffix would misdescribe them, and each already names what it
+  does more precisely than the sibling name it was compared against.
+
 - **The rehearsal re-locks, and every build step passes `--locked`**
   (btclib-org/.github#128). The `dev-version` action rewrites the version
   in `pyproject.toml` on the rehearsal path, and the build steps after it


### PR DESCRIPTION
Bundled because all three touch only `.github/workflows/release.yml`, are cosmetic/consistency fixes, and share no design decision worth a pull request each.

- The comment paragraph above `Check that the tag is on main` sat at exactly the 100-column yamllint limit while every neighbouring line wraps 63-73; it now wraps the same way.
- `Check that the tag matches the declared version`, `Check that the tag is on main` and `Check that the release notes are retitled for the tag` each carry `if: github.event_name == 'push'` and now say `(release only)` in their name, matching both siblings' convention for the same condition. `Sign a build provenance statement for the sdist` and `Create the release, with RELEASE_NOTES.md as its notes` keep their own names: both jobs gate on `always()` rather than on that event check, so the suffix would misdescribe them.
- The comment above `github-release`'s sdist-only download stated the release matrix's asset count as "thirty", a number nothing in the workflow computes; it is dropped rather than corrected, per this repository's rule against stating an uncounted figure.

Gates on the worktree, exit codes: `pre-commit run --all-files` 0; `pytest --cov` 0, 811 passed, 100.00% coverage; `sphinx-build -W --keep-going` 0; `git status --porcelain` empty after each.

Local review cleared this head at 82c4452.

Closes #340, closes #341, closes #342.