### PR TITLE
[project].name takes the canonical hyphen (issue btclib-org/.github#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1412,6 +1412,15 @@ release-notes length in the first place, and are still in
   check --strict`, `check-wheel-contents` and `pyroma --min 10` each
   exit 0 on the new archives.
 
+- **`[project].name` takes the canonical hyphen** (btclib-org/.github#277).
+  It was declared `btclib_secp256k1`, the import package's own spelling,
+  where the organization standard's section 3 asks every publisher's
+  `name` for PEP 503's hyphen regardless of what the import package
+  takes. The wheel filename and the `.dist-info` directory are
+  unchanged: PEP 427's escaping rule already folds either spelling to
+  the same `btclib_secp256k1-<version>`, and `uv.lock`'s own package
+  record already carried the hyphenated form before this change.
+
 ### The release path
 
 - **`build-sdist` pins the sdist's `mtime` to the tagged commit's date**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "btclib_secp256k1"
+name = "btclib-secp256k1"
 version = "0.8.0.5"
 description = "Simple python bindings to libsecp256k1"
 readme = "README.md"


### PR DESCRIPTION
Part of [btclib-org/.github#277](https://github.com/btclib-org/.github/issues/277).

`[project].name` becomes `btclib-secp256k1`, the canonical spelling.
PEP 503 folds runs of `-`, `_` and `.` in a distribution name to a
single `-`, and section 3 of the standard says `name` takes that
spelling too. This was the one publisher of five declaring an
underscore.

**Nothing downstream changes**, measured rather than assumed. PEP 427
escapes any run of `-_.` back to `_` for the built artifact, so both
spellings already produce `btclib_secp256k1-<version>` — confirmed
against a real install, whose `.dist-info` directory is byte-identical
before and after. The import package is untouched: it was and remains
`btclib_secp256k1`, an identifier, where a hyphen is not merely
discouraged but absent from the grammar. `pip` and `uv` normalize
either spelling to the same project.

So there is nothing for a caller to act on, and `RELEASE_NOTES.md` gets
no entry — that file's test being whether a caller has to *act*.

A companion branch in the standard's own tree removes the backlog row
that recorded this tree as the exception, and closes the issue there.
The two land back to back: between them a strict `xfail` passes, which
is red.

The gates were re-run after a rebase onto
btclib-org/btclib-secp256k1#371, with the patch proved identical.

## Summary by Sourcery

Adopt the canonical PEP 503 spelling for the project name.

Enhancements:
- Use the canonical hyphenated project name `btclib-secp256k1` in package metadata without changing the generated artifacts or import package.

Chores:
- Record the project-name normalization in the changelog.