### PR TITLE
CLAUDE.md records the codeql.yml pull_request decline (issue #387)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,10 @@ precisely so these stay true, and both must report zero findings.
 - a hook that needs a tool carries it in `additional_dependencies`, with
   a version: unpinned it is whatever existed when each environment was
   built, and nothing ever moves it
+- `codeql.yml` carries no `pull_request` trigger, unlike
+  btclib-org/.github#349's ask: its own `on:` block argues the GitHub
+  Free concurrent-job-slot cost that trigger would add, a tradeoff that
+  issue leaves unaddressed as of this writing
 
 ## Verifying
 


### PR DESCRIPTION
Part of ISS 387: this is only the "codeql.yml on pull_request" checklist
item, not the whole issue -- ISS 387 is a multi-item checklist and this
does not close it.

btclib-org/.github#349 asks every tree to add a pull_request trigger to
codeql.yml so Scorecard's SAST check credits it. This repository's
codeql.yml already argues, in its own on: block, why that trigger is not
worth the GitHub Free concurrent-job-slot cost it would add -- a
tradeoff btclib-org/.github#349 does not address. The maintainer's
decision, made directly, is to decline the trigger change and record the
decision instead, per section 2 of the organization standard: "a gap
with the reason beside it ... is a decision rather than a gap." That
decision now has a bullet in CLAUDE.md's Conventions to match, pointing
back at the workflow's own comment rather than restating it.

Locally reviewed and CLEARED at 52e70ced23b0386fcfb1b83e5616ab11abd95c16
(one round of CHANGES REQUESTED on an unqualified cross-repository
reference, fixed and re-cleared).

(issue #387)

## Summary by Sourcery

Record the decision to decline adding a CodeQL `pull_request` trigger and point to the workflow’s existing rationale.

Enhancements:
- Document the decision to retain the existing CodeQL workflow without a `pull_request` trigger because of its GitHub Free concurrency cost.

Documentation:
- Add the CodeQL trigger decision and its rationale to the repository conventions in `CLAUDE.md`.