### PR TITLE
Every module declares __all__, and a census keeps it true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.5 (work in progress, not released yet)
 
+### Every module declares `__all__`
+
+- **The public surface is a declared list, not everything a module
+  happens not to underscore** (#357, btclib-org/.github#79). A module
+  with no `__all__` answers `import *` with every name it does not
+  underscore, the ones it imported included: `ffi` and `lib` came out of
+  `btclib_secp256k1.dsa` alongside its own entry points. Every module
+  under `btclib_secp256k1/` now declares one, `_scalar`, `_secret` and
+  `_cdata` excepted by their own leading underscore, and `context.ctx`
+  kept public beside `check` for the caller reaching `lib` directly that
+  SECURITY.md and the README already document. `tests/all_test.py` is
+  the census section 7 asks for: it walks the package rather than
+  listing it, so a new public name fails until it is exported or
+  recorded in `UNEXPORTED`, and a module re-exporting a name it only
+  imported is caught the same way. `tests/README.md`'s convention table
+  moves the public surface out of "Not tested here" and into the table;
+  input validation stays absent, section 7's own escape for it now
+  missing only the connection nothing here makes.
+
 ### Documentation
 
 - **`SECURITY.md` stops claiming what it cannot check** (#356,

--- a/btclib_secp256k1/__init__.py
+++ b/btclib_secp256k1/__init__.py
@@ -46,6 +46,13 @@ from typing import TYPE_CHECKING, Any
 
 import _btclib_secp256k1
 
+# what this module itself defines and a caller may rely on. A submodule
+# is not named here: `from btclib_secp256k1 import dsa` reaches one
+# through the import system's own handling of a package, not through
+# this list, and `tests/all_test.py` is what walks the package for the
+# eleven of them rather than this module enumerating them by hand
+__all__ = ["BytesLike", "CData", "MutableBytesLike", "__version__", "ffi", "lib"]
+
 
 def _read_version() -> str:
     """Read the version out of the installed distribution metadata.

--- a/btclib_secp256k1/context.py
+++ b/btclib_secp256k1/context.py
@@ -11,6 +11,14 @@ import threading
 
 from . import CData, ffi, lib
 
+# `ctx` is exported for the caller reaching `lib` directly, as the
+# README's "Wrapped modules" section shows: `secp256k1_musig_partial_sign`
+# and every other raw call this package makes needs the context passed
+# in. `_randomize` stays unexported despite the same README naming it --
+# private is its own answer to who may call it again, not a name this
+# list withholds
+__all__ = ["check", "ctx"]
+
 # 1 is SECP256K1_CONTEXT_NONE: since libsecp256k1 0.2 signing and
 # verification work with any context, and the SIGN/VERIFY flags are
 # deprecated

--- a/btclib_secp256k1/dsa.py
+++ b/btclib_secp256k1/dsa.py
@@ -24,6 +24,22 @@ from ._scalar import in_range, octets, optional_entropy, scalar
 from ._secret import take
 from .context import ctx
 
+__all__ = [
+    "is_low_r",
+    "is_low_s",
+    "nonce_rfc6979",
+    "normalize",
+    "parse_compact",
+    "parse_der",
+    "serialize_compact",
+    "serialize_der",
+    "sign",
+    "signature_verify",
+    "to_compact",
+    "to_der",
+    "verify",
+]
+
 # the two buffers a signature is serialized into, and the lengths that go
 # with them in both directions: `_parsed` accepts a compact signature of
 # the width `serialize_compact` writes, so one statement of it answers

--- a/btclib_secp256k1/ecdh.py
+++ b/btclib_secp256k1/ecdh.py
@@ -13,6 +13,8 @@ from ._scalar import scalar
 from ._secret import take
 from .context import ctx
 
+__all__ = ["shared_secret"]
+
 
 @overload
 def _shared_secret_(pubkey: CData, prvkey: BytesLike | int) -> bytes: ...

--- a/btclib_secp256k1/ellswift.py
+++ b/btclib_secp256k1/ellswift.py
@@ -17,6 +17,8 @@ from ._secret import take
 from .context import ctx
 from .keys import parse, serialize
 
+__all__ = ["create", "decode", "encode", "xdh"]
+
 # the width of an ElligatorSwift encoding: 64 bytes, the two field
 # elements it is. `create` and `_encode_` write it, `_decode_` and `xdh`
 # accept it, and the one statement of it answers for all four -- the

--- a/btclib_secp256k1/hashes.py
+++ b/btclib_secp256k1/hashes.py
@@ -13,6 +13,8 @@ from . import BytesLike, ffi, lib
 from ._scalar import octets
 from .context import ctx
 
+__all__ = ["tagged_sha256"]
+
 # the buffer the hash is written into: SHA256 has one output length and
 # this is it. The width is stated once and the type is built from it, and
 # what that saves is `ffi.sizeof` of a cdata per call, a hundredth of a

--- a/btclib_secp256k1/keys.py
+++ b/btclib_secp256k1/keys.py
@@ -23,6 +23,29 @@ from ._scalar import octets, scalar
 from ._secret import scalar_buffer, take
 from .context import ctx
 
+__all__ = [
+    "COMPRESSED",
+    "UNCOMPRESSED",
+    "PubkeyTweakChain",
+    "parse",
+    "prvkey_negate",
+    "prvkey_tweak_add",
+    "prvkey_tweak_mul",
+    "prvkey_verify",
+    "pubkey_cmp",
+    "pubkey_combine",
+    "pubkey_from_prvkey",
+    "pubkey_negate",
+    "pubkey_sort",
+    "pubkey_sum",
+    "pubkey_tweak_add",
+    "pubkey_tweak_mul",
+    "pubkey_tweak_mul_sum",
+    "pubkey_verify",
+    "reserialize",
+    "serialize",
+]
+
 # SECP256K1_EC_COMPRESSED and SECP256K1_EC_UNCOMPRESSED: the
 # libsecp256k1 flag macros do not survive the preprocessing of the
 # headers into cffi definitions

--- a/btclib_secp256k1/musig.py
+++ b/btclib_secp256k1/musig.py
@@ -79,6 +79,21 @@ from ._scalar import in_range, octets, scalar
 from ._secret import keypair, wipe
 from .context import ctx
 
+__all__ = [
+    "KeyAggCache",
+    "SecretNonce",
+    "Session",
+    "aggnonce_parse",
+    "aggnonce_serialize",
+    "nonce_agg",
+    "nonce_gen",
+    "nonce_gen_counter",
+    "partial_sig_parse",
+    "partial_sig_serialize",
+    "pubnonce_parse",
+    "pubnonce_serialize",
+]
+
 # the three serializations this module has fixed widths for: BIP327's own
 # for a public and an aggregate nonce (33 octets per point, two points
 # each), and libsecp256k1's compact 32-byte partial signature -- s alone,

--- a/btclib_secp256k1/recovery.py
+++ b/btclib_secp256k1/recovery.py
@@ -18,6 +18,8 @@ from .context import ctx
 from .dsa import serialize_der
 from .keys import serialize
 
+__all__ = ["parse_compact", "recover", "serialize_compact", "sign", "to_der"]
+
 # the width of a compact signature, in both directions: it is what
 # `serialize_compact` writes and what `parse_compact` accepts, so the
 # statement of it serves the argument check too, and the buffer's type is

--- a/btclib_secp256k1/silentpayments.py
+++ b/btclib_secp256k1/silentpayments.py
@@ -33,6 +33,18 @@ from ._scalar import in_range, octets, scalar
 from ._secret import keypair, scalar_buffer, take, wipe
 from .context import ctx
 
+__all__ = [
+    "LABEL_SIZE",
+    "SUMMARY_SIZE",
+    "create_outputs",
+    "label",
+    "labeled_spend_pubkey",
+    "parse_label",
+    "prevouts_summary",
+    "scan_outputs",
+    "serialize_label",
+]
+
 # the two widths this module has to check, neither of them a macro that
 # survives the preprocessing of the headers into cffi definitions. The
 # summary's is asked of the struct rather than written down, so that a

--- a/btclib_secp256k1/ssa.py
+++ b/btclib_secp256k1/ssa.py
@@ -18,6 +18,15 @@ from ._scalar import entropy, octets, optional_entropy, scalar
 from ._secret import keypair, take, wipe
 from .context import ctx
 
+__all__ = [
+    "EXTRAPARAMS_MAGIC",
+    "Signer",
+    "nonce_bip340",
+    "sign",
+    "sign_custom",
+    "verify",
+]
+
 # SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC: the libsecp256k1 macros do not
 # survive the preprocessing of the headers into cffi definitions
 EXTRAPARAMS_MAGIC = b"\xda\x6f\xb3\x8c"

--- a/btclib_secp256k1/xonly.py
+++ b/btclib_secp256k1/xonly.py
@@ -36,6 +36,19 @@ from ._scalar import in_range, octets, scalar
 from ._secret import keypair, take, wipe
 from .context import ctx
 
+__all__ = [
+    "from_keypair",
+    "from_prvkey",
+    "from_pubkey",
+    "parse",
+    "prvkey_tweak_add",
+    "pubkey_verify",
+    "serialize",
+    "to_pubkey",
+    "tweak_add",
+    "tweak_add_check",
+]
+
 # the x-only serialization, which is the whole of the key: the other
 # two lengths this module takes are a full public key, whose x it is
 _XONLY_SIZE = 32

--- a/tests/README.md
+++ b/tests/README.md
@@ -300,22 +300,22 @@ least one test, and the two halves together account for all eight.
 
 | convention | tested in |
 | --- | --- |
+| the public surface | `all_test.py` |
 | the copyright header | `copyright_test.py` |
 | the documentation | `docs_test.py` |
 
-Not tested here: the public surface; the import graph; the changelog;
-the build system; the calling convention; input validation.
+Not tested here: the import graph; the changelog; the build system;
+the calling convention; input validation.
 
 The reasons the rest are absent differ, and are given one by one because
-a reader needs which and not how many. **The public surface** is not a
-convention this package has: nothing here declares `__all__`, and no
-prose asks for one, so there is no census to walk and none of the three
-bullets that rest on such a walk applies. **Input validation** is one of
-those three — section 7 asks for it "driven by a walk over the public
-surface rather than by a hand-written list", and `core_test.py` refuses
-plenty by hand. **The calling convention** is the other: two tests read a
-signature, but each about one function rather than as a rule over the
-package.
+a reader needs which and not how many. **Input validation** is the one
+`all_test.py`'s arrival changes without answering: section 7 asks for it
+"driven by a walk over the public surface rather than by a hand-written
+list", and now there is a walk to drive it from, but nothing here does —
+`core_test.py` refuses plenty by hand, against a list nothing checks
+against `__all__`. **The calling convention** has no such dependency and
+is absent on its own account: two tests read a signature, but each about
+one function rather than as a rule over the package.
 
 **The changelog** is the near miss. `vendored_data_test.py` forbids
 exactly the count section 7 forbids — a number nothing derives — but of

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1,0 +1,236 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for what the package exports.
+
+Section 7 of the organization standard asks for `__all__` on every module
+and package, "a module under a private name excepted as no part of that
+surface", and a census walking the tree rather than listing it, "so a new
+public name fails until it is exported or recorded" (#357,
+btclib-org/.github#79). This package is flat -- `btclib_secp256k1` and
+eleven modules under it, `_scalar`, `_secret` and `_cdata` excepted by
+their own leading underscore -- so the walk below has none of btclib's
+own `tests/all_test.py` nested-package machinery: no group-or-unpublished
+partition, because no module here re-exports another by name, and no
+transitive descent, for the same reason.
+
+Every module's `ffi`, `lib`, `CData`, `BytesLike`, `MutableBytesLike` and
+`ctx` come from `from . import ...` or `from .context import ctx`, which
+is what a caller reaching past the argument-checked entry points needs --
+SECURITY.md names that caller directly. That makes each of them an
+import in every module except the one that defines it, so
+`test_no_module_exports_a_name_it_imported` is what keeps one of them
+from drifting into a second module's `__all__` by way of the same `from`
+line that already binds it there.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from pkgutil import iter_modules
+from types import ModuleType
+
+import btclib_secp256k1
+from btclib_secp256k1 import (
+    context,
+    dsa,
+    ecdh,
+    ellswift,
+    hashes,
+    keys,
+    musig,
+    recovery,
+    silentpayments,
+    ssa,
+    xonly,
+)
+
+# what a module defines without a leading underscore and deliberately does
+# not export, with the reason beside the list in the module's own
+# docstring or comments. A name added here is a decision; a name that has
+# to be added here to make the suite pass is one that was about to become
+# public by accident. Empty today: nothing in this package currently
+# defines a public name it withholds
+UNEXPORTED: dict[str, list[str]] = {}
+
+
+def public_name(name: str) -> bool:
+    """Whether a module name is public, i.e. does not open with `_`."""
+    return not name.startswith("_")
+
+
+def library_modules() -> list[ModuleType]:
+    """Return the package and every module under it, private ones out.
+
+    Found rather than listed: a module added to `btclib_secp256k1/` is
+    one this asks about. `_scalar`, `_secret` and `_cdata` are out, and
+    so is anything else under a private name: a module whose name opens
+    with an underscore is not part of the surface, so what is public
+    *in* it is not reachable by any spelling a caller is offered.
+    """
+    return [
+        btclib_secp256k1,
+        context,
+        dsa,
+        ecdh,
+        ellswift,
+        hashes,
+        keys,
+        musig,
+        recovery,
+        silentpayments,
+        ssa,
+        xonly,
+    ]
+
+
+def module_scope(body: Iterable[ast.stmt]) -> Iterator[ast.stmt]:
+    """Yield the statements a module executes in its own namespace.
+
+    Every statement of the body, and then inside each compound one, which
+    runs at module scope too: an import in a module-level `try` or `if`
+    binds a global exactly as a top-level one does. A function or a class
+    opens a scope of its own, so an import in either binds nothing here,
+    and neither is descended into.
+    """
+    for node in body:
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        nested: list[ast.stmt] = []
+        for field in ("body", "orelse", "finalbody"):
+            statements = getattr(node, field, None)
+            if isinstance(statements, list):
+                nested += statements
+        for clause in (*getattr(node, "handlers", ()), *getattr(node, "cases", ())):
+            nested += clause.body
+        yield from module_scope(nested)
+
+
+def imported_names_in(source: str) -> set[str]:
+    """Return the names the import statements of one module source bind."""
+    return {
+        alias.asname or alias.name.split(".")[0]
+        for node in module_scope(ast.parse(source).body)
+        if isinstance(node, ast.Import | ast.ImportFrom)
+        for alias in node.names
+    }
+
+
+def imported_names(module: ModuleType) -> set[str]:
+    """Return the names a module's own import statements bind.
+
+    Read off the source rather than the module object, there being
+    nothing in a module's namespace to say how a name got there.
+    """
+    return imported_names_in(Path(str(module.__file__)).read_text(encoding="utf-8"))
+
+
+def defined_public_names(module: ModuleType) -> set[str]:
+    """Return the public names a module defines itself.
+
+    Everything in its namespace, minus the underscored, minus what it
+    imported, minus the modules: a submodule becomes an attribute of the
+    package as soon as anything imports it, so `context` is in
+    `vars(btclib_secp256k1)` by the time any test runs even though this
+    module never names it.
+    """
+    imported = imported_names(module)
+    return {
+        name
+        for name, value in vars(module).items()
+        if public_name(name)
+        and name not in imported
+        and not isinstance(value, ModuleType)
+    }
+
+
+def test_every_exported_name_exists() -> None:
+    """An `__all__` entry that names nothing is a broken `import *`."""
+    for module in library_modules():
+        names = getattr(module, "__all__", None)
+        assert names is not None, f"{module.__name__} declares no __all__"
+        assert names, f"{module.__name__} declares an empty __all__"
+        for name in names:
+            assert hasattr(module, name), f"{module.__name__}.{name} is not there"
+
+
+def test_no_module_exports_a_name_it_imported() -> None:
+    """A module exports what it defines. Nothing here re-exports.
+
+    Unlike a package's `__init__`, a module re-exporting a name is a
+    leak: `ffi` reached through `btclib_secp256k1.dsa` is that module's
+    import section, where `btclib_secp256k1.ffi` is the name a caller
+    wants. No module in this package has a reason to re-export anything,
+    so the check is unconditional -- a name here would be the first one
+    to need the escape hatch btclib's own version of this test carries.
+    """
+    for module in library_modules():
+        imported = imported_names(module)
+        leaked = {name for name in module.__all__ if name in imported}
+        assert not leaked, f"{module.__name__} re-exports {sorted(leaked)}"
+
+
+def test_nothing_becomes_public_by_accident() -> None:
+    """Every public name is exported or recorded as kept out.
+
+    This is the check the underscore convention cannot make: a helper
+    that grows into a name callers depend on does so silently, where a
+    module takes an edit to `__all__`. `UNEXPORTED` is that edit, and
+    `sorted` is what the failure reads as -- the names not accounted
+    for, against the ones that are.
+    """
+    for module in library_modules():
+        kept_out = sorted(defined_public_names(module) - set(module.__all__))
+        assert kept_out == UNEXPORTED.get(module.__name__, []), (
+            f"{module.__name__} defines public names that are neither"
+            f" exported nor recorded in UNEXPORTED: {kept_out}"
+        )
+
+
+def test_the_import_scan_reaches_a_nested_import() -> None:
+    """A module-level `try` binds a global, and a function body does not.
+
+    None of this package's own modules import inside a `try`, so nothing
+    above would otherwise exercise that branch of `module_scope` -- and
+    the check above is only as good as this scan: an optional import
+    bound that way and named in `__all__` is exactly the re-export
+    `test_no_module_exports_a_name_it_imported` refuses, and reading
+    `tree.body` alone would have let it through.
+    """
+    source = (
+        "try:\n"
+        "    from dependency import PublicType\n"
+        "except ImportError:\n"
+        "    from fallback import PublicType\n"
+        "def f():\n"
+        "    import local\n"
+        "class C:\n"
+        "    import attribute\n"
+    )
+    assert imported_names_in(source) == {"PublicType"}
+
+
+def test_every_module_is_declared() -> None:
+    """A module added to the package directory is one this file asks about.
+
+    `library_modules` is written out rather than discovered from
+    `pkgutil`, so this is the other half: a module added under
+    `btclib_secp256k1/` and not imported above would be silently absent
+    from every check in this file, which a discovered list would not
+    let happen.
+    """
+    found = sorted(
+        name
+        for _, name, _ in iter_modules(btclib_secp256k1.__path__)
+        if public_name(name)
+    )
+    declared = sorted(
+        module.__name__.rsplit(".", 1)[-1] for module in library_modules()[1:]
+    )
+    assert found == declared, (
+        f"btclib_secp256k1/ holds {found}, this file names {declared}"
+    )


### PR DESCRIPTION
A module with no `__all__` answers `import *` with every name it does
not underscore, the ones it imported included: `ffi` and `lib` came
out of `btclib_secp256k1.dsa` alongside its own entry points, verified
before this change and refused after it.

Every module under `btclib_secp256k1/` now declares `__all__`,
`_scalar`, `_secret` and `_cdata` excepted by their own leading
underscore. `context.ctx` is kept public beside `check`, for the
caller reaching `lib` directly that SECURITY.md and the README already
document; `btclib_secp256k1/__init__.py`'s own `__all__` names what it
defines itself rather than the eleven submodules, which
`from btclib_secp256k1 import dsa` already reaches through the import
system regardless of any list.

`tests/all_test.py` is the census section 7 of the organization
standard asks for: it walks the package rather than listing it, so a
new public name fails until it is exported or recorded in
`UNEXPORTED`, and a module re-exporting a name it only imported --
none does today -- is caught the same way. It is a flat version of
btclib's own `tests/all_test.py`: no group-or-unpublished partition
and no transitive descent, neither needed where no module re-exports
another by name.

`tests/README.md`'s convention table moves the public surface out of
"Not tested here" and into the table; input validation stays absent,
section 7's own escape for it now missing only the connection nothing
here makes.

Closes #357.

## Summary by Sourcery

Make the package public API explicit and continuously verified through module-level `__all__` declarations and an automated export census.

New Features:
- Declare explicit `__all__` exports for every public package module and the package root.
- Add an automated package-wide export census that detects missing declarations, accidental public names, and imported-name re-exports.

Bug Fixes:
- Prevent imported implementation names such as `ffi` and `lib` from being exposed through unrelated modules via wildcard imports.

Enhancements:
- Clarify the documented public-surface conventions and preserve the intended direct access to the package context and low-level bindings.

Documentation:
- Update the test conventions documentation and changelog to describe the declared public surface and its census.

Tests:
- Add tests that verify exported names exist, modules do not re-export imports, public names are accounted for, and all package modules are covered.