### PR TITLE
Every workflow step is named

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -149,7 +149,8 @@ jobs:
         language: [actions, python]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # no `submodules:`, and that is the analysis default setup ran:

--- a/.github/workflows/deps-latest.yml
+++ b/.github/workflows/deps-latest.yml
@@ -106,14 +106,16 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # the vendored library is what gets compiled, so unlike
           # links.yml this one needs it
           submodules: true
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # a week where nothing moved is a full hit, and a week where
           # something did is a week this job has work to do anyway
@@ -160,11 +162,13 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -190,7 +194,8 @@ jobs:
       # coincidence, and
       #   git grep -n 'pre-commit-\${{' -- .github/workflows/
       # is what re-reads the two together: they are meant to agree
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache the pre-commit hook environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: >-
@@ -226,12 +231,14 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           submodules: true
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,7 +94,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # every automodule directive imports this package, which compiles
@@ -102,7 +103,8 @@ jobs:
           # docs job, which builds nothing
           submodules: true
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -102,7 +102,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # no `submodules:`, which is what keeps the vendored tree out of

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,7 +121,8 @@ jobs:
       # the submodule, and a --depth=1 clone carries no tag at all -- and
       # it is the whole cost of moving that check off the release path.
       # Every other hook here reads files this repository owns
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           submodules: true
@@ -161,7 +162,8 @@ jobs:
       # the rest, and it health-checks each restored environment against
       # the interpreter it finds, so a stale one is rebuilt rather than
       # run -- which is what makes a partial restore safe to want
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache the pre-commit hook environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: >-
@@ -170,7 +172,8 @@ jobs:
           restore-keys: |
             pre-commit-${{ runner.os }}-${{ steps.image.outputs.os }}-
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the lint group, pre-commit itself among them;
           # the hook environments are the cache step above

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -89,13 +89,15 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # the extension has to be built for the suite to import anything
           submodules: true
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -172,7 +174,8 @@ jobs:
       # the session as well as the reports: a .sqlite is what cr-report and
       # cr-html are re-run against, and what a later `cosmic-ray exec`
       # resumes, so a downloaded one answers a question the log did not
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the sessions and the reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: mutation-session

--- a/.github/workflows/os-macos.yml
+++ b/.github/workflows/os-macos.yml
@@ -105,13 +105,15 @@ jobs:
           - "pypy3.11"
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # the vendored library is what gets compiled here
           submodules: recursive
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the test group, not the extension, which is built
           # from the tree twice below whatever the cache holds

--- a/.github/workflows/os-ubuntu.yml
+++ b/.github/workflows/os-ubuntu.yml
@@ -156,13 +156,15 @@ jobs:
           - "pypy3.11"
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # the vendored library is what gets compiled here
           submodules: recursive
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the test group, not the extension, which is built
           # from the tree twice below whatever the cache holds

--- a/.github/workflows/os-windows.yml
+++ b/.github/workflows/os-windows.yml
@@ -114,13 +114,15 @@ jobs:
             python-version: "3.10"
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # the vendored library is what gets compiled here
           submodules: recursive
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the test group, not the extension, which is built
           # from the tree twice below whatever the cache holds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,12 +249,14 @@ jobs:
 
     needs: changes
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the test group, not the extension: the root
           # project is installed editable, so its build hook (and the
@@ -319,7 +321,8 @@ jobs:
 
     needs: changes
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -333,12 +336,14 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       # skipped on every trigger but a release rehearsal: the inputs
       # context is empty unless this workflow was called, and an empty
       # string is what the release passes for a tag push
-      - uses: ./.github/actions/dev-version
+      - name: Make the version unique for TestPyPI (rehearsal only)
+        uses: ./.github/actions/dev-version
         if: inputs.version-suffix != ''
         with:
           suffix: ${{ inputs.version-suffix }}
