### PR TITLE
CONTRIBUTING.md's shared half is the organization's copy again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,16 @@ release-notes length in the first place, and are still in
   names allowed, where a package stands on the organization that
   publishes it and where it sits in the family.
 
+- **`CONTRIBUTING.md`'s shared half is the organization's copy again**
+  (#375). Section 14's own `verbatim_test.py` compares everything above
+  `## This repository in particular` against `btclib-org/.github`'s
+  copy, and this tree's had drifted from it: a `### The landing queue`
+  subsection the shared half has gained since, and a rewritten paragraph
+  on what a commit message becomes once it lands on `main`, were both
+  missing here. Replaced with the organization's copy of the same text
+  byte for byte -- the same hash the issue's own measurement checks
+  for -- leaving everything from that heading down untouched.
+
 - **`.gitattributes` is the organization's file byte for byte**
   (btclib-org/.github#192). Section 14 of the standard makes the two
   `merge=union` entries and the reasoning beside them the standard's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ restated here: a second wording is the one that goes stale, which is
 that section's own *One fact in one place*.
 
 A commit message is prose this tree ships too, though section 9 does not
-say so: squash is the only merge method and the landing commit carries
-the messages, so what is written in one is read on `main` long after the
-branch is gone.
+say so: [the only merge method the rule accepts][s11] puts it on `main`
+as the landing commit's body, so what is written in one is read there
+long after the branch is gone.
 
 ## Pull requests
 
@@ -84,6 +84,36 @@ because a plain rebase replays the base's old commit inside the child,
 and the forge then shows the base's old text as additions with nothing
 red anywhere. Read the child's diff afterwards rather than trusting the
 rebase, and retarget each child onto `main` as its parent lands.
+
+### The landing queue
+
+Where more than one pull request is open against this repository, only
+one is carried to `main` at a time: rebased onto the tip, reviewed on
+that head, and landed, while every other one waits, untouched, for its
+turn. This governs which of several *already open* pull requests reaches
+`main` next; *One subject, opened as soon as it is written* above governs
+the moment before that, when a finished one is opened — the two do not
+conflict, since a pull request is still opened without delay and still
+waits its turn once several are open.
+
+The reason is CI throughput, not the ack a waiting pull request keeps —
+`REVIEWING.md`'s *The verdict* states what an ack belongs to, and
+*Landing it* below states which rebase voids one. Every rebase queues
+this repository's whole check matrix against the organization's ceiling
+on concurrent jobs, so rebasing every waiting pull request after each
+landing spends that capacity on runs the next landing invalidates
+anyway, and delays the one pull request that is actually next: work
+spent on a pull request that is not next is work that delays the one
+that is.
+
+Order is cheapest and least contended first, most invasive last, so that
+a large change does not sit at the head blocking everything behind it.
+
+The maintainer may declare a bounded exception — several pull requests in
+flight against one repository, for a named piece of work — trading the
+cost above for throughput; it is recorded as a comment in
+[btclib-org/.github](https://github.com/btclib-org/.github/issues), by
+*The issue tracker* above, and holds only for the work it names.
 
 ### The review
 


### PR DESCRIPTION
Everything above `## This repository in particular` is the same file in
every repository of the organization (section 14), and
`verbatim_test.py` in btclib-org/.github compares copies against it.
This tree's had drifted: the `### The landing queue` subsection and a
rewritten commit-message paragraph, both gained since, were missing
here.

Replaced with the organization's copy byte for byte — the same SHA-1
the issue's own measurement checks for — leaving everything from that
heading down untouched.

Closes #375

## Summary by Sourcery

Synchronize CONTRIBUTING.md’s shared guidance with the organization-wide standard.

Enhancements:
- Synchronize the shared portion of CONTRIBUTING.md with the organization-wide copy while preserving repository-specific guidance.

Documentation:
- Restore the organization’s landing-queue guidance and updated commit-message wording in CONTRIBUTING.md.

Chores:
- Record the CONTRIBUTING.md synchronization in the changelog.