### PR TITLE
claude-review.yml converges on .github's current copy again

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,13 +13,9 @@ name: claude-review
 # which ones those are is REPOSITORY.md's to record and the endpoint's
 # to answer.
 #
-# A decided verdict is posted as a pull request review rather than a
-# comment. GitHub refuses only a *self*-approval, and this workflow
-# does not run as the pull request's author, so that refusal never
-# reaches it -- section 11 of the organization's standard has the
-# reasoning. A reading that reaches no verdict stays a comment, an
-# opinion for the author to weigh, same as every summary was before
-# this job posted a review at all.
+# What it produces is a review of type COMMENT, an opinion for the
+# author to weigh -- never `--approve` and never `--request-changes`,
+# section 11 of the organization's standard having why.
 #
 # It is one more job on every pull request, which is not free: GitHub Free
 # gives this organization twenty concurrent jobs and REPOSITORY.md measures
@@ -67,16 +63,35 @@ jobs:
     #
     # Compared by full_name rather than by `.fork`, which asks whether the
     # head repository is a fork of anything and is true of a branch of
-    # btclib-org/bbt, itself a fork
+    # btclib-org/bbt, itself a fork.
+    #
+    # CLAUDE_REVIEW_ENABLED is the switch, an *organization* variable,
+    # and section 11 of the organization's standard, *Review*, is
+    # where what it does is stated rather than here a second time.
+    #
+    # On the job and not on a step. A step declining to run leaves
+    # `steps.review.outcome` at `skipped`, which the guard below reads as
+    # anything-but-success and reports as a review that never ran -- a
+    # deliberate switch-off turned into a permanent red check, pointing
+    # at a runner line no skipped step wrote. A skipped job costs nothing
+    # and says nothing
     if: >-
