### PR TITLE
scorecard.yml runs the OpenSSF Scorecard against this repository

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,93 @@
+---
+name: scorecard
+
+# OpenSSF Scorecard: eighteen checks against this repository's
+# supply-chain posture, computed by a third party rather than by
+# anything this organization asked itself. btclib-org/.github#339 is
+# where this sentinel and its permissions are decided; this file adopts
+# it, and does not restate the reasoning.
+#
+# This repository is public and is not a fork, which is the property
+# section 10 of the standard keys the sentinel on:
+#
+#   gh api repos/btclib-org/btclib-secp256k1 --jq '.fork, .private'
+#
+# answers `false` and `false`.
+
+on:
+  push:
+    # only the default branch is analysed -- ossf/scorecard-action's own
+    # README names this and schedule as the supported triggers and calls
+    # workflow_dispatch experimental, so unlike every other workflow here
+    # this one carries no dispatch and no pull_request: its triggers are
+    # the action's, not section 10's general rule
+    branches: [main]
+  schedule:
+    # btclib-org/.github#363 proposes this row: Saturday and hour 03 from
+    # section 10's calendar, minute 08 from this repository's own row in
+    # that section's second table -- neither is this file's to restate.
+    # The issue is open rather than landed as of this file
+    - cron: "8 3 * * 6"
+
+# least privilege for the GITHUB_TOKEN at the workflow level, with one
+# elevation on the job below: the analysis reads the tree, requests a
+# transparency-log entry for its own result and files that result as
+# code-scanning alerts, and pushes nothing back to the tree.
+permissions:
+  contents: read
+
+concurrency:
+  # named literally, never through github.workflow. A run with no pull
+  # request -- every run of this workflow, since it carries none -- has
+  # no number and groups by github.ref, which is refs/heads/main for the
+  # one trigger this workflow has, so two pushes in quick succession
+  # supersede each other -- wanted, since they ask the same question of
+  # the same tree
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # the transparency-log entry publish_results below asks for
+      id-token: write
+      # SARIF results filed as code-scanning alerts
+      security-events: write
+      # elevation-per-job: this job writes neither a release nor
+      # anything else to the tree, so contents stays at its workflow
+      # default of read
+      actions: read
+      contents: read
+    # a run past this is hung rather than analysing
+    timeout-minutes: 15
+    steps:
+      # every action pinned to a commit SHA with the tag in the comment:
+      # a tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # the analysis reads the tree and nothing pushes it back
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # feeds the score api.scorecard.dev/projects/... serves, which
+          # is what README.md's badge and the scorecard.dev viewer read
+          publish_results: true
+
+      - name: Upload the SARIF as a workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload the SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1195,6 +1195,23 @@ release-notes length in the first place, and are still in
   `git grep -n 'pre-commit-\${{' -- .github/workflows/` beside it as the
   command that re-reads both keys together.
 
+- **`scorecard.yml` runs the OpenSSF Scorecard against this repository**
+  (issue #387, btclib-org/.github#339), section 10's sentinel keyed on a
+  repository being public and not a fork:
+  `gh api repos/btclib-org/btclib-secp256k1 --jq '.fork, .private'`
+  answers `false` and `false`. `publish_results: true` feeds the score
+  `api.scorecard.dev` serves and files what it finds as code-scanning
+  alerts; `id-token: write` is the transparency-log entry the publish
+  asks for, `security-events: write` the alert upload. Its triggers are
+  the action's own rather than section 10's usual set -- `push:` on
+  `main` only, no `pull_request`, no `workflow_dispatch` -- and it
+  carries a `schedule:` block: Saturday and hour 03 from section 10's
+  calendar, minute 08 from this repository's own row in that section's
+  second table. btclib-org/.github#363 proposes that row and is open
+  rather than landed as of this entry. No badge: that is a separate
+  pull request, and `fuzz` is out of scope here, its design unresolved
+  at btclib-org/.github#342.
+
 ### The gate
 
 - **`show_error_codes` leaves `[tool.mypy]`** (btclib-org/.github#191).


### PR DESCRIPTION
Part of ISS 387: this is only the "scorecard.yml" checklist item, not the
whole issue -- ISS 387 is a multi-item checklist and this does not close
it.

Adopts .github/workflows/scorecard.yml, converged on btclib's own
already-landed copy, with a schedule: block at cron 8 3 * * 6 (this
repository's own minute, 08, and Saturday/hour 03 from
btclib-org/.github's section 10 calendar).

The calendar row landed first (btclib-org/.github#382, closing the
row-half of btclib-org/.github#363) so the schedule is real rather than
speculative by the time this lands.

Locally reviewed and CLEARED at 177e27c (one round of CHANGES REQUESTED:
a premature "landed" claim about the still-open calendar row, and a
non-closing title carrying a citation parenthetical it shouldn't have
-- both fixed), then rebased onto main's current tip and re-gated at
5a28c1de8a56e9efacfd94863cf38079ea416ed2.

(issue #387, btclib-org/.github#339)

## Summary by Sourcery

Add automated OpenSSF Scorecard analysis for the repository and publish its findings to security tooling.

New Features:
- Add a scheduled and main-branch-triggered OpenSSF Scorecard workflow that publishes results and uploads SARIF findings to code scanning.

Enhancements:
- Configure least-privilege permissions, pinned action versions, concurrency cancellation, and a 15-minute timeout for Scorecard analysis.

CI:
- Add CI coverage for repository supply-chain posture through OpenSSF Scorecard.

Chores:
- Document the new Scorecard workflow and its scope in the changelog.