### PR TITLE
The link to the repository is not a badge the row can audit (issue btclib-org/.github#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1776,6 +1776,17 @@ release-notes length in the first place, and are still in
   `git check-ignore -v docs/build/html/index.html` names `build/` as the
   matching pattern, and `docs/_build/` matches none of it.
 
+### `README.md` drops the badge linking to the repository
+
+- **The badge row's link to the repository on GitHub is gone** (issue
+  btclib-org/.github#381). Section 2 of the organization standard
+  refuses it now: the badge renders the repository's name because the
+  URL says so, and the row is an audit, so the item that measures
+  nothing is the one that does not belong in it. `[project.urls]`'s
+  `repository` key already carries the same link for the reader who
+  meets this file as the long description an index renders or as the
+  `README.md` an unpacked sdist carries.
+
 ## v0.8.0.4
 
 ### `musig` wraps MuSig2, closing the one exception `lib` was for

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # btclib_secp256k1
 
 <!-- The badges are what the reader decides with: the first line says what
-this is and whether it can be used, the second whether it works, the third
-where the code is and where to ask about it. A badge that reports no state
--- "we use ruff", "we use uv" -- reports a choice instead, and those are in
-CONTRIBUTING.md, beside the prose that says how the choice is enforced. One
-badge per line keeps a change to one line and every line inside MD013,
-whose 80 columns bind only where a space follows them. btclib and
-bitcoin-core-rpc carry the same three lines.
+this is and whether it can be used, and the second whether it works. A
+badge that reports no state -- "we use ruff", "we use uv" -- reports a
+choice instead, and those are in CONTRIBUTING.md, beside the prose that
+says how the choice is enforced. One badge per line keeps a change to
+one line and every line inside MD013, whose 80 columns bind only where a
+space follows them. btclib and bitcoin-core-rpc carry the same two
+lines.
 Scorecard is placed last among the sentinel badges rather than in the
 calendar order the rest follow, matching btclib's and portanode's own
 placement: btclib-org/.github#358 is where that placement is asked to
@@ -40,8 +40,6 @@ sits. -->
 [![mutation workflow status](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml/badge.svg)](https://github.com/btclib-org/btclib-secp256k1/actions/workflows/mutation.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/btclib-org/btclib-secp256k1/badge)](https://scorecard.dev/viewer/?uri=github.com/btclib-org/btclib-secp256k1)
 [![documentation build](https://app.readthedocs.org/projects/btclib-secp256k1/badge/?version=latest)](https://btclib-secp256k1.readthedocs.io)
-
-[![GitHub repository: btclib-org/btclib-secp256k1](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib--secp256k1-181717?logo=github)](https://github.com/btclib-org/btclib-secp256k1/)
 
 ---
 


### PR DESCRIPTION
Section 2 of the standard refuses the link-to-the-repository badge: it
renders the repository's name because the URL says so, and the row is an
audit, so the one item that measures nothing is the one that does not
belong in it.

What the badge gave up is a pointer for a reader meeting this
`README.md` as an unpacked sdist's `PKG-INFO` long description, and
`[project.urls]`'s `repository` already carries that link.

**The file's own head comment is corrected in the same diff**, because
the deletion falsifies it. It described a "third" badge block — "where
the code is and where to ask about it" — and asserted that `btclib` and
`bitcoin-core-rpc` "carry the same three lines". Both statements stop
being true the moment the block goes, so this is the same file
describing the row being edited rather than collateral.

`(issue btclib-org/.github#381)` and not `(closes …)`: five trees carry
this badge and this is not the last of them.

## Gates

| gate | exit |
| --- | --- |
| `uv run --locked --only-group lint pre-commit run --all-files` | 0 |
| `uv run --locked --no-default-groups --group test pytest --cov` | 0 — 829 passed, 100.00% coverage |
| `uv run --locked --no-default-groups --group docs sphinx-build -n -W --keep-going -b html docs/source <out>` | 0 |

## Summary by Sourcery

Align the README badge row with the organization standard by removing the repository-link badge.

Enhancements:
- Remove the non-auditing repository link badge from the README badge row and update its accompanying guidance to reflect the two remaining badge lines.

Documentation:
- Document the README badge removal in the changelog.