### PR TITLE
REVIEWING.md takes the shared half byte for byte from btclib-org/.github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,14 @@ release-notes length in the first place, and are still in
   told in a comment to go — section 14 of the standard, the shared half
   byte for byte.
 
+- **`REVIEWING.md`'s *The verdict* posts the summary to the forge as a
+  review and says which verdict is the ack of record.** The organization's
+  copy, shared half byte for byte (section 14): `APPROVE` carries the
+  `ACK <sha>` summary and `REQUEST_CHANGES` the `CHANGES REQUESTED <sha>`
+  one, section 11 says whose verdict that is, and every other summary is
+  a comment rather than an ack, a forge approval by the pull request's own
+  author included (btclib-org/.github#353).
+
 - **`CODE_OF_CONDUCT.md` is gone, and the inherited copy is what GitHub
   shows** (btclib-org/.github#123). Section 14 of the organization
   standard no longer lists it: the file was a pointer to the PSF code of

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -24,11 +24,11 @@ request and no memory of how the last review went. Read the other way
 round, before a pull request is opened, it is what that pull request
 will be answered against.
 
-A review produces comments on a pull request and issues filed against
-the repository. **A reviewer writes nothing to the branch**: no push, no
-amend, no merge. The one commit a review can lead to is the author's own
-click on a suggestion, below, which is theirs to make and theirs to
-decline.
+A review produces a verdict and comments on a pull request, and issues
+filed against the repository. **A reviewer writes nothing to the
+branch**: no push, no amend, no merge. The one commit a review can lead
+to is the author's own click on a suggestion, below, which is theirs to
+make and theirs to decline.
 
 ## The standard an ack is given against
 
@@ -151,9 +151,9 @@ gh issue create --title "<the finding, as a claim>" \
   --body "<what was noticed and where, how it is known, why it matters>"
 ```
 
-Name the issues filed at the foot of the summary comment, under a line
-saying they are **not** findings against this pull request. Without that
-line the list reads as more things to fix before merging, which is the
+Name the issues filed at the foot of the summary, under a line saying
+they are **not** findings against this pull request. Without that line
+the list reads as more things to fix before merging, which is the
 opposite of what filing them was for.
 
 ## What a finding says
@@ -362,9 +362,10 @@ a gap.
 
 ## The verdict
 
-Inline comments for the line-anchored findings, then exactly one summary
-comment. **A review that decides whether the pull request lands** ends
-that comment with one of two lines:
+Inline comments for the line-anchored findings, then exactly one
+summary. **A review that decides whether the pull request lands** posts
+that summary to the forge as a review, and ends it with one of two
+lines:
 
 ```text
 CHANGES REQUESTED <sha>
@@ -374,11 +375,15 @@ CHANGES REQUESTED <sha>
 ACK <sha>
 ```
 
-Nothing else is an ack — not "looks good", and not a forge approval,
-which section 11 of the standard records GitHub as refusing to the author
-of the pull request. That refusal is why the record of a review here is a
-comment at all. It names the sha because an ack belongs to a tree and
-not to a branch.
+`APPROVE` carries the `ACK <sha>` summary and `REQUEST_CHANGES` the
+`CHANGES REQUESTED <sha>` one. Section 11 of the standard says whose
+verdict is the ack of record, and why the forge has to hold a review of
+it rather than a comment.
+
+Every other summary is a comment. Nothing else is an ack — not "looks
+good", and not a forge approval by the author of the pull request, which
+section 11 records GitHub as refusing. Either line names the sha,
+because an ack belongs to a tree and not to a branch.
 
 **A review that does not decide ends without one, and is not an
 unfinished review.** Somebody who reads a diff and says what they found


### PR DESCRIPTION
Part of ISS 387: this is only the "REVIEWING.md" checklist item, not the
whole issue -- ISS 387 is a multi-item checklist and this does not close
it.

The one sentence btclib-org/.github#353 measured no longer matches the
source: btclib-org/.github#361 restructured "The verdict" further after
#353 landed there, moving the ack-of-record procedure and two other
sentences of the shared half along with it. This takes the whole shared
half verbatim from btclib-org/.github's current REVIEWING.md instead of
the narrower delta #353 recorded, per that issue's own "what each tree
takes".

Locally reviewed: one round of CHANGES REQUESTED (missing CHANGELOG.md
entry), fixed with a new bullet rather than rewriting either pre-existing
REVIEWING.md bullet -- verified neither of those describes a paragraph
this port touches. CLEARED at d805dfaa9f470b3d16d32bb3f8f9c6d2243d1e04,
then rebased (patch-identical, confirmed via range-diff) onto current
main and re-gated at 1f8c7890dfcfcab6bdaeeb569920ea224dc8812d.

Collateral filed: btclib-org/.github#379 (issue #353's own "Measured"
section quotes the same stale intermediate wording).

(issue #387, btclib-org/.github#353)

## Summary by Sourcery

Synchronize the review checklist with the organization’s current standard and clarify how review verdicts are recorded.

Enhancements:
- Synchronize the shared portions of REVIEWING.md with the organization’s current review standard, clarifying that decisive reviews are posted as forge reviews and identifying the recorded verdict.
- Clarify that review summaries and findings are comments while preserving the distinction between reviewer actions and author changes.

Documentation:
- Document how APPROVE and REQUEST_CHANGES carry the corresponding commit-specific acknowledgment or change-request verdict, including exclusions for author approvals and other summaries.

Chores:
- Add a changelog entry describing the REVIEWING.md synchronization and verdict-recording rules.