### PR TITLE
codeql.yml drops the aggregate job no branch rule can require

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -182,37 +182,11 @@ jobs:
           # a copy of it is opened by this workflow
           category: "/language:${{ matrix.language }}"
 
-  # one context for the branch rule, instead of the matrix's own, for the
-  # reason test.yml gives at its own aggregate: a rule naming
-  # `Analyze python with CodeQL` names a context that stops being produced
-  # the moment the matrix changes, and a required check that produces no run
-  # blocks every merge with nothing in the tree to explain why. A job added
-  # to this workflow belongs in the `needs` below or it gates nothing.
-  #
-  # The name carries the workflow because a context is keyed by name alone:
-  # two workflows with a job named `every job passed` would produce one
-  # ambiguous check
-  codeql-passed:
-    name: "codeql: every job passed"
-    needs: [analyze]
-    # not success(): a job whose dependencies failed is skipped, and a
-    # skipped check reports `skipped`, which branch protection counts as
-    # satisfied. The gate has to run to be able to fail
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      # the condition reads the whole needs context rather than testing each
-      # job by name, so a job added to needs above is covered without
-      # touching this. `skipped` is a failure here too: nothing in this
-      # workflow is conditional, so a skip means something upstream did not
-      # run
-      - name: Fail unless every job above succeeded
-        if: >-
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'cancelled') ||
-          contains(needs.*.result, 'skipped')
-        run: |
-          echo "::error::a job this gate depends on did not succeed"
-          exit 1
+  # no aggregate job, where test.yml has one. A branch rule can only name
+  # a context a pull request's own run produces, and the `on:` block
+  # above has no `pull_request` trigger, so no rule could ever require a
+  # name this workflow produces — btclib-org/.github#90 is where the
+  # organization settled that reading as section 10's one rule, in place
+  # of the two the standard used to hold apart. `analyze`'s matrix cells
+  # are therefore the whole of the checks list this workflow contributes
+  # to a commit, one per language rather than one aggregate over both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,22 @@ release-notes length in the first place, and are still in
 
 ### CI
 
