### PR TITLE
check-sdist gates the archive against git, and its own timestamp is this repository's

### DIFF
--- a/.github/scripts/normalize_sdist.py
+++ b/.github/scripts/normalize_sdist.py
@@ -1,0 +1,121 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Rewrite an sdist's member `mtime` to `SOURCE_DATE_EPOCH`.
+
+Unlike the siblings' script, this one touches one field and not five.
+Hatchling's sdist writer already stamps every member's ownership at
+`uid`/`gid` `0` and `uname`/`gname` `""`, measurable with
+`tarfile.getmembers()` against a build of this tree, so rewriting them
+again would not change a byte. Mode is not rewritten at all: each
+member's mode is the executable bit git tracks for that file, `0o755`
+for `secp256k1/autogen.sh` and the small set of vendored tools beside
+it, `0o644` for everything else, and flattening that to one constant
+would strip the bit a plain `tar -x` of the archive needs to run them.
+
+`mtime` is the field left. Hatchling's sdist writer reads
+`SOURCE_DATE_EPOCH` when it is set and falls back to a fixed constant,
+`1580601600`, when it is not -- neither is the tagged commit's own
+date, which is what this script writes instead. Measured by building
+this tree twice, once with the variable unset and once set to an
+arbitrary second:
+
+    uv build --sdist -o a && SOURCE_DATE_EPOCH=1000000000 \
+      uv build --sdist -o b && shasum -a 256 a/* b/*
+
+answers with one digest per build, agreeing on every field but `mtime`,
+which is the one this script moves to the commit's own date rather than
+either of hatchling's two choices. RELEASING.md's "Rebuild a release
+from its tag" runs this script for that reason: skip it there and the
+rebuild's `mtime` disagrees with the published archive.
+
+What is *in* the archive, and every other member attribute, is already
+this repository's own; only `mtime` is rewritten here, on every member
+including directories, and the gzip header carries the same timestamp
+instead of the moment it was compressed.
+
+Run it after the sdist is built and before anything reads dist/:
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/normalize_sdist.py dist/
+
+RELEASING.md has the command that verifies a published release against a
+rebuild of its tag.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+
+def normalize(archive: Path, epoch: int) -> None:
+    """Rewrite one archive in place, every member's `mtime` at `epoch`."""
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    with tarfile.open(archive, "r:gz") as source:
+        for member in source.getmembers():
+            # extractfile returns None for anything that is not a regular
+            # file, a directory member being one of them
+            stream = source.extractfile(member) if member.isfile() else None
+            members.append((member, stream.read() if stream is not None else None))
+
+    tar = io.BytesIO()
+    with tarfile.open(fileobj=tar, mode="w", format=tarfile.PAX_FORMAT) as target:
+        for member, content in members:
+            member.mtime = epoch
+            # the record a sub-second mtime would need: mtime becomes an
+            # integer above, so none of the members this script has ever
+            # met need one, but a stale record from the source archive
+            # would otherwise survive the rewrite unexamined. Reassigned
+            # rather than popped from in place: the attribute is typed as
+            # a Mapping, immutable to a type checker even though it is a
+            # dict at runtime
+            member.pax_headers = {
+                key: value
+                for key, value in member.pax_headers.items()
+                if key != "mtime"
+            }
+            target.addfile(member, io.BytesIO(content) if content is not None else None)
+
+    compressed = io.BytesIO()
+    # mtime, not the clock, and filename empty: gzip stores both in its
+    # header, and the name of a temporary file is not the archive's
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=compressed, mtime=epoch, compresslevel=9
+    ) as compressor:
+        compressor.write(tar.getvalue())
+    archive.write_bytes(compressed.getvalue())
+
+
+def main(argv: list[str]) -> int:
+    """Normalize every sdist in the directory named on the command line."""
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <dist directory>", file=sys.stderr)
+        return 2
+
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch is None:
+        # not a default of "now": a default would make the failure a
+        # reproducibility bug found by whoever tried to verify a release,
+        # which is the one person who cannot fix it
+        print("SOURCE_DATE_EPOCH is not set", file=sys.stderr)
+        return 1
+
+    archives = sorted(Path(argv[1]).glob("*.tar.gz"))
+    if not archives:
+        print(f"no sdist in {argv[1]}", file=sys.stderr)
+        return 1
+
+    for archive in archives:
+        normalize(archive, int(epoch))
+        print(f"normalized {archive}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -518,9 +518,35 @@ jobs:
         with:
           suffix: ${{ inputs.version-suffix }}
 
+      # what the build below and the normalizer after it both read.
+      # hatchling's sdist writer honours this when it is set and falls
+      # back to a fixed constant, 1580601600, when it is not -- so this
+      # step is what makes the published mtime the tagged commit's own
+      # date rather than that constant, section 12 of the organization
+      # standard asking every publisher for it regardless of what its own
+      # backend already does. The commit date, not the tag's: a
+      # lightweight tag has none of its own to prefer, and this job's
+      # checkout is the commit a release tags
+      - name: Pin the build timestamp to the commit
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+
       # the build group and --locked: see build-cibuildwheel
       - name: Build source
         run: uv run --locked --only-group build python -m build -s
+
+      # insurance rather than the fix: the step above already leaves the
+      # sdist's own mtime at SOURCE_DATE_EPOCH, and this rewrites it again
+      # so that the published value stays this repository's choice
+      # regardless of what a future hatchling release does with the
+      # variable. The script's own docstring has the measurement of what
+      # else hatchling already writes the same way, untouched here.
+      # --no-project, so this runs on the interpreter actions/setup-python
+      # already installed and touches nothing this job is about to publish
+      - name: Make the sdist's determinism this tree's own
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/normalize_sdist.py dist/
+          sha256sum dist/*
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -648,6 +648,47 @@ repos:
     hooks:
       - id: uv-lock
 
+  # check-sdist compares the sdist's members against git's tracked
+  # files: a tracked file the archive leaves out and [tool.check-sdist]
+  # below does not name is reported missing, and a member neither git
+  # nor that table accounts for is reported extra. hatchling's own
+  # excludes -- [tool.hatch.build.targets.sdist]'s exclude list above --
+  # are read through check-sdist's hatchling.build plugin, keyed on
+  # [build-system], so nothing here repeats them; [tool.check-sdist]
+  # holds only what that plugin does not reach.
+  # --installer=pip, as pyroma above: the default installer is uv|pip,
+  # which resolves to uv wherever a uv is importable or on PATH and
+  # then runs `uv build` -- not PEP 517 for this backend, uv building
+  # with the copy of uv_build bundled in itself regardless of what
+  # [build-system] declares, so additional_dependencies would decide
+  # nothing. --installer=pip runs `python -m build --sdist
+  # --no-isolation` instead, which reads this hook's own environment
+  # rather than an isolated one.
+  # additional_dependencies is [build-system]'s requires verbatim,
+  # unlike pyroma's hatchling alone: build --no-isolation checks the
+  # whole of requires before calling the backend, packing an sdist
+  # asking nothing of the cffi and cmake requirements themselves --
+  # measured, the same command with hatchling alone dying
+  # "Getting build dependencies for sdist... ERROR Missing
+  # dependencies: cmake>=3.22, setuptools, cffi>=2.0" -- but requiring
+  # every declared package to be installable first regardless.
+  # --inject-junk plants an egg-info directory beside the sources for
+  # the length of the run, which [tool.check-sdist]'s git-only below
+  # accounts for
+  - repo: https://github.com/henryiii/check-sdist
+    rev: v1.6.0
+    hooks:
+      - id: check-sdist
+        args: [--inject-junk, --installer=pip]
+        additional_dependencies:
+          - "hatchling>=1.27"
+          - 'cffi>=1.6; python_version<"3.13"'
+          - 'cffi>=1.17; python_version=="3.13"'
+          - 'cffi>=2.0; python_version>="3.14"'
+          - 'setuptools; python_version>="3.12"'
+          - "cmake>=3.22"
+          - 'typing_extensions; python_version<"3.12"'
+
   # what test.yml's own pyroma step rates the sdist for -- a missing
   # classifier or url, metadata that is valid but poor -- this rates the
   # source tree instead, for an answer before pushing rather than after

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -673,8 +673,11 @@ repos:
   # dependencies: cmake>=3.22, setuptools, cffi>=2.0" -- but requiring
   # every declared package to be installable first regardless.
   # --inject-junk plants an egg-info directory beside the sources for
-  # the length of the run, which [tool.check-sdist]'s git-only below
-  # accounts for
+  # the length of the run. git-only below cannot be what keeps it out --
+  # it is read against files git tracks, and an injected directory is
+  # never one -- .gitignore's own "*.egg-info/" is what hatchling's
+  # sdist target drops it on, the same VCS-ignore reading the comment
+  # above names for .python-version's absence
   - repo: https://github.com/henryiii/check-sdist
     rev: v1.6.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1328,6 +1328,27 @@ release-notes length in the first place, and are still in
 
 ### Packaging metadata
 
+- **`check-sdist` gates the sdist against what git tracks** (#344).
+  Section 12 of the organization standard asks it of every repository
+  that builds an sdist, and this was the one tree the standard's own
+  exemption used to cover, on the strength of an exclude-list archive
+  rather than an allowlisted one. Run with `--installer=pip`, which
+  reads this hook's own environment rather than resolving `uv`
+  regardless of what `[build-system]` declares, and
+  `additional_dependencies` is that table's `requires` verbatim: `build
+  --no-isolation` checks the whole of it before calling the backend,
+  packing an sdist asking nothing of the cffi and cmake requirements
+  themselves. `--inject-junk` found seven common OS and editor droppings
+  `.gitignore` did not stop from reaching the archive --
+  `.Spotlight-V100`, `.Trashes`, `Thumbs.db`, `ehthumbs.db`, a vim swap
+  file and two spellings of `.DS_Store` and an AppleDouble sidecar --
+  now excluded in `[tool.hatch.build.targets.sdist]` beside the build
+  artifacts the same table already kept out. `.python-version` is the
+  one tracked file `[tool.check-sdist]`'s `git-only` now names on
+  purpose: both tracked and `.gitignore`-matched, it pins the
+  interpreter a checkout resolves against, which is the only place
+  anything reads it.
+
 - **`COPYRIGHT` leaves the wheel and the sdist** (btclib-org/.github#135).
   That issue decides that every package of the organization ships the
   same license files and `COPYRIGHT` is not among them: the holder a
@@ -1344,6 +1365,33 @@ release-notes length in the first place, and are still in
   the script's constants say the same set, and the verifier, `twine
   check --strict`, `check-wheel-contents` and `pyroma --min 10` each
   exit 0 on the new archives.
+
+### The release path
+
+- **`build-sdist` pins the sdist's `mtime` to the tagged commit's date**
+  (#345, btclib-org/.github#140). Section 12 of the organization
+  standard asks every publisher for a `SOURCE_DATE_EPOCH` step and a
+  normalizing one regardless of what its own backend already does, one
+  process across the three repositories rather than one bounded by
+  whichever backend happens to need it; `RELEASING.md` used to explain
+  the absence of both by a `setuptools.build_meta` backend neither
+  sibling has carried since before this file was written, and by a
+  script it called a no-op, which the standard's own correction on
+  btclib-org/.github#140 withdraws -- the step does not sit over a value
+  that is already right, it replaces one. Measured before this change:
+  hatchling's sdist writer stamps `1580601600` on every member when the
+  variable is unset, `1580601600` being neither the moment of the build
+  nor the tagged commit's date, and honours the variable exactly when it
+  is set. `.github/scripts/normalize_sdist.py` is the siblings' script
+  cut down to the one field hatchling does not already write this
+  repository's way: measured with `tarfile.getmembers()`, ownership is
+  already `uid`/`gid` `0` and `uname`/`gname` `""`, and mode is each
+  member's own git-tracked executable bit -- `secp256k1/autogen.sh` and
+  the small set of vendored tools beside it stay executable on a plain
+  extract, which flattening mode to one constant would have undone.
+  `tests/normalize_sdist_test.py` covers the script the way the
+  siblings' own does. `RELEASING.md`'s "Rebuild a release from its tag"
+  runs both steps now, and no longer explains their absence.
 
 ## v0.8.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1341,8 +1341,9 @@ release-notes length in the first place, and are still in
   themselves. `--inject-junk` found seven common OS and editor droppings
   `.gitignore` did not stop from reaching the archive --
   `.Spotlight-V100`, `.Trashes`, `Thumbs.db`, `ehthumbs.db`, a vim swap
-  file and two spellings of `.DS_Store` and an AppleDouble sidecar --
-  now excluded in `[tool.hatch.build.targets.sdist]` beside the build
+  file, an AppleDouble sidecar and the wildcard spelling of `.DS_Store`
+  that plain `.DS_Store` in `.gitignore` does not match -- now excluded
+  in `[tool.hatch.build.targets.sdist]` beside the build
   artifacts the same table already kept out. `.python-version` is the
   one tracked file `[tool.check-sdist]`'s `git-only` now names on
   purpose: both tracked and `.gitignore`-matched, it pins the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -607,54 +607,56 @@ version comparison, the `RELEASE_NOTES.md` section, and the ancestry on
 
 ## Rebuild a release from its tag
 
-A rebuild of a released tag is the same bytes as the sdist that was
-published, and needs neither `SOURCE_DATE_EPOCH` nor a normalizing step
-to get there:
+`build-sdist` in `test.yml` exports `SOURCE_DATE_EPOCH` from the commit
+date and normalizes the sdist, so a rebuild of a released tag is the
+same bytes as what was published — that job's own upload is what
+`publish-pypi` publishes, unchanged. A worktree and not `git checkout`,
+for the reason CLAUDE.md gives:
 
 ```shell
 git worktree add --detach /tmp/btclib-secp256k1-rebuild v0.8.0.4
 cd /tmp/btclib-secp256k1-rebuild
 git submodule update --init --recursive
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 uv run --locked --only-group build python -m build -s
+uv run --no-project --python 3.14 \
+  .github/scripts/normalize_sdist.py dist/
 shasum -a 256 dist/btclib_secp256k1-0.8.0.4.tar.gz
 ```
 
-is the whole of it — against a worktree rather than the primary
-checkout, for the reason CLAUDE.md gives, and with the command
-`build-sdist` in `test.yml` runs, `--locked` included: a rebuild from a
-released tag has nothing rewriting the version, so the lock and
-`pyproject.toml` already agree, and the flag asserts that the lock is
-the one the tag committed rather than taking `uv.lock` as it finds it.
-Compare the digest against
+is the whole of it, `--locked` included for the same reason as before: a
+rebuild from a released tag has nothing rewriting the version, so the
+lock and `pyproject.toml` already agree, and the flag asserts that the
+lock is the one the tag committed rather than taking `uv.lock` as it
+finds it. Compare the digest against
 `pypi.org/pypi/btclib-secp256k1/<version>/json`'s own, or against the
 `sdist` artifact `gh run download` pulls from the release's run; both
 name the file this reproduces.
 
-**Why no `SOURCE_DATE_EPOCH` step, where both siblings have one.** The
-build backend does the work here on its own. This repository's
-`build-system.build-backend` is `hatchling.build`; both siblings' is
-`setuptools.build_meta`. Hatchling's sdist and wheel writers default to
-a `reproducible` mode that reads `SOURCE_DATE_EPOCH` and, when it is
-unset, falls back to a fixed constant — `1580601600`, not the moment of
-the build — for every member's timestamp, and stamp ownership and mode
-the same way regardless of who built it or when. Nothing in
-`pyproject.toml` turns that default off. setuptools' sdist writer has no
-such fallback: unset, it stamps the actual checkout's clock, sub-second,
-which is why both siblings each carry a
-`.github/scripts/normalize_sdist.py` and a `SOURCE_DATE_EPOCH` step in
-their release workflow, rewriting after the fact what their backend
-will not fix by default. Looking for that script here on the strength
-of the siblings' example finds nothing, and correctly so — there is
-nothing here for it to fix, and adding one would rewrite bytes that
-already reproduce.
+**What the script rewrites here, and what it leaves alone.** This
+repository's `build-system.build-backend` is `hatchling.build`, unlike
+both siblings' `uv_build`, and hatchling's sdist writer already stamps
+every member's ownership at `uid`/`gid` `0` and `uname`/`gname` `""` —
+measurable with `tarfile.getmembers()` against a build of this tree —
+so the script does not touch them. Nor does it touch mode: each
+member's mode is the executable bit git tracks for that file,
+`secp256k1/autogen.sh` and the small set of vendored tools beside it
+staying executable on a plain extract, and flattening that to one
+constant would strip the bit those files need to run. `mtime` is the
+field left, and the one hatchling does not fix on its own: unset,
+`SOURCE_DATE_EPOCH` falls back to hatchling's own constant,
+`1580601600`, neither of which is the tagged commit's date, so the
+script — and the `SOURCE_DATE_EPOCH` step ahead of the build, belt and
+braces against a future hatchling release deciding the variable
+differently — is what makes it that instead. The step is section 12 of
+the organization standard: one process across the three repositories,
+`btclib-org/.github#140`'s decision, rather than one bounded by
+whichever backend happens to need it.
 
-The vendored `secp256k1` submodule is not a second source of drift, and
-looks riskier than it is: `.gitmodules` pins it to a commit, and a git
-checkout of a pinned commit is the same bytes wherever and whenever it
-happens, the recursive `submodule update` above included. What made the
-siblings' sdists non-reproducible was never vendored content — neither
-sibling vendors any — it was their build backend's clock, and this
-repository's backend does not read one.
+The vendored `secp256k1` submodule is not a source of drift on top of
+that: `.gitmodules` pins it to a commit, and a git checkout of a pinned
+commit is the same bytes wherever and whenever it happens, the
+recursive `submodule update` above included.
 
 Only the sdist reproduces this way; the wheels do not, and are not
 worth chasing to make them. They are `cibuildwheel` output over that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,8 @@ ignore = ["W003", "W009"]
 # resolve against a checkout, which is the only place anything reads
 # it, so its absence from an installed sdist costs nothing
 git-only = [".python-version"]
+
+# PEP 735 groups, resolved by uv (or by pip --group): they replace the
 # hatch environments, which duplicated what nox and pre-commit already
 # did. The authoritative versions of the linters remain the revisions
 # pinned in .pre-commit-config.yaml, which is the gate; the ones here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,19 @@ exclude = [
     "**/*.lo",
     "**/*.la",
     "**/*~",
