### PR TITLE
tests/copyright_test.py derives notice-rgx from COPYRIGHT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1410,6 +1410,23 @@ release-notes length in the first place, and are still in
   siblings' own does. `RELEASING.md`'s "Rebuild a release from its tag"
   runs both steps now, and no longer explains their absence.
 
+### `notice-rgx` derives from `COPYRIGHT`
+
+- **A test compares them** (#346, btclib-org/.github#135). `CPY` checks
+  every source file's header against `[tool.ruff.lint.flake8-copyright]`'s
+  `notice-rgx`, which is `COPYRIGHT`'s text transcribed by hand as a
+  regex, and nothing checked the regex against the file it was
+  transcribed from: a `COPYRIGHT` edited without the regex, or the
+  other way round, passed every gate. `tests/copyright_test.py` now
+  derives the expected pattern from `COPYRIGHT` itself and asserts
+  equality, deliberately narrower than `re.escape` for it: that
+  function's own special-character set is the same across every
+  CPython and PyPy version this package supports, but is
+  unconditionally wider than what's committed -- it also escapes `#`
+  and whitespace, for `re.VERBOSE` safety, where `notice-rgx` does not
+  -- so deriving through it would fail this test's round trip on every
+  supported interpreter alike, not on some of them.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""LICENSE and pyproject.toml's author, checked together.
+"""LICENSE, COPYRIGHT and pyproject.toml, checked against each other.
 
 btclib's own LICENSE named "Ferdinando M. Ametrano and btclib
 contributors" for years after the rest of that project had moved to "The
@@ -11,9 +11,15 @@ here named "Giacomo Caironi" the same way, against this project's own
 COPYRIGHT and `authors` already saying "The btclib developers" -- caught
 by hand, not by a check, which is what this one is.
 
-Regex rather than `tomllib` for the one line wanted out of
-pyproject.toml: the floor here is 3.10, and `tomllib` is 3.11. Once that
-floor moves, this can read the file directly instead.
+`[tool.ruff.lint.flake8-copyright]`'s `notice-rgx` is COPYRIGHT's text
+transcribed by hand as a regex, and the CPY hook it configures checks
+every source file's header against the regex rather than against the
+file it was transcribed from: a COPYRIGHT edited without the regex, or
+the other way round, passes every gate (btclib-org/.github#135).
+
+Regex rather than `tomllib` for the lines wanted out of pyproject.toml:
+the floor here is 3.10, and `tomllib` is 3.11. Once that floor moves,
+this can read the file directly instead.
 """
 
 import re
@@ -27,6 +33,22 @@ _ROOT = Path(__file__).parents[1]
 # rather than tolerating it
 _HOLDER_RE = r"Copyright \([Cc]\) (.+)"
 _AUTHOR_RE = r'authors\s*=\s*\[\{\s*name\s*=\s*"([^"]+)"'
+# a TOML basic string: any run of characters that are neither a quote nor
+# a backslash, or a backslash followed by whatever it escapes -- general
+# enough to capture notice-rgx's own backslash escapes without assuming
+# which ones it uses
+_NOTICE_RGX_RE = r'notice-rgx\s*=\s*"((?:[^"\\]|\\.)*)"'
+# the regex metacharacters notice-rgx itself has to escape to stay a
+# literal match for COPYRIGHT's text: this is deliberately narrower than
+# `re.escape`, whose own special-character set is the same across every
+# CPython and PyPy version this package supports (3.10 through 3.14,
+# verified against 3.15.0b4 too) but is unconditionally wider than what
+# notice-rgx actually escapes -- it also escapes "#" and whitespace, for
+# re.VERBOSE safety, which the committed notice-rgx does not. A
+# derivation through re.escape would fail this test's round trip on
+# every interpreter alike, not on some of them; the mismatch is with
+# notice-rgx's own narrower escaping, not with Python's version history
+_REGEX_SPECIAL_RE = re.compile(r"([\\^$.|?*+()\[\]{}])")
 
 
 def _license_holder() -> str:
@@ -43,6 +65,23 @@ def _pyproject_author() -> str:
     return match.group(1)
 
 
+def _pyproject_notice_rgx() -> str:
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(_NOTICE_RGX_RE, text)
+    assert match, "pyproject.toml has no [tool.ruff.lint.flake8-copyright] notice-rgx"
+    # undoes exactly the escaping a TOML basic string commits: "\\" is the
+    # only two-character escape notice-rgx's own text needs, "\\(" naming
+    # a single backslash followed by a literal "(" rather than two
+    # backslashes
+    return match.group(1).replace("\\\\", "\\")
+
+
+def _copyright_as_regex() -> str:
+    text = (_ROOT / "COPYRIGHT").read_text(encoding="utf-8")
+    escaped = _REGEX_SPECIAL_RE.sub(r"\\\1", text.rstrip("\n"))
+    return "^" + escaped.replace("\n", "\\n")
+
+
 def test_license_holder_matches_the_declared_author() -> None:
     """The wheel's `Author` metadata is the same holder LICENSE names."""
     license_holder = _license_holder()
@@ -51,4 +90,16 @@ def test_license_holder_matches_the_declared_author() -> None:
         f"LICENSE names {license_holder!r}, pyproject.toml's author "
         f"{author!r}. A wheel built from one and read from the other "
         "would disagree about who holds the copyright"
+    )
+
+
+def test_notice_rgx_is_copyright_transcribed() -> None:
+    """`notice-rgx` is COPYRIGHT's own text, escaped for a regex, no more."""
+    notice_rgx = _pyproject_notice_rgx()
+    derived = _copyright_as_regex()
+    assert notice_rgx == derived, (
+        f"pyproject.toml's notice-rgx is {notice_rgx!r}, which COPYRIGHT's "
+        f"own text does not derive: expected {derived!r}. Every source "
+        "header is checked against notice-rgx and not against COPYRIGHT "
+        "itself, so a drift between the two passes CPY either way"
     )


### PR DESCRIPTION
CPY checks every source file's header against
`[tool.ruff.lint.flake8-copyright]`'s `notice-rgx`, which is
`COPYRIGHT`'s text transcribed by hand as a regex, and nothing checked
the regex against the file it was transcribed from: a `COPYRIGHT`
edited without the regex, or the other way round, passed every gate.

The new test derives the expected pattern from `COPYRIGHT` itself,
escaping only the regex metacharacters actually present rather than
through `re.escape`: that function's own special-character set is
identical across every CPython and PyPy version this package supports
(3.10 through 3.14, checked against 3.15.0b4 too), but is
unconditionally wider than what `notice-rgx` actually escapes -- it
also escapes `#` and whitespace, for `re.VERBOSE` safety, which the
committed `notice-rgx` does not. A derivation through `re.escape`
would fail this test's round trip on every supported interpreter
alike, not on some of them.

Verified against a hand mutation of `COPYRIGHT`: the test fails as
expected, and passes again once reverted.

Closes #346.

## Summary by Sourcery

Keep Ruff's copyright notice pattern synchronized with the canonical COPYRIGHT file.

Bug Fixes:
- Add a regression test that detects drift between the COPYRIGHT file and Ruff's configured notice-rgx.

Enhancements:
- Derive the expected copyright regex directly from COPYRIGHT while preserving the project's intended escaping behavior.
- Expand the copyright test documentation to cover the relationship between COPYRIGHT and notice-rgx.

Documentation:
- Document the new notice-rgx consistency check in the changelog.

Tests:
- Add coverage asserting that pyproject.toml's notice-rgx exactly matches the regex transcription of COPYRIGHT.