+- **`codeql.yml` carries no aggregate job any more** (#355,
+  btclib-org/.github#90). Its `on:` block triggers on `push` to `main`
+  and on a weekly schedule alone, no `pull_request` among them, and a
+  branch rule can only name a context a pull request's own run
+  produces -- so `codeql-passed`, producing `codeql: every job passed`,
+  named a context no rule could ever require, which the organization
+  standard now states as section 10's one rule rather than the two it
+  used to hold apart. `analyze`'s two matrix cells are the whole of
+  what this workflow contributes to a commit now, one check per
+  language. `REPOSITORY.md`'s own account of that context -- kept
+  deliberately once already, for the concurrency-slot trade the section
+  above it records, and the ordering that mattered around toggling code
+  scanning's default setup off -- is corrected alongside: what it
+  described as a rule change away is now a workflow change too, and the
+  ordering it walked through has nothing left to sequence around.
+
 - **`release.yml`'s prose stays inside the width its neighbours hold, and
   states no count nothing derives** (#340, #342). The paragraph above
   `Check that the tag is on main` left one line at exactly the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -43,9 +43,15 @@ in it: this one, bitcoin-core-rpc and one more repository each ask for
 more jobs than that on every commit, so a pull request in any of the
 three waited for a slot rather than for the work. `codeql.yml` now runs
 on `main` and on its weekly schedule, the analysis landing on the merge
-commit rather than ahead of it, and it still produces that aggregate —
-the name is available, so requiring it again is a patch to the rule and
-nothing in the tree.
+commit rather than ahead of it, and it carries no aggregate any more
+either: a branch rule can only name a context a pull request's own run
+produces, and this workflow's `on:` block has no `pull_request` trigger,
+so no rule could ever require a name it produces —
+btclib-org/.github#90 is where the organization settled that reading as
+section 10's one rule rather than the two the standard used to hold
+apart. Re-requiring the analysis is therefore a workflow change and not
+only a rule change: the trigger and the aggregate would have to return
+together.
 
 What still reads a branch before it merges is the workflow half of the same
 question: `zizmor` is a `pre-commit` hook, so `lint.yml` audits these very
@@ -123,10 +129,10 @@ CodeQL analyses from advanced configurations cannot be processed when
 the default setup is enabled
 ```
 
-So while the setting is on the analysing jobs and the aggregate are red
-rather than absent, and the file is still the one that can be reviewed in a
-diff. What the setting holds is read from the endpoint, `state` being the
-field that says whether it holds anything:
+So while the setting is on the analysing jobs are red rather than absent,
+and the file is still the one that can be reviewed in a diff. What the
+setting holds is read from the endpoint, `state` being the field that
+says whether it holds anything:
 
 ```shell
 gh api repos/btclib-org/btclib-secp256k1/code-scanning/default-setup
@@ -142,22 +148,22 @@ gh api -X PATCH \
   -F state=not-configured
 ```
 
-The order matters in both directions, and it is the branch rule that
-decides it: while the setting is on, `codeql.yml` produces a red
-`codeql: every job passed` rather than none at all, and while it is off,
-nothing produces that context until the workflow has run. So the rule drops
-the `CodeQL` context first, the setting moves second, the checks are
-re-run, and the rule names the new context last — each step leaving the
-merge path open, where any other order closes it on a context nothing
-reports. `enforce_admins` being off is what makes that window survivable
+The order used to matter here, back when the branch rule still named
+`codeql: every job passed`: dropping that context from the rule before
+turning the setting off, and naming it again only after the workflow
+had produced it fresh, was what kept the merge path open through the
+switch rather than closing it on a context nothing reported for one
+step. `enforce_admins` being off is what made that window survivable
 rather than a lock.
 
-That exchange has been made: the endpoint above answers `not-configured`.
-What the rule does *not* name any more is `codeql: every job passed`, for
-the reason the section above gives — so the last step of that order was
-undone afterwards, deliberately, and the order is kept here because the
-setting can be configured again and because requiring the context again is
-the same `PATCH` with one entry more.
+Neither half of that sequence is live any more. That exchange has been
+made: the endpoint above answers `not-configured`, and it was already
+true before this repository's own aggregate went — the rule dropped
+`codeql: every job passed` first, for the reason the section above
+gives. Turning the setting back on today has nothing left to sequence
+around: `codeql.yml` produces no aggregate to be red or to be named, so
+the switch would only turn the `analyze` matrix red, with no rule
+reading either context.
 
 A `CodeQL` check and an `Analyze (python)` job outlive it, and neither
 comes from this tree: GitHub keeps a generated


### PR DESCRIPTION
`on:` triggers on push to `main` and a weekly schedule alone, no `pull_request` among them, and a branch rule can only name a context a pull request's own run produces — so `codeql-passed`, producing `codeql: every job passed`, named a context no rule could ever require. `btclib-org/.github#90` is where the organization standard settled this as section 10's one rule rather than the two it used to hold apart; `btclib` already carries the same fix, and `bitcoin-core-rpc`'s own issue for it (btclib-org/bitcoin-core-rpc#233) is open and untouched here. `analyze`'s two matrix cells are the whole of what this workflow contributes to a commit now, one check per language.

`REPOSITORY.md` documented `codeql-passed` as kept deliberately once already, for the concurrency-slot trade recorded beside it, and walked through an operational ordering for toggling code scanning's default setup off around a branch rule that named the aggregate. Both are corrected: requiring the analysis again is now a workflow change and not only a rule change, and the ordering has nothing left to sequence around, the rule having already dropped the context before this change and the workflow now never producing it.

Gates on the worktree, exit codes: `pre-commit run --all-files` 0 (`actionlint`, `zizmor`, `check-sdist` included); `pytest --cov` 0, 820 passed, 100.00% coverage; `sphinx-build -W --keep-going` 0; `git status --porcelain` empty after each.

Local review cleared this head at a26194d, including independent verification of the branch-protection and ruleset state this repository actually has today, and of `btclib-org/.github#90`'s resolution text.

Closes #355.

## Summary by Sourcery

Remove the obsolete CodeQL aggregate job and update the repository documentation to match the workflow’s supported checks.

Enhancements:
- Remove the unused CodeQL aggregate check so the workflow reports only its language-specific analysis results.
- Update repository guidance to reflect the current CodeQL workflow and branch-protection behavior.

CI:
- Align the CodeQL workflow and documentation with the organization’s branch-protection standard.

Documentation:
- Document the removal of the obsolete CodeQL aggregate context and revise the related code-scanning setup guidance.