### PR TITLE
CHANGELOG.md's lint derogation goes, and codespell fixes in place (closes #379)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,6 +220,7 @@ repos:
   # default rule set, less the two .yamllint.yaml disables by name, with
   # the width at 100 rather than the 80 the prose gets -- that file
   # carries the arithmetic behind both
+  # check-only: yamllint has no fix mode, and its own README names none
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
@@ -239,6 +240,8 @@ repos:
     rev: v2.4.3
     hooks:
       - id: codespell
+        name: codespell (in place fixes)
+        args: [--write-changes]
   # the second spell checker, and the pair is the point: the two are blind
   # in different places, so neither subsumes the other. codespell matches
   # whole words against a list of known misspellings and keeps the hyphen
@@ -247,6 +250,11 @@ repos:
   # camelCase, and carries a dictionary of its own. typos' configuration
   # is in pyproject.toml; codespell needs none today -- measured, with its
   # default dictionaries it finds nothing here to skip or allow for
+  # in place fixes already, by upstream's own .pre-commit-hooks.yaml:
+  # args: [--write-changes, --force-exclude], inherited because this
+  # file passes no args: of its own. An args: added here later for a
+  # different reason would silently drop that default and turn the
+  # fixing off
   - repo: https://github.com/crate-ci/typos
     rev: v1.49.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-<!-- markdownlint-disable MD022 MD032 -->
-<!-- This file is merge=union, so a rebase joins two sections and drops
-     the blank line between them without a conflict: the rule is off
-     here for the duration of btclib-org/.github#33, and goes back on
-     when that queue is empty. btclib-org/.github#138 is the record. -->
-
 # Changelog
 
 <!-- markdownlint-configure-file
@@ -27,6 +21,19 @@ release-notes length in the first place, and are still in
 [RELEASE_NOTES.md](./RELEASE_NOTES.md) rather than duplicated here.
 
 ## v0.8.0.5 (work in progress, not released yet)
+
+### Every fixable hook fixes, and `CHANGELOG.md`'s derogation is gone
+
+- **`codespell` gains `--write-changes`, and `.pre-commit-config.yaml`
+  now states that `typos` already fixes in place through its own
+  upstream default, so an `args:` added there later cannot silently
+  drop it** (closes #379). `markdownlint-cli2` already fixes;
+  `yamllint` is noted where it has no fix mode to turn on.
+- **With every markdown-fixing hook running in place, the two-comment
+  directive at `CHANGELOG.md`'s head has nothing left to guard against:
+  a rebase-dropped blank line is repaired on the next hook run instead
+  of failing a gate with nothing behind it to fix.** The directive is
+  gone, and MD022 and MD032 apply to this file again.
 
 ### Every module declares `__all__`
 


### PR DESCRIPTION
`CHANGELOG.md`'s head directive turning MD022 and MD032 off for the whole
file is deleted, and `codespell` gains `--write-changes`.

The directive exists because `merge=union` joins two branches' sections
without a conflict and drops the blank line between two `###` blocks while
doing it, which lands as a red gate with nothing behind it a machine can
repair. With `markdownlint-cli2` running with `--fix`, the same drop is the
hook's own repair on its next run, so both rules apply to this file again.

`typos` gains a comment naming the `--write-changes --force-exclude` it
inherits from its upstream hook, so an `args:` added later for another
reason finds them in the list instead of dropping the fixing by leaving
them out. `yamllint` gains one saying it has no fix mode.

`codespell --write-changes` over this project's own tracked files rewrites
nothing, which is the measurement behind turning the flag on: a markdown
fixer's repairs are deterministic where a spell-checker's are guesses, and
this tree's prose is about elliptic-curve cryptography. The vendored C tree
is outside what the hook is handed — pre-commit tags a gitlink as a
directory, and the hook declares `types: [text]`.

Closes #379

## Summary by Sourcery

Restore full markdownlint coverage for `CHANGELOG.md` and make the pre-commit spell-checking configuration consistently support automatic fixes.

Bug Fixes:
- Re-enable markdownlint MD022 and MD032 checks for `CHANGELOG.md` now that fixable formatting issues can be repaired automatically.

Enhancements:
- Enable in-place fixes for codespell and document the inherited typos fix arguments and yamllint's check-only behavior.

Documentation:
- Update the changelog to document the spell-checking and markdownlint configuration changes.