### PR TITLE
The scorecard sentinel joins the badge row, last among sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1614,6 +1614,13 @@ release-notes length in the first place, and are still in
   and the PyPI and pepy links beside them. The documentation-build badge
   image now points at `app.readthedocs.org`; `readthedocs.org` answers
   that path with a redirect to it.
+- **The `scorecard` sentinel joins the row, last among the sentinels**
+  (issue #387, btclib-org/.github#338). Not in calendar order with the
+  rest: btclib-org/.github#358 is the open question of whether a
+  Scorecard badge's place is a stated rule or each tree's own reading of
+  a silent one, and `btclib` and `portanode` both currently place it
+  last regardless of whether their own calendar row exists yet -- this
+  matches that precedent rather than deciding #358 unilaterally.
 
 ## v0.8.0.4
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ where the code is and where to ask about it. A badge that reports no state
 CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
 badge per line keeps a change to one line and every line inside MD013,
 whose 80 columns bind only where a space follows them. btclib and
-bitcoin-core-rpc carry the same three lines. -->
+bitcoin-core-rpc carry the same three lines.
+Scorecard is placed last among the sentinel badges rather than in the
+calendar order the rest follow, matching btclib's and portanode's own
+placement: btclib-org/.github#358 is where that placement is asked to
+become the stated rule rather than each tree's own reading of a silent
+one. btclib-org/.github#363's row has since landed, which does not
+settle #358 -- section 10's own trigger-exemption reasoning for
+Scorecard is about which events it runs on, not about where its badge
+sits. -->
 [![PyPI version](https://img.shields.io/pypi/v/btclib-secp256k1.svg?logo=pypi)](https://pypi.python.org/pypi/btclib-secp256k1/)
 [![downloads](https://static.pepy.tech/badge/btclib-secp256k1)](https://pepy.tech/project/btclib-secp256k1)
 [![development status](https://img.shields.io/pypi/status/btclib-secp256k1.svg)](https://pypi.python.org/pypi/btclib-secp256k1/)
@@ -30,6 +38,7 @@ bitcoin-core-rpc carry the same three lines. -->
 [![os-macos workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-macos.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-macos.yml)
 [![os-windows workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-windows.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/os-windows.yml)
 [![mutation workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib-secp256k1/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib-secp256k1)
 [![documentation build](https://app.readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--secp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)


### PR DESCRIPTION
Part of ISS 387: this is only the follow-up to the README badges
checklist item, not the whole issue -- ISS 387 is a multi-item checklist
and this does not close it.

scorecard.yml (#392) landed after the badges PR (#390) had already
merged, so #390 correctly skipped a scorecard badge. This adds it,
placed last among the sentinel badges rather than in calendar order,
matching btclib's and portanode's own placement: btclib-org/.github#358
is the open question of whether that placement is a stated rule or each
tree's own reading of a silent one, and this follows the established
precedent rather than deciding #358 unilaterally. btclib-org/.github#363's
calendar row has since landed, which does not settle #358.

Locally reviewed: one round of CHANGES REQUESTED (the branch had not
actually been pushed, and the badge was placed in calendar order without
citing the open #358 question or the contrary precedent in two sibling
repositories) -- both fixed. CLEARED at 6025e8a0bc3567c9dffdf0e0d1a98884afe9f793.

(issue #387, btclib-org/.github#338)

## Summary by Sourcery

Add the OpenSSF Scorecard badge to the README while preserving the established sentinel-badge ordering convention.

New Features:
- Add the OpenSSF Scorecard badge to the README badge row after the existing sentinel badges.

Documentation:
- Document the Scorecard badge placement convention and its relationship to the outstanding upstream placement discussion.