### PR TITLE
CHANGELOG.md's two "### CI" headings under v0.8.0.5 become one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,22 +28,6 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.5 (work in progress, not released yet)
 
-### CI
-
-- **Every workflow step is named** (#300). An unnamed step is rendered
-  as its command on the run page, which a release run reads by
-  expanding rather than by scanning, dozens deep; it also cost the
-  alignment work across the three repositories, a step named in two
-  files and not the third being harder to recognise as the same step
-  (btclib-org/btclib#1141, btclib-org/btclib#1142). Names match what
-  `btclib` and `bitcoin-core-rpc` already carry for the same step --
-  "Checkout code", "Setup uv", "Cache the pre-commit hook
-  environments", "Make the version unique for TestPyPI (rehearsal
-  only)" -- and an upload or download names what it moves rather than
-  repeating the action. Held deliberately until this repository had no
-  open pull request, a whole-file sweep rebasing worst against one that
-  had touched only a few lines of the same workflow.
-
 ### Every module declares `__all__`
 
 - **The public surface is a declared list, not everything a module
@@ -535,6 +519,20 @@ release-notes length in the first place, and are still in
   into any text a diff of the rendered page would show.
 
 ### CI
+
+- **Every workflow step is named** (#300). An unnamed step is rendered
+  as its command on the run page, which a release run reads by
+  expanding rather than by scanning, dozens deep; it also cost the
+  alignment work across the three repositories, a step named in two
+  files and not the third being harder to recognise as the same step
+  (btclib-org/btclib#1141, btclib-org/btclib#1142). Names match what
+  `btclib` and `bitcoin-core-rpc` already carry for the same step --
+  "Checkout code", "Setup uv", "Cache the pre-commit hook
+  environments", "Make the version unique for TestPyPI (rehearsal
+  only)" -- and an upload or download names what it moves rather than
+  repeating the action. Held deliberately until this repository had no
+  open pull request, a whole-file sweep rebasing worst against one that
+  had touched only a few lines of the same workflow.
 
 - **`codeql.yml` carries no aggregate job any more** (#355,
   btclib-org/.github#90). Its `on:` block triggers on `push` to `main`


### PR DESCRIPTION
#368 (issue #355) and #373 (issue #300) each added a "### CI" heading
under the same v0.8.0.5 release, landing independently and never
seeing each other's diff. markdownlint's MD024, `siblings_only`,
exists for exactly this: two headings with the same text under one
parent fail it, and the gate reported so -- a false "pre-commit 0" was
carried on #373's own round, the round that landed second and could
have seen it.

The two sections merge into one, #300's bullet first: chronologically
the more recent of the two landings, matching how every other section
under this release already orders its own entries.

Closes #374.

## Summary by Sourcery

Consolidate the duplicate v0.8.0.5 CI headings into one lint-compliant changelog section.

Bug Fixes:
- Merge the duplicate v0.8.0.5 CI changelog sections to satisfy markdownlint's sibling-heading rule.

Documentation:
- Consolidate the v0.8.0.5 CI entries into a single chronologically ordered changelog section.