### PR TITLE
release.yml gets a public-api job: griffe check against the last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,120 @@ jobs:
           echo "run $GITHUB_RUN_NUMBER attempt $GITHUB_RUN_ATTEMPT: $suffix"
           echo "version-suffix=$suffix" >> "$GITHUB_OUTPUT"
 
+  # walks the public API of the release before this one against the one
+  # being cut and reports what broke: a removed object, a changed
+  # parameter kind or default, a narrowed type. It runs here rather than
+  # as a merge gate -- btclib-org/.github#326's own decision -- because
+  # before 1.0 the surface breaks deliberately and often, and a gate
+  # reporting every such break on every pull request has nothing to say
+  # about which ones are allowed. Here the answer arrives while
+  # RELEASE_NOTES.md is already being written, so a break with no entry
+  # is refused at the moment somebody is already writing entries.
+  # Matches btclib's own job of the same name, the landed precedent for
+  # this check (btclib-org/btclib .github/workflows/release.yml)
+  public-api:
+    name: Check the public API against the last release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # the previous tag has to be reachable in this checkout for the
+          # step below to find it, and a single-commit checkout -- what
+          # every other job's checkout takes -- would not carry it
+          fetch-depth: 0
+          fetch-tags: true
+
+      # a release tag is already on the remote by the time this job runs,
+      # so the "latest tag" griffe would resolve on its own is the release
+      # being cut, not the one before it -- comparing a tag against itself
+      # reports no break whatever changed. The previous tag is resolved
+      # explicitly instead, by walking the ref's own ancestry rather than
+      # a version sort, so a tag pushed on a branch this history never
+      # merged is not picked up as "previous". A rehearsal has no tag of
+      # its own, so it asks from HEAD directly rather than HEAD^
+      - name: Resolve the previous release
+        id: previous
+        env:
+          REF: >-
+            ${{ github.event_name == 'push' && format('{0}^', github.ref_name)
+            || 'HEAD' }}
+        run: |
+          if tag=$(git describe --tags --abbrev=0 --match 'v*' "$REF" 2>&1); then
+            echo "previous release: $tag"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "has-previous=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no previous v* tag reachable from $REF: $tag"
+            echo "has-previous=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # caching off, as in version-check above: this job runs on the same
+      # tag-push and workflow_dispatch triggers that job's own comment
+      # gives for downloading fresh rather than trusting a cache entry
+      # written by a run this one cannot vouch for
+      - name: Setup uv
+        if: steps.previous.outputs.has-previous == 'true'
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
+
+      # griffe runs from PyPI through uvx rather than from a pyproject.toml
+      # dependency group: unlike pre-commit -- pinned by uv.lock because
+      # every contributor's own run has to agree with the gate's -- this
+      # runs at release time only, on the maintainer's own action, so a
+      # dependency group buys reproducibility nothing here needs. The
+      # version pin on the line below is what still keeps this comparison
+      # from answering differently on two release days for a reason that
+      # has nothing to do with either release.
+      #
+      # griffe does static analysis -- it parses source, it does not
+      # import the package -- so this needs no C toolchain, no submodule
+      # checkout and no built extension: measured against this tree's own
+      # history, a comparison against v0.8.0.4 (btclib_secp256k1/ at the
+      # repository root) succeeds unbuilt in a bare checkout of that tag.
+      # `_btclib_secp256k1`, the compiled cffi extension `__init__.py`
+      # imports, is never resolved by griffe's loader either way -- it is
+      # a leading-underscore name, so it is out of the public surface on
+      # both sides of every comparison, `stubs/_btclib_secp256k1.pyi`
+      # included on the search path or not, measured both ways.
+      #
+      # -s . -s src covers both layouts this repository has published
+      # under: every tag through v0.8.0.4 has btclib_secp256k1/ at the
+      # repository root, and CHANGELOG.md's "## v0.8.0.5" section moved
+      # it under src/ -- a search path that finds nothing in one
+      # reference is skipped in favour of the other, measured clean
+      # across that exact move (v0.8.0.4 against a src-layout tree
+      # reports no break).
+      #
+      # No base ref on a rehearsal: workflow_dispatch has no tag to check
+      # a public surface at, so the comparison falls back to griffe's own
+      # default, the current code
+      - name: Check the public API against the previous release
+        if: steps.previous.outputs.has-previous == 'true'
+        env:
+          PREVIOUS_TAG: ${{ steps.previous.outputs.tag }}
+          BASE_REF: ${{ github.event_name == 'push' && github.ref_name || '' }}
+        run: |
+          base_args=()
+          if [ -n "$BASE_REF" ]; then
+            base_args=(-b "$BASE_REF")
+          fi
+          if ! uvx griffe==2.2.0 check btclib_secp256k1 -s . -s src \
+              -a "$PREVIOUS_TAG" "${base_args[@]}" -f github; then
+            msg="the public API changed since $PREVIOUS_TAG:"
+            echo "::error::$msg add a breaking-changes bullet to" \
+              "RELEASE_NOTES.md, or say here why the change is not one"
+            exit 1
+          fi
+      - name: Skip the check (no previous release to compare against)
+        if: steps.previous.outputs.has-previous == 'false'
+        run: |
+          echo "::notice::no previous v* tag is reachable; nothing to" \
+            "compare this release's public API against"
+
   # reuse the whole build/test pipeline: every artifact the release ships
   # is built and tested here, by the very matrices that run on a push
   test:
