### PR TITLE
SECURITY.md points at the address's home instead of restating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ release-notes length in the first place, and are still in
 
 ### Documentation
 
+- **`SECURITY.md` stops claiming what it cannot check** (#356,
+  btclib-org/.github#109). "as for every btclib project" was an
+  enumeration this file has no way to verify, and it was already
+  false when measured: `btclib-benchmarks` gave a different address,
+  `devs@btclib.org`, until it dropped `SECURITY.md` entirely. The
+  reporting address is unchanged -- *security at btclib dot org* -- and
+  the sentence now points at where it actually lives, section 2 of
+  the organization standard, rather than restating a claim about
+  repositories this file does not read.
+
 - **`RELEASING.md` and `REPOSITORY.md` stop naming `btclib` to justify
   this package's own choices** (btclib-org/.github#81). The first pass
   held both files out of scope, reading a maintainer's runbook as prose

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,11 @@
 Please do not open a GitHub issue. Provide responsible disclosure
 either privately through GitHub, from the Security tab of this
 repository ("Report a vulnerability"), or by emailing
-*security at btclib dot org*, as for every btclib project.
+*security at btclib dot org* — the organization's own address, kept in
+section 2 of the standard in
+[btclib-org/.github](https://github.com/btclib-org/.github), rather than
+repeated here as a claim about every other repository this file does
+not read.
 
 ## What belongs here, and what belongs upstream
 


### PR DESCRIPTION
\"as for every btclib project\" is an enumeration this file has no way
to check, and it was already false when measured: `btclib-benchmarks`
gave a different address, `devs@btclib.org`, until it dropped
`SECURITY.md` entirely (btclib-org/.github#109). The reporting address
is unchanged; the sentence now points at section 2 of the organization
standard, where it is kept, rather than asserting something about
repositories this file does not read.

Closes #356.

## Summary by Sourcery

Clarify the source of truth for the organization’s security reporting address in `SECURITY.md`.

Enhancements:
- Update `SECURITY.md` to reference the organization-wide security reporting standard instead of asserting that all repositories use the same address.

Documentation:
- Clarify that the security reporting address remains unchanged and is maintained in section 2 of the organization standard.