### PR TITLE
CONTRIBUTING.md's repository-specific section stops naming btclib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,24 @@ release-notes length in the first place, and are still in
   comparison against `btclib`'s own settings or history, in both files,
   now states the same fact without the name.
 
+- **`CONTRIBUTING.md`'s repository-specific section stops comparing
+  against `btclib` by name** (#365, btclib-org/.github#81). The same
+  census finds four more instances below `## This repository in
+  particular`, each the same shape: a fact about this repository's own
+  build or gates, explained by contrast with `btclib`'s rather than
+  stated on its own -- the documentation build needing the submodule
+  checked out, the organization's shared concurrent-jobs ceiling, and
+  the benchmarks' own dependency list. Each now states the fact without
+  the name, or names it as "the library downstream of these bindings"
+  where the relationship itself is what the sentence is about. Left
+  unchanged, and read against the standard's own "positioning in the
+  family" carve-out rather than assumed a violation: the routing
+  sentence telling a contributor that a wallet, a transaction or a
+  signing session belongs in `btclib`'s own tracker, which is what
+  these bindings are for -- the same shape section 9 of the standard
+  names allowed, where a package stands on the organization that
+  publishes it and where it sits in the family.
+
 - **`.gitattributes` is the organization's file byte for byte**
   (btclib-org/.github#192). Section 14 of the standard makes the two
   `merge=union` entries and the reasoning beside them the standard's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,9 +250,9 @@ uv run --locked --no-default-groups --group docs \
     sphinx-build -W --keep-going -b html docs/source docs/build/html
 ```
 
-The documentation build needs the submodule checked out, unlike btclib's
-own equivalent: every `automodule` directive imports this package, which
-means compiling libsecp256k1 first. Coverage is measured in branch mode
+The documentation build needs the submodule checked out: every
+`automodule` directive imports this package, which means compiling
+libsecp256k1 first. Coverage is measured in branch mode
 and gated by the `fail_under` ratchet in `pyproject.toml`.
 
 The group flags are not decoration. `uv run` syncs the environment
@@ -344,8 +344,9 @@ To time these bindings against the other python wrappers of
 libsecp256k1, clone
 [btclib-benchmarks](https://github.com/btclib-org/btclib-benchmarks) and
 run `scripts/libsecp256k1_wrappers.py` there. The comparands are that
-project's dependencies rather than this one's, which is the point: btclib
-is one of them, and btclib is what depends on these bindings.
+project's dependencies rather than this one's, which is the point: the
+library downstream of these bindings is one of them, and depends on
+these bindings itself.
 
 To test against another supported interpreter, bypass the build cache:
 uv keys it on the sources, which do not tell it that the compiled
@@ -505,9 +506,9 @@ command at all, for the reason above, and no longer gates.
   own. What turned it red is one of them, in the run
 
 - `Build the documentation`, the same command `.readthedocs.yaml` runs
-  and `docs/README.rst` documents. Needs the submodule checked out,
-  unlike btclib's own equivalent job: every `automodule` directive
-  imports this package, which means compiling libsecp256k1 first
+  and `docs/README.rst` documents. Needs the submodule checked out:
+  every `automodule` directive imports this package, which means
+  compiling libsecp256k1 first
 
   ```shell
   git submodule update --init
@@ -683,10 +684,11 @@ each.
 
 Why so little gates is one number: GitHub Free gives an organization twenty
 concurrent jobs (as of 2026-08-21), shared across every repository in it. A
-commit here, in btclib and in bitcoin-core-rpc each ask for more jobs than
-that ceiling alone allows, so a pull request in any of the three spent its
-wall clock waiting for a slot. At that ceiling a cell before a review buys a
-rarer answer at the price of every review: macOS runners queue for tens of
+commit here, in bitcoin-core-rpc and in one more repository each ask for
+more jobs than that ceiling alone allows, so a pull request in any of the
+three spent its wall clock waiting for a slot. At that ceiling a cell
+before a review buys a rarer answer at the price of every review: macOS
+runners queue for tens of
 minutes rather than for two, and the twenty-one Windows suite cells were
 27.3 of a run's 112.9 runner-minutes, the largest family of jobs in it and
 ahead of every wheel build. The numbers are in `test.yml`'s header.


### PR DESCRIPTION
The census RELEASING.md and REPOSITORY.md were already read against
(592f1bc, #366) finds four more instances of the same shape below
"This repository in particular": a fact about this repository's own
build or gates, explained by contrast with btclib's rather than
stated on its own. The documentation build needing the submodule
checked out, the organization's shared concurrent-jobs ceiling twice
(the prose paragraph and the workflow-to-job table), and the
benchmarks' own dependency list -- each now states the fact without
the name, or names the relationship itself ("the library downstream
of these bindings") where that relationship is what the sentence is
about, matching the substitution REPOSITORY.md already made for the
same ceiling sentence.

Left unchanged, and read against the standard's carve-out rather than
assumed a violation: the routing sentence sending a contributor with
state of their own -- a wallet, a transaction, a signing session -- to
btclib's own tracker, which is what these bindings are for. Section 9
of the organization standard excepts a package standing on the
organization that publishes it and where it sits in the family, and
this sentence is that shape: it says what this package is for and
where a report that is not about it belongs, not a comparison
explaining this repository's own choices by reference to a downstream
consumer.

Closes #365.

## Summary by Sourcery

Clarify repository-specific contribution guidance without naming btclib when describing this repository’s own build and CI characteristics.

Enhancements:
- Update repository-specific contribution guidance to describe documentation, benchmarking, and CI constraints without unnecessary comparisons to btclib.
- Retain the guidance directing reports about downstream wallet, transaction, and signing-session state to btclib’s tracker.

Documentation:
- Clarify repository-specific build and benchmarking guidance in CONTRIBUTING.md while preserving the valid tracker-routing exception.

Chores:
- Record the contribution-documentation cleanup in the changelog.