@@ -325,7 +439,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, ubuntu, macos, windows]
+    needs: [public-api, test, lint, docs, ubuntu, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -362,7 +476,7 @@ jobs:
     name: Publish to PyPI
     # see publish-testpypi for the repository condition
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib-secp256k1'
-    needs: [test, lint, docs, ubuntu, macos, windows]
+    needs: [public-api, test, lint, docs, ubuntu, macos, windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1556,6 +1556,25 @@ release-notes length in the first place, and are still in
 
 ### The release path
 
+- **A `public-api` job runs `griffe check` against the tag before the
+  one being cut** (issue #387, btclib-org/.github#326), converging on
+  `btclib`'s own job of the same name. Section 12 of the organization
+  standard puts this in the release path rather than on a merge gate: a
+  pull request breaks the public surface deliberately before 1.0, and a
+  gate reporting every such break has nothing to say about which of them
+  are allowed, where the release path's answer arrives while
+  `RELEASE_NOTES.md` is already being written. griffe does static
+  analysis rather than importing the package, so the job needs no C
+  toolchain, no submodule checkout and no built extension: measured
+  against a bare checkout of `v0.8.0.4`, the comparison succeeds
+  unbuilt. `_btclib_secp256k1`, the compiled cffi extension
+  `__init__.py` imports, is a leading-underscore name and is out of the
+  public surface griffe compares on either side of the comparison,
+  `stubs/_btclib_secp256k1.pyi` on the search path or not, both measured.
+  `-s . -s src` is what carries the comparison across "The package sits
+  under `src/`" above: measured clean between `v0.8.0.4`, with
+  `btclib_secp256k1/` at the repository root, and a `src/`-layout tree.
+
 - **`build-sdist` pins the sdist's `mtime` to the tagged commit's date**
   (#345, btclib-org/.github#140). Section 12 of the organization
   standard asks every publisher for a `SOURCE_DATE_EPOCH` step and a


### PR DESCRIPTION
Part of ISS 387: this is only the "griffe check" checklist item, not
the whole issue -- ISS 387 is a multi-item checklist and this does not
close it. Deferred until #357 (__all__ in every module) landed, which
it now has.

A public-api job runs griffe check against the tag before the one being
cut, converging on btclib's own job of the same name (section 12 of the
organization standard). This package is not pure Python, so before
writing the workflow the invocation was verified against real git
references of this repository: griffe needs nothing built (static
analysis, no C toolchain, no submodule, no compiled extension), the
stubs/_btclib_secp256k1.pyi file doesn't change the comparison, the
root->src/ layout move is handled cleanly by -s . -s src, a no-op
control (tag against itself) passes clean, and a constructed real break
(a keyword-only parameter's default dropped) is caught and precisely
named.

Locally reviewed and CLEARED at ac9d4fc -- the reviewer independently
re-ran all four load-bearing griffe invocations against a different
constructed break than the coder's own, confirmed the convergence with
btclib's landed job line-for-line, and traced the full needs: graph to
confirm no path reaches PyPI, TestPyPI or the GitHub release without
this job running and succeeding first -- then rebased onto main's
current tip (CHANGELOG.md only, union-merge, no conflict) and re-gated
at 84681ce0ae8aa568392e489037a41028c6c8efaf.

(issue #387, btclib-org/.github#326)

## Summary by Sourcery

Add a release-time public API compatibility check and gate package publishing and GitHub releases on its success.

New Features:
- Add a release workflow job that checks the package’s public API against the previous reachable release tag using Griffe.

Enhancements:
- Require the public API check to pass before publishing to PyPI or creating the GitHub release, while skipping it when no previous release tag exists.

CI:
- Ensure release checks have access to complete tag history and support both the repository’s root and src layouts.

Documentation:
- Document the new public API compatibility check in the changelog.