### PR TITLE
README.md's badge head follows section 2's fixed order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1537,6 +1537,23 @@ release-notes length in the first place, and are still in
   -- so deriving through it would fail this test's round trip on every
   supported interpreter alike, not on some of them.
 
+### `README.md`'s badge head follows section 2's fixed order
+
+- **`wheel`, `implementation` and `github/v/release` join the badge
+  block, and every remaining badge takes its place in the order section
+  2 of the organization standard fixes, sentinels included for every
+  weekly workflow this tree runs** (issue #387, btclib-org/.github#338).
+  `wheel` and `implementation` read `img.shields.io/pypi/wheel` and
+  `img.shields.io/pypi/implementation` off the files a release uploaded;
+  `github/v/release` reads the forge rather than the index, next to the
+  PyPI version badge it is paired with. Every badge path naming the
+  distribution now takes PEP 503's hyphen, `btclib-secp256k1`, rather
+  than the import package's `btclib_secp256k1` -- the version,
+  downloads, development-status and supported-Python-versions badges
+  and the PyPI and pepy links beside them. The documentation-build badge
+  image now points at `app.readthedocs.org`; `readthedocs.org` answers
+  that path with a redirect to it.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/README.md
+++ b/README.md
@@ -8,17 +8,29 @@ CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
 badge per line keeps a change to one line and every line inside MD013,
 whose 80 columns bind only where a space follows them. btclib and
 bitcoin-core-rpc carry the same three lines. -->
-[![PyPI version](https://img.shields.io/pypi/v/btclib_secp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib_secp256k1/)
-[![downloads](https://static.pepy.tech/badge/btclib_secp256k1)](https://pepy.tech/project/btclib_secp256k1)
-[![development status](https://img.shields.io/pypi/status/btclib_secp256k1.svg)](https://pypi.python.org/pypi/btclib_secp256k1/)
+[![PyPI version](https://img.shields.io/pypi/v/btclib-secp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib-secp256k1/)
+[![downloads](https://static.pepy.tech/badge/btclib-secp256k1)](https://pepy.tech/project/btclib-secp256k1)
+[![development status](https://img.shields.io/pypi/status/btclib-secp256k1.svg)](https://pypi.python.org/pypi/btclib-secp256k1/)
 [![license](https://img.shields.io/github/license/btclib-org/btclib-secp256k1.svg)](https://github.com/btclib-org/btclib-secp256k1/blob/main/LICENSE)
-[![supported Python versions](https://img.shields.io/pypi/pyversions/btclib_secp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib_secp256k1/)
+[![supported Python versions](https://img.shields.io/pypi/pyversions/btclib-secp256k1.svg?logo=python)](https://pypi.python.org/pypi/btclib-secp256k1/)
+[![wheel](https://img.shields.io/pypi/wheel/btclib-secp256k1.svg)](https://pypi.python.org/pypi/btclib-secp256k1/)
+[![implementation](https://img.shields.io/pypi/implementation/btclib-secp256k1.svg)](https://pypi.python.org/pypi/btclib-secp256k1/)
+[![GitHub release](https://img.shields.io/github/v/release/btclib-org/btclib-secp256k1.svg)](https://github.com/btclib-org/btclib-secp256k1/releases)
 
 [![test workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/test.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/lint.yml)
 [![docs workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/docs.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/docs.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib-secp256k1/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib-secp256k1/main)
-[![documentation build](https://readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
+[![links workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/links.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/links.yml)
+[![vendored-vectors workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/vendored-vectors.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/vendored-vectors.yml)
+[![codeql workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/codeql.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/codeql.yml)
+[![deps-latest workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/deps-latest.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/deps-latest.yml)
+[![pypi-install workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/pypi-install.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/pypi-install.yml)
+[![os-ubuntu workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-ubuntu.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-ubuntu.yml)
+[![os-macos workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-macos.yml)
+[![os-windows workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-windows.yml)
+[![mutation workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml)
+[![documentation build](https://app.readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--secp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
 


### PR DESCRIPTION
Part of ISS 387: this is only the "README.md's head" checklist item, not
the whole issue -- ISS 387 is a multi-item checklist and this does not
close it.

Converges this repository's README.md badge block onto
btclib-org/.github's section 2 fixed order and onto btclib's own already
-landed badge block:

- distribution-name badge paths and hrefs (version, downloads,
  development status, supported Python versions) take the hyphen
  (btclib-secp256k1), not the underscore
- adds the missing wheel, implementation and github/v/release badges
- adds a sentinel badge for every weekly workflow this tree actually
  runs, in section 10's calendar order
- fixes the Read the Docs badge image host to app.readthedocs.org
  (readthedocs.org answers that path with a 307)

No scorecard badge yet (that workflow does not exist on main as of this
branch) and no fuzz badge (design unresolved elsewhere,
btclib-org/.github#342).

Locally reviewed and CLEARED at f10a5ae5ce45b6e0ac84fe962c60b22871e92e4e.

(issue #387, btclib-org/.github#338)

## Summary by Sourcery

Standardize the README badge block with the organization-wide ordering and complete coverage for the package and active workflows.

New Features:
- Add wheel, implementation, GitHub release, and status badges for the package and its active workflows.

Bug Fixes:
- Correct package badge URLs to use the distribution name and update the Read the Docs badge host to avoid redirects.

Enhancements:
- Align the README badge block with the organization’s fixed ordering and include workflow sentinels in calendar order.

Documentation:
- Update the README badge block and changelog to reflect the standardized badge set and ordering.