### PR TITLE
docs group and conf.py take furo, and the build runs -n

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,11 +111,17 @@ jobs:
       # the same command .readthedocs.yaml runs and docs/README.rst
       # documents, so what CI checks is what gets published. -W turns a
       # module sphinx cannot import into a failed build rather than a bare
-      # heading; --keep-going reports every problem in one run
+      # heading; --keep-going reports every problem in one run. -n turns
+      # an unresolved cross-reference into a warning for -W to fail on --
+      # without it a renamed class or a moved function in a :class: role
+      # builds green and links nowhere. conf.py's intersphinx_mapping is
+      # what -n resolves a stdlib name against; nitpick_ignore is where a
+      # reference that genuinely cannot resolve would be excepted, and
+      # carries no entry today
       - name: Build the docs
         run: >
           uv run --locked --no-default-groups --group docs
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
 
       # the one defect the build above cannot report on itself, matching
       # btclib's own second step and the reasoning in its docs/source/conf.py:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -69,10 +69,12 @@ build:
   # rather than resolving something else.
   # -W turns a failed import into a failed build, which is the point of
   # the whole file; --keep-going comes first so one broken module
-  # reports every other problem in the same run instead of one per push
+  # reports every other problem in the same run instead of one per push.
+  # -n is docs.yml's own flag, kept in step here so the site this file
+  # publishes is built by the same command that gates a merge
   commands:
     - pip install uv
     - uv sync --locked --no-default-groups --group docs
     - >-
       uv run --locked --no-default-groups --group docs
-      sphinx-build -W --keep-going -b html docs/source $READTHEDOCS_OUTPUT/html
+      sphinx-build -n -W --keep-going -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,42 @@ release-notes length in the first place, and are still in
 
 ## v0.8.0.5 (work in progress, not released yet)
 
