### PR TITLE
RELEASING.md and REPOSITORY.md stop naming btclib, on the reading bitcoin-core-rpc landed (issue btclib-org/.github#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,12 @@ release-notes length in the first place, and are still in
   who may not have `btclib` at all, and that reading is what lands here
   too. `RELEASING.md`'s CycloneDX paragraph — the case this round turns
   on — now states its own reasoning instead of sending that reader to
-  `btclib`'s `RELEASING.md` for it, and points at `btclib-org/.github#24`
-  for what would reopen the question. Every other comparison against
-  `btclib`'s own settings or history, in both files, now states the same
-  fact without the name.
+  `btclib`'s `RELEASING.md` for it: a generator that read only
+  `Requires-Dist` could not describe a vendored submodule's pin, that
+  limit is fixed upstream (btclib-org/btclib#1280), and what remains is
+  adoption here, tracked at `btclib-org/.github#24`. Every other
+  comparison against `btclib`'s own settings or history, in both files,
+  now states the same fact without the name.
 
 - **`.gitattributes` is the organization's file byte for byte**
   (btclib-org/.github#192). Section 14 of the standard makes the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`RELEASING.md` and `REPOSITORY.md` stop naming `btclib` to justify
+  this package's own choices** (btclib-org/.github#81). The first pass
+  held both files out of scope, reading a maintainer's runbook as prose
+  the rule does not reach; `bitcoin-core-rpc`'s later half
+  (bitcoin-core-rpc#245) read the same rule as reaching a new maintainer
+  who may not have `btclib` at all, and that reading is what lands here
+  too. `RELEASING.md`'s CycloneDX paragraph — the case this round turns
+  on — now states its own reasoning instead of sending that reader to
+  `btclib`'s `RELEASING.md` for it, and points at `btclib-org/.github#24`
+  for what would reopen the question. Every other comparison against
+  `btclib`'s own settings or history, in both files, now states the same
+  fact without the name.
+
 - **`.gitattributes` is the organization's file byte for byte**
   (btclib-org/.github#192). Section 14 of the standard makes the two
   `merge=union` entries and the reasoning beside them the standard's

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,12 +22,15 @@ extension, a dynamic (ABI-mode) build ships it as a shared object
 beside the extension instead (see CLAUDE.md's Architecture section) —
 `Requires-Dist` says nothing about the pin either way, so a document
 built from it would look complete while staying silent about the one
-component a verifier would most want described. The limit is the
-generator's rather than this package's, so the decision is
-conditional: if the generator ever learns to describe a submodule pin
-as a component, it reopens.
+component a verifier would most want described. That was the
+generator's own limit rather than this package's, and it no longer
+holds:
+[btclib-org/btclib#1280](https://github.com/btclib-org/btclib/issues/1280)
+taught a generator to read a submodule's pinned commit from its
+`.gitmodules` entry and gitlink instead of from `Requires-Dist`. What
+is still missing is adoption here, not a technical inability.
 [btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24)
-records that trigger and stays open; an issue no longer open watches
+stays open until that adoption lands; an issue no longer open watches
 nothing.
 
 The version published is the one in `pyproject.toml`; the tag only

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,22 +11,21 @@ The `attest` job then signs a build provenance statement for the sdist,
 which is the file the GitHub release attaches and therefore the one copy
 the index's attestation says nothing about.
 
-**No CycloneDX bill of materials is attached, on purpose**, unlike
-btclib's release. This package's `Requires-Dist` names only `cffi` —
-the dependency it actually wraps, the vendored libsecp256k1 C
-library at its pinned commit in the `secp256k1` submodule, does not
-appear there and so is invisible to the generator btclib uses. That
-holds for both wheels this package ships, not only the static one:
-a static build links the library into the extension, a dynamic
-(ABI-mode) build ships it as a shared object beside the extension
-instead (see CLAUDE.md's Architecture section) — `Requires-Dist`
-says nothing about the pin either way. btclib's `RELEASING.md` (the
-"Read the bill of materials attached to the release" step) has the
-full reasoning, and issue
-[btclib-org/btclib#1159](https://github.com/btclib-org/btclib/issues/1159)
-has the evaluation behind it. The limit is the generator's rather than
-this package's, so the decision is conditional: if the generator ever
-learns to describe a submodule pin as a component, it reopens.
+**No CycloneDX bill of materials is attached, on purpose.** This
+package's `Requires-Dist` names only `cffi` — the dependency it
+actually wraps, the vendored libsecp256k1 C library at its pinned
+commit in the `secp256k1` submodule, does not appear there and so is
+invisible to a generator that builds its components from
+`Requires-Dist`. That holds for both wheels this package ships, not
+only the static one: a static build links the library into the
+extension, a dynamic (ABI-mode) build ships it as a shared object
+beside the extension instead (see CLAUDE.md's Architecture section) —
+`Requires-Dist` says nothing about the pin either way, so a document
+built from it would look complete while staying silent about the one
+component a verifier would most want described. The limit is the
+generator's rather than this package's, so the decision is
+conditional: if the generator ever learns to describe a submodule pin
+as a component, it reopens.
 [btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24)
 records that trigger and stays open; an issue no longer open watches
 nothing.
@@ -162,8 +161,8 @@ Then:
    against — `python -c "import btclib_secp256k1 as m;
    print(m.__version__)"` answers the real version regardless. The list
    of what else to discount is per release rather than inherited, the
-   way btclib's own griffe step names `Union[X, Y] -> X | Y` as PEP 604
-   spelling and nothing to act on.
+   way a sibling repository's own griffe step names `Union[X, Y] -> X | Y`
+   as PEP 604 spelling and nothing to act on.
 
    Measured rather than assumed: `v0.8.0.3` to `main` (0.8.0.4) reports
    nothing beyond the `__version__` line above, `musig` being purely
@@ -638,7 +637,7 @@ the build — for every member's timestamp, and stamp ownership and mode
 the same way regardless of who built it or when. Nothing in
 `pyproject.toml` turns that default off. setuptools' sdist writer has no
 such fallback: unset, it stamps the actual checkout's clock, sub-second,
-which is why btclib and bitcoin-core-rpc each carry a
+which is why both siblings each carry a
 `.github/scripts/normalize_sdist.py` and a `SOURCE_DATE_EPOCH` step in
 their release workflow, rewriting after the fact what their backend
 will not fix by default. Looking for that script here on the strength

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -39,13 +39,13 @@ gh api repos/btclib-org/btclib-secp256k1/branches/main/protection \
 `codeql: every job passed` is not among them, and that is the one place a
 check was traded for the slots it held. GitHub Free gives an organization
 twenty concurrent jobs (as of 2026-08-21), shared across every repository
-in it: this one, btclib and bitcoin-core-rpc each ask for more jobs than
-that on every commit, so a pull request in any of the three waited for a
-slot rather than for the work. `codeql.yml` now runs on `main`
-and on its weekly schedule, the analysis landing on the merge commit rather
-than ahead of it, and it still produces that aggregate — the name is
-available, so requiring it again is a patch to the rule and nothing in the
-tree.
+in it: this one, bitcoin-core-rpc and one more repository each ask for
+more jobs than that on every commit, so a pull request in any of the
+three waited for a slot rather than for the work. `codeql.yml` now runs
+on `main` and on its weekly schedule, the analysis landing on the merge
+commit rather than ahead of it, and it still produces that aggregate —
+the name is available, so requiring it again is a patch to the rule and
+nothing in the tree.
 
 What still reads a branch before it merges is the workflow half of the same
 question: `zizmor` is a `pre-commit` hook, so `lint.yml` audits these very
@@ -274,10 +274,11 @@ checks already described, one approving review with
 `dismiss_stale_reviews`, **required signatures**, linear history, no force
 pushes, no deletions, `required_conversation_resolution`, and
 `enforce_admins` **off** — an administrator can bypass all of it, matching
-btclib now and for the same reason: a solo-maintainer repository cannot
-satisfy "one approving review" from the author, GitHub refusing
-self-approval, so the review is a stop rather than a speed bump, and the
-admin bypass is the only way past it without a second maintainer to add.
+another repository in the organization now and for the same reason: a
+solo-maintainer repository cannot satisfy "one approving review" from the
+author, GitHub refusing self-approval, so the review is a stop rather than
+a speed bump, and the admin bypass is the only way past it without a
+second maintainer to add.
 
 ```shell
 gh api -X DELETE \
@@ -292,7 +293,8 @@ onto the trunk, admin included. Off would not undo that squash today
 either — that commit is what PyPI's PEP 740 attestations for 0.7.1 are
 bound to, and moving it now would desynchronize a published release from
 what it attests to rather than restore anything. What changed is only
-whether the next incident has the same escape hatch btclib already keeps.
+whether the next incident has the same escape hatch another repository in
+the organization already keeps.
 
 One protected branch is the whole of it, which is a consequence of there
 being one long-lived branch:
@@ -427,8 +429,8 @@ delete by hand. Measured on
 at 12:39:19 and `head_ref_deleted` at 12:39:20, with nobody asking. The
 thing not to do is get ahead of it — deleting the branch before the
 reconciliation is what leaves a pull request Closed with its commit on
-`main` all the same, as btclib's
-<https://github.com/btclib-org/btclib/pull/930> came out.
+`main` all the same, as has happened once at another repository in the
+organization.
 
 ## Merge methods
 
@@ -659,11 +661,11 @@ for a plan — on this repository it is the answer, and the plan below
 Enterprise that would undo it does not exist.
 
 What Team would buy is the rest: the Linux and Windows crowding, and the
-contention with the other repositories of the organization, `btclib` and
-`bitcoin-core-rpc` each asking for well more than the twenty on their own
-commits too. Whether that is worth three seats is a question for whoever
-pays for them, and it is recorded here so that it is asked with the
-second column in view.
+contention with the other repositories of the organization,
+`bitcoin-core-rpc` and one more each asking for well more than the twenty
+on their own commits too. Whether that is worth three seats is a question
+for whoever pays for them, and it is recorded here so that it is asked
+with the second column in view.
 
 ## Topics
 
@@ -692,12 +694,9 @@ and `bip324` are in a list of what this package wraps.
 
 ## No website
 
-Unlike btclib, this repository serves no GitHub Pages site, so no file in
-its root is a URL anywhere:
+This repository serves no GitHub Pages site, so no file in its root is a
+URL anywhere:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1/pages   # 404
 ```
-
-btclib.org is built from the btclib repository's `main` root, which is
-why that project's README is also a web page and this one's is not.


### PR DESCRIPTION
Part of [btclib-org/.github#81](https://github.com/btclib-org/.github/issues/81),
and the second pass this tree owed.

The first pass held `RELEASING.md` and `REPOSITORY.md` out of scope, on
the reading that prose read by somebody already inside the organization
is not what section 9 protects. `bitcoin-core-rpc`'s half then landed on
the opposite reading — a maintainer's admin and release runbooks are
read by someone who may be a stranger, this package declaring no
dependencies and being meant to be vendored, so a new maintainer
plausibly arrives without the downstream project. Two trees on two
readings of one rule is the drift this organization files issues about,
so this brings the tree onto the landed one.

Three sites in `RELEASING.md` and six in `REPOSITORY.md`. The
comparisons — the griffe discount, `normalize_sdist.py`, the
twenty-concurrent-jobs ceiling, `enforce_admins`, Team-seat contention,
a premature branch deletion — now say *a sibling repository* and keep
the fact each carried. The *No website* paragraph is deleted outright
rather than rewritten: it was about another project's infrastructure and
left no fact about this package behind.

The CycloneDX paragraph is the case this issue's own thread named as the
test, and it needed two corrections rather than one. It no longer defers
its reasoning to another repository's `RELEASING.md`; and it no longer
says the decision reopens *if* a generator ever learns to describe a
submodule pin, because that has already happened —
[btclib-org/btclib#1280](https://github.com/btclib-org/btclib/issues/1280)
taught it to read the gitlink instead of `Requires-Dist`. The decision
stands, no bill of materials being attached today, but what remains is
adoption here rather than a technical inability, and
[btclib-org/.github#24](https://github.com/btclib-org/.github/issues/24)
is what watches it.

Both files now answer nothing to the rule's own pattern, measured with
the whitespace flattened, that pattern wrapping across line breaks.

`CONTRIBUTING.md`'s repository-specific section carries the same shape
and is tracked at #365, having its own triage question.

Local review CHANGES REQUESTED on the stale trigger, then the fix
verified against the sources rather than against the summary. Rebased,
gates re-run.

## Summary by Sourcery

Align repository and release documentation with the organization’s policy by removing sibling-project naming and keeping the relevant guidance self-contained.

Enhancements:
- Remove references to btclib from repository-specific release and maintenance guidance while preserving the underlying rationale and comparisons.
- Make the CycloneDX documentation self-contained and reflect that submodule pin detection is now technically supported, with adoption still tracked separately.
- Remove the repository-specific website comparison that does not provide a fact about this package.

Documentation:
- Update the changelog to document the documentation alignment and rationale changes.