-      ${{ github.event_name == 'pull_request'
+      ${{ vars.CLAUDE_REVIEW_ENABLED == 'true'
+          && github.event_name == 'pull_request'
           && !github.event.pull_request.draft
           && github.event.pull_request.head.repo.full_name
              == github.repository }}
     runs-on: ubuntu-latest
-    # a diff read and a review or a comment posted; a job past this is
-    # hung on the API
-    timeout-minutes: 15
+    # the review's own budget is on its step below, and this is the
+    # ceiling for the steps around it, which read the API and post. It
+    # has to be the larger of the two: a job that hits its own limit is
+    # *cancelled*, which the pull request shows as a failed check with
+    # nothing from this file beside it -- two reviews that ran out of
+    # time read as reviews that had found something, and the jobs API
+    # was what said otherwise. The step's limit *fails* the step, with
+    # the runner's own line saying it timed out, and the guard below it
+    # then runs and says what that means for the verdict
+    timeout-minutes: 20
     # per job rather than per workflow, so that a push cancelling a
     # superseded review does not also cancel somebody's @claude question
     # running beside it. Named literally rather than through
@@ -101,7 +116,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # as every other checkout here, lint.yml's included
+          # nothing here needs a token: the diff comes from `gh pr diff`
+          # against the forge
           persist-credentials: false
           # depth 1 is enough because the diff comes from `gh pr diff`,
           # which is the base...head three-dot diff REVIEWING.md asks for,
@@ -125,57 +141,76 @@ jobs:
       - name: Review against REVIEWING.md
         id: review
         uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1
+        # a diff read and a comment posted; a review past this is hung
+        # on the API or on its own reasoning, and either way it has
+        # written no verdict. On the step rather than on the job for the
+        # reason the job's ceiling gives
+        timeout-minutes: 15
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # dependabot opens a pull request here every Thursday, and the
-          # action refuses a run a bot initiated unless that bot is named:
-          # "Workflow initiated by non-human actor". Without this those are
-          # the one class of pull request that can never carry the ack of
-          # record, which REVIEWING.md says comes from this workflow.
-          # Named rather than `*`, which this input's own description warns
-          # against on a public repository: with it an external App could
-          # invoke this action carrying a prompt it wrote.
-          # The mention job below takes no such input, deliberately -- what
-          # triggers it is somebody writing @claude, and a bot doing that
-          # is not a thing this repository has asked for
+          # the action refuses a run a bot initiated unless that bot is
+          # named -- "Workflow initiated by non-human actor" -- so a
+          # pull request Dependabot opens would otherwise never carry
+          # the ack of record. Named rather than `*`, which the input's
+          # own description warns against on a public repository: with
+          # it an external App could invoke this action carrying a
+          # prompt it wrote. The credential for such a run is a second
+          # fact a port has to know: a Dependabot-initiated run reads
+          # the organization's *Dependabot* secret store, not the
+          # Actions one, and section 11 of the organization's standard
+          # has both.
+          # The mention job below takes no such input, deliberately --
+          # what triggers it is somebody writing @claude
           allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Read REVIEWING.md in the repository root and review this pull
-            request against it. That file is the standard: what is under
-            review, what to look for and in what order, what a finding
-            must contain and how it labels its severity, what becomes of
-            everything you notice that the diff is not about, and the two
-            forms the verdict takes. Follow it rather than the review
-            habits you would otherwise bring. CONTRIBUTING.md's last
-            section has the gates and the rules a finding cites, and
+            REVIEWING.md is what a review here is written against, and
+            it is the same file in every repository of the organization
+            -- its last section is this tree's. The organization's
+            standard is what a finding cites, being where the rules
+            live; CONTRIBUTING.md's last section has the gates, and
             CLAUDE.md the facts about this tree a review has to know.
 
+            The title and description are the forge's, `gh pr view`,
+            and are read again before a finding about either is written:
+            a correction to them lands seconds behind the push that
+            fired this run, and a finding about a title the pull request
+            no longer carries is a finding about nothing.
+
+            The summary's last line is the verdict, `ACK <sha>`,
+            `CHANGES REQUESTED <sha>` or `NACK <sha>`, naming the sha
+            because an ack belongs to a tree and not to a branch.
+            REVIEWING.md has the three lines and section 11's *Review*
+            what each concludes. For this review the line is not
+            optional: this is the ack of record, the one a landing
+            reads, and it is the only part of a review that anything
+            other than a person can read -- a review of record ending
+            without it cannot be told apart from one that never
+            finished. A person reading the same diff may say what they
+            found and deliver no verdict; REVIEWING.md has why that is
+            not a NACK.
+
             Do not run the gates. They are running beside you on this
-            same sha, which is the reliance REVIEWING.md provides for and
-            CONTRIBUTING.md's last section makes sound. Review everything else the standard
-            asks for, and say in the summary that no gates were run by
-            this job and that those runs are what stands.
+            same sha, which is the reliance REVIEWING.md provides for
+            and CONTRIBUTING.md's last section makes sound. Say in the
+            summary that no gates were run by this job and that the
+            author's own statement of what they ran is what stands --
+            and say so too when a pull request makes no such statement.
 
-            Do not file issues from here: a collateral finding goes in the
-            summary, under a line saying it is not a finding against this
-            pull request, and a person decides whether it becomes one.
+            Do not file issues from here: a collateral finding goes
+            in the summary, under a line saying it is not a finding
+            against this pull request, and a person decides whether it
+            becomes one.
 
-            The summary is a GitHub review where it reaches a verdict,
-            and a plain comment otherwise. Where REVIEWING.md's `## The
-            verdict` section is answered -- the summary's last line is
-            `ACK <sha>` or `CHANGES REQUESTED <sha>` -- post that summary
-            as a review and not as a comment: `gh pr review <PR NUMBER>
-            --approve --body "..."` for an ack, `gh pr review <PR NUMBER>
-            --request-changes --body "..."` for changes requested, the
-            body ending with that same last line. Where the review is a
-            reading and reaches no verdict, the summary stays a plain
-            comment, `gh pr comment`, exactly as before.
+            Post to the forge and not as a message only this job's
+            log reads. `gh pr review --comment` for the summary, which
+            is what puts the ack of record in the forge's own record of
+            reviews; never `--approve` and never `--request-changes`,
+            section 11's *Review* having why.
             `mcp__github_inline_comment__create_inline_comment` (with
-            `confirmed: true`) is for a finding a line is the subject of,
-            unaffected either way.
+            `confirmed: true`) for a finding a line is the subject of.
           # folded rather than literal, and `gh pr` rather than the three
           # subcommands spelled out: the flag has to reach the CLI as one
           # line, and the line that spells out comment, diff and view is
@@ -196,10 +231,51 @@ jobs:
       # edits this file, this job is red until the change is on `main`.
       # It gates nothing, and a red check that says "no review happened"
       # is the honest shape of that.
+      #
+      # Run when the step above failed too, which is what `!cancelled()`
+      # buys over the default: a review that hit its budget, or that the
+      # action refused, ended without writing a verdict, and that is
+      # the fact to report rather than leave to the step's own error. A
+      # job cancelled by the concurrency group is the one case this
+      # still skips, a superseded review having nothing to say.
       - name: Refuse to report a review that never ran
+        if: ${{ !cancelled() }}
         env:
+          OUTCOME: ${{ steps.review.outcome }}
           EXECUTION: ${{ steps.review.outputs.execution_file }}
         run: |
+          # A failing review names no cause in the log: the action
+          # prints the result message with `api_error_status`, the stop
+          # reason and the error text sanitized out of it, and writes
+          # every message unsanitized to the execution file this step
+          # already names. What it drops is read from there rather than
+          # turned on with `show_full_output: true`, which prints every
+          # message including tool results and whose own description
+          # warns against that on a public repository. The debug rerun
+          # the action also suggests is no third option: it keys on
+          # ACTIONS_STEP_DEBUG in the step's environment, which
+          # `gh run rerun --debug` does not put there.
+          #
+          # An error subtype's own `errors` are not read here, the
+          # action printing those itself.
+          #
+          # `|| true` because the step runs under `bash -e`: a jq that
+          # fails on a half-written file would exit before the
+          # annotation below, losing the one line this guard exists to
+          # write.
+          if [ "$OUTCOME" != success ]; then
+            if [ -f "$EXECUTION" ]; then
+              jq -r '.[] | select(.type == "result")
+                     | "api_error_status \(.api_error_status), stop_reason \(.stop_reason)",
+                       (.result // empty)' "$EXECUTION" || true
+            fi
+            echo "::error::the review step ended in $OUTCOME, so no" \
+                 "verdict was written -- the runner's line above says" \
+                 "whether it ran out of its timeout-minutes or failed" \
+                 "another way. No verdict is no ack: that is why this" \
+                 "is red, and it is not a finding against the tree."
+            exit 1
+          fi
           if [ -z "$EXECUTION" ]; then
             echo "::error::the action produced no execution file, so no" \
                  "review was written. The usual cause is workflow" \
@@ -210,23 +286,27 @@ jobs:
       # Green here means an ack of this tree, and nothing weaker. The
       # guard above answers whether the action started, and a run that
       # starts, finishes green and posts nothing at all walks through
-      # it: on btclib-org/.github's pull request 139 two runs of the same
-      # sha both concluded success, the first having written no comment
-      # and the second the review -- posted as a comment there, under
-      # the mechanism this step no longer reads.
+      # it: on btclib-org/.github#139 two runs of the same sha both
+      # concluded success, the first having written no comment and the
+      # second the review. The commands below take the tree they are
+      # run in, `gh` resolving the braces from its checkout.
       #
-      #   gh api "repos/btclib-org/.github/actions/runs?head_sha=<sha>" \
+      #   gh api "repos/{owner}/{repo}/actions/runs?head_sha=<sha>" \
       #     --jq '.workflow_runs[] | select(.name == "claude-review")
       #           | {id, conclusion, run_started_at, updated_at}'
       #
       # So what is read here is what was posted rather than what the
-      # action produced: the verdict is the last line of a review's
-      # body on the pull request, which is where section 11 of the
-      # standard puts the ack of record, and only a review claude[bot]
-      # posted is one -- an author's own ack is not.
+      # action produced: the verdict is the last line of a review body,
+      # which is where REVIEWING.md puts it, and only what claude[bot]
+      # wrote is the ack of record -- section 11's *Review* is what
+      # says an author's own is not.
       #
-      #   gh api repos/<owner>/<repo>/pulls/<n>/reviews \
-      #     --jq '.[] | "\(.user.login) \(.state) \(.body | split("\n") | last)"'
+      # The reviews endpoint and not the issue comments one, those being
+      # two stores rather than two views: a review posted with `gh pr
+      # review` is in the first and in neither of the second.
+      #
+      #   gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+      #     --jq '.[] | "\(.user.login) \(.body | split("\n") | last)"'
       #
       # The last verdict decides, rather than any verdict naming the
       # head: a second reading of the same tree can refuse what an
@@ -244,7 +324,7 @@ jobs:
       #
       # Red, and gating nothing: this check is not required, and what
       # the colour buys is a reader who sees a refusal in the checks
-      # instead of under the fold at the foot of a review.
+      # instead of under the fold at the foot of a comment.
       - name: Refuse to report anything but an ack of this head
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -255,26 +335,53 @@ jobs:
           # --paginate because the API pages at thirty reviews and the
           # newest sit on the last page; --jq answers once per page, so
           # the last line of the output is the last verdict posted.
+          #
+          # `.body // ""` is for a null body: `null | split` aborts,
+          # and it aborts the filter over the whole page rather than
+          # skipping that one review, so a single such body loses every
+          # verdict beside it. The API description has that field
+          # required and carries no `nullable` on it, where `commit_id`
+          # beside it in the same schema does, and
+          #
+          #   gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+          #     --jq '.[].body | type'
+          #
+          # answers `string` throughout this organization. It is
+          # guarded regardless: a description is no contract, and being
+          # wrong about one costs every verdict on the page where the
+          # guard costs nothing.
+          #
+          # An empty summary is a different shape and wants no guard,
+          # `split("\n")` answering `[]` for it. A body of whitespace
+          # or newlines alone is what `map(select(length > 0))` is for,
+          # splitting into fields that the `sub` before it then empties.
           verdict=$(gh api "repos/$REPO/pulls/$NUMBER/reviews" --paginate \
             --jq '[ .[]
                     | select(.user.login == "claude[bot]")
-                    | .body
+                    | .body // ""
                     | split("\n")
                     | map(sub("\\s+$"; ""))
                     | map(select(length > 0))
                     | last // empty
-                    | select(test("^(ACK|CHANGES REQUESTED) [0-9a-f]{7,40}$"))
+                    | select(test("^(ACK|NACK|CHANGES REQUESTED) [0-9a-f]{7,40}$"))
                   ] | last // empty' | tail -1)
           if [ -z "$verdict" ]; then
             echo "::error::the review posted no verdict on this pull" \
                  "request, so nothing says whether $HEAD_SHA was read at" \
                  "all. A job that finishes green having written no" \
-                 "review is what this reports."
+                 "review, or a review whose last line is not a verdict," \
+                 "is what this reports."
             exit 1
           fi
           sha=${verdict##* }
           case "$verdict" in
             "ACK "*) ;;
+            "NACK "*)
+              echo "::error::the review nacked $sha: the change itself" \
+                   "is disagreed with, and no rewrite of it is asked" \
+                   "for. The review body has the argument."
+              exit 1
+              ;;
             *)
               echo "::error::the review requested changes on $sha."
               exit 1