+### The documentation build is `furo`, and `-n` is on
+
+- **The `docs` group declares `furo` and `docs/source/conf.py` names it as
+  `html_theme`, replacing `sphinx_rtd_theme`, and the build adds `-n` to
+  `-W`** (issue #387, btclib-org/.github#329, btclib-org/.github#324).
+  Section 2 of the organization standard gives both: `furo` over the
+  theme a Read the Docs project starts with by default, and `-n` because
+  `-W` alone never sees a cross-reference that resolves to nothing -- a
+  renamed class or a moved function in a `:class:` role builds green and
+  the link goes nowhere. `docs.yml`, `.readthedocs.yaml`,
+  `docs/README.rst` and `CONTRIBUTING.md`'s own copy of the command all
+  carry the flag, so what CI checks, what gets published and what a
+  contributor runs by hand stay one command.
+- **`sphinx.ext.intersphinx` comes first in `extensions`, with a mapping
+  for python**, ahead of turning `-n` on: without an inventory, a name
+  from outside this tree -- `collections.abc.Sequence`,
+  `collections.abc.Mapping`, `collections.abc.Callable`,
+  `types.TracebackType`, the stdlib names this package's own annotations
+  reach -- resolves to nothing and reads as this tree's own broken link.
+  No `nitpick_ignore` entry was needed: every name the public API's
+  annotations reach is either a builtin sphinx's own domain answers for,
+  or stdlib the mapping now resolves.
+- **Every `Returns:` section whose first line carried a colon, in
+  `dsa.py`, `keys.py`, `musig.py`, `silentpayments.py` and `xonly.py`,
+  loses it.** `-n` turned each into a broken cross-reference of its own
+  making rather than a genuine one: Napoleon's Google-style parser reads
+  a `Returns:` section's first line as `type: description` wherever a
+  colon appears in it, so a colon inside the description's own prose was
+  read as a bogus return type, which sphinx's python domain then split
+  again on every `,` and ` of ` it contained and tried to resolve each
+  fragment as a class of its own -- `xonly.from_prvkey`'s
+  `"The 32-byte x coordinate of kG, and the parity of its y"` is the
+  case with the most fragments to split into. The wording is unchanged;
+  the colon that was never meant as a type separator is an em dash
+  instead.
+
 ### The uv floor is raised to the Dependabot ceiling
 
 - **`[tool.uv]`'s `required-version` moves from `>=0.12.0` to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,7 @@ workflow runs:
 uv run --locked --only-group lint pre-commit run --all-files
 uv run --locked --no-default-groups --group test pytest --cov
 uv run --locked --no-default-groups --group docs \
-    sphinx-build -W --keep-going -b html docs/source docs/build/html
+    sphinx-build -n -W --keep-going -b html docs/source docs/build/html
 ```
 
 The documentation build needs the submodule checked out: every
@@ -543,7 +543,7 @@ command at all, for the reason above, and no longer gates.
   ```shell
   git submodule update --init
   uv run --locked --no-default-groups --group docs \
-      sphinx-build -W --keep-going -b html docs/source docs/build/html
+      sphinx-build -n -W --keep-going -b html docs/source docs/build/html
   ```
 
 The `pypi-install` workflow has no local equivalent by design: what it

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -26,7 +26,7 @@ Build from the project root, exactly as ``.readthedocs.yaml`` does:
 .. sourcecode:: bash
 
     $ uv run --locked --no-default-groups --group docs \
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
+          sphinx-build -n -W --keep-going -b html docs/source docs/build/html
 
 Open ``docs/build/html/index.html`` in a browser to see the result. The
 ``Makefile`` and ``make.bat`` here drive the same build, from within this
@@ -40,7 +40,10 @@ directory and without the flags:
 ``-W`` is not decoration: without it a module that fails to import is a
 warning and nothing more, and the published documentation silently has
 no API in it. Read the docs builds with the same flag, so a build that
-is green here is green there.
+is green here is green there. ``-n`` turns an unresolved cross-reference
+into a warning for ``-W`` to fail on -- without it a renamed class or a
+moved function in a role such as ``:class:`` builds green and links
+nowhere.
 
 Adding or removing a module
 ----------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,7 @@ release = PYPROJECT["project"]["version"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinx.ext.intersphinx",
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
@@ -66,6 +67,19 @@ extensions = [
 # build instead
 
 source_suffix = [".rst", ".md"]
+
+# -n on the build (CONTRIBUTING.md's documented command, and docs.yml)
+# turns an unresolved cross-reference into a warning for -W to fail on.
+# Without an inventory to resolve against, a name from outside this tree
+# -- collections.abc.Sequence, collections.abc.Mapping, types.TracebackType,
+# the stdlib names this package's own annotations reach -- reports as
+# this tree's own broken link; sphinx's own domain answers for the
+# builtins (int, bytes, str), so no mapping is needed for those. cffi's
+# own ffi and lib are out of scope of intersphinx, cffi publishing no
+# inventory to map them against, but neither draws a reference here:
+# CData, the boundary's own name for cffi's cdata objects, is declared in
+# this package (__init__.py) rather than imported from cffi
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # unlike btclib's own conf.py, which needs none of this: CONTRIBUTING.md
 # links to "README.md#build", an anchor into a markdown heading rather
@@ -85,7 +99,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # no html_static_path, matching btclib's own conf.py and for the same
 # reason: neither an overridden stylesheet nor a shipped image exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,13 +269,14 @@ check = ["twine", "check-wheel-contents", "pyroma"]
 # runs this -- the scheduled mutation workflow is the only consumer, and it
 # asks for --group test as well, cosmic-ray shelling out to pytest
 mutation = ["cosmic-ray"]
-# matching btclib's own docs group exactly: myst-parser reads the four
-# root markdown files docs/source/*_link.md includes, sphinx_rtd_theme
-# is the html theme docs/source/conf.py names, and sphinx itself compiles
-# this package to autodoc it -- the reason the environment section of
-# CONTRIBUTING.md and the git submodule matter here in a way they do not for
-# btclib's own pure Python build
-docs = ["myst-parser", "sphinx", "sphinx_rtd_theme"]
+# myst-parser reads the four root markdown files docs/source/*_link.md
+# includes, furo is the html theme docs/source/conf.py names -- section 2
+# of the organization standard, over sphinx_rtd_theme, the theme a Read
+# the Docs project starts with by default and not a reason to keep it --
+# and sphinx itself compiles this package to autodoc it: the reason the
+# environment section of CONTRIBUTING.md and the git submodule matter
+# here in a way they do not for btclib's own pure Python build
+docs = ["furo", "myst-parser", "sphinx"]
 dev = [
     { include-group = "test" },
     { include-group = "lint" },

--- a/src/btclib_secp256k1/dsa.py
+++ b/src/btclib_secp256k1/dsa.py
@@ -513,7 +513,7 @@ def sign(  # noqa: PLR0913
             check it is for.
 
     Returns:
-        The signature, in the lower-s form libsecp256k1 always produces:
+        The signature, in the lower-s form libsecp256k1 always produces --
         DER, or the 64 octets of `r || s` where `compact` asks for them.
         Where `grind` asks for it, of the low r as well.
 
@@ -891,7 +891,7 @@ def to_der(signature_bytes: BytesLike) -> bytes:
         signature_bytes: the 64 bytes of r and s.
 
     Returns:
-        The same signature in DER encoding. s is not normalized: a
+        The same signature in DER encoding. s is not normalized -- a
         high-s input gives a DER signature `verify` refuses, which
         `normalize` is for.
 

--- a/src/btclib_secp256k1/keys.py
+++ b/src/btclib_secp256k1/keys.py
@@ -287,7 +287,7 @@ def pubkey_from_prvkey(prvkey: BytesLike | int, compressed: bool = True) -> byte
         compressed: whether to return 33 bytes rather than 65.
 
     Returns:
-        The serialized point kG: 33 bytes whose first octet carries the
+        The serialized point kG -- 33 bytes whose first octet carries the
         parity of y, or the 65 bytes of 0x04 || x || y.
 
     Raises:

--- a/src/btclib_secp256k1/musig.py
+++ b/src/btclib_secp256k1/musig.py
@@ -517,7 +517,7 @@ def nonce_gen(
             requirement.
 
     Returns:
-        The secret nonce, held rather than returned as octets: the
+        The secret nonce, held rather than returned as octets -- the
         module docstring says why, and `SecretNonce` is what a caller
         wipes if this session is abandoned before `partial_sign`.
 

--- a/src/btclib_secp256k1/silentpayments.py
+++ b/src/btclib_secp256k1/silentpayments.py
@@ -547,7 +547,7 @@ def _scan_outputs_(
             published.
 
     Returns:
-        One triple per output found, in vout order: its 32-byte x-only
+        One triple per output found, in vout order -- its 32-byte x-only
         public key, the 32-byte tweak to add to the spend private key to
         spend it, and the 33-byte label it was found with, or None where
         it was paid to the unlabeled address.
@@ -649,7 +649,7 @@ def scan_outputs(
             are what a mapping cannot be keyed on, being unhashable.
 
     Returns:
-        One triple per output found, in vout order: its 32-byte x-only
+        One triple per output found, in vout order -- its 32-byte x-only
         public key, the 32-byte tweak to add to the spend private key to
         spend it, and the 33-byte label it was found with, or None where
         it was paid to the unlabeled address. An empty list where the

--- a/src/btclib_secp256k1/xonly.py
+++ b/src/btclib_secp256k1/xonly.py
@@ -190,7 +190,7 @@ def from_pubkey(pubkey_bytes: BytesLike) -> tuple[bytes, int]:
         pubkey_bytes: the public key, 32, 33 or 65 bytes.
 
     Returns:
-        The 32-byte x coordinate, and the parity of the y it was handed:
+        The 32-byte x coordinate, and the parity of the y it was handed --
         0 for even, 1 for odd, and 0 for a key that arrived x-only, an
         x naming the even-y point. The parity is answered rather than
         dropped because a caller may want to know which serialization it
@@ -222,7 +222,7 @@ def from_prvkey(prvkey: BytesLike | int) -> tuple[bytes, int]:
         prvkey: the private key, 32 bytes or an int below 2**256.
 
     Returns:
-        The 32-byte x coordinate of kG, and the parity of its y: 0 for
+        The 32-byte x coordinate of kG, and the parity of its y -- 0 for
         even, 1 for odd. That parity is what BIP340 signing negates the
         key for, so a signer wanting only the key it signs under can
         ignore it.
@@ -301,7 +301,7 @@ def from_keypair(keypair_obj: CData) -> tuple[bytes, int]:
             holds and as `secp256k1_keypair_create` writes.
 
     Returns:
-        The 32-byte x coordinate, and the parity of y: 0 for even, 1 for
+        The 32-byte x coordinate, and the parity of y -- 0 for even, 1 for
         odd. The parity is of the point the private key gives, the
         keypair being the negated key where that y is odd.
 
@@ -370,7 +370,7 @@ def tweak_add(pubkey_bytes: BytesLike, tweak: BytesLike | int) -> tuple[bytes, i
         tweak: the tweak, 32 bytes or an int below 2**256.
 
     Returns:
-        The 32-byte tweaked x-only key, and the parity of its y: that
+        The 32-byte tweaked x-only key, and the parity of its y -- that
         parity is what a taproot output commits to, and what
         `tweak_add_check` is given back.
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +343,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -366,6 +391,7 @@ dev = [
     { name = "cibuildwheel", version = "2.23.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "cibuildwheel", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "delocate" },
+    { name = "furo" },
     { name = "hatchling" },
     { name = "mypy" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -378,16 +404,15 @@ dev = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
     { name = "types-cffi" },
 ]
 docs = [
+    { name = "furo" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
 ]
 lint = [
     { name = "hatchling" },
@@ -429,6 +454,7 @@ dev = [
     { name = "build" },
     { name = "cibuildwheel" },
     { name = "delocate" },
+    { name = "furo" },
     { name = "hatchling" },
     { name = "mypy" },
     { name = "myst-parser" },
@@ -438,13 +464,12 @@ dev = [
     { name = "pytest-randomly" },
     { name = "ruff" },
     { name = "sphinx" },
-    { name = "sphinx-rtd-theme" },
     { name = "types-cffi" },
 ]
 docs = [
+    { name = "furo" },
     { name = "myst-parser" },
     { name = "sphinx" },
-    { name = "sphinx-rtd-theme" },
 ]
 lint = [
     { name = "hatchling" },
@@ -1278,6 +1303,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -2773,6 +2816,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
 name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2869,20 +2921,17 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "3.1.0"
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jquery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
 ]
 
 [[package]]
@@ -2910,20 +2959,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jquery"
-version = "4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of ISS 387: this is only the "pyproject.toml" (docs group) and
"docs/source/conf.py and the build" checklist items, bundled per the
issue's own "same file, and apart they buy a rebase" -- not the whole
issue, and this does not close it.

- docs group and conf.py: sphinx_rtd_theme -> furo (section 2 of the
  organization standard)
- docs.yml, .readthedocs.yaml, docs/README.rst, CONTRIBUTING.md: -n
  added alongside -W, kept as one command across all four
- conf.py: sphinx.ext.intersphinx added first, mapped for python, so -n
  measures the documentation rather than the standard library
- ten Returns: docstrings across dsa/keys/musig/silentpayments/xonly
  reworded (colon -> em dash on the section's first line) -- the actual
  fix for what -n surfaced: Napoleon mis-parses a first-line colon as a
  type annotation and the python domain shreds the fragment into bogus
  cross-references. Wording-only, no nitpick_ignore entries needed.
- uv.lock relocked

Locally reviewed and CLEARED at a73f9c1 (one round of CHANGES
REQUESTED: a non-closing title carrying a citation parenthetical it
shouldn't have, plus a nit on an imprecise comment -- both fixed; the
reviewer independently reran the docs build and reproduced the Napoleon
failure mode by reverting one fix), then rebased onto main's current tip
and re-gated at 5b1b4fcb4af0e441a6c865f6148ceed77bbafae1.

Collateral filed: btclib-org/btclib#1366 (a discrepancy in btclib's own
docs.yml/README.rst, unrelated repository, not fixed here).

(issue #387, btclib-org/.github#329, btclib-org/.github#324)

## Summary by Sourcery

Strengthen the documentation build by adopting Furo and enforcing cross-reference validation consistently across local and published builds.

Bug Fixes:
- Fix documentation parsing issues that produced bogus cross-references in return descriptions.

Enhancements:
- Adopt the Furo Sphinx theme and enable strict unresolved-reference checking with Python intersphinx support.
- Keep the documentation build command consistent across CI, Read the Docs, and contributor instructions.

Build:
- Update the documentation dependency group and lockfile for the new theme and documentation tooling.

Documentation:
- Document the updated documentation theme and stricter build configuration in the changelog and contributor-facing build instructions.