### PR TITLE
pyproject.toml's uv floor is the ceiling Dependabot allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.5 (work in progress, not released yet)
 
+### The uv floor is raised to the Dependabot ceiling
+
+- **`[tool.uv]`'s `required-version` moves from `>=0.12.0` to
+  `>=0.12.1`, the uv Dependabot's own uv-ecosystem updater bundles, and
+  the comment beside it now points at the organization standard's
+  section 1 and section 15 rather than restating their argument**
+  (closes #380).
+
 ### Every fixable hook fixes, and `CHANGELOG.md`'s derogation is gone
 
 - **`codespell` gains `--write-changes`, and `.pre-commit-config.yaml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,22 +284,10 @@ dev = [
 ]
 
 [tool.uv]
-# the oldest uv allowed to touch uv.lock -- not the version the uv-lock
-# hook of .pre-commit-config.yaml pins, which is newer and moves on its
-# own schedule under pre-commit.ci; a floor here has to stay at or below
-# whatever Dependabot's own uv-ecosystem updater bundles instead. That
-# updater runs `uv lock` with exactly the uv it bundles regardless of
-# this key, and refuses rather than upgrading itself when it falls short
-# of the key, so raising this past what it bundles silently stops every
-# lock update it attempts, including security ones. Declared here the
-# floor still holds for every uv command rather than for that one
-# updater alone, so an older uv on a developer's machine says so instead
-# of rewriting the lock in a format the runners then fail to read — uv
-# is pre-1.0 and changes that format. It also reaches CI without a
-# second pin: setup-uv, given no version input, reads this key, and a
-# bare minimum specifier makes it install the latest uv, so the runners
-# are never behind the floor and there is nothing here to go stale
-required-version = ">=0.12.0"
+# the oldest uv that may read uv.lock, at the ceiling rather than safely
+# below it -- section 1 has the argument and section 15 the command that
+# re-derives the ceiling
+required-version = ">=0.12.1"
 
 [tool.mypy]
 # the package ships py.typed: its annotations are what btclib downstream


### PR DESCRIPTION
Closes #380

Raises `[tool.uv] required-version` from `>=0.12.0` to `>=0.12.1`, the
ceiling Dependabot's uv-ecosystem updater bundles, and replaces the
inline comment with a pointer to the organization standard's section 1
(the argument) and section 15 (the re-derivation command), rather than
restating the Dependabot mechanism here.

## Test plan
- `uv run --locked --only-group lint pre-commit run --all-files`
- `uv run --locked --no-default-groups --group test pytest --cov`
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`

All exit 0; reviewed locally, CLEARED 0402081057f261772fdd32ba7827a298fd37ecc0.

## Summary by Sourcery

Align the project’s uv version floor with Dependabot’s bundled uv ceiling.

Enhancements:
- Raise the minimum supported uv version to 0.12.1 so it matches the version bundled by Dependabot and update the configuration guidance to reference the organization standard.

Chores:
- Document the uv version-floor change in the changelog.