### PR TITLE
CLAUDE.md names check-sdist's untracked-file trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,15 @@ Do not use Fable unless explicitly instructed.
   rather than a broken workflow. A red there still means the outside
   world moved, which is why it is a workflow of its own and not a job of
   `release`
+- **`check-sdist` compares the sdist it builds against `git ls-files`,
+  not against `git status`.** An untracked directory left inside a
+  worktree -- a wheel built there for manual verification, say -- is
+  swept into that build and fails the hook with "SDist does not match
+  git", even though `git status --porcelain` reports the tree clean: an
+  untracked file passes that check silently and still breaks this one.
+  The fix is not rerunning the hook; it is not leaving such a directory
+  inside the worktree in the first place, or building it somewhere else
+  entirely
 
 ## Conventions to match
 


### PR DESCRIPTION
Documentation only, no linked issue.

`check-sdist` builds its sdist from the working tree rather than from
git's tracked state, so an untracked directory left inside a worktree
— a wheel built there for manual verification, say — is swept in and
fails the hook with "SDist does not match git", past a clean
`git status`. Found while verifying ISS 382's wheel contents; naming
it in CLAUDE.md's "Non-obvious facts" section is what saves the next
session from rediscovering it.

## Test plan
- `uv run --locked --group lint pre-commit run --all-files`
- `uv run --locked --group test pytest --cov`
- `uv run --locked --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`

All exit 0.

## Summary by Sourcery

Document the untracked-worktree artifact trap that can cause `check-sdist` to report an sdist mismatch.

Enhancements:
- Document the `check-sdist` behavior that causes untracked directories inside a worktree to make the hook fail despite a clean Git status.

Documentation:
- Add guidance to CLAUDE.md for avoiding misleading `check-sdist` failures caused by untracked build artifacts.