### PR TITLE
claude-review.yml's comments name what the file does, and state no plan-dependent figure

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,12 +17,13 @@ name: claude-review
 # author to weigh -- never `--approve` and never `--request-changes`,
 # section 11 of the organization's standard having why.
 #
-# It is one more job on every pull request, which is not free: GitHub Free
-# gives this organization twenty concurrent jobs and REPOSITORY.md measures
-# what a commit at that ceiling costs in wall clock. It earns the slot by
-# being short -- it reads a diff, it does not build a matrix -- and by
-# skipping a draft, which is the condition test.yml and lint.yml already
-# carry.
+# It is one more job on every pull request, which is not free: the
+# concurrency ceiling belongs to the organization and is shared, so this
+# job competes for a slot with the other repositories' matrices.
+# REPOSITORY.md's *Plan-gated settings* has the ceiling and the command
+# that answers the plan setting it. It earns the slot by being short --
+# it reads a diff, it does not build a matrix -- and by skipping a draft,
+# which is the condition test.yml and lint.yml already carry.
 
 on:
   pull_request:
@@ -213,7 +214,7 @@ jobs:
             `confirmed: true`) for a finding a line is the subject of.
           # folded rather than literal, and `gh pr` rather than the three
           # subcommands spelled out: the flag has to reach the CLI as one
-          # line, and the line that spells out comment, diff and view is
+          # line, and the line that spells out diff, review and view is
           # past the 100 columns yamllint holds this file to
           claude_args: >-
             --allowedTools
@@ -430,19 +431,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
-      # a missing credential is a silent pass without this, which is the
-      # worst shape a gate can take: measured on the first run after the
-      # organization secret was deleted -- the action found the token
-      # empty, reviewed nothing, and reported success. Fail loudly
-      # instead, and say which secret and where it lives
-      - name: Refuse to review without a credential
+      # a missing credential is a silent pass without this, for the
+      # reason the review job above gives
+      - name: Refuse to answer without a credential
         env:
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           if [ -z "$TOKEN" ]; then
             echo "::error::CLAUDE_CODE_OAUTH_TOKEN is empty. It is an" \
                  "organization secret of btclib-org, visible to all" \
-                 "repositories; without it this workflow reviews nothing."
+                 "repositories; without it this workflow answers nothing."
             exit 1
           fi
       - name: Answer the mention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1341,6 +1341,26 @@ release-notes length in the first place, and are still in
   -- is ported to "the organization's standard" with no section
   number.
 
+- **`claude-review.yml`'s comments name the `gh pr` subcommands the
+  prompt uses, word the `mention` job's credential refusal for the job
+  it guards, and argue the concurrency cost without a plan-dependent
+  figure** (issue btclib-org/.github#398, btclib-org/.github#402,
+  btclib-org/.github#405, btclib-org/.github#410). The prompt reaches
+  the CLI through `gh pr
+  diff`, `gh pr view` and `gh pr review --comment`, so the comment
+  explaining why `claude_args` is a folded scalar spells out `diff,
+  review and view`. The step guarding `mention` -- the job that answers
+  an `@claude` comment and reviews nothing -- is `Refuse to answer
+  without a credential` and says the workflow answers nothing, taken
+  byte for byte from `btclib-org/portanode`, with the comment above it
+  naming the review job's reason rather than restating it. The header's
+  argument for one more job per pull request rests on the ceiling being
+  the organization's and shared with the other repositories' matrices,
+  and sends a reader to `REPOSITORY.md`'s *Plan-gated settings* for the
+  ceiling and for the command that answers the plan setting it: a
+  figure written into a comment is one no hook reads and no test
+  compares, so it goes on reading true after the plan moves.
+
 ### The gate
 
 - **`show_error_codes` leaves `[tool.mypy]`** (btclib-org/.github#191).


### PR DESCRIPTION
Answers part of
[ISS 398](https://github.com/btclib-org/.github/issues/398),
[ISS 402](https://github.com/btclib-org/.github/issues/402),
[ISS 405](https://github.com/btclib-org/.github/issues/405) and
[ISS 410](https://github.com/btclib-org/.github/issues/410). Tracking
issues, all four: none is closed here, each being owed by several
repositories, and `btclib`'s copy is held by another branch, so the
keyword belongs to the last tree to converge.

**The `mention` job speaks for itself.** It answers an `@claude` comment
and reviews nothing, and two of its strings were the review job's above
it, copied rather than written for it. Both are now `portanode`'s, taken
from its bytes: the step `Refuse to answer without a credential`, whose
message ends `this workflow answers nothing`, and the comment above it,
which points at the review job's reason instead of restating it. The
restatement narrated a measurement made on the review job -- a token
found empty, a review reported successful -- inside the job that reviews
nothing.

**The `claude_args` comment names the subcommands the prompt calls.**
`grep -n 'gh pr '` answers `diff`, `view` and `review --comment`, where
the comment had named `comment, diff and view` from before the verdict
moved to `gh pr review --comment`.

**The header argues the concurrency cost without a plan-dependent
figure.** It said GitHub Free gives this organization twenty concurrent
jobs -- true today, `gh api orgs/btclib-org --jq .plan.name` answering
`free`, and silently wrong on a plan change, since no hook reads a
comment and no test compares this file. The argument does not rest on
the number: it rests on the ceiling being the organization's and shared,
so a slot taken here is one a sibling's matrix waits behind. That
survives intact, and the reader is sent to `REPOSITORY.md`'s
*Plan-gated settings*, which carries the ceiling, the plan-by-plan table
and the command that answers which plan sets it.

One clause did not survive: the old sentence credited `REPOSITORY.md`
with measuring what a commit at that ceiling costs in wall clock. That
measurement is `os-windows.yml`'s and `test.yml`'s headers', which
`REPOSITORY.md` itself says. The replacement claims only what is there.

The same figure still stands undated in six other files of this tree.
That is [ISS 412](https://github.com/btclib-org/.github/issues/412),
filed rather than swept in: those files are this tree's own and are
governed differently, where the workflow is one of eight copies under a
cross-repository decision.

## Summary by Sourcery

Clarify claude-review workflow documentation and make its concurrency rationale independent of the organization’s current plan.

Enhancements:
- Clarify the claude workflow comments by aligning the mention-job credential guard with its purpose and documenting the actual pull-request subcommands used.
- Replace the plan-dependent concurrency figure with a durable explanation of shared organizational concurrency and a reference to the plan-gated settings documentation.

Documentation:
- Add a changelog entry documenting the workflow comment and concurrency rationale updates.