@@ -298,13 +405,18 @@ jobs:
     # that triggered it and answers what was actually asked, where a
     # prompt of ours would answer something else. `github.event.issue.pull
     # _request` is what tells a comment on a pull request from a comment
-    # on an issue, the issue_comment event carrying both
+    # on an issue, the issue_comment event carrying both.
+    #
+    # Behind the same switch as the review job above: this job shares
+    # that job's credential and its action, so a file that is not to run
+    # is not to run here either
     if: >-
-      ${{ (github.event_name == 'issue_comment'
-           && github.event.issue.pull_request
-           && contains(github.event.comment.body, '@claude'))
-          || (github.event_name == 'pull_request_review_comment'
-              && contains(github.event.comment.body, '@claude')) }}
+      ${{ vars.CLAUDE_REVIEW_ENABLED == 'true'
+          && ((github.event_name == 'issue_comment'
+               && github.event.issue.pull_request
+               && contains(github.event.comment.body, '@claude'))
+              || (github.event_name == 'pull_request_review_comment'
+                  && contains(github.event.comment.body, '@claude'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1292,6 +1292,55 @@ release-notes length in the first place, and are still in
   as the pull request's author, so nothing stops it approving one; the
   job stays what it was, not a required check.
 
+- **`claude-review.yml` converges on `btclib-org/.github`'s current
+  copy again: a job-level gate, a guard that reads the SDK's own error
+  fields, and a verdict posted as a `COMMENT` review rather than an
+  approval** (issue btclib-org/.github#364, btclib-org/.github#385,
+  btclib-org/.github#340). The review job has ended `is_error: true`
+  since 2026-08-23 on every `pull_request` run sampled across the four
+  repositories the first of those issues measured, this one included --
+  `num_turns: 1` and `total_cost_usd: 0` together saying the first
+  turn never completed billably, not that none ran. Nothing in these
+  repositories changed across the moment the runs turned red, which is
+  a narrower claim than the cause lying outside them;
+  `if: vars.CLAUDE_REVIEW_ENABLED == 'true'` now gates both jobs,
+  unset organization-wide, so the job skips cleanly instead of failing
+  loudly on every pull request until the shared workflow or credential
+  that issue points at is fixed. It sits on the job and not on a step:
+  a step that declines to run still leaves `steps.review.outcome` at
+  `skipped`, which the guard below reads as a review that never ran.
+
+  That guard, `Refuse to report a review that never ran`, now runs on
+  `!cancelled()` rather than only when the execution file is missing,
+  and reads `api_error_status`, `stop_reason` and `.result` off that
+  file when `steps.review.outcome` is not `success` -- fields the
+  action's own log sanitizes out of the result message it prints, and
+  writes unsanitized to the file `steps.review.outputs.execution_file`
+  already names.
+
+  The verdict itself moves from `gh pr review --approve` /
+  `--request-changes` to `gh pr review --comment`, always: OpenSSF
+  Scorecard's `Code-Review` check excludes a bot's review of any kind,
+  approving or otherwise, so the self-approval reasoning the previous
+  entry gave for preferring an approval over a comment does not survive
+  it -- what a review buys over a comment is only that the forge
+  records it under `pulls/<n>/reviews`, which the guard already reads.
+  The last line stays `ACK <sha>`, `CHANGES REQUESTED <sha>` or `NACK
+  <sha>`, the guard's regex now accepting `NACK` alongside the other
+  two, and the read-back treats a null review body as empty rather than
+  aborting the whole page it sits on.
+
+  The prompt's own citations of the standard are adapted rather than
+  copied, following section 14's rule for a receiving copy. `.github`'s
+  own copy cites `README.md` because that file is the standard there;
+  a citation naming a rule section 11 actually holds is ported to name
+  section 11 instead -- "section 11 of the organization's standard",
+  and "section 11's *Review*" for the subsection. The one citing
+  `README.md` for the standard as a whole -- the rules a finding cites
+  living in section 9 and in *How to use this file*, not in section 11
+  -- is ported to "the organization's standard" with no section
+  number.
+
 ### The gate
 
 - **`show_error_codes` leaves `[tool.mypy]`** (btclib-org/.github#191).


### PR DESCRIPTION
Answers part of [ISS 364](https://github.com/btclib-org/.github/issues/364),
[ISS 385](https://github.com/btclib-org/.github/issues/385) and
[ISS 340](https://github.com/btclib-org/.github/issues/340), and closes
none of them: seven trees owe this port and the closing keyword goes on
the last landing.

`claude-review.yml` converges with the organization's copy. Both jobs
gain the `CLAUDE_REVIEW_ENABLED` gate, so a run that cannot work skips
instead of failing. The guard step reads `api_error_status`,
`stop_reason` and `.result` off the SDK's execution file under
`!cancelled()`, so a failure arrives with the name the action's log
drops — this repository's own run 32907526287 answers `is_error: true`,
`num_turns: 1`, `total_cost_usd: 0`, the two fields together saying the
first turn never completed billably. The verdict is posted as a review
of type `COMMENT`, never `--approve` and never `--request-changes`, and
the verification step reads the reviews endpoint.

The entry supersedes the reasoning PR #398's own entry gave, rather than
rewriting it: that entry stands as what was true at its release.

Citations of the standard take the three shapes section 14's rule for a
receiving copy produces. Where section 11 holds the rule, the citation
names it — the switch, the two secret stores a Dependabot-initiated run
reads, what each verdict concludes, why never `--approve`, and that an
author's own ack is not the ack of record. Where the source cited
`README.md` for the standard as a whole, the citation names the standard
with no section number: the rules a finding cites live in section 9 and
in *How to use this file*, not in section 11, which is *GitHub
settings*.
[ISS 396](https://github.com/btclib-org/.github/issues/396) carries that
measurement and the standard's own misattribution behind it.

The prompt keeps this tree's naming of its gates rather than the
standard's own single one: three gates decide a merge here.

## Summary by Sourcery

Bring the Claude review workflow back in line with the organization's current behavior and make failed or missing review verdicts accurately visible.

New Features:
- Gate both Claude review jobs behind the organization-level `CLAUDE_REVIEW_ENABLED` switch so disabled reviews skip cleanly.
- Post Claude's verdict as a `COMMENT` pull request review and recognize `NACK` verdicts during verification.

Bug Fixes:
- Report failed or incomplete Claude executions using the SDK execution file and fail when no verdict is written.
- Verify the recorded verdict through the pull request reviews endpoint, including resilient handling of null review bodies.

Enhancements:
- Align the workflow prompt, citations, timeouts, and review verification behavior with the organization's current standard.