### PR TITLE
The `typos` hook is `repo: local`, and `.gitignore` drops a `docs/_build/` that decides nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,6 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
-docs/_build/
-
 # PyBuilder
 target/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -250,15 +250,27 @@ repos:
   # camelCase, and carries a dictionary of its own. typos' configuration
   # is in pyproject.toml; codespell needs none today -- measured, with its
   # default dictionaries it finds nothing here to skip or allow for
-  # in place fixes already, by upstream's own .pre-commit-hooks.yaml:
-  # args: [--write-changes, --force-exclude], inherited because this
-  # file passes no args: of its own. An args: added here later for a
-  # different reason would silently drop that default and turn the
-  # fixing off
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.49.0
+  #
+  # crate-ci/typos re-tags a moving `v1` alias onto the same commit
+  # as each release, and `git describe --tags` breaks the tie between
+  # two tags on one commit by creation date, which names the alias.
+  # `autoupdate` proposes that alias on every run and `pinned-rev` above
+  # refuses it on every run, so the pin stays stuck rather than moving.
+  # `autoupdate` walks every `repo:` entry except `local` and `meta`, so
+  # a local hook is the one shape it cannot reach; `additional_dependencies`
+  # below carries the version pin in its place, and `language`, `entry`,
+  # `args` and `types` are upstream's own typos hook definition, copied
+  # in rather than fetched
+  - repo: local
     hooks:
       - id: typos
+        name: typos
+        language: python
+        additional_dependencies: [typos==1.49.0]
+        entry: typos
+        args: [--write-changes, --force-exclude]
+        types: [text]
+        stages: [pre-commit, pre-merge-commit, pre-push, manual]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.23.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1617,6 +1617,19 @@ release-notes length in the first place, and are still in
   `uvx pre-commit run local-link-prefix --all-files` re-derives the
   whole of it.
 
+- **The `typos` hook is `repo: local`, pinned through
+  `additional_dependencies: [typos==1.49.0]`, rather than a
+  `crate-ci/typos` mirror pinned by `rev:`** (issue
+  btclib-org/.github#399). `autoupdate` walks every `repo:` entry except
+  `local` and `meta`, and `crate-ci/typos` re-tags a moving `v1` alias
+  onto the same commit as each release, which `git describe --tags`
+  then names by creation date -- `autoupdate` would propose that alias
+  on every run and `pinned-rev` above would refuse it on every run, so a
+  mirror entry here can only ever answer that refusal, never converge.
+  `language`, `entry`, `args` and `types` are upstream's own typos hook
+  definition, copied in rather than fetched, matching
+  `btclib-org/.github`'s own `.pre-commit-config.yaml` byte for byte.
+
 ### Packaging metadata
 
 - **`check-sdist` gates the sdist against what git tracks** (#344).
@@ -1753,6 +1766,15 @@ release-notes length in the first place, and are still in
   a silent one, and `btclib` and `portanode` both currently place it
   last regardless of whether their own calendar row exists yet -- this
   matches that precedent rather than deciding #358 unilaterally.
+
+### `docs/_build/` leaves `.gitignore`
+
+- **`.gitignore`'s `docs/_build/` entry is gone** (issue
+  btclib-org/.github#411). `build/` already
+  covers `docs/build/html`, the directory the documented `sphinx-build`
+  command in `CONTRIBUTING.md` and `docs.yml` writes to:
+  `git check-ignore -v docs/build/html/index.html` names `build/` as the
+  matching pattern, and `docs/_build/` matches none of it.
 
 ## v0.8.0.4
 


### PR DESCRIPTION
Two converging edits to two configuration files, bundled because a review round costs the same either way.

**`.pre-commit-config.yaml`'s `typos` entry converges on `btclib-org/.github`'s own**, which landed at `6c97576` ([ISS 399](https://github.com/btclib-org/.github/issues/399)). `pre-commit autoupdate` walks every `repo:` entry except `local` and `meta`, and `crate-ci/typos` re-tags a moving `v1` alias onto the same commit as each release — so `git describe --tags` breaks the tie by creation date and names the alias, `autoupdate` proposes it every run, and `pinned-rev` refuses it every run. A `repo: local` hook is the one shape `autoupdate` cannot reach, and `additional_dependencies: [typos==1.49.0]` carries the version pin in its place. The block is taken byte for byte rather than re-derived, which is what the issue's *Done when* asks for.

**`.gitignore`'s `docs/_build/` is gone** ([ISS 411](https://github.com/btclib-org/.github/issues/411)). `build/` already covers `docs/build/html`, which is what `CONTRIBUTING.md` and `docs.yml` both document `sphinx-build` writing to, and `docs/Makefile` and `docs/make.bat` both set `BUILDDIR = build` — so not even a hand-run `make html` reaches `_build`.

**This closes neither issue.** ISS 399 is owed by seven trees and ISS 411 by four; each takes its closing keyword on the last of them, and this tree is not the last of either. Tracking issues: btclib-org/.github#399 and btclib-org/.github#411

**A decision ISS 411 reserved is closed here, and this is the notice it asked for.** That issue's *Not measured* names one reading under which the line is not inert: a hand-run `sphinx-build` with Sphinx's own default output directory would now leave an untracked tree. The measurement above is the ground for deciding it does not apply — this tree's two documented paths and both its Makefiles write under `docs/build/`. The cut-back, if that answer is unwanted, is restoring the two `.gitignore` lines; nothing else in the branch depends on them.

**Local review took two rounds** and both findings were prose, not behaviour:

- the changelog entry said `build/` was "a few lines above" `docs/_build/`. Measured, they are lines 11 and 75 of a 152-line file, in different sections of the stock template. `CHANGELOG.md` is append-only, so that clause could not have been corrected after landing; it is struck at both sites, the entry's and the commit message's, and nothing replaces it — the `git check-ignore -v` already in the sentence is the re-derivation, and a line number would be a figure nothing re-derives.
- the retained codespell paragraph ran straight into the copied block, giving a reader "…nothing here to skip or allow for crate-ci/typos re-tags a moving `v1` alias…". A bare `#` now ends it, which the reviewer then measured to be this file's own idiom rather than a guess: the construct appears twenty times at the base.

The reviewer verified convergence again after the fix, `diff` exit 0 against `btclib-org/.github` at `77407e7`, and re-ran the hook over the new tree — `typos --force-exclude` over the tracked paths exits 0, with `teh fisrt hex_strin` as the positive control that exits 2.

Gates, on the tip: lint `pre-commit run --all-files` exit 0; suite `pytest --cov` exit 0, 829 passed, 100.00% coverage floor reached; docs `sphinx-build -n -W --keep-going` exit 0. Those are the three `CONTRIBUTING.md`'s *The environment and the gates* names.

Round two's edits were made by the orchestrator rather than by the coder, so the same hand made the change and ran the gates; the reviewer records that plainly rather than smoothing it over.