@@ -401,7 +406,8 @@ jobs:
         shell: bash
         run: uv run --locked --only-group build cibuildwheel
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: static-wheels-${{ matrix.os }}
           path: ./wheelhouse/*
@@ -429,7 +435,8 @@ jobs:
 
     needs: changes
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -439,10 +446,12 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       # see build-cibuildwheel
-      - uses: ./.github/actions/dev-version
+      - name: Make the version unique for TestPyPI (rehearsal only)
+        uses: ./.github/actions/dev-version
         if: inputs.version-suffix != ''
         with:
           suffix: ${{ inputs.version-suffix }}
@@ -481,7 +490,8 @@ jobs:
         if: runner.os == 'macOS'
         run: uv run --locked --only-group build delocate-wheel -w wheelhouse dist/*
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dynamic-wheels-${{ matrix.os }}
           path: ./wheelhouse/*
@@ -500,7 +510,8 @@ jobs:
 
     needs: changes
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -510,10 +521,12 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       # see build-cibuildwheel
-      - uses: ./.github/actions/dev-version
+      - name: Make the version unique for TestPyPI (rehearsal only)
+        uses: ./.github/actions/dev-version
         if: inputs.version-suffix != ''
         with:
           suffix: ${{ inputs.version-suffix }}
@@ -548,7 +561,8 @@ jobs:
             .github/scripts/normalize_sdist.py dist/
           sha256sum dist/*
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the source distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -601,7 +615,8 @@ jobs:
     needs: build-sdist
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -613,7 +628,8 @@ jobs:
           # default, the architecture of the runner
           architecture: ${{ matrix.architecture }}
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist
@@ -661,7 +677,8 @@ jobs:
 
     needs: changes
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -671,10 +688,12 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       # see build-cibuildwheel
-      - uses: ./.github/actions/dev-version
+      - name: Make the version unique for TestPyPI (rehearsal only)
+        uses: ./.github/actions/dev-version
         if: inputs.version-suffix != ''
         with:
           suffix: ${{ inputs.version-suffix }}
@@ -691,7 +710,8 @@ jobs:
           BTCLIB_LIBSECP256K1_CROSS_COMPILE=true CFFI_PLATFORM=Windows \
             uv run --locked --only-group build python -m build -w
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload the wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dynamic-wheels-windows
           path: dist/*
@@ -709,23 +729,27 @@ jobs:
 
     steps:
       # for the check-wheel-contents configuration in pyproject.toml
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # the wheels of the check group, the three tools below among
           # them, keyed on uv.lock
           enable-cache: true
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*-wheels-*"
           merge-multiple: true
           path: dist
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download the source distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdist
           path: dist

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -96,11 +96,13 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -149,7 +151,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # shallow is enough: the one tag this needs is fetched below,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.5 (work in progress, not released yet)
 
+### CI
+
+- **Every workflow step is named** (#300). An unnamed step is rendered
+  as its command on the run page, which a release run reads by
+  expanding rather than by scanning, dozens deep; it also cost the
+  alignment work across the three repositories, a step named in two
+  files and not the third being harder to recognise as the same step
+  (btclib-org/btclib#1141, btclib-org/btclib#1142). Names match what
+  `btclib` and `bitcoin-core-rpc` already carry for the same step --
+  "Checkout code", "Setup uv", "Cache the pre-commit hook
+  environments", "Make the version unique for TestPyPI (rehearsal
+  only)" -- and an upload or download names what it moves rather than
+  repeating the action. Held deliberately until this repository had no
+  open pull request, a whole-file sweep rebasing worst against one that
+  had touched only a few lines of the same workflow.
+
 ### Every module declares `__all__`
 
 - **The public surface is a declared list, not everything a module


### PR DESCRIPTION
An unnamed step is rendered as its command on the run page, which a
release run reads by expanding steps rather than by scanning them,
dozens deep. It also cost the alignment work already under way across
btclib, bitcoin-core-rpc and this repository: a step named in two
files and not the third is harder to recognise as the same step, which
is how a fix has already landed in one repository and not the others
(btclib-org/btclib#1141, btclib-org/btclib#1142).

Names match what btclib and bitcoin-core-rpc already carry for the
same step -- "Checkout code", "Setup uv", "Cache the pre-commit hook
environments", "Make the version unique for TestPyPI (rehearsal
only)" -- measured against both checkouts rather than invented here,
and an upload or download artifact step names what it moves rather
than repeating the action's own name, matching the name a sibling
artifact of the same kind already carries elsewhere in this
repository's own workflows.

Held deliberately until this repository had no open pull request, per
the issue's own comment: a whole-file sweep rebases worst against a
branch that had touched only a few lines of the same workflow, and the
condition is measured rather than assumed.

Closes #300.

## Summary by Sourcery

Name every GitHub Actions workflow step to improve CI run readability and maintain consistent workflow identification across repositories.

Enhancements:
- Add descriptive names to all GitHub Actions workflow steps, including checkout, setup, caching, versioning, and artifact operations, for clearer run-page visibility and consistent cross-repository workflow alignment.

CI:
- Standardize workflow step names across CodeQL, dependency, documentation, lint, mutation, platform, testing, and vendored-vector workflows.

Documentation:
- Document the workflow step naming convention in the unreleased changelog.