+    # OS and editor droppings a working tree can pick up between commits,
+    # .gitignore not covering all of them: it excludes "**/.DS_Store"
+    # but nothing here excluded "**/.DS_Store?", "**/._*", Windows'
+    # "**/Thumbs.db" and "**/ehthumbs.db", or a vim swap file, and
+    # `check-sdist --inject-junk` plants exactly these to prove an
+    # sdist built from an untidy tree never ships them
+    "**/.DS_Store*",
+    "**/._*",
+    "**/.Spotlight-V100",
+    "**/.Trashes",
+    "**/Thumbs.db",
+    "**/ehthumbs.db",
+    "**/*.swp",
     "secp256k1/src/btclib_default_callbacks.c",
     "secp256k1/autom4te.cache",
     "secp256k1/aclocal.m4",
@@ -198,7 +211,19 @@ exclude = [
 # are exactly what that wheel is supposed to contain
 ignore = ["W003", "W009"]
 
-# PEP 735 groups, resolved by uv (or by pip --group): they replace the
+[tool.check-sdist]
+# check-sdist reads [tool.hatch.build.targets.sdist]'s exclude list
+# above through its own hatchling.build plugin, so this table holds
+# only what that plugin does not reach: hatchling's sdist target also
+# drops whatever the tree's own VCS-ignore files match, independently
+# of the exclude list, and check-sdist's plugin does not read
+# .gitignore to explain the gap.
+#
+# .python-version is tracked and .gitignore-matched both, one of the
+# few files here that are: it pins the interpreter `uv run` and CI
+# resolve against a checkout, which is the only place anything reads
+# it, so its absence from an installed sdist costs nothing
+git-only = [".python-version"]
 # hatch environments, which duplicated what nox and pre-commit already
 # did. The authoritative versions of the linters remain the revisions
 # pinned in .pre-commit-config.yaml, which is the gate; the ones here
@@ -570,6 +595,14 @@ max-complexity = 10
 # green run of check-dist shows in its own log: same exemption, same
 # reason as the two scripts above
 ".github/scripts/verify_wheel_contents.py" = ["print"]
+# the sdist normalizer, whose usage message and per-archive report are
+# what the workflow step that runs it shows in its own log: same
+# exemption, same reason as the three scripts above
+".github/scripts/normalize_sdist.py" = ["print"]
+# one keyword per sdist member field the script and its tests care
+# about; splitting it into a dataclass would move the same seven names
+# one level down rather than removing any of them
+"tests/normalize_sdist_test.py" = ["too-many-arguments"]
 
 [tool.ruff.lint.flake8-copyright]
 # notice-rgx is COPYRIGHT's text as one regex, anchored with ^ so a

--- a/tests/normalize_sdist_test.py
+++ b/tests/normalize_sdist_test.py
@@ -1,0 +1,251 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `.github/scripts/normalize_sdist.py`.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+other scripts under it are tested.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import runpy
+import sys
+import tarfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "normalize_sdist.py"
+
+_EPOCH = 1_700_000_000
+
+
+@pytest.fixture
+def script() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("normalize_sdist", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_archive(
+    path: Path,
+    *,
+    mtime: int = 12345,
+    file_mode: int = 0o644,
+    dir_mode: int = 0o755,
+    uid: int = 0,
+    gid: int = 0,
+    uname: str = "",
+    gname: str = "",
+) -> None:
+    """Write a two-member sdist: one directory, one file, given metadata.
+
+    Ownership and mode default to what hatchling's own sdist writer
+    already produces here -- the two fields the script leaves alone --
+    so a test that changes `mtime` alone is exercising the one field
+    the script actually rewrites.
+    """
+    with tarfile.open(path, "w:gz") as archive:
+        directory = tarfile.TarInfo("pkg")
+        directory.type = tarfile.DIRTYPE
+        directory.mtime = mtime
+        directory.mode = dir_mode
+        directory.uid, directory.gid = uid, gid
+        directory.uname, directory.gname = uname, gname
+        archive.addfile(directory)
+
+        content = b"content"
+        member = tarfile.TarInfo("pkg/module.py")
+        member.mtime = mtime
+        member.mode = file_mode
+        member.uid, member.gid = uid, gid
+        member.uname, member.gname = uname, gname
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+
+def read_members(path: Path) -> list[tarfile.TarInfo]:
+    """Read every member of an archive back, for the test to inspect."""
+    with tarfile.open(path, "r:gz") as archive:
+        return archive.getmembers()
+
+
+def test_normalize_rewrites_mtime_alone(script: ModuleType, tmp_path: Path) -> None:
+    """Every member's `mtime` moves to the epoch; nothing else does."""
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(
+        archive,
+        file_mode=0o755,
+        dir_mode=0o700,
+        uid=1000,
+        gid=1000,
+        uname="a",
+        gname="b",
+    )
+
+    script.normalize(archive, _EPOCH)
+
+    directory, file_member = read_members(archive)
+    assert {directory.mtime, file_member.mtime} == {_EPOCH}
+    assert directory.mode == 0o700
+    assert file_member.mode == 0o755
+    assert (directory.uid, directory.gid, directory.uname, directory.gname) == (
+        1000,
+        1000,
+        "a",
+        "b",
+    )
+
+
+def test_normalize_preserves_order_and_content(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The member order and their bytes are the archive's own, untouched."""
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+
+    script.normalize(archive, _EPOCH)
+
+    members = read_members(archive)
+    assert [m.name for m in members] == ["pkg", "pkg/module.py"]
+    with tarfile.open(archive, "r:gz") as reopened:
+        extracted = reopened.extractfile("pkg/module.py")
+        assert extracted is not None
+        assert extracted.read() == b"content"
+
+
+def test_normalize_clears_a_stale_mtime_pax_record(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A PAX record from a sub-second mtime does not survive the rewrite.
+
+    `member.mtime = epoch` alone leaves the old extended header in place
+    -- it is `member.pax_headers` that carries it, not `member.mtime` --
+    which is why the script drops that one key explicitly rather than
+    relying on the new value being an integer.
+    """
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    with tarfile.open(archive, "w:gz", format=tarfile.PAX_FORMAT) as source:
+        member = tarfile.TarInfo("pkg/module.py")
+        member.mtime = 12345.5
+        content = b"content"
+        member.size = len(content)
+        source.addfile(member, io.BytesIO(content))
+    with tarfile.open(archive, "r:gz") as reopened:
+        (before,) = reopened.getmembers()
+    assert before.pax_headers == {"mtime": "12345.5"}
+
+    script.normalize(archive, _EPOCH)
+
+    (after,) = read_members(archive)
+    assert after.pax_headers == {}
+    assert after.mtime == _EPOCH
+
+
+def test_normalize_matches_what_hatchling_already_writes_but_for_mtime(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`mtime` is the one field the rewrite changes against hatchling.
+
+    Hatchling already writes root ownership and each member's own
+    tracked mode; only its `mtime` -- `1580601600` when
+    `SOURCE_DATE_EPOCH` is unset -- is not the tagged commit's date, so
+    an archive built exactly like that changes digest on the `mtime`
+    rewrite alone, which is what a rebuild without this step would miss.
+    """
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive, mtime=1_580_601_600)
+    before = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    script.normalize(archive, _EPOCH)
+
+    after = hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert before != after
+    directory, file_member = read_members(archive)
+    assert directory.mode == 0o755
+    assert file_member.mode == 0o644
+
+
+def test_main_says_how_to_be_called_when_it_is_not(
+    script: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No dist directory, or two of them, is the usage rather than a crash."""
+    assert script.main(["prog"]) == 2
+    assert capsys.readouterr().err == "usage: prog <dist directory>\n"
+
+
+def test_main_refuses_to_default_source_date_epoch_to_now(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset is a failure, not "now": the script's own docstring has why."""
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+
+    assert script.main(["prog", str(tmp_path)]) == 1
+    assert "SOURCE_DATE_EPOCH is not set" in capsys.readouterr().err
+
+
+def test_main_names_a_dist_directory_with_no_sdist(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directory with a wheel and no sdist is named, not silently skipped."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    (tmp_path / "btclib_secp256k1-1.0-cp314-cp314-linux_x86_64.whl").write_bytes(b"")
+
+    assert script.main(["prog", str(tmp_path)]) == 1
+    assert f"no sdist in {tmp_path}" in capsys.readouterr().err
+
+
+def test_main_normalizes_every_sdist_and_reports_it(
+    script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The success path: every `*.tar.gz` in the directory is rewritten."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+
+    assert script.main(["prog", str(tmp_path)]) == 0
+
+    assert f"normalized {archive}" in capsys.readouterr().out
+    directory, file_member = read_members(archive)
+    assert directory.mtime == _EPOCH
+    assert file_member.mtime == _EPOCH
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    This project collects no coverage from a child interpreter, so a real
+    subprocess would leave the guard as uncovered as it is in
+    `mutation_counts.py`. `runpy.run_path` executes the file fresh with
+    `__name__` set to `"__main__"` in this one.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    archive = tmp_path / "pkg-1.0.tar.gz"
+    write_archive(archive)
+    monkeypatch.setattr(sys, "argv", ["prog", str(tmp_path)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
Bundled: both are about the sdist's own correctness, and both touch the same packaging configuration.

- `check-sdist` compares the sdist's members against git's tracked files. `--installer=pip` reads this hook's own environment; `additional_dependencies` is `[build-system]`'s `requires` verbatim, since `python -m build --no-isolation` checks the whole of it before calling the backend. `--inject-junk` found seven OS and editor droppings `.gitignore` did not stop from reaching the archive, now excluded in `[tool.hatch.build.targets.sdist]` beside the existing build-artifact patterns. `.python-version` is the one tracked file `[tool.check-sdist]`'s `git-only` now names on purpose: it pins the interpreter a checkout resolves against, which is the only place anything reads it.
- `build-sdist` in `test.yml` exports `SOURCE_DATE_EPOCH` from the commit date and runs `.github/scripts/normalize_sdist.py`, cut down from the siblings' script to the one field hatchling does not already write this repository's way. Measured: hatchling's sdist writer already stamps ownership at `uid`/`gid` `0` and `uname`/`gname` `""`, and mode is each member's own git-tracked executable bit — `secp256k1/autogen.sh` and the vendored tools beside it stay executable on a plain extract. `mtime` is the field left: unset, `SOURCE_DATE_EPOCH` falls back to hatchling's constant, `1580601600`, neither of which is the tagged commit's date. `RELEASING.md`'s "Rebuild a release from its tag" runs both steps now, and no longer explains their absence by a setuptools backend neither sibling has carried in a while, or by a script it called a no-op — which `btclib-org/.github#140`'s correction withdraws: the step replaces a value, it does not sit over one that was already right.

Gates on the worktree, exit codes: `pre-commit run --all-files` 0 (`check-sdist` and `pyroma` included); `pytest --cov` 0, 820 passed, 100.00% coverage; `sphinx-build -W --keep-going` 0; `git status --porcelain` empty after each.

Local review cleared this head at 9ec8497, after two rounds (a stranded comment in `pyproject.toml` and a wrong mechanism named in `.pre-commit-config.yaml`, both fixed) and a rebase onto `origin/main` (a real conflict in `RELEASING.md` against #366, resolved and re-cleared).

Closes #344, closes #345.

## Summary by Sourcery

Harden source distribution packaging by validating archive contents and making release archives reproducible.

New Features:
- Add validation that source distributions contain exactly the expected tracked files.
- Add reproducible sdist timestamp normalization based on the tagged commit date.

Bug Fixes:
- Exclude common operating-system and editor artifacts from source distributions.
- Ensure release rebuild instructions reproduce the published sdist bytes.

Enhancements:
- Integrate sdist validation into pre-commit with the project’s complete build requirements.
- Update the release workflow and documentation to apply deterministic sdist timestamps.

CI:
- Pin source distribution build timestamps to the commit date and normalize generated archives in CI.

Documentation:
- Document the updated release rebuild process and sdist reproducibility behavior.

Tests:
- Add comprehensive tests for sdist timestamp normalization and archive preservation.

Chores:
- Record the packaging and release-process changes in